### PR TITLE
Syslog observer doesn't honor logLevels

### DIFF
--- a/twisted/names/test/test_examples.py
+++ b/twisted/names/test/test_examples.py
@@ -9,7 +9,7 @@ import sys
 from StringIO import StringIO
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest, TestCase
+from twisted.trial.unittest import TestCase, FailTest
 
 
 
@@ -46,14 +46,14 @@ class ExampleTestBase(object):
         here = (
             FilePath(__file__)
             .parent().parent().parent().parent()
-            .child('docs').child('projects')
+            .child('docs')
         )
 
         # Find the example script within this branch
         for childName in self.exampleRelativePath.split('/'):
             here = here.child(childName)
             if not here.exists():
-                raise SkipTest(
+                raise FailTest(
                     "Examples (%s) not found - cannot test" % (here.path,))
         self.examplePath = here
 

--- a/twisted/names/test/test_examples.py
+++ b/twisted/names/test/test_examples.py
@@ -9,7 +9,7 @@ import sys
 from StringIO import StringIO
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import TestCase, FailTest
+from twisted.trial.unittest import SkipTest, TestCase
 
 
 
@@ -53,7 +53,7 @@ class ExampleTestBase(object):
         for childName in self.exampleRelativePath.split('/'):
             here = here.child(childName)
             if not here.exists():
-                raise FailTest(
+                raise SkipTest(
                     "Examples (%s) not found - cannot test" % (here.path,))
         self.examplePath = here
 

--- a/twisted/python/test/test_syslog.py
+++ b/twisted/python/test/test_syslog.py
@@ -149,3 +149,22 @@ class SyslogObserverTests(TestCase):
             self.events,
             [(stdsyslog.LOG_INFO, '[-] hello,'),
              (stdsyslog.LOG_INFO, '[-] \tworld')])
+
+    def test_emitWithLoglevel(self):
+        """
+        Emit should map python logging levels to stdsyslog levels, otherwise
+            running twistd --syslog would map WARNING to INFO
+                    
+            DEBUG -> LOG_DEBUG
+            INFO -> LOG_INFO
+            WARNING -> LOG_WARNING
+            ERROR -> LOG_ERROR
+            FATAL -> LOG_CRIT
+        """
+        import logging
+        self.observer.emit({
+                'message': ('hello, world',), 'isError': False, 'system': '-',
+                'logLevel': logging.WARNING})
+        self.assertEqual(
+            self.events,
+            [(stdsyslog.LOG_WARNING, '[-] hello, world')])


### PR DESCRIPTION
Running an application using logLevel in twistd doesn't preserve logLevels 

Reproduce:
1- run #twistd --syslog ...
2- wait for an event with logLevel=WARNING

I expect:
3- the log has syslogSeverity = LOG_WARNING

Instead
4- the syslogSeverity = DEFAULT == LOG_INFO

The following code reproduces the issue.

If you're interested I'll provide a patch.

Thx+Peace,
R.
