### PR TITLE
fix the problem of the poll reactor cost much CPU time when remove re…

### DIFF
--- a/twisted/internet/pollreactor.py
+++ b/twisted/internet/pollreactor.py
@@ -98,6 +98,8 @@ class PollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
         except:
             # the hard way: necessary because fileno() may disappear at any
             # moment, thanks to python's underlying sockets impl
+            if fd >= 0:
+                return
             for fd, fdes in self._selectables.items():
                 if selectable is fdes:
                     break

--- a/twisted/test/test_poll_client.py
+++ b/twisted/test/test_poll_client.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import socket
+import time
+import os
+
+HOST = '127.0.0.1'
+PORT = 9529
+
+conns = []
+def do_run_cycle():
+  i = 0
+  while 1:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if not s:
+      print "can not create socket"
+      continue
+    s.settimeout(20)
+    s.connect((HOST, PORT))
+    conns.append(s)
+    i += 1
+    if i >= 10000:
+      break
+    print 'done connection ', i
+
+if __name__ == '__main__':
+  do_run_cycle()
+  time.sleep(1)
+  del conns
+

--- a/twisted/test/test_poll_server.py
+++ b/twisted/test/test_poll_server.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+try:
+  from twisted.internet import pollreactor
+  pollreactor.install()
+except :
+  pass
+
+from twisted.internet.protocol import Factory
+from twisted.internet import reactor
+import twisted
+from twisted.web import server
+from twisted.protocols.basic import LineReceiver
+class Chat(LineReceiver):
+  def __init__(self, users):
+    self.users = users
+    self.name = None
+    self.state = "GETNAME"
+  
+  def connectionMade(self):
+    pass
+    #self.sendLine("What's your name?")
+  
+  def connectionLost(self, reason):
+    if self.users.has_key(self.name):
+      del self.users[self.name]
+
+  def lineReceived(self, line):
+    if self.state == "GETNAME":
+      self.handle_GETNAME(line)
+    else:
+      self.handle_CHAT(line)
+  
+  def handle_GETNAME(self, name):
+    if self.users.has_key(name):
+      self.sendLine("Name taken, please choose another.")
+      return
+    self.sendLine("Welcome, %s!" % (name,))
+    self.name = name
+    self.users[name] = self
+    self.state = "CHAT"
+
+  def handle_CHAT(self, message):
+    message = "<%s> %s" % (self.name, message)
+    for name, protocol in self.users.iteritems():
+      if protocol != self:
+        protocol.sendLine(message)
+
+class ChatFactory(Factory):
+  def __init__(self):
+    self.users = {} # maps user names to Chat instances
+    
+  def buildProtocol(self, addr):
+    return Chat(self.users)
+
+def start_server():
+  reactor.listenTCP(9529, ChatFactory())
+  reactor.run(installSignalHandlers=0)
+
+if __name__ == '__main__':
+  start_server()
+


### PR DESCRIPTION
fix the problem of the poll reactor cost much CPU time when remove reader of writer which has beed removed.  A simple chat server with poll reactor. About  more than 5000 (or even much more) test clients  connected to the server but do nothing, and then the 5000 test clients all closed. With many paths to go to the function  _dictRemove  in pollreactor.py, the fd in mdict and _selectables will be deleted at the first time reach here, but when the second of third time reach here, this code 
`for fd, fdes in self._selectables.items():`
will do a whole traverse. It will cost much CPU time(may more than 20 seconds). 
