### PR TITLE
Cast CacheResolver TTL diff to int

### DIFF
--- a/twisted/names/cache.py
+++ b/twisted/names/cache.py
@@ -68,7 +68,7 @@ class CacheResolver(common.ResolverBase):
         else:
             if self.verbose:
                 log.msg('Cache hit for ' + repr(name))
-            diff = now - when
+            diff = int(now - when)
 
             try:
                 result = (


### PR DESCRIPTION
This fixes an unhandled python3 exception when RRHeader.encode is called on the cached record.

See https://twistedmatrix.com/trac/ticket/8340
