### PR TITLE
[#6521] StringTransportWithDisconnection should use failure.

### DIFF
--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from zope.interface import implementer, implementedBy
 from zope.interface.verify import verifyClass
 
+from twisted.python import failure
 from twisted.python.compat import unicode
 from twisted.internet.interfaces import (
     ITransport, IConsumer, IPushProducer, IConnector)
@@ -257,10 +258,15 @@ class StringTransport:
 
 
 class StringTransportWithDisconnection(StringTransport):
+    """
+    A StringTransport which can be disconnected.
+    """
+
     def loseConnection(self):
         if self.connected:
             self.connected = False
-            self.protocol.connectionLost(error.ConnectionDone("Bye."))
+            self.protocol.connectionLost(
+                failure.Failure(error.ConnectionDone("Bye.")))
 
 
 

--- a/twisted/test/test_memcache.py
+++ b/twisted/test/test_memcache.py
@@ -304,6 +304,7 @@ class MemCacheTestCase(CommandMixin, TestCase):
         def checkMessage(error):
             self.assertEqual(str(error), "Connection timeout")
         d1.addCallback(checkMessage)
+        self.assertFailure(d3, ConnectionDone)
         return gatherResults([d1, d2, d3])
 
 
@@ -336,6 +337,7 @@ class MemCacheTestCase(CommandMixin, TestCase):
         self.proto.dataReceived("VALUE foo 0 10\r\n12345")
         self.clock.advance(self.proto.persistentTimeOut)
         self.assertFailure(d1, TimeoutError)
+        self.assertFailure(d2, ConnectionDone)
         return gatherResults([d1, d2])
 
 
@@ -351,6 +353,7 @@ class MemCacheTestCase(CommandMixin, TestCase):
         self.proto.dataReceived("STAT foo bar\r\n")
         self.clock.advance(self.proto.persistentTimeOut)
         self.assertFailure(d1, TimeoutError)
+        self.assertFailure(d2, ConnectionDone)
         return gatherResults([d1, d2])
 
 
@@ -396,6 +399,7 @@ class MemCacheTestCase(CommandMixin, TestCase):
         self.clock.advance(1)
         self.assertFailure(d1, TimeoutError)
         self.assertFailure(d2, TimeoutError)
+        self.assertFailure(d3, ConnectionDone)
         return gatherResults([d1, d2, d3])
 
 
@@ -428,7 +432,6 @@ class MemCacheTestCase(CommandMixin, TestCase):
                 self.assertFalse(success)
                 result.trap(ConnectionDone)
         return done.addCallback(checkFailures)
-
 
     def test_tooLongKey(self):
         """


### PR DESCRIPTION
# Problem description

The current implementation of t.test.proto_helpers.StringTransportWithDisconnection.connectionLost is calling self.protocol.connectionLost() with an Exception and not a Failure.
# Changes description

I have fixed the implementation and also updated the failing tests.

There  is still one un-caught exceptions but I don't know how to track it

```
$ trial twisted.test

....

[ERROR]
Traceback (most recent call last):
Failure: twisted.internet.error.ConnectionDone: Connection was closed cleanly: Bye..

twisted.test.test_pb.BrokerTestCase.test_cache
-------------------------------------------------------------------------------
Ran 2074 tests in 30.939s

FAILED (skips=58, expectedFailures=4, errors=1, successes=2011)



$ trial twisted.test.test_pb

...

    test_sync ...                                                          [OK]

-------------------------------------------------------------------------------
Ran 45 tests in 0.527s

PASSED (successes=45)

```
