### PR TITLE
Fetch the trunk branch from origin before running tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,9 @@ env:
 install:
   - pip install tox tox-travis
 
+before_script:
+  - git remote set-branches --add origin trunk
+  - git fetch origin trunk
+
 script:
   - tox


### PR DESCRIPTION
By default, Travis only clones one branch.

However, _release.py invokes this command which requires
the trunk branch to be in the cloned repo:

   git diff --name-only origin/trunk...

If the trunk branch is not in the repo, then this command
fails, and the topfiles target in tox fails.
