### PR TITLE
PEP 3113 - Remove use of tuple parameter unpacking

### DIFF
--- a/docs/core/examples/cred.py
+++ b/docs/core/examples/cred.py
@@ -106,7 +106,8 @@ class Protocol(basic.LineReceiver):
         self.sendLine("You have the following privileges: ")
         self.sendLine(" ".join(map(str, self.avatar.getPrivileges())))
 
-    def _cbLogin(self, (interface, avatar, logout)):
+    def _cbLogin(self, interface_avatar_logout):
+        (interface, avatar, logout) = interface_avatar_logout
         assert interface is IProtocolUser
         self.avatar = avatar
         self.logout = logout

--- a/docs/core/examples/cred.py
+++ b/docs/core/examples/cred.py
@@ -106,8 +106,8 @@ class Protocol(basic.LineReceiver):
         self.sendLine("You have the following privileges: ")
         self.sendLine(" ".join(map(str, self.avatar.getPrivileges())))
 
-    def _cbLogin(self, interface_avatar_logout):
-        (interface, avatar, logout) = interface_avatar_logout
+    def _cbLogin(self, result):
+        (interface, avatar, logout) = result
         assert interface is IProtocolUser
         self.avatar = avatar
         self.logout = logout

--- a/docs/words/examples/oscardemo.py
+++ b/docs/words/examples/oscardemo.py
@@ -46,7 +46,8 @@ if any of those features don't work, tell paul (Z3Penguin).  thanks."""%SN)
         self.setIdleTime(0)
         self.clientReady()
         self.createChat('%s Chat'%SN).addCallback(self.createdRoom)
-    def createdRoom(self, (exchange, fullName, instance)):
+    def createdRoom(self, result):
+        (exchange, fullName, instance) = result
         print 'created room',exchange, fullName, instance
         self.joinChat(exchange, fullName, instance).addCallback(self.chatJoined)
     def updateBuddy(self, user):
@@ -66,7 +67,8 @@ if any of those features don't work, tell paul (Z3Penguin).  thanks."""%SN)
             self.lastUser = user.name
             self.sendMessage(user.name, multiparts, wantAck = 1, autoResponse = (self.awayMessage!=None)).addCallback( \
                 self.messageAck)
-    def messageAck(self, (username, message)):
+    def messageAck(self, result):
+        (username, message) = result
         print 'message sent to %s acked' % username
     def gotAway(self, away, user):
         if away != None:

--- a/twisted/conch/insults/window.py
+++ b/twisted/conch/insults/window.py
@@ -423,7 +423,8 @@ def verticalLine(terminal, x, top, bottom):
 
 
 def rectangle(terminal, position, dimension):
-    """ Draw a rectangle
+    """
+    Draw a rectangle
 
     @type position: C{tuple}
     @param position: A tuple of the (top, left) coordinates of the rectangle.

--- a/twisted/conch/insults/window.py
+++ b/twisted/conch/insults/window.py
@@ -386,10 +386,12 @@ class Canvas(Widget):
         if self.y >= height:
             self.y = height - 1
 
-    def __getitem__(self, (x, y)):
+    def __getitem__(self, index):
+        (x, y) = index
         return self.contents[(self._width * y) + x]
 
-    def __setitem__(self, (x, y), value):
+    def __setitem__(self, index, value):
+        (x, y) = index
         self.contents[(self._width * y) + x] = value
 
     def clear(self):
@@ -420,7 +422,16 @@ def verticalLine(terminal, x, top, bottom):
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 
 
-def rectangle(terminal, (top, left), (width, height)):
+def rectangle(terminal, position, dimension):
+    """ Draw a rectangle
+
+    @type position: C{tuple}
+    @param position: A tuple of the (top, left) coordinates of the rectangle.
+    @type dimension: C{tuple}
+    @param dimension: A tuple of the (width, height) size of the rectangle.
+    """
+    (top, left) = position
+    (width, height) = dimension
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
 
     terminal.cursorPosition(top, left)

--- a/twisted/conch/ssh/forwarding.py
+++ b/twisted/conch/ssh/forwarding.py
@@ -185,9 +185,17 @@ class SSHForwardingClient(protocol.Protocol):
             self.channel = None
 
 
-def packOpen_direct_tcpip((connHost, connPort), (origHost, origPort)):
+def packOpen_direct_tcpip(destination, source):
     """Pack the data suitable for sending in a CHANNEL_OPEN packet.
+
+    @type destination: C{tuple}
+    @param destination: A tuple of the (host, port) of the destination host.
+
+    @type source: C{tuple}
+    @param source: A tuple of the (host, port) of the source host.
     """
+    (connHost, connPort) = destination
+    (origHost, origPort) = source
     conn = common.NS(connHost) + struct.pack('>L', connPort)
     orig = common.NS(origHost) + struct.pack('>L', origPort)
     return conn + orig
@@ -205,7 +213,8 @@ def unpackOpen_direct_tcpip(data):
 
 unpackOpen_forwarded_tcpip = unpackOpen_direct_tcpip
     
-def packGlobal_tcpip_forward((host, port)):
+def packGlobal_tcpip_forward(host_port):
+    (host, port) = host_port
     return common.NS(host) + struct.pack('>L', port)
 
 def unpackGlobal_tcpip_forward(data):

--- a/twisted/conch/ssh/forwarding.py
+++ b/twisted/conch/ssh/forwarding.py
@@ -186,7 +186,8 @@ class SSHForwardingClient(protocol.Protocol):
 
 
 def packOpen_direct_tcpip(destination, source):
-    """Pack the data suitable for sending in a CHANNEL_OPEN packet.
+    """
+    Pack the data suitable for sending in a CHANNEL_OPEN packet.
 
     @type destination: C{tuple}
     @param destination: A tuple of the (host, port) of the destination host.
@@ -212,10 +213,20 @@ def unpackOpen_direct_tcpip(data):
     return (connHost, connPort), (origHost, origPort)
 
 unpackOpen_forwarded_tcpip = unpackOpen_direct_tcpip
-    
-def packGlobal_tcpip_forward(host_port):
-    (host, port) = host_port
+
+
+
+def packGlobal_tcpip_forward(peer):
+    """
+    Pack the data for tcpip forwarding.
+
+    @param peer: A tuple of the (host, port) .
+    @type peer: C{tuple}
+    """
+    (host, port) = peer
     return common.NS(host) + struct.pack('>L', port)
+
+
 
 def unpackGlobal_tcpip_forward(data):
     host, rest = common.getNS(data)

--- a/twisted/conch/ssh/session.py
+++ b/twisted/conch/ssh/session.py
@@ -323,11 +323,15 @@ def parseRequest_pty_req(data):
     modes = [(ord(modes[i]), struct.unpack('>L', modes[i+1: i+5])[0]) for i in range(0, len(modes)-1, 5)]
     return term, winSize, modes
 
-def packRequest_pty_req(term, (rows, cols, xpixel, ypixel), modes):
+def packRequest_pty_req(term, geometry, modes):
     """Pack a pty-req request so that it is suitable for sending.
 
     NOTE: modes must be packed before being sent here.
+
+    @type geometry: C{tuple}
+    @param geometry: A tuple of (rows, columns, xpixel, ypixel)
     """
+    (rows, cols, xpixel, ypixel) = geometry
     termPacked = common.NS(term)
     winSizePacked = struct.pack('>4L', cols, rows, xpixel, ypixel)
     modesPacked = common.NS(modes) # depend on the client packing modes
@@ -341,9 +345,13 @@ def parseRequest_window_change(data):
     cols, rows, xpixel, ypixel = struct.unpack('>4L', data)
     return rows, cols, xpixel, ypixel
 
-def packRequest_window_change((rows, cols, xpixel, ypixel)):
+def packRequest_window_change(geometry):
     """Pack a window-change request so that it is suitable for sending.
+
+    @type geometry: C{tuple}
+    @param geometry: A tuple of (rows, columns, xpixel, ypixel)
     """
+    (rows, cols, xpixel, ypixel) = geometry
     return struct.pack('>4L', cols, rows, xpixel, ypixel)
 
 import connection

--- a/twisted/conch/ssh/session.py
+++ b/twisted/conch/ssh/session.py
@@ -324,7 +324,8 @@ def parseRequest_pty_req(data):
     return term, winSize, modes
 
 def packRequest_pty_req(term, geometry, modes):
-    """Pack a pty-req request so that it is suitable for sending.
+    """
+    Pack a pty-req request so that it is suitable for sending.
 
     NOTE: modes must be packed before being sent here.
 
@@ -346,7 +347,8 @@ def parseRequest_window_change(data):
     return rows, cols, xpixel, ypixel
 
 def packRequest_window_change(geometry):
-    """Pack a window-change request so that it is suitable for sending.
+    """
+    Pack a window-change request so that it is suitable for sending.
 
     @type geometry: C{tuple}
     @param geometry: A tuple of (rows, columns, xpixel, ypixel)

--- a/twisted/conch/ssh/userauth.py
+++ b/twisted/conch/ssh/userauth.py
@@ -187,12 +187,13 @@ class SSHUserAuthServer(service.SSHService):
         return d
 
 
-    def _cbFinishedAuth(self, (interface, avatar, logout)):
+    def _cbFinishedAuth(self, result):
         """
         The callback when user has successfully been authenticated.  For a
         description of the arguments, see L{twisted.cred.portal.Portal.login}.
         We start the service requested by the user.
         """
+        (interface, avatar, logout) = result
         self.transport.avatar = avatar
         self.transport.logoutFunction = logout
         service = self.transport.factory.getService(self.transport,

--- a/twisted/internet/test/test_inotify.py
+++ b/twisted/internet/test/test_inotify.py
@@ -70,7 +70,8 @@ class INotifyTests(unittest.TestCase):
         if expectedPath is None:
             expectedPath = self.dirname.child("foo.bar")
         notified = defer.Deferred()
-        def cbNotified((watch, filename, events)):
+        def cbNotified(watch_filename_events):
+            (watch, filename, events) = watch_filename_events
             self.assertEqual(filename, expectedPath)
             self.assertTrue(events & mask)
         notified.addCallback(cbNotified)
@@ -387,7 +388,8 @@ class INotifyTests(unittest.TestCase):
         expectedPath.touch()
 
         notified = defer.Deferred()
-        def cbNotified((ignored, filename, events)):
+        def cbNotified(ignored_filename_events):
+            (ignored, filename, events) = ignored_filename_events
             self.assertEqual(filename, expectedPath)
             self.assertTrue(events & inotify.IN_DELETE_SELF)
 
@@ -423,7 +425,8 @@ class INotifyTests(unittest.TestCase):
         expectedPath2.touch()
 
         notified = defer.Deferred()
-        def cbNotified((ignored, filename, events)):
+        def cbNotified(ignored_filename_events):
+            (ignored, filename, events) = ignored_filename_events
             self.assertEqual(filename, expectedPath2)
             self.assertTrue(events & inotify.IN_DELETE_SELF)
 

--- a/twisted/internet/test/test_inotify.py
+++ b/twisted/internet/test/test_inotify.py
@@ -70,8 +70,8 @@ class INotifyTests(unittest.TestCase):
         if expectedPath is None:
             expectedPath = self.dirname.child("foo.bar")
         notified = defer.Deferred()
-        def cbNotified(watch_filename_events):
-            (watch, filename, events) = watch_filename_events
+        def cbNotified(result):
+            (watch, filename, events) = result
             self.assertEqual(filename, expectedPath)
             self.assertTrue(events & mask)
         notified.addCallback(cbNotified)
@@ -388,8 +388,8 @@ class INotifyTests(unittest.TestCase):
         expectedPath.touch()
 
         notified = defer.Deferred()
-        def cbNotified(ignored_filename_events):
-            (ignored, filename, events) = ignored_filename_events
+        def cbNotified(result):
+            (ignored, filename, events) = result
             self.assertEqual(filename, expectedPath)
             self.assertTrue(events & inotify.IN_DELETE_SELF)
 
@@ -425,8 +425,8 @@ class INotifyTests(unittest.TestCase):
         expectedPath2.touch()
 
         notified = defer.Deferred()
-        def cbNotified(ignored_filename_events):
-            (ignored, filename, events) = ignored_filename_events
+        def cbNotified(result):
+            (ignored, filename, events) = result
             self.assertEqual(filename, expectedPath2)
             self.assertTrue(events & inotify.IN_DELETE_SELF)
 

--- a/twisted/mail/imap4.py
+++ b/twisted/mail/imap4.py
@@ -666,7 +666,8 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         else:
             handler(*args)
 
-    def __cbDispatch(self, (arg, rest), tag, fn, args, parseargs, uid):
+    def __cbDispatch(self, arg_rest, tag, fn, args, parseargs, uid):
+        (arg, rest) = arg_rest
         args.append(arg)
         self.__doCommand(tag, fn, args, parseargs, rest, uid)
 
@@ -1006,7 +1007,8 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
                 (tag,), None, (tag,), None
             )
 
-    def __cbAuthResp(self, (iface, avatar, logout), tag):
+    def __cbAuthResp(self, iface_avatar_logout, tag):
+        (iface, avatar, logout) = iface_avatar_logout
         assert iface is IAccount, "IAccount is the only supported interface"
         self.account = avatar
         self.state = 'auth'
@@ -1076,7 +1078,8 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
             )
         raise UnauthorizedLogin()
 
-    def __cbLogin(self, (iface, avatar, logout), tag):
+    def __cbLogin(self, iface_avatar_logout, tag):
+        (iface, avatar, logout) = iface_avatar_logout
         if iface is not IAccount:
             self.sendBadResponse(tag, 'Server error: login returned unexpected value')
             log.err("__cbLogin called with %r, IAccount expected" % (iface,))
@@ -1668,7 +1671,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
     def search_NEW(self, query, id, msg):
         return '\\Recent' in msg.getFlags() and '\\Seen' not in msg.getFlags()
 
-    def search_NOT(self, query, id, msg, (lastSequenceId, lastMessageId)):
+    def search_NOT(self, query, id, msg, lastIDs):
         """
         Returns C{True} if the message does not match the query.
 
@@ -1681,13 +1684,13 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         @type msg: Provider of L{imap4.IMessage}
         @param msg: The message being checked.
 
-        @type lastSequenceId: C{int}
-        @param lastSequenceId: The highest sequence number of a message in the
-            mailbox.
-
-        @type lastMessageId: C{int}
-        @param lastMessageId: The highest UID of a message in the mailbox.
+        @type lastIDs: C{tuple}
+        @param lastIDs: A tuple of (last sequence id, last message id).
+        The I{last sequence id} is an C{int} containing the highest sequence
+        number of a message in the mailbox.  The I{last message id} is an
+        C{int} containing the highest UID of a message in the mailbox.
         """
+        (lastSequenceId, lastMessageId) = lastIDs
         return not self._singleSearchStep(query, id, msg,
                                           lastSequenceId, lastMessageId)
 
@@ -1698,7 +1701,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         date = parseTime(query.pop(0))
         return rfc822.parsedate(msg.getInternalDate()) == date
 
-    def search_OR(self, query, id, msg, (lastSequenceId, lastMessageId)):
+    def search_OR(self, query, id, msg, last_sequence_id_message_id):
         """
         Returns C{True} if the message matches any of the first two query
         items.
@@ -1719,6 +1722,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         @type lastMessageId: C{int}
         @param lastMessageId: The highest UID of a message in the mailbox.
         """
+        (lastSequenceId, lastMessageId) = last_sequence_id_message_id
         a = self._singleSearchStep(query, id, msg,
                                    lastSequenceId, lastMessageId)
         b = self._singleSearchStep(query, id, msg,
@@ -1799,7 +1803,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         to = msg.getHeaders(False, 'to').get('to', '')
         return to.lower().find(query.pop(0).lower()) != -1
 
-    def search_UID(self, query, id, msg, (lastSequenceId, lastMessageId)):
+    def search_UID(self, query, id, msg, last_sequence_id_message_id):
         """
         Returns C{True} if the message UID is in the range defined by the
         search query.
@@ -1815,13 +1819,13 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         @type msg: Provider of L{imap4.IMessage}
         @param msg: The message being checked.
 
-        @type lastSequenceId: C{int}
-        @param lastSequenceId: The highest sequence number of a message in the
-            mailbox.
-
-        @type lastMessageId: C{int}
-        @param lastMessageId: The highest UID of a message in the mailbox.
+        @type last_sequence_id_message_id: A C{tuple} of C{int}
+        @param last_sequence_id_message_id: The first element should be
+            a C{int} which is the highest sequence number of a message in the
+            mailbox.  The second element should be a C{int} which is
+            the highest UID of a message in the mailbox.
         """
+        (lastSequenceId, lastMessageId) = last_sequence_id_message_id
         c = query.pop(0)
         m = parseIdList(c, lastMessageId)
         return msg.getUID() in m
@@ -2544,7 +2548,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbCapabilities)
         return d
 
-    def __cbCapabilities(self, (lines, tagline)):
+    def __cbCapabilities(self, lines_tagline):
+        (lines, tagline) = lines_tagline
         caps = {}
         for rest in lines:
             for cap in rest[1:]:
@@ -2577,7 +2582,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbLogout)
         return d
 
-    def __cbLogout(self, (lines, tagline)):
+    def __cbLogout(self, lines_tagline):
+        (lines, tagline) = lines_tagline
         self.transport.loseConnection()
         # We don't particularly care what the server said
         return None
@@ -2596,9 +2602,10 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbNoop)
         return d
 
-    def __cbNoop(self, (lines, tagline)):
+    def __cbNoop(self, lines_tagline):
         # Conceivable, this is elidable.
         # It is, afterall, a no-op.
+        (lines, tagline) = lines_tagline
         return lines
 
     def startTLS(self, contextFactory=None):
@@ -2810,7 +2817,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbNamespace)
         return d
 
-    def __cbNamespace(self, (lines, last)):
+    def __cbNamespace(self, lines_last):
+        (lines, last) = lines_last
         for parts in lines:
             if len(parts) == 4 and parts[0] == 'NAMESPACE':
                 return [e or [] for e in parts[1:]]
@@ -2909,14 +2917,13 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
             raise IllegalServerResponse(phrase)
 
 
-    def __cbSelect(self, (lines, tagline), rw):
+    def __cbSelect(self, lines_tagline, rw):
         """
         Handle lines received in response to a SELECT or EXAMINE command.
 
         See RFC 3501, section 6.3.1.
         """
-        # In the absence of specification, we are free to assume:
-        #   READ-WRITE access
+        (lines, tagline) = lines_tagline
         datum = {'READ-WRITE': rw}
         lines.append(parseNestedParens(tagline))
         for split in lines:
@@ -3080,7 +3087,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbList, 'LSUB')
         return d
 
-    def __cbList(self, (lines, last), command):
+    def __cbList(self, lines_last, command):
+        (lines, last) = lines_last
         results = []
         for parts in lines:
             if len(parts) == 4 and parts[0] == command:
@@ -3116,7 +3124,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         d.addCallback(self.__cbStatus)
         return d
 
-    def __cbStatus(self, (lines, last)):
+    def __cbStatus(self, lines_last):
+        (lines, last) = lines_last
         status = {}
         for parts in lines:
             if parts[0] == 'STATUS':
@@ -3228,7 +3237,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         return d
 
 
-    def __cbExpunge(self, (lines, last)):
+    def __cbExpunge(self, lines_last):
+        (lines, last) = lines_last
         ids = []
         for parts in lines:
             if len(parts) == 2 and parts[1] == 'EXPUNGE':
@@ -3263,7 +3273,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         return d
 
 
-    def __cbSearch(self, (lines, end)):
+    def __cbSearch(self, lines_end):
+        (lines, end) = lines_end
         ids = []
         for parts in lines:
             if len(parts) > 0 and parts[0] == 'SEARCH':
@@ -3684,7 +3695,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         return values
 
 
-    def _cbFetch(self, (lines, last), requestedParts, structured):
+    def _cbFetch(self, lines_last, requestedParts, structured):
+        (lines, last) = lines_last
         info = {}
         for parts in lines:
             if len(parts) == 3 and parts[1] == 'FETCH':

--- a/twisted/mail/pop3.py
+++ b/twisted/mail/pop3.py
@@ -776,14 +776,14 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         ).addErrback(self._ebUnexpected)
 
 
-    def _cbMailbox(self, interface_avatar_logout, user):
+    def _cbMailbox(self, result, user):
         """
         Complete successful authentication.
 
         Save the mailbox and logout function for the authenticated user and
         send a successful response to the client.
 
-        @type interface_avatar_logout: C{tuple}
+        @type result: C{tuple}
         @param interface_avatar_logout: The first item of the tuple is a
             C{zope.interface.Interface} which is the interface
             supported by the avatar.  The second item of the tuple is a
@@ -795,7 +795,7 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         @type user: L{bytes}
         @param user: The user being authenticated.
         """
-        (interface, avatar, logout) = interface_avatar_logout
+        (interface, avatar, logout) = result
         if interface is not IMailbox:
             self.failResponse('Authentication failed')
             log.err("_cbMailbox() called with an interface other than IMailbox")

--- a/twisted/mail/pop3.py
+++ b/twisted/mail/pop3.py
@@ -776,26 +776,26 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         ).addErrback(self._ebUnexpected)
 
 
-    def _cbMailbox(self, (interface, avatar, logout), user):
+    def _cbMailbox(self, interface_avatar_logout, user):
         """
         Complete successful authentication.
 
         Save the mailbox and logout function for the authenticated user and
         send a successful response to the client.
 
-        @type interface: C{zope.interface.Interface}
-        @param interface: The interface supported by the avatar.
-
-        @type avatar: L{IMailbox} provider
-        @param avatar: The mailbox for the authenticated user.
-
-        @type logout: no-argument callable
-        @param logout: The function to be invoked when the session is
+        @type interface_avatar_logout: C{tuple}
+        @param interface_avatar_logout: The first item of the tuple is a
+            C{zope.interface.Interface} which is the interface
+            supported by the avatar.  The second item of the tuple is a
+            L{IMailbox} provider which is the mailbox for the
+            authenticated user.  The third item of the tuple is a no-argument
+            callable which is a function to be invoked when the session is
             terminated.
 
         @type user: L{bytes}
         @param user: The user being authenticated.
         """
+        (interface, avatar, logout) = interface_avatar_logout
         if interface is not IMailbox:
             self.failResponse('Authentication failed')
             log.err("_cbMailbox() called with an interface other than IMailbox")

--- a/twisted/mail/pop3client.py
+++ b/twisted/mail/pop3client.py
@@ -109,17 +109,16 @@ class _ListSetter:
         self.L = L
 
 
-    def setitem(self, (item, value)):
+    def setitem(self, itemAndValue):
         """
         Add the value at the specified position, padding out missing entries.
 
-        @type item: L{int}
-        @param item: The 0-based index in the list at which the value should
-            be placed.
-
-        @type value: L{object}
-        @param value: The value to put in the list.
+        @type itemAndValue: C{tuple}
+        @param item: A tuple of (item, value).  The I{item} is the 0-based
+        index in the list at which the value should be placed.  The value is
+        is an L{object} to put in the list.
         """
+        (item, value) = itemAndValue
         diff = item - len(self.L) + 1
         if diff > 0:
             self.L.extend([None] * diff)

--- a/twisted/mail/smtp.py
+++ b/twisted/mail/smtp.py
@@ -841,10 +841,11 @@ class SMTP(basic.LineOnlyReceiver, policies.TimeoutMixin):
             self.sendCode(250, 'Delivery in progress')
 
 
-    def _cbAnonymousAuthentication(self, (iface, avatar, logout)):
+    def _cbAnonymousAuthentication(self, iface_avatar_logout):
         """
         Save the state resulting from a successful anonymous cred login.
         """
+        (iface, avatar, logout) = iface_avatar_logout
         if issubclass(iface, IMessageDeliveryFactory):
             self.deliveryFactory = avatar
             self.delivery = None

--- a/twisted/mail/smtp.py
+++ b/twisted/mail/smtp.py
@@ -841,11 +841,11 @@ class SMTP(basic.LineOnlyReceiver, policies.TimeoutMixin):
             self.sendCode(250, 'Delivery in progress')
 
 
-    def _cbAnonymousAuthentication(self, iface_avatar_logout):
+    def _cbAnonymousAuthentication(self, result):
         """
         Save the state resulting from a successful anonymous cred login.
         """
-        (iface, avatar, logout) = iface_avatar_logout
+        (iface, avatar, logout) = result
         if issubclass(iface, IMessageDeliveryFactory):
             self.deliveryFactory = avatar
             self.delivery = None

--- a/twisted/mail/test/test_pop3client.py
+++ b/twisted/mail/test/test_pop3client.py
@@ -177,8 +177,8 @@ class ListConsumer:
     def __init__(self):
         self.data = {}
 
-    def consume(self, item_value):
-        (item, value) = item_value
+    def consume(self, result):
+        (item, value) = result
         self.data.setdefault(item, []).append(value)
 
 class MessageConsumer:

--- a/twisted/mail/test/test_pop3client.py
+++ b/twisted/mail/test/test_pop3client.py
@@ -177,7 +177,8 @@ class ListConsumer:
     def __init__(self):
         self.data = {}
 
-    def consume(self, (item, value)):
+    def consume(self, item_value):
+        (item, value) = item_value
         self.data.setdefault(item, []).append(value)
 
 class MessageConsumer:

--- a/twisted/names/srvconnect.py
+++ b/twisted/names/srvconnect.py
@@ -103,8 +103,8 @@ class SRVConnector:
         self.servers = []
         self.orderedServers = []
 
-    def _cbGotServers(self, answers_auth_add):
-        (answers, auth, add) = answers_auth_add
+    def _cbGotServers(self, result):
+        (answers, auth, add) = result
         if len(answers) == 1 and answers[0].type == dns.SRV \
                              and answers[0].payload \
                              and answers[0].payload.target == dns.Name('.'):

--- a/twisted/names/srvconnect.py
+++ b/twisted/names/srvconnect.py
@@ -103,7 +103,8 @@ class SRVConnector:
         self.servers = []
         self.orderedServers = []
 
-    def _cbGotServers(self, (answers, auth, add)):
+    def _cbGotServers(self, answers_auth_add):
+        (answers, auth, add) = answers_auth_add
         if len(answers) == 1 and answers[0].type == dns.SRV \
                              and answers[0].payload \
                              and answers[0].payload.target == dns.Name('.'):

--- a/twisted/news/database.py
+++ b/twisted/news/database.py
@@ -1031,7 +1031,8 @@ class NewsStorageAugmentation:
         return self.dbpool.runQuery(sql).addCallback(
             lambda result: result[0]
         ).addCallback(
-            lambda index_id_body: (index_id_body[0], index_id_body[1], StringIO.StringIO(index_id_body[2]))
+            # result is a tupple of (index, id, body)
+            lambda result: (result[0], result[1], StringIO.StringIO(result[2]))
         )
 
 ####

--- a/twisted/news/database.py
+++ b/twisted/news/database.py
@@ -1031,7 +1031,7 @@ class NewsStorageAugmentation:
         return self.dbpool.runQuery(sql).addCallback(
             lambda result: result[0]
         ).addCallback(
-            lambda (index, id, body): (index, id, StringIO.StringIO(body))
+            lambda index_id_body: (index_id_body[0], index_id_body[1], StringIO.StringIO(index_id_body[2]))
         )
 
 ####

--- a/twisted/news/nntp.py
+++ b/twisted/news/nntp.py
@@ -429,8 +429,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotSubscriptions(self._endState())
 
 
-    def _headerGroup(self, code_line):
-        (code, line) = code_line
+    def _headerGroup(self, response):
+        (code, line) = response
         self.gotGroup(tuple(line.split()))
         self._endState()
 
@@ -460,8 +460,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotBody('\n'.join(self._endState())+'\n')
 
 
-    def _headerPost(self, code_message):
-        (code, message) = code_message
+    def _headerPost(self, response):
+        (code, message) = response
         if code == 340:
             self.transport.write(self._postText[0].replace('\n', '\r\n').replace('\r\n.', '\r\n..'))
             if self._postText[0][-1:] != '\n':
@@ -474,8 +474,8 @@ class NNTPClient(basic.LineReceiver):
         self._endState()
 
 
-    def _headerPosted(self, code_message):
-        (code, message) = code_message
+    def _headerPosted(self, response):
+        (code, message) = response
         if code == 240:
             self.postedOk()
         else:
@@ -504,8 +504,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotNewGroups(self._endState())
 
 
-    def _headerMode(self, code_message):
-        (code, message) = code_message
+    def _headerMode(self, response):
+        (code, message) = response
         if code == 203:
             self.setStreamSuccess()
         else:
@@ -621,8 +621,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotListGroup, self._errListGroup)
 
 
-    def _gotListGroup(self, group_articles):
-        (group, articles) = group_articles
+    def _gotListGroup(self, result):
+        (group, articles) = result
         self.currentGroup = group
         if len(articles):
             self.currentIndex = int(articles[0])
@@ -772,8 +772,8 @@ class NNTPServer(basic.LineReceiver):
         defer.addCallbacks(self._gotGroup, self._errGroup)
 
 
-    def _gotGroup(self, name_num_high_low_flags):
-        (name, num, high, low, flags) = name_num_high_low_flags
+    def _gotGroup(self, result):
+        (name, num, high, low, flags) = result
         self.currentGroup = name
         self.currentIndex = low
         self.sendLine('211 %d %d %d %s group selected' % (num, low, high, name))
@@ -810,8 +810,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotArticle, self._errArticle)
 
 
-    def _gotArticle(self, index_id_article):
-        (index, id, article) = index_id_article
+    def _gotArticle(self, result):
+        (index, id, article) = result
         self.currentIndex = index
         self.sendLine('220 %d %s article' % (index, id))
         s = basic.FileSender()
@@ -840,8 +840,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotStat, self._errStat)
 
 
-    def _gotStat(self, index_id_article):
-        (index, id, article) = index_id_article
+    def _gotStat(self, result):
+        (index, id, article) = result
         self.currentIndex = index
         self.sendLine('223 %d %s article retreived - request text separately' % (index, id))
 
@@ -857,8 +857,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotHead, self._errHead)
 
 
-    def _gotHead(self, index_id_head):
-        (index, id, head) = index_id_head
+    def _gotHead(self, result):
+        (index, id, head) = result
         self.currentIndex = index
         self.sendLine('221 %d %s article retrieved' % (index, id))
         self.transport.write(head + '\r\n')
@@ -876,8 +876,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotBody, self._errBody)
 
 
-    def _gotBody(self, index_id_body):
-        (index, id, body) = index_id_body
+    def _gotBody(self, result):
+        (index, id, body) = result
         self.currentIndex = index
         self.sendLine('221 %d %s article retrieved' % (index, id))
         self.lastsent = ''

--- a/twisted/news/nntp.py
+++ b/twisted/news/nntp.py
@@ -398,7 +398,8 @@ class NNTPClient(basic.LineReceiver):
         log.err('Passive Error: %s' % (error,))
 
 
-    def _headerInitial(self, (code, message)):
+    def _headerInitial(self, response):
+        (code, message) = response
         if code == 200:
             self.canPost = 1
         else:
@@ -428,7 +429,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotSubscriptions(self._endState())
 
 
-    def _headerGroup(self, (code, line)):
+    def _headerGroup(self, code_line):
+        (code, line) = code_line
         self.gotGroup(tuple(line.split()))
         self._endState()
 
@@ -458,7 +460,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotBody('\n'.join(self._endState())+'\n')
 
 
-    def _headerPost(self, (code, message)):
+    def _headerPost(self, code_message):
+        (code, message) = code_message
         if code == 340:
             self.transport.write(self._postText[0].replace('\n', '\r\n').replace('\r\n.', '\r\n..'))
             if self._postText[0][-1:] != '\n':
@@ -471,7 +474,8 @@ class NNTPClient(basic.LineReceiver):
         self._endState()
 
 
-    def _headerPosted(self, (code, message)):
+    def _headerPosted(self, code_message):
+        (code, message) = code_message
         if code == 240:
             self.postedOk()
         else:
@@ -500,7 +504,8 @@ class NNTPClient(basic.LineReceiver):
             self.gotNewGroups(self._endState())
 
 
-    def _headerMode(self, (code, message)):
+    def _headerMode(self, code_message):
+        (code, message) = code_message
         if code == 203:
             self.setStreamSuccess()
         else:
@@ -616,7 +621,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotListGroup, self._errListGroup)
 
 
-    def _gotListGroup(self, (group, articles)):
+    def _gotListGroup(self, group_articles):
+        (group, articles) = group_articles
         self.currentGroup = group
         if len(articles):
             self.currentIndex = int(articles[0])
@@ -766,7 +772,8 @@ class NNTPServer(basic.LineReceiver):
         defer.addCallbacks(self._gotGroup, self._errGroup)
 
 
-    def _gotGroup(self, (name, num, high, low, flags)):
+    def _gotGroup(self, name_num_high_low_flags):
+        (name, num, high, low, flags) = name_num_high_low_flags
         self.currentGroup = name
         self.currentIndex = low
         self.sendLine('211 %d %d %d %s group selected' % (num, low, high, name))
@@ -803,7 +810,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotArticle, self._errArticle)
 
 
-    def _gotArticle(self, (index, id, article)):
+    def _gotArticle(self, index_id_article):
+        (index, id, article) = index_id_article
         self.currentIndex = index
         self.sendLine('220 %d %s article' % (index, id))
         s = basic.FileSender()
@@ -832,7 +840,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotStat, self._errStat)
 
 
-    def _gotStat(self, (index, id, article)):
+    def _gotStat(self, index_id_article):
+        (index, id, article) = index_id_article
         self.currentIndex = index
         self.sendLine('223 %d %s article retreived - request text separately' % (index, id))
 
@@ -848,7 +857,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotHead, self._errHead)
 
 
-    def _gotHead(self, (index, id, head)):
+    def _gotHead(self, index_id_head):
+        (index, id, head) = index_id_head
         self.currentIndex = index
         self.sendLine('221 %d %s article retrieved' % (index, id))
         self.transport.write(head + '\r\n')
@@ -866,7 +876,8 @@ class NNTPServer(basic.LineReceiver):
             defer.addCallbacks(self._gotBody, self._errBody)
 
 
-    def _gotBody(self, (index, id, body)):
+    def _gotBody(self, index_id_body):
+        (index, id, body) = index_id_body
         self.currentIndex = index
         self.sendLine('221 %d %s article retrieved' % (index, id))
         self.lastsent = ''

--- a/twisted/pair/test/test_rawudp.py
+++ b/twisted/pair/test/test_rawudp.py
@@ -11,7 +11,8 @@ class MyProtocol(protocol.DatagramProtocol):
     def __init__(self, expecting):
         self.expecting = list(expecting)
 
-    def datagramReceived(self, data, (host, port)):
+    def datagramReceived(self, data, peer):
+        (host, port) = peer
         assert self.expecting, 'Got a packet when not expecting anymore.'
         expectData, expectHost, expectPort = self.expecting.pop(0)
 

--- a/twisted/protocols/ftp.py
+++ b/twisted/protocols/ftp.py
@@ -874,8 +874,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
             reply = USR_LOGGED_IN_PROCEED
         del self._user
 
-        def _cbLogin(interface_avatar_logout):
-            (interface, avatar, logout) = interface_avatar_logout
+        def _cbLogin(result):
+            (interface, avatar, logout) = result
             assert interface is IFTPShell, "The realm is busted, jerk."
             self.shell = avatar
             self.logout = logout
@@ -1316,8 +1316,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
         except InvalidPath:
             return defer.fail(FileNotFoundError(path))
 
-        def cbStat(size_arg):
-            (size,) = size_arg
+        def cbStat(result):
+            (size,) = result
             return (FILE_STATUS, str(size))
 
         return self.shell.stat(newsegs, ('size',)).addCallback(cbStat)
@@ -1341,8 +1341,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
         except InvalidPath:
             return defer.fail(FileNotFoundError(path))
 
-        def cbStat(modified_arg):
-            (modified,) = modified_arg
+        def cbStat(result):
+            (modified,) = result
             return (FILE_STATUS, time.strftime('%Y%m%d%H%M%S', time.gmtime(modified)))
 
         return self.shell.stat(newsegs, ('modified',)).addCallback(cbStat)

--- a/twisted/protocols/ftp.py
+++ b/twisted/protocols/ftp.py
@@ -874,7 +874,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
             reply = USR_LOGGED_IN_PROCEED
         del self._user
 
-        def _cbLogin((interface, avatar, logout)):
+        def _cbLogin(interface_avatar_logout):
+            (interface, avatar, logout) = interface_avatar_logout
             assert interface is IFTPShell, "The realm is busted, jerk."
             self.shell = avatar
             self.logout = logout
@@ -1315,7 +1316,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
         except InvalidPath:
             return defer.fail(FileNotFoundError(path))
 
-        def cbStat((size,)):
+        def cbStat(size_arg):
+            (size,) = size_arg
             return (FILE_STATUS, str(size))
 
         return self.shell.stat(newsegs, ('size',)).addCallback(cbStat)
@@ -1339,7 +1341,8 @@ class FTP(object, basic.LineReceiver, policies.TimeoutMixin):
         except InvalidPath:
             return defer.fail(FileNotFoundError(path))
 
-        def cbStat((modified,)):
+        def cbStat(modified_arg):
+            (modified,) = modified_arg
             return (FILE_STATUS, time.strftime('%Y%m%d%H%M%S', time.gmtime(modified)))
 
         return self.shell.stat(newsegs, ('modified',)).addCallback(cbStat)

--- a/twisted/protocols/ident.py
+++ b/twisted/protocols/ident.py
@@ -100,8 +100,8 @@ class IdentServer(basic.LineOnlyReceiver):
             )
 
 
-    def _cbLookup(self, sysname_userid, sport, cport):
-        (sysName, userId) = sysname_userid
+    def _cbLookup(self, result, sport, cport):
+        (sysName, userId) = result
         self.sendLine('%d, %d : USERID : %s : %s' % (sport, cport, sysName, userId))
 
     def _ebLookup(self, failure, sport, cport):

--- a/twisted/protocols/ident.py
+++ b/twisted/protocols/ident.py
@@ -100,7 +100,8 @@ class IdentServer(basic.LineOnlyReceiver):
             )
 
 
-    def _cbLookup(self, (sysName, userId), sport, cport):
+    def _cbLookup(self, sysname_userid, sport, cport):
+        (sysName, userId) = sysname_userid
         self.sendLine('%d, %d : USERID : %s : %s' % (sport, cport, sysName, userId))
 
     def _ebLookup(self, failure, sport, cport):

--- a/twisted/protocols/sip.py
+++ b/twisted/protocols/sip.py
@@ -787,8 +787,9 @@ class Base(protocol.DatagramProtocol):
                 self.handle_response(m, addr)
         self.messages[:] = []
 
-    def _fixupNAT(self, message, (srcHost, srcPort)):
+    def _fixupNAT(self, message, sourcePeer):
         # RFC 2543 6.40.2,
+        (srcHost, srcPort) = sourcePeer
         senderVia = parseViaHeader(message.headers["via"][0])
         if senderVia.host != srcHost:
             senderVia.received = srcHost
@@ -930,7 +931,7 @@ class Proxy(Base):
                     self.deliverResponse(self.responseFromRequest(e.code, message))
                 )
 
-    def handle_request_default(self, message, (srcHost, srcPort)):
+    def handle_request_default(self, message, sourcePeer):
         """Default request handler.
 
         Default behaviour for OPTIONS and unknown methods for proxies
@@ -939,6 +940,7 @@ class Proxy(Base):
         Since at the moment we are stateless proxy, that's basically
         everything.
         """
+        (srcHost, srcPort) = sourcePeer
         def _mungContactHeader(uri, message):
             message.headers['contact'][0] = uri.toString()
             return self.sendMessage(uri, message)
@@ -1165,19 +1167,21 @@ class RegisterProxy(Proxy):
         if "digest" not in self.authorizers:
             self.authorizers["digest"] = DigestAuthorizer()
 
-    def handle_ACK_request(self, message, (host, port)):
+    def handle_ACK_request(self, message, host_port):
         # XXX
         # ACKs are a client's way of indicating they got the last message
         # Responding to them is not a good idea.
         # However, we should keep track of terminal messages and re-transmit
         # if no ACK is received.
+        (host, port) = host_port
         pass
 
-    def handle_REGISTER_request(self, message, (host, port)):
+    def handle_REGISTER_request(self, message, host_port):
         """Handle a registration request.
 
         Currently registration is not proxied.
         """
+        (host, port) = host_port
         if self.portal is None:
             # There is no portal.  Let anyone in.
             self.register(message, host, port)
@@ -1221,8 +1225,9 @@ class RegisterProxy(Proxy):
         else:
             self.deliverResponse(self.responseFromRequest(501, message))
 
-    def _cbLogin(self, (i, a, l), message, host, port):
+    def _cbLogin(self, i_a_l, message, host, port):
         # It's stateless, matey.  What a joke.
+        (i, a, l) = i_a_l
         self.register(message, host, port)
 
     def _ebLogin(self, failure, message, host, port):

--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -639,7 +639,8 @@ class NewsBuilder(object):
         for description in reverse:
             reverse[description].sort()
         reverse = reverse.items()
-        reverse.sort(key=lambda descr_tickets: descr_tickets[1][0])
+        # result is a tupple of (descr, tickets)
+        reverse.sort(key=lambda result: result[1][0])
 
         fileObj.write(header + '\n' + '-' * len(header) + '\n')
         for (description, relatedTickets) in reverse:

--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -639,7 +639,7 @@ class NewsBuilder(object):
         for description in reverse:
             reverse[description].sort()
         reverse = reverse.items()
-        reverse.sort(key=lambda (descr, tickets): tickets[0])
+        reverse.sort(key=lambda descr_tickets: descr_tickets[1][0])
 
         fileObj.write(header + '\n' + '-' * len(header) + '\n')
         for (description, relatedTickets) in reverse:

--- a/twisted/python/htmlizer.py
+++ b/twisted/python/htmlizer.py
@@ -17,9 +17,9 @@ class TokenPrinter:
     def __init__(self, writer):
         self.writer = writer
 
-    def printtoken(self, type, token, srow_scol, erow_ecol, line):
-        (srow, scol) = srow_scol
-        (erow, ecol) = erow_ecol
+    def printtoken(self, type, token, sCoordinates, eCoordinates, line):
+        (srow, scol) = sCoordinates
+        (erow, ecol) = eCoordinates
         #print "printtoken(%r,%r,%r,(%r,%r),(%r,%r),%r), row=%r,col=%r" % (
         #    self, type, token, srow,scol, erow,ecol, line,
         #    self.currentLine, self.currentCol)

--- a/twisted/python/htmlizer.py
+++ b/twisted/python/htmlizer.py
@@ -17,7 +17,9 @@ class TokenPrinter:
     def __init__(self, writer):
         self.writer = writer
 
-    def printtoken(self, type, token, (srow, scol), (erow, ecol), line):
+    def printtoken(self, type, token, srow_scol, erow_ecol, line):
+        (srow, scol) = srow_scol
+        (erow, ecol) = erow_ecol
         #print "printtoken(%r,%r,%r,(%r,%r),(%r,%r),%r), row=%r,col=%r" % (
         #    self, type, token, srow,scol, erow,ecol, line,
         #    self.currentLine, self.currentCol)

--- a/twisted/spread/pb.py
+++ b/twisted/spread/pb.py
@@ -1157,8 +1157,8 @@ class PBClientFactory(protocol.ClientFactory):
         return root.callRemote("login", username).addCallback(
             self._cbResponse, password, client)
 
-    def _cbResponse(self, challenge_challenger, password, client):
-        (challenge, challenger) = challenge_challenger
+    def _cbResponse(self, result, password, client):
+        (challenge, challenger) = result
         return challenger.callRemote("respond", respond(challenge, password), client)
 
 
@@ -1317,12 +1317,12 @@ class _JellyableAvatarMixin:
     Helper class for code which deals with avatars which PB must be capable of
     sending to a peer.
     """
-    def _cbLogin(self, interface_avatar_logout):
+    def _cbLogin(self, result):
         """
         Ensure that the avatar to be returned to the client is jellyable and
         set up disconnection notification to call the realm's logout object.
         """
-        (interface, avatar, logout) = interface_avatar_logout
+        (interface, avatar, logout) = result
         if not IJellyable.providedBy(avatar):
             avatar = AsReferenceable(avatar, "perspective")
 

--- a/twisted/spread/pb.py
+++ b/twisted/spread/pb.py
@@ -1157,7 +1157,8 @@ class PBClientFactory(protocol.ClientFactory):
         return root.callRemote("login", username).addCallback(
             self._cbResponse, password, client)
 
-    def _cbResponse(self, (challenge, challenger), password, client):
+    def _cbResponse(self, challenge_challenger, password, client):
+        (challenge, challenger) = challenge_challenger
         return challenger.callRemote("respond", respond(challenge, password), client)
 
 
@@ -1316,11 +1317,12 @@ class _JellyableAvatarMixin:
     Helper class for code which deals with avatars which PB must be capable of
     sending to a peer.
     """
-    def _cbLogin(self, (interface, avatar, logout)):
+    def _cbLogin(self, interface_avatar_logout):
         """
         Ensure that the avatar to be returned to the client is jellyable and
         set up disconnection notification to call the realm's logout object.
         """
+        (interface, avatar, logout) = interface_avatar_logout
         if not IJellyable.providedBy(avatar):
             avatar = AsReferenceable(avatar, "perspective")
 

--- a/twisted/test/test_ftp.py
+++ b/twisted/test/test_ftp.py
@@ -739,7 +739,8 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
             return defer.gatherResults([d1, d2])
         chainDeferred.addCallback(queueCommand)
 
-        def downloadDone((ignored, downloader)):
+        def downloadDone(ignored_downloader):
+            (ignored, downloader) = ignored_downloader
             return downloader.buffer
         return chainDeferred.addCallback(downloadDone)
 
@@ -1308,7 +1309,8 @@ class FTPFileListingTests(unittest.TestCase):
     def testOneLine(self):
         # This example line taken from the docstring for FTPFileListProtocol
         line = '-rw-r--r--   1 root     other        531 Jan 29 03:26 README'
-        def check(((file,), other)):
+        def check(file_other):
+            ((file,), other) = file_other
             self.assertFalse(other,
                              'unexpect unparsable lines: %s' % (repr(other),))
             self.assertTrue(file['filetype'] == '-', 'misparsed fileitem')
@@ -1326,7 +1328,8 @@ class FTPFileListingTests(unittest.TestCase):
         line1 = 'drw-r--r--   2 root     other        531 Jan  9  2003 A'
         line2 = 'lrw-r--r--   1 root     other          1 Jan 29 03:26 B -> A'
         line3 = 'woohoo! '
-        def check(((file1, file2), (other,))):
+        def check(file1_file2_other):
+            ((file1, file2), (other,)) = file1_file2_other
             self.assertTrue(other == 'woohoo! \r', 'incorrect other line')
             # file 1
             self.assertTrue(file1['filetype'] == 'd', 'misparsed fileitem')
@@ -1351,7 +1354,8 @@ class FTPFileListingTests(unittest.TestCase):
         return self.getFilesForLines([line1, line2, line3]).addCallback(check)
 
     def testUnknownLine(self):
-        def check((files, others)):
+        def check(files_others):
+            (files, others) = files_others
             self.assertFalse(files, 'unexpected file entries')
             self.assertTrue(others == ['ABC\r', 'not a file\r'],
                             'incorrect unparsable lines: %s' % repr(others))
@@ -1368,7 +1372,8 @@ class FTPFileListingTests(unittest.TestCase):
             'B A -> D C/A B'
             )
 
-        def check((files, others)):
+        def check(files_others):
+            (files, others) = files_others
             self.assertEqual([], others, 'unexpected others entries')
             self.assertEqual(
                 'A B', files[0]['filename'], 'misparsed filename')
@@ -1389,7 +1394,8 @@ class FTPFileListingTests(unittest.TestCase):
             'B A -> D\ C/A B'
             )
 
-        def check((files, others)):
+        def check(files_others):
+            (files, others) = files_others
             self.assertEqual([], others, 'unexpected others entries')
             self.assertEqual(
                 'A B', files[0]['filename'], 'misparsed filename')

--- a/twisted/test/test_ftp.py
+++ b/twisted/test/test_ftp.py
@@ -739,8 +739,8 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
             return defer.gatherResults([d1, d2])
         chainDeferred.addCallback(queueCommand)
 
-        def downloadDone(ignored_downloader):
-            (ignored, downloader) = ignored_downloader
+        def downloadDone(result):
+            (ignored, downloader) = result
             return downloader.buffer
         return chainDeferred.addCallback(downloadDone)
 
@@ -1328,8 +1328,8 @@ class FTPFileListingTests(unittest.TestCase):
         line1 = 'drw-r--r--   2 root     other        531 Jan  9  2003 A'
         line2 = 'lrw-r--r--   1 root     other          1 Jan 29 03:26 B -> A'
         line3 = 'woohoo! '
-        def check(file1_file2_other):
-            ((file1, file2), (other,)) = file1_file2_other
+        def check(result):
+            ((file1, file2), (other,)) = result
             self.assertTrue(other == 'woohoo! \r', 'incorrect other line')
             # file 1
             self.assertTrue(file1['filetype'] == 'd', 'misparsed fileitem')
@@ -1354,8 +1354,8 @@ class FTPFileListingTests(unittest.TestCase):
         return self.getFilesForLines([line1, line2, line3]).addCallback(check)
 
     def testUnknownLine(self):
-        def check(files_others):
-            (files, others) = files_others
+        def check(result):
+            (files, others) = result
             self.assertFalse(files, 'unexpected file entries')
             self.assertTrue(others == ['ABC\r', 'not a file\r'],
                             'incorrect unparsable lines: %s' % repr(others))
@@ -1372,8 +1372,8 @@ class FTPFileListingTests(unittest.TestCase):
             'B A -> D C/A B'
             )
 
-        def check(files_others):
-            (files, others) = files_others
+        def check(result):
+            (files, others) = result
             self.assertEqual([], others, 'unexpected others entries')
             self.assertEqual(
                 'A B', files[0]['filename'], 'misparsed filename')
@@ -1394,8 +1394,8 @@ class FTPFileListingTests(unittest.TestCase):
             'B A -> D\ C/A B'
             )
 
-        def check(files_others):
-            (files, others) = files_others
+        def check(result):
+            (files, others) = result
             self.assertEqual([], others, 'unexpected others entries')
             self.assertEqual(
                 'A B', files[0]['filename'], 'misparsed filename')

--- a/twisted/test/test_pb.py
+++ b/twisted/test/test_pb.py
@@ -1190,7 +1190,8 @@ class NewCredLeakTests(unittest.TestCase):
         connectionBroken = []
         root = clientBroker.remoteForName("root")
         d = root.callRemote("login", 'guest')
-        def cbResponse((challenge, challenger)):
+        def cbResponse(challenge_challenger):
+            (challenge, challenger) = challenge_challenger
             mind = SimpleRemote()
             return challenger.callRemote("respond",
                     pb.respond(challenge, 'guest'), mind)
@@ -1462,12 +1463,14 @@ class NewCredTests(unittest.TestCase):
         secondLogin = factory.login(
             credentials.UsernamePassword('baz', 'quux'), "BRAINS!")
         d = gatherResults([firstLogin, secondLogin])
-        def cbLoggedIn((first, second)):
+        def cbLoggedIn(first_second):
+            (first, second) = first_second
             return gatherResults([
                     first.callRemote('getAvatarId'),
                     second.callRemote('getAvatarId')])
         d.addCallback(cbLoggedIn)
-        def cbAvatarIds((first, second)):
+        def cbAvatarIds(first_second):
+            (first, second) = first_second
             self.assertEqual(first, 'foo')
             self.assertEqual(second, 'baz')
         d.addCallback(cbAvatarIds)

--- a/twisted/test/test_pb.py
+++ b/twisted/test/test_pb.py
@@ -1190,8 +1190,8 @@ class NewCredLeakTests(unittest.TestCase):
         connectionBroken = []
         root = clientBroker.remoteForName("root")
         d = root.callRemote("login", 'guest')
-        def cbResponse(challenge_challenger):
-            (challenge, challenger) = challenge_challenger
+        def cbResponse(result):
+            (challenge, challenger) = result
             mind = SimpleRemote()
             return challenger.callRemote("respond",
                     pb.respond(challenge, 'guest'), mind)
@@ -1463,14 +1463,14 @@ class NewCredTests(unittest.TestCase):
         secondLogin = factory.login(
             credentials.UsernamePassword('baz', 'quux'), "BRAINS!")
         d = gatherResults([firstLogin, secondLogin])
-        def cbLoggedIn(first_second):
-            (first, second) = first_second
+        def cbLoggedIn(result):
+            (first, second) = result
             return gatherResults([
                     first.callRemote('getAvatarId'),
                     second.callRemote('getAvatarId')])
         d.addCallback(cbLoggedIn)
-        def cbAvatarIds(first_second):
-            (first, second) = first_second
+        def cbAvatarIds(result):
+            (first, second) = result
             self.assertEqual(first, 'foo')
             self.assertEqual(second, 'baz')
         d.addCallback(cbAvatarIds)

--- a/twisted/words/protocols/oscar.py
+++ b/twisted/words/protocols/oscar.py
@@ -230,7 +230,7 @@ class SSIBuddy:
                 self.alertSound = v
  
     def oscarRep(self, groupID, buddyID):
-        tlvData = reduce(lambda x,y: x+y, map(lambda (k,v):TLV(k,v), self.tlvs.items()), '\000\000')
+        tlvData = reduce(lambda x,y: x+y, map(lambda k_v:TLV(k_v[0],k_v[1]), self.tlvs.items()), '\000\000')
         return struct.pack('!H', len(self.name)) + self.name + \
                struct.pack('!HH', groupID, buddyID) + '\000\000' + tlvData
 

--- a/twisted/words/protocols/oscar.py
+++ b/twisted/words/protocols/oscar.py
@@ -230,7 +230,8 @@ class SSIBuddy:
                 self.alertSound = v
  
     def oscarRep(self, groupID, buddyID):
-        tlvData = reduce(lambda x,y: x+y, map(lambda k_v:TLV(k_v[0],k_v[1]), self.tlvs.items()), '\000\000')
+        # Result is a tupple of (k, v)
+        tlvData = reduce(lambda x,y: x+y, map(lambda result:TLV(result[0],result[1]), self.tlvs.items()), '\000\000')
         return struct.pack('!H', len(self.name)) + self.name + \
                struct.pack('!HH', groupID, buddyID) + '\000\000' + tlvData
 

--- a/twisted/words/service.py
+++ b/twisted/words/service.py
@@ -382,7 +382,8 @@ class IRCUser(irc.IRC):
          ":End of /MOTD command.")
         ]
 
-    def _cbLogin(self, (iface, avatar, logout)):
+    def _cbLogin(self, result):
+        (iface, avatar, logout) = result
         assert iface is iwords.IUser, "Realm is buggy, got %r" % (iface,)
 
         # Let them send messages to the world


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8346

This command:

```
2to3 -f tuple_params
```

was useful for locating the places that need to be fixed.
