### PR TITLE
PEP 3127 - Prefix octal literals with "0o"

### DIFF
--- a/twisted/conch/insults/window.py
+++ b/twisted/conch/insults/window.py
@@ -409,14 +409,14 @@ class Canvas(Widget):
 def horizontalLine(terminal, y, left, right):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
     terminal.cursorPosition(left, y)
-    terminal.write(chr(0161) * (right - left))
+    terminal.write(chr(0o161) * (right - left))
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 
 def verticalLine(terminal, x, top, bottom):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
     for n in xrange(top, bottom):
         terminal.cursorPosition(x, n)
-        terminal.write(chr(0170))
+        terminal.write(chr(0o170))
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 
 
@@ -424,18 +424,18 @@ def rectangle(terminal, (top, left), (width, height)):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
 
     terminal.cursorPosition(top, left)
-    terminal.write(chr(0154))
-    terminal.write(chr(0161) * (width - 2))
-    terminal.write(chr(0153))
+    terminal.write(chr(0o154))
+    terminal.write(chr(0o161) * (width - 2))
+    terminal.write(chr(0o153))
     for n in range(height - 2):
         terminal.cursorPosition(left, top + n + 1)
-        terminal.write(chr(0170))
+        terminal.write(chr(0o170))
         terminal.cursorForward(width - 2)
-        terminal.write(chr(0170))
+        terminal.write(chr(0o170))
     terminal.cursorPosition(0, top + height - 1)
-    terminal.write(chr(0155))
-    terminal.write(chr(0161) * (width - 2))
-    terminal.write(chr(0152))
+    terminal.write(chr(0o155))
+    terminal.write(chr(0o161) * (width - 2))
+    terminal.write(chr(0o152))
 
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 

--- a/twisted/conch/test/test_filetransfer.py
+++ b/twisted/conch/test/test_filetransfer.py
@@ -94,7 +94,7 @@ class SFTPTestBase(unittest.TestCase):
         f = file(os.path.join(self.testDir, 'testfile1'),'w')
         f.write('a'*10+'b'*10)
         f.write(file('/dev/urandom').read(1024*64)) # random data
-        os.chmod(os.path.join(self.testDir, 'testfile1'), 0644)
+        os.chmod(os.path.join(self.testDir, 'testfile1'), 0o644)
         file(os.path.join(self.testDir, 'testRemoveFile'), 'w').write('a')
         file(os.path.join(self.testDir, 'testRenameFile'), 'w').write('a')
         file(os.path.join(self.testDir, '.testHiddenFile'), 'w').write('a')

--- a/twisted/conch/test/test_openssh_compat.py
+++ b/twisted/conch/test/test_openssh_compat.py
@@ -84,12 +84,12 @@ class OpenSSHFactoryTests(TestCase):
         """
         keyFile = self.keysDir.child("ssh_host_two_key")
         # Fake permission error by changing the mode
-        keyFile.chmod(0000)
-        self.addCleanup(keyFile.chmod, 0777)
+        keyFile.chmod(0o000)
+        self.addCleanup(keyFile.chmod, 0o777)
         # And restore the right mode when seteuid is called
         savedSeteuid = os.seteuid
         def seteuid(euid):
-            keyFile.chmod(0777)
+            keyFile.chmod(0o777)
             return savedSeteuid(euid)
         self.patch(os, "seteuid", seteuid)
         keys = self.factory.getPrivateKeys()

--- a/twisted/conch/unix.py
+++ b/twisted/conch/unix.py
@@ -464,7 +464,7 @@ class UnixSFTPFile:
             mode = attrs["permissions"]
             del attrs["permissions"]
         else:
-            mode = 0777
+            mode = 0o777
         fd = server.avatar._runAsUser(os.open, filename, openFlags, mode)
         if attrs:
             server.avatar._runAsUser(server._setAttrs, filename, attrs)

--- a/twisted/mail/maildir.py
+++ b/twisted/mail/maildir.py
@@ -97,11 +97,11 @@ def initializeMaildir(dir):
     @param dir: The path name for a user directory.
     """
     if not os.path.isdir(dir):
-        os.mkdir(dir, 0700)
+        os.mkdir(dir, 0o700)
         for subdir in ['new', 'cur', 'tmp', '.Trash']:
-            os.mkdir(os.path.join(dir, subdir), 0700)
+            os.mkdir(os.path.join(dir, subdir), 0o700)
         for subdir in ['new', 'cur', 'tmp']:
-            os.mkdir(os.path.join(dir, '.Trash', subdir), 0700)
+            os.mkdir(os.path.join(dir, '.Trash', subdir), 0o700)
         # touch
         open(os.path.join(dir, '.Trash', 'maildirfolder'), 'w').close()
 
@@ -484,7 +484,7 @@ class _MaildirMailboxAppendMessageTask:
         while True:
             self.tmpname = os.path.join(self.mbox.path, "tmp", _generateMaildirName())
             try:
-                self.fh = self.osopen(self.tmpname, attr, 0600)
+                self.fh = self.osopen(self.tmpname, attr, 0o600)
                 return None
             except OSError:
                 tries += 1

--- a/twisted/mail/test/test_mail.py
+++ b/twisted/mail/test/test_mail.py
@@ -1986,7 +1986,7 @@ rm -f process.alias.out
 while read i; do
     echo $i >> process.alias.out
 done""")
-        os.chmod(sh.path, 0700)
+        os.chmod(sh.path, 0o700)
         a = mail.alias.ProcessAlias(sh.path, None, None)
         m = a.createMessageReceiver()
 

--- a/twisted/test/test_ftp.py
+++ b/twisted/test/test_ftp.py
@@ -880,7 +880,7 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
         return self._listTestHelper(
             "LIST",
             (u'my resum\xe9', (
-                0, 1, filepath.Permissions(0777), 0, 0, 'user', 'group')),
+                0, 1, filepath.Permissions(0o777), 0, 0, 'user', 'group')),
             'drwxrwxrwx   0 user      group                   '
             '0 Jan 01  1970 my resum\xc3\xa9\r\n')
 
@@ -893,7 +893,7 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
         return self._listTestHelper(
             "LIST",
             ('my resum\xc3\xa9', (
-                0, 1, filepath.Permissions(0777), 0, 0, 'user', 'group')),
+                0, 1, filepath.Permissions(0o777), 0, 0, 'user', 'group')),
             'drwxrwxrwx   0 user      group                   '
             '0 Jan 01  1970 my resum\xc3\xa9\r\n')
 
@@ -990,7 +990,7 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
         return self._listTestHelper(
             "NLST",
             (u'my resum\xe9', (
-                0, 1, filepath.Permissions(0777), 0, 0, 'user', 'group')),
+                0, 1, filepath.Permissions(0o777), 0, 0, 'user', 'group')),
             'my resum\xc3\xa9\r\n')
 
 
@@ -1001,7 +1001,7 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
         return self._listTestHelper(
             "NLST",
             ('my resum\xc3\xa9', (
-                0, 1, filepath.Permissions(0777), 0, 0, 'user', 'group')),
+                0, 1, filepath.Permissions(0o777), 0, 0, 'user', 'group')),
             'my resum\xc3\xa9\r\n')
 
 

--- a/twisted/words/protocols/irc.py
+++ b/twisted/words/protocols/irc.py
@@ -47,10 +47,10 @@ from twisted.protocols import basic
 from twisted.python import log, reflect, _textattributes
 
 NUL = chr(0)
-CR = chr(015)
-NL = chr(012)
+CR = chr(0o15)
+NL = chr(0o12)
 LF = NL
-SPC = chr(040)
+SPC = chr(0o40)
 
 # This includes the CRLF terminator characters.
 MAX_COMMAND_LENGTH = 512
@@ -3633,7 +3633,7 @@ def stripFormatting(text):
 
 # CTCP constants and helper functions
 
-X_DELIM = chr(001)
+X_DELIM = chr(0o01)
 
 def ctcpExtract(message):
     """
@@ -3677,7 +3677,7 @@ def ctcpExtract(message):
 
 # CTCP escaping
 
-M_QUOTE= chr(020)
+M_QUOTE= chr(0o20)
 
 mQuoteTable = {
     NUL: M_QUOTE + '0',


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8347

This command helped locate the places that needed to be fixed:

```
2to3 -f numliterals
```
