### PR TITLE
fixed: #7352. Test on missing files now Fail. Example path is now correc...

### DIFF
--- a/twisted/names/test/test_examples.py
+++ b/twisted/names/test/test_examples.py
@@ -9,7 +9,7 @@ import sys
 from StringIO import StringIO
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest, TestCase
+from twisted.trial.unittest import TestCase, FailTest
 
 
 
@@ -46,14 +46,14 @@ class ExampleTestBase(object):
         here = (
             FilePath(__file__)
             .parent().parent().parent().parent()
-            .child('docs').child('projects')
+            .child('docs')
         )
 
         # Find the example script within this branch
         for childName in self.exampleRelativePath.split('/'):
             here = here.child(childName)
             if not here.exists():
-                raise SkipTest(
+                raise FailTest(
                     "Examples (%s) not found - cannot test" % (here.path,))
         self.examplePath = here
 


### PR DESCRIPTION
Fixed https://twistedmatrix.com/trac/ticket/7352

1- if tests can't find example files, raise FailTest instead of SkipTest

2- fixed example directory path 
