### PR TITLE
fix race condition in HTTPConnectionPool

### DIFF
--- a/twisted/web/client.py
+++ b/twisted/web/client.py
@@ -1126,11 +1126,12 @@ class HTTPConnectionPool(object):
             dropped.transport.loseConnection()
             self._timeouts[dropped].cancel()
             del self._timeouts[dropped]
-        connections.append(connection)
+
         cid = self._reactor.callLater(self.cachedConnectionTimeout,
                                       self._removeConnection,
                                       key, connection)
         self._timeouts[connection] = cid
+        connections.append(connection)
 
 
     def closeCachedConnections(self):


### PR DESCRIPTION
a race condition occurs between HTTPConnectionPool getConnection and _putConnection

_putConnection adds a connection to the connection list (self._connections[key].append)
before adding the connection to the _timeouts dict
calling callLater will eventually trigger a system call which will cause the GIL to be released and will allow for a context switch to occur.
if in that point in time getConnection is called, it will pop the connections from the _connections[key] list and then try to access that connection on the _timeouts dict and will fail with a KeyError since it wasn't added to that dict yet.
