### PR TITLE
portforward: make the client-connection behaviour overrideable in subclasses

### DIFF
--- a/twisted/protocols/portforward.py
+++ b/twisted/protocols/portforward.py
@@ -74,6 +74,10 @@ class ProxyServer(Proxy):
         if self.reactor is None:
             from twisted.internet import reactor
             self.reactor = reactor
+
+        self.connectProxyClient(client)
+
+    def connectProxyClient(self, client)
         self.reactor.connectTCP(self.factory.host, self.factory.port, client)
 
 


### PR DESCRIPTION
This makes it a bit easier to implement non-TCP proxies, similar to what socat can do. My particular use case is to proxy traffic from an incoming connection to an outgoing socks client connection (txsocksx provides this).
