### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/core/development/policy/coding-standard.rst
+++ b/docs/core/development/policy/coding-standard.rst
@@ -622,7 +622,7 @@ C Code
 C code must be optional, and work across multiple platforms (MSVC++9/10/14 for Pythons 2.7, 3.3/3.4, and 3.5 on Windows, as well as recent GCCs and Clangs for Linux, OS X, and FreeBSD).
 
 C code should be kept in external bindings packages which Twisted depends on.
-If creating new C extension modules, using `cffi <https://cffi.readthedocs.org/en/latest/>`_ is highly encouraged, as it will perform well on PyPy and CPython, and be easier to use on Python 2 and 3.
+If creating new C extension modules, using `cffi <https://cffi.readthedocs.io/en/latest/>`_ is highly encouraged, as it will perform well on PyPy and CPython, and be easier to use on Python 2 and 3.
 Consider optimizing for `PyPy <http://pypy.org/performance.html>`_ instead of creating bespoke C code.
 
 

--- a/docs/web/howto/web-in-60/wsgi.rst
+++ b/docs/web/howto/web-in-60/wsgi.rst
@@ -74,7 +74,7 @@ simple one just to get things going:
 
 
 If this doesn't make sense to you, take a look at one of
-these `fine tutorials <http://wsgi.readthedocs.org/en/latest/learn.html>`_ . Otherwise,
+these `fine tutorials <https://wsgi.readthedocs.io/en/latest/learn.html>`_ . Otherwise,
 or once you're done with that, the next step is to create
 a ``WSGIResource`` instance, as this is going to be
 another :doc:`rpy script <rpy-scripts>` example:

--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -32,7 +32,7 @@ VERSION_OFFSET = 2000
 
 intersphinxURLs = [
     "https://docs.python.org/2/objects.inv",
-    "https://pyopenssl.readthedocs.org/en/stable/objects.inv",
+    "https://pyopenssl.readthedocs.io/en/stable/objects.inv",
 ]
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
