### PR TITLE
Use TestCase.assertRegex() instead of TestCase.assertRegexpMatches()

### DIFF
--- a/twisted/test/test_amp.py
+++ b/twisted/test/test_amp.py
@@ -2643,7 +2643,7 @@ class CommandTests(unittest.TestCase):
         error = self.assertRaises(
             TypeError, type, "NewCommand", (amp.Command, ),
             {"commandName": u"FOO"})
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), "^Command names must be byte strings, got: u?'FOO'$")
 
 
@@ -2654,7 +2654,7 @@ class CommandTests(unittest.TestCase):
         error = self.assertRaises(
             TypeError, type, "NewCommand", (amp.Command, ),
             {"arguments": [(u"foo", None)]})
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), "^Argument names must be byte strings, got: u?'foo'$")
 
 
@@ -2665,7 +2665,7 @@ class CommandTests(unittest.TestCase):
         error = self.assertRaises(
             TypeError, type, "NewCommand", (amp.Command, ),
             {"response": [(u"foo", None)]})
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), "^Response names must be byte strings, got: u?'foo'$")
 
 
@@ -2688,7 +2688,7 @@ class CommandTests(unittest.TestCase):
         error = self.assertRaises(
             TypeError, type, "NewCommand", (amp.Command, ),
             {"errors": [(ZeroDivisionError, u"foo")]})
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), "^Error names must be byte strings, got: u?'foo'$")
 
 
@@ -2712,7 +2712,7 @@ class CommandTests(unittest.TestCase):
         error = self.assertRaises(
             TypeError, type, "NewCommand", (amp.Command, ),
             {"fatalErrors": [(ZeroDivisionError, u"foo")]})
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), "^Fatal error names must be byte strings, "
             "got: u?'foo'$")
 
@@ -3290,7 +3290,7 @@ class RemoteAmpErrorTests(unittest.TestCase):
         failure = Failure(Exception("Something came loose"))
         error = amp.RemoteAmpError(
             b"BROKEN", "Something has broken", local=failure)
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(error), (
                 "^Code<BROKEN> [(]local[)]: Something has broken\n"
                 "Traceback [(]failure with no frames[)]: "

--- a/twisted/trial/_synctest.py
+++ b/twisted/trial/_synctest.py
@@ -792,6 +792,20 @@ class _Assertions(pyunit.TestCase, object):
 
 
 
+    def assertRegex(self, text, regex, msg=None):
+        """
+        Fail the test if a C{regexp} search of C{text} fails.
+
+        """
+        if sys.version_info[:2] > (2, 7):
+            super(_Assertions, self).assertRegex(text, regex, msg)
+        else:
+            # Python 2.7 has unittest.assertRegexpMatches() which was
+            # renamed to unittest.assertRegex() in Python 3.2
+            super(_Assertions, self).assertRegexpMatches(text, regex, msg)
+
+
+
 class _LogObserver(object):
     """
     Observes the Twisted logs and catches any errors.

--- a/twisted/web/test/test_wsgi.py
+++ b/twisted/web/test/test_wsgi.py
@@ -1309,7 +1309,7 @@ class StartResponseTests(WSGITestsMixin, TestCase):
         request.requestReceived()
 
         def checkMessage(error):
-            self.assertRegexpMatches(
+            self.assertRegex(
                 str(error), "headers must be a list, not "
                 "<list_?iterator .+> [(]list_?iterator[)]")
 
@@ -1359,7 +1359,7 @@ class StartResponseTests(WSGITestsMixin, TestCase):
         request.requestReceived()
 
         def checkMessage(error):
-            self.assertRegexpMatches(
+            self.assertRegex(
                 str(error), "header must be a [(]str, str[)] tuple, not "
                 "<tuple_?iterator .+> [(]tuple_?iterator[)]")
 


### PR DESCRIPTION
TestCase.assertRegexpMatches() was introduced in Python 2.7:
https://docs.python.org/2.7/library/unittest.html#unittest.TestCase.assertRegexpMatches

but renamed to TestCase.assertRegex() in Python 3.2:
https://docs.python.org/3.2/library/unittest.html#unittest.TestCase.assertRegex

See:
https://twistedmatrix.com/trac/ticket/8372
