### PR TITLE
Add parentheses in list comprehension to eliminate Python 3 syntax error

### DIFF
--- a/twisted/mail/imap4.py
+++ b/twisted/mail/imap4.py
@@ -1215,7 +1215,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
     select_DELETE = auth_DELETE
 
     def do_RENAME(self, tag, oldname, newname):
-        oldname, newname = [self._parseMbox(n) for n in oldname, newname]
+        oldname, newname = [self._parseMbox(n) for n in (oldname, newname)]
         if oldname.lower() == 'inbox' or newname.lower() == 'inbox':
             self.sendNegativeResponse(tag, 'You cannot rename the inbox, or rename another mailbox to inbox.')
             return


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8351

From this example: http://bugs.python.org/issue2367

In Python 2, this code is legal:

```
 [x for x in 1, 2]
```

but it is a syntax error in Python 3.
The code needs to be fixed in this way:

```
 [x for x in (1, 2)]
```

Some of these cases can be found with:  **2to3 -f paren**
