### PR TITLE
Replace dict.has_key() with the 'in' keyword, for twisted/mail

### DIFF
--- a/twisted/mail/pb.py
+++ b/twisted/mail/pb.py
@@ -98,10 +98,10 @@ class MaildirBroker(pb.Broker):
             self.sendAnswer(requestID, collection)
 
     def getCollection(self, name, domain, password):
-        if not self.domains.has_key(domain):
+        if domain not in self.domains:
             return
         domain = self.domains[domain]
-        if (domain.dbm.has_key(name) and
+        if (name in domain.dbm and
             domain.dbm[name] == password):
             return MaildirCollection(domain.userDirectory(name))
 

--- a/twisted/mail/test/test_mail.py
+++ b/twisted/mail/test/test_mail.py
@@ -85,7 +85,6 @@ class DomainWithDefaultsTests(unittest.TestCase):
             self.assertEqual(d[x], x + 10)
             self.assertEqual(d.get(x), x + 10)
             self.assertTrue(x in d)
-            self.assertTrue(d.has_key(x))
 
         del d[2], d[4], d[6]
 


### PR DESCRIPTION
See: 
https://twistedmatrix.com/trac/ticket/8361

This is recommended in PEP 290 for testing
testing dictionary membership.

Remove d.has_keyx() from test_mail.py, since
it already tests for "x in d"
