### PR TITLE
Spike for extracting cleanup logic to separate classes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ def main(args):
         sys.path.insert(0, '.')
 
     setup_args = {}
-    requirements = ["zope.interface >= 3.6.0"]
+    requirements = [
+        "zope.interface >= 3.6.0",
+        "fixtures >= 1.4.0",
+    ]
 
     setup_args['install_requires'] = requirements
     setup_args['include_package_data'] = True

--- a/twisted/trial/test/test_tests.py
+++ b/twisted/trial/test/test_tests.py
@@ -937,6 +937,24 @@ class AddCleanupMixin(object):
         self.assertEqual(error1.getErrorMessage(), 'bar')
         self.assertEqual(error2.getErrorMessage(), 'foo')
 
+    def test_reentrant(self):
+        """
+        A test with cleanups can be run more than once.
+        """
+        log = []
+
+        class SomeTest(self.AddCleanup):
+            def test_withCleanups(self):
+                log.append('test_withCleanups')
+                self.addCleanup(log.append, 'cleanup')
+
+        test = SomeTest('test_withCleanups')
+        test.run(self.result)
+        test.run(self.result)
+        self.assertEqual(
+            ([], ['test_withCleanups', 'cleanup'] * 2),
+            (self.result.errors, log))
+
 
 
 class SynchronousAddCleanupTests(AddCleanupMixin, unittest.SynchronousTestCase):


### PR DESCRIPTION
Not so much a pull request as a starting point for a discussion. 

testtools.TestCase has a `useFixture` method which is very useful. A `Fixture` is a thing that can be set up and torn down, has an `addCleanup` method, and itself has a `useFixture` method, which means that they can be composed. 

For example, a database server fixture might use the temporary directory fixture to create storage space. The database server fixture would know how to shut down the server, and the temporary directory fixture would know to clean up the failure. It's really nice.

Another way to think about it is that in lots of test code you have:

``` python
foo = do_some_set_up(42)
self.addCleanup(foo.some_tear_down)
```

But with fixtures, you have:

``` python
foo = self.useFixture(Foo(42))
```

That is, it gives the idiom a name and an abstraction. 

Unfortunately, due to the essential nature of things, if you want to return Deferreds, you are out of luck. https://github.com/testing-cabal/fixtures/issues/18 has been filed on the fixtures side of things. 

This PR begins to do the work of creating an asynchronous fixture object by:
1. Using `fixtures` to provide our synchronous clean up logic.
2. Extracting the bare minimum from the async `TestCase` in order to handle cleanups

Future work would be to:
- add `setUp`, `reset`, and `useFixture` methods to `AsyncFixture`
- add `useFixture` methods to `SynchronousTestCase` and `TestCase`
- add adapters for synchronous fixtures so that they return Deferreds (probably both a `maybeDeferred` one and a `deferToThread` one)

Probably the most novel thing about this patch is that it adds a dependency to Twisted beyond zope.interface.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/twisted/twisted/58)

<!-- Reviewable:end -->
