### PR TITLE
Bugfix: ticket #6607, ckeygen default key file.

### DIFF
--- a/twisted/conch/scripts/ckeygen.py
+++ b/twisted/conch/scripts/ckeygen.py
@@ -101,7 +101,9 @@ def generateDSAkey(options):
 def printFingerprint(options):
     if not options['filename']:
         filename = os.path.expanduser('~/.ssh/id_rsa')
-        options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
+        options['filename'] = raw_input('Enter file in which the key is (default: %s): ' % filename)
+        if not options['filename']:
+            options['filename'] = filename
     if os.path.exists(options['filename']+'.pub'):
         options['filename'] += '.pub'
     try:


### PR DESCRIPTION
Bugfix - ckeygen will use default publickey file on empty stdin.

$ ckeygen -p
Enter file in which the key is (/home/therve/.ssh/id_rsa):

will now read

$ ckeygen -p
Enter file in which the key is (default: /home/therve/.ssh/id_rsa):
