### PR TITLE
Bracket IPv6 addresses in host headers

### DIFF
--- a/twisted/web/client.py
+++ b/twisted/web/client.py
@@ -37,6 +37,7 @@ from twisted.web.iweb import IPolicyForHTTPS, IAgentEndpointFactory
 from twisted.python.deprecate import getDeprecationWarningString
 from twisted.web import http
 from twisted.internet import defer, protocol, task, reactor
+from twisted.internet.abstract import isIPv6Address
 from twisted.internet.interfaces import IProtocol
 from twisted.internet.endpoints import TCP4ClientEndpoint, SSL4ClientEndpoint
 from twisted.python.util import InsensitiveDict
@@ -1352,6 +1353,8 @@ class _AgentBase(object):
         Compute the string to use for the value of the I{Host} header, based on
         the given scheme, host name, and port number.
         """
+        if (isIPv6Address(nativeString(host))):
+            host = b'[' + host + b']'
         if (scheme, port) in ((b'http', 80), (b'https', 443)):
             return host
         return host + b":" + intToBytes(port)

--- a/twisted/web/test/test_agent.py
+++ b/twisted/web/test/test_agent.py
@@ -920,6 +920,18 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin):
         self.assertEqual(req.headers.getRawHeaders(b'host'), [b'example.com'])
 
 
+    def test_hostIPv6Bracketed(self):
+        """
+        If an IPv6 address is used in the C{uri} passed to L{Agent.request},
+        the computed I{Host} header needs to be bracketed.
+        """
+        self.agent._getEndpoint = lambda *args: self
+        self.agent.request(b'GET', b'http://[::1]/')
+
+        req, res = self.protocol.requests.pop()
+        self.assertEqual(req.headers.getRawHeaders(b'host'), [b'[::1]'])
+
+
     def test_hostOverride(self):
         """
         If the headers passed to L{Agent.request} includes a value for the

--- a/twisted/web/topfiles/8369.bugfix
+++ b/twisted/web/topfiles/8369.bugfix
@@ -1,0 +1,1 @@
+twisted.web.client._AgentBase as well as all Agent's inheriting from it, will now bracket IPv6 addresses in the host header they send.


### PR DESCRIPTION
This is a fix for bug 8369 (https://twistedmatrix.com/trac/ticket/8369), where IPv6 addresses are not bracketed in host headers sent in requests from Agent. 
