### PR TITLE
Port python zippath

### DIFF
--- a/twisted/python/dist3.py
+++ b/twisted/python/dist3.py
@@ -100,6 +100,7 @@ modules = [
     "twisted.python.test",
     "twisted.python.test.deprecatedattributes",
     "twisted.python.test.modules_helpers",
+    "twisted.python.test.test_zippath",
     "twisted.python.threadable",
     "twisted.python.threadpool",
     "twisted.python.usage",

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -105,7 +105,12 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         self.assertEqual(repr(self.path), pathRepr)
 
         # Create a path to the file rooted in the current working directory
-        relativeCommon = self.cmn.replace(os.getcwd().encode(encoding) + os.sep.encode(encoding), b"", 1) + b".zip"
+        relativeCommon = self.cmn.replace(
+            os.getcwd().encode(encoding) + os.sep.encode(encoding),
+            b"",
+            1
+        )
+        relativeCommon = relativeCommon + b".zip"
         relpath = ZipArchive(relativeCommon)
 
         # Check using a path without the cwd prepended

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -105,7 +105,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         self.assertEqual(repr(self.path), pathRepr)
 
         # Create a path to the file rooted in the current working directory
-        relativeCommon = self.cmn.replace(os.getcwd() + os.sep, "", 1) + ".zip"
+        relativeCommon = self.cmn.replace(os.getcwd().encode(encoding) + os.sep.encode(encoding), b"", 1) + b".zip"
         relpath = ZipArchive(relativeCommon)
 
         # Check using a path without the cwd prepended

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -57,7 +57,9 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         self.assertEqual(repr(child), pathRepr)
 
         # Create a path to the file rooted in the current working directory
-        relativeCommon = self.cmn.replace(os.getcwd() + os.sep, "", 1) + ".zip"
+        relativeCommon = self.cmn.replace(
+            os.getcwd().encode(encoding) + os.sep.encode(encoding), b"", 1)
+        relativeCommon += b".zip"
         relpath = ZipArchive(relativeCommon)
         child = relpath.child("foo")
 

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -50,7 +50,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         """
         child = self.path.child("foo")
         pathRepr = "ZipPath(%r)" % (
-            os.path.abspath(self.cmn + ".zip" + os.sep + 'foo'),)
+            os.path.abspath(self.cmn + b".zip" + os.sep.encode() + b'foo'),)
 
         # Check for an absolute path
         self.assertEqual(repr(child), pathRepr)
@@ -72,7 +72,8 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         """
         child = self.path.child("foo").child("..").child("bar")
         pathRepr = "ZipPath(%r)" % (
-            self.cmn + ".zip" + os.sep.join(["", "foo", "..", "bar"]))
+            self.cmn +
+            (".zip" + os.sep.join(["", "foo", "..", "bar"])).encode("utf-8"))
         self.assertEqual(repr(child), pathRepr)
 
 
@@ -82,8 +83,8 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         string literals are escaped in the ZipPath repr.
         """
         child = self.path.child("'")
-        path = self.cmn + ".zip" + os.sep.join(["", "'"])
-        pathRepr = "ZipPath('%s')" % (path.encode('string-escape'),)
+        path = self.cmn + (".zip" + os.sep.join(["", "'"])).encode("utf-8")
+        pathRepr = "ZipPath('%s')" % (path,)
         self.assertEqual(repr(child), pathRepr)
 
 
@@ -92,7 +93,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         Make sure that invoking ZipArchive's repr prints the correct class
         name and an absolute path to the zip file.
         """
-        pathRepr = 'ZipArchive(%r)' % (os.path.abspath(self.cmn + '.zip'),)
+        pathRepr = 'ZipArchive(%r)' % (os.path.abspath(self.cmn + b'.zip'),)
 
         # Check for an absolute path
         self.assertEqual(repr(self.path), pathRepr)

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -10,18 +10,22 @@ import os, zipfile
 from twisted.test.test_paths import AbstractFilePathTestCase
 from twisted.python.zippath import ZipArchive
 
+import sys
+
+encoding = sys.getfilesystemencoding()
+
 
 def zipit(dirname, zfname):
     """
     Create a zipfile on zfname, containing the contents of dirname'
     """
-    zf = zipfile.ZipFile(zfname, "w")
+    zf = zipfile.ZipFile(zfname.decode(encoding), "w")
     for root, ignored, files, in os.walk(dirname):
         for fname in files:
             fspath = os.path.join(root, fname)
             arcpath = os.path.join(root, fname)[len(dirname)+1:]
             # print fspath, '=>', arcpath
-            zf.write(fspath, arcpath)
+            zf.write(fspath.decode(encoding), arcpath.decode(encoding))
     zf.close()
 
 
@@ -34,7 +38,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
     def setUp(self):
         AbstractFilePathTestCase.setUp(self)
         zipit(self.cmn, self.cmn + b'.zip')
-        self.path = ZipArchive(self.cmn + b'.zip')
+        self.path = ZipArchive((self.cmn + b'.zip').decode(encoding))
         self.root = self.path
         self.all = [x.replace(self.cmn, self.cmn + b'.zip') for x in self.all]
 

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -9,6 +9,7 @@ import os, zipfile
 
 from twisted.test.test_paths import AbstractFilePathTestCase
 from twisted.python.zippath import ZipArchive
+import twisted.python.compat as compat
 
 import sys
 
@@ -84,7 +85,10 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         """
         child = self.path.child("'")
         path = self.cmn + (".zip" + os.sep.join(["", "'"])).encode("utf-8")
-        pathRepr = "ZipPath(%s)" % (path,)
+        if compat._PY3:
+            pathRepr = "ZipPath(%s)" % (path,)
+        else:
+            pathRepr = "ZipPath(%r)" % (path,)
         self.assertEqual(repr(child), pathRepr)
 
 

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -13,20 +13,20 @@ import twisted.python.compat as compat
 
 import sys
 
-encoding = sys.getfilesystemencoding()
+ENCODING = sys.getfilesystemencoding()
 
 
 def zipit(dirname, zfname):
     """
     Create a zipfile on zfname, containing the contents of dirname'
     """
-    zf = zipfile.ZipFile(zfname.decode(encoding), "w")
+    zf = zipfile.ZipFile(zfname.decode(ENCODING), "w")
     for root, ignored, files, in os.walk(dirname):
         for fname in files:
             fspath = os.path.join(root, fname)
             arcpath = os.path.join(root, fname)[len(dirname)+1:]
             # print fspath, '=>', arcpath
-            zf.write(fspath.decode(encoding), arcpath.decode(encoding))
+            zf.write(fspath.decode(ENCODING), arcpath.decode(ENCODING))
     zf.close()
 
 
@@ -39,7 +39,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
     def setUp(self):
         AbstractFilePathTestCase.setUp(self)
         zipit(self.cmn, self.cmn + b'.zip')
-        self.path = ZipArchive((self.cmn + b'.zip').decode(encoding))
+        self.path = ZipArchive((self.cmn + b'.zip').decode(ENCODING))
         self.root = self.path
         self.all = [x.replace(self.cmn, self.cmn + b'.zip') for x in self.all]
 
@@ -106,7 +106,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
 
         # Create a path to the file rooted in the current working directory
         relativeCommon = self.cmn.replace(
-            os.getcwd().encode(encoding) + os.sep.encode(encoding),
+            os.getcwd().encode(ENCODING) + os.sep.encode(ENCODING),
             b"",
             1
         )

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -84,7 +84,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         """
         child = self.path.child("'")
         path = self.cmn + (".zip" + os.sep.join(["", "'"])).encode("utf-8")
-        pathRepr = "ZipPath('%s')" % (path,)
+        pathRepr = "ZipPath(%s)" % (path,)
         self.assertEqual(repr(child), pathRepr)
 
 

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -49,7 +49,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         Make sure that invoking ZipPath's repr prints the correct class name
         and an absolute path to the zip file.
         """
-        child = self.path.child("foo")
+        child = self.path.child(b"foo")
         pathRepr = "ZipPath(%r)" % (
             os.path.abspath(self.cmn + b".zip" + os.sep.encode() + b'foo'),)
 
@@ -58,10 +58,10 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
 
         # Create a path to the file rooted in the current working directory
         relativeCommon = self.cmn.replace(
-            os.getcwd().encode(encoding) + os.sep.encode(encoding), b"", 1)
+            os.getcwd().encode(ENCODING) + os.sep.encode(ENCODING), b"", 1)
         relativeCommon += b".zip"
         relpath = ZipArchive(relativeCommon)
-        child = relpath.child("foo")
+        child = relpath.child(b"foo")
 
         # Check using a path without the cwd prepended
         self.assertEqual(repr(child), pathRepr)
@@ -73,7 +73,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         includes the C{".."} rather than applying the usual parent directory
         meaning.
         """
-        child = self.path.child("foo").child("..").child("bar")
+        child = self.path.child(b"foo").child(b"..").child(b"bar")
         pathRepr = "ZipPath(%r)" % (
             self.cmn +
             (".zip" + os.sep.join(["", "foo", "..", "bar"])).encode("utf-8"))
@@ -85,7 +85,7 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
         Bytes in the ZipPath path which have special meaning in Python
         string literals are escaped in the ZipPath repr.
         """
-        child = self.path.child("'")
+        child = self.path.child(b"'")
         path = self.cmn + (".zip" + os.sep.join(["", "'"])).encode("utf-8")
         if compat._PY3:
             pathRepr = "ZipPath(%s)" % (path,)

--- a/twisted/python/test/test_zippath.py
+++ b/twisted/python/test/test_zippath.py
@@ -33,10 +33,10 @@ class ZipFilePathTestCase(AbstractFilePathTestCase):
     """
     def setUp(self):
         AbstractFilePathTestCase.setUp(self)
-        zipit(self.cmn, self.cmn + '.zip')
-        self.path = ZipArchive(self.cmn + '.zip')
+        zipit(self.cmn, self.cmn + b'.zip')
+        self.path = ZipArchive(self.cmn + b'.zip')
         self.root = self.path
-        self.all = [x.replace(self.cmn, self.cmn + '.zip') for x in self.all]
+        self.all = [x.replace(self.cmn, self.cmn + b'.zip') for x in self.all]
 
 
     def test_zipPathRepr(self):

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -70,12 +70,12 @@ class ZipPath(AbstractFilePath):
     def __repr__(self):
         parts = [os.path.abspath(self.archive.path)]
         parts.extend(self.pathInArchive.encode().split(ZIP_PATH_SEP))
-        path = os.sep.join(parts)
-        return "ZipPath('%s')" % (path,)
+        path = os.sep.encode().join(parts)
+        return "ZipPath(%s)" % (path,)
 
 
     def parent(self):
-        splitup = self.pathInArchive.encode.split(ZIP_PATH_SEP)
+        splitup = self.pathInArchive.encode().split(ZIP_PATH_SEP)
         if len(splitup) == 1:
             return self.archive
         return ZipPath(self.archive, ZIP_PATH_SEP.join(splitup[:-1]))

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -36,6 +36,8 @@ from zope.interface import implementer
 ZIP_PATH_SEP = b'/'             # In zipfiles, "/" is universally used as the
                                 # path separator, regardless of platform.
 
+ENCODING = sys.getfilesystemencoding()
+
 
 @implementer(IFilePath)
 class ZipPath(AbstractFilePath):
@@ -204,6 +206,11 @@ class ZipArchive(ZipPath):
 
         @param archivePathname: a str, naming a path in the filesystem.
         """
+
+        # convert to string because python3 ZipFile doesn't take bytes
+        if isinstance(archivePathname, bytes):
+            archivePathname = archivePathname.decode(ENCODING)
+
         if _USE_ZIPFILE:
             self.zipfile = ZipFile(archivePathname)
         else:

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -58,12 +58,7 @@ class ZipPath(AbstractFilePath):
         @param pathInArchive: a ZIP_PATH_SEP-separated string.
         """
         self.archive = archive
-
-        # Keep pathInArchive as bytes
-        if isinstance(pathInArchive, bytes):
-            self.pathInArchive = pathInArchive
-        else:
-            self.pathInArchive = pathInArchive.encode(ENCODING)
+        self.pathInArchive = pathInArchive
 
         # self.path pretends to be os-specific because that's the way the
         # 'zipimport' module does it.

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -58,7 +58,7 @@ class ZipPath(AbstractFilePath):
         # self.path pretends to be os-specific because that's the way the
         # 'zipimport' module does it.
         self.path = os.path.join(archive.zipfile.filename.encode(),
-                                 *(self.pathInArchive.split(ZIP_PATH_SEP)))
+                                 *(self.pathInArchive.encode().split(ZIP_PATH_SEP)))
 
     def __cmp__(self, other):
         if not isinstance(other, ZipPath):
@@ -69,13 +69,13 @@ class ZipPath(AbstractFilePath):
 
     def __repr__(self):
         parts = [os.path.abspath(self.archive.path)]
-        parts.extend(self.pathInArchive.split(ZIP_PATH_SEP))
+        parts.extend(self.pathInArchive.encode().split(ZIP_PATH_SEP))
         path = os.sep.join(parts)
         return "ZipPath('%s')" % (path,)
 
 
     def parent(self):
-        splitup = self.pathInArchive.split(ZIP_PATH_SEP)
+        splitup = self.pathInArchive.encode.split(ZIP_PATH_SEP)
         if len(splitup) == 1:
             return self.archive
         return ZipPath(self.archive, ZIP_PATH_SEP.join(splitup[:-1]))

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -101,7 +101,11 @@ class ZipPath(AbstractFilePath):
             it) as this means it may include special names with special
             meaning outside of the context of a zip archive.
         """
-        encodedPath = path.encode(ENCODING)
+        try:
+            encodedPath = path.encode(ENCODING)
+        except AttributeError:
+            encodedPath = path
+
         return ZipPath(self.archive,
                        ZIP_PATH_SEP.join([self.pathInArchive, encodedPath]))
 

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -71,7 +71,7 @@ class ZipPath(AbstractFilePath):
         parts = [os.path.abspath(self.archive.path)]
         parts.extend(self.pathInArchive.encode().split(ZIP_PATH_SEP))
         path = os.sep.encode().join(parts)
-        return "ZipPath(%s)" % (path,)
+        return "ZipPath(%r)" % (path,)
 
 
     def parent(self):

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -7,6 +7,7 @@ This module contains implementations of IFilePath for zip files.
 
 See the constructor for ZipArchive for use.
 """
+from __future__ import print_function, division, absolute_import
 
 __metaclass__ = type
 

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -71,7 +71,7 @@ class ZipPath(AbstractFilePath):
         parts = [os.path.abspath(self.archive.path)]
         parts.extend(self.pathInArchive.split(ZIP_PATH_SEP))
         path = os.sep.join(parts)
-        return "ZipPath('%s')" % (path.encode('unicode-escape'),)
+        return "ZipPath('%s')" % (path,)
 
 
     def parent(self):

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -71,7 +71,7 @@ class ZipPath(AbstractFilePath):
         parts = [os.path.abspath(self.archive.path)]
         parts.extend(self.pathInArchive.split(ZIP_PATH_SEP))
         path = os.sep.join(parts)
-        return "ZipPath('%s')" % (path.encode('string-escape'),)
+        return "ZipPath('%s')" % (path.encode('unicode-escape'),)
 
 
     def parent(self):

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -29,6 +29,7 @@ else:
 from twisted.python.filepath import IFilePath, FilePath, AbstractFilePath
 
 from zope.interface import implementer
+from twisted.python.compat import comparable, cmp
 
 # Using FilePath here exclusively rather than os to make sure that we don't do
 # anything OS-path-specific here.
@@ -39,6 +40,7 @@ ZIP_PATH_SEP = b'/'             # In zipfiles, "/" is universally used as the
 ENCODING = sys.getfilesystemencoding()
 
 
+@comparable
 @implementer(IFilePath)
 class ZipPath(AbstractFilePath):
     """

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -173,7 +173,8 @@ class ZipPath(AbstractFilePath):
         @return: file size, in bytes
         """
 
-        return self.archive.zipfile.NameToInfo[self.pathInArchive].file_size
+        pathInArchive = self.pathInArchive.decode("utf-8")
+        return self.archive.zipfile.NameToInfo[pathInArchive].file_size
 
     def getAccessTime(self):
         """
@@ -192,8 +193,9 @@ class ZipPath(AbstractFilePath):
 
         @return: a number of seconds since the epoch.
         """
+        pathInArchive = self.pathInArchive.decode("utf-8")
         return time.mktime(
-            self.archive.zipfile.NameToInfo[self.pathInArchive].date_time
+            self.archive.zipfile.NameToInfo[pathInArchive].date_time
             + (0, 0, 0))
 
 

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -122,7 +122,7 @@ class ZipPath(AbstractFilePath):
         return self.pathInArchive in self.archive.childmap
 
     def isfile(self):
-        return self.pathInArchive in self.archive.zipfile.NameToInfo
+        return self.pathInArchive.decode(ENCODING) in self.archive.zipfile.NameToInfo
 
     def islink(self):
         return False
@@ -130,7 +130,7 @@ class ZipPath(AbstractFilePath):
     def listdir(self):
         if self.exists():
             if self.isdir():
-                return self.archive.childmap[self.pathInArchive].keys()
+                return self.archive.childmap[self.pathInArchive.decode(ENCODING)].keys()
             else:
                 raise OSError(errno.ENOTDIR, "Leaf zip entry listed")
         else:
@@ -157,11 +157,11 @@ class ZipPath(AbstractFilePath):
 
     def open(self, mode="r"):
         if _USE_ZIPFILE:
-            return self.archive.zipfile.open(self.pathInArchive, mode=mode)
+            return self.archive.zipfile.open(self.pathInArchive.decode(ENCODING), mode=mode)
         else:
             # XXX oh man, is this too much hax?
             self.archive.zipfile.mode = mode
-            return self.archive.zipfile.readfile(self.pathInArchive)
+            return self.archive.zipfile.readfile(self.pathInArchive.decode(ENCODING))
 
     def changed(self):
         pass
@@ -173,7 +173,7 @@ class ZipPath(AbstractFilePath):
         @return: file size, in bytes
         """
 
-        pathInArchive = self.pathInArchive.decode("utf-8")
+        pathInArchive = self.pathInArchive.decode(ENCODING)
         return self.archive.zipfile.NameToInfo[pathInArchive].file_size
 
     def getAccessTime(self):
@@ -193,7 +193,7 @@ class ZipPath(AbstractFilePath):
 
         @return: a number of seconds since the epoch.
         """
-        pathInArchive = self.pathInArchive.decode("utf-8")
+        pathInArchive = self.pathInArchive.decode(ENCODING)
         return time.mktime(
             self.archive.zipfile.NameToInfo[pathInArchive].date_time
             + (0, 0, 0))
@@ -230,7 +230,7 @@ class ZipArchive(ZipPath):
         else:
             self.zipfile = ChunkingZipFile(archivePathname)
         try:
-            self.path = archivePathname.encode("utf-8")
+            self.path = archivePathname.encode(ENCODING)
         except AttributeError:
             self.path = archivePathname
 

--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -30,7 +30,7 @@ from twisted.python.filepath import IFilePath, FilePath, AbstractFilePath
 
 from zope.interface import implementer
 
-# using FilePath here exclusively rather than os to make sure that we don't do
+# Using FilePath here exclusively rather than os to make sure that we don't do
 # anything OS-path-specific here.
 
 ZIP_PATH_SEP = b'/'             # In zipfiles, "/" is universally used as the
@@ -57,7 +57,7 @@ class ZipPath(AbstractFilePath):
         """
         self.archive = archive
 
-        # keep pathInArchive as bytes
+        # Keep pathInArchive as bytes
         if isinstance(pathInArchive, bytes):
             self.pathInArchive = pathInArchive
         else:
@@ -130,8 +130,7 @@ class ZipPath(AbstractFilePath):
     def listdir(self):
         if self.exists():
             if self.isdir():
-                # py3 changes the return type of dict().keys(),
-                # so a manual conversion is needed to reflect FilePath.listdir()
+                # py3's dict().keys() is no longer a list
                 return list(self.archive.childmap[self.pathInArchive])
             else:
                 raise OSError(errno.ENOTDIR, "Leaf zip entry listed")
@@ -152,18 +151,22 @@ class ZipPath(AbstractFilePath):
     def basename(self):
         return self.pathInArchive.split(ZIP_PATH_SEP)[-1]
 
+
     def dirname(self):
         # XXX NOTE: This API isn't a very good idea on filepath, but it's even
         # less meaningful here.
         return self.parent().path
 
+
     def open(self, mode="r"):
         if _USE_ZIPFILE:
-            return self.archive.zipfile.open(self.pathInArchive.decode(ENCODING), mode=mode)
+            return self.archive.zipfile.open(
+                self.pathInArchive.decode(ENCODING), mode=mode)
         else:
             # XXX oh man, is this too much hax?
             self.archive.zipfile.mode = mode
-            return self.archive.zipfile.readfile(self.pathInArchive.decode(ENCODING))
+            return self.archive.zipfile.readfile(
+                self.pathInArchive.decode(ENCODING))
 
     def changed(self):
         pass
@@ -213,12 +216,13 @@ class ZipPath(AbstractFilePath):
 
 
 class ZipArchive(ZipPath):
-    """ I am a FilePath-like object which can wrap a zip archive as if it were a
-    directory.
+    """ I am a FilePath-like object which can wrap a zip archive as if it were
+    a directory.
     """
     archive = property(lambda self: self)
     def __init__(self, archivePathname):
-        """Create a ZipArchive, treating the archive at archivePathname as a zip file.
+        """Create a ZipArchive, treating the archive at archivePathname as a
+        zip file.
 
         @param archivePathname: a str, naming a path in the filesystem.
         """


### PR DESCRIPTION
For fixing #6917

https://twistedmatrix.com/trac/ticket/6917

Most of the changes involve keeping file paths as bytestrings except when hitting python3 stdlib zipfile, which only allows you to use strs.
