### PR TITLE
Introduce new command line runner for Twisted: twist

### DIFF
--- a/bin/twist
+++ b/bin/twist
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Run a Twisted application.
+"""
+
+import sys
+import os
+
+try:
+    import _preamble
+    _preamble
+except ImportError:
+    try:
+        sys.exc_clear()
+    except AttributeError:
+        # exc_clear() (and the requirement for it) has been removed from Py3
+        pass
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from twisted.application.twist import Twist
+Twist.main()

--- a/twisted/application/runner/__init__.py
+++ b/twisted/application/runner/__init__.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.runner.test -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/runner/__init__.py
+++ b/twisted/application/runner/__init__.py
@@ -8,6 +8,9 @@ Facilities for running a Twisted application.
 __all__ = [
     "exit",
     "ExitStatus",
+    "Runner",
+    "RunnerOptions",
 ]
 
 from ._exit import exit, ExitStatus
+from ._runner import Runner, RunnerOptions

--- a/twisted/application/runner/__init__.py
+++ b/twisted/application/runner/__init__.py
@@ -6,4 +6,8 @@ Facilities for running a Twisted application.
 """
 
 __all__ = [
+    "exit",
+    "ExitStatus",
 ]
+
+from ._exit import exit, ExitStatus

--- a/twisted/application/runner/__init__.py
+++ b/twisted/application/runner/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Facilities for running a Twisted application.
+"""
+
+__all__ = [
+]

--- a/twisted/application/runner/__init__.py
+++ b/twisted/application/runner/__init__.py
@@ -5,13 +5,3 @@
 """
 Facilities for running a Twisted application.
 """
-
-__all__ = [
-    "exit",
-    "ExitStatus",
-    "Runner",
-    "RunnerOptions",
-]
-
-from ._exit import exit, ExitStatus
-from ._runner import Runner, RunnerOptions

--- a/twisted/application/runner/_exit.py
+++ b/twisted/application/runner/_exit.py
@@ -5,7 +5,7 @@
 System exit support.
 """
 
-import sys
+from sys import stdout, stderr, exit as sysexit
 
 from twisted.python.constants import Values, ValueConstant
 
@@ -25,13 +25,13 @@ def exit(status, message=None):
 
     if message:
         if code == 0:
-            out = sys.stdout
+            out = stdout
         else:
-            out = sys.stderr
+            out = stderr
         out.write(message)
         out.write("\n")
 
-    sys.exit(code)
+    sysexit(code)
 
 
 

--- a/twisted/application/runner/_exit.py
+++ b/twisted/application/runner/_exit.py
@@ -70,6 +70,54 @@ except ImportError:
 class ExitStatus(Values):
     """
     Standard exit status codes for system programs.
+
+    @cvar EX_OK: Successful termination.
+    @type EX_OK: L{ValueConstant}
+
+    @cvar EX_USAGE: Command line usage error.
+    @type EX_USAGE: L{ValueConstant}
+
+    @cvar EX_DATAERR: Data format error.
+    @type EX_DATAERR: L{ValueConstant}
+
+    @cvar EX_NOINPUT: Cannot open input.
+    @type EX_NOINPUT: L{ValueConstant}
+
+    @cvar EX_NOUSER: Addressee unknown.
+    @type EX_NOUSER: L{ValueConstant}
+
+    @cvar EX_NOHOST: Host name unknown.
+    @type EX_NOHOST: L{ValueConstant}
+
+    @cvar EX_UNAVAILABLE: Service unavailable.
+    @type EX_UNAVAILABLE: L{ValueConstant}
+
+    @cvar EX_SOFTWARE: Internal software error.
+    @type EX_SOFTWARE: L{ValueConstant}
+
+    @cvar EX_OSERR: System error (e.g., can't fork).
+    @type EX_OSERR: L{ValueConstant}
+
+    @cvar EX_OSFILE: Critical OS file missing.
+    @type EX_OSFILE: L{ValueConstant}
+
+    @cvar EX_CANTCREAT: Can't create (user) output file.
+    @type EX_CANTCREAT: L{ValueConstant}
+
+    @cvar EX_IOERR: Input/output error.
+    @type EX_IOERR: L{ValueConstant}
+
+    @cvar EX_TEMPFAIL: Temporary failure; the user is invited to retry.
+    @type EX_TEMPFAIL: L{ValueConstant}
+
+    @cvar EX_PROTOCOL: Remote error in protocol.
+    @type EX_PROTOCOL: L{ValueConstant}
+
+    @cvar EX_NOPERM: Permission denied.
+    @type EX_NOPERM: L{ValueConstant}
+
+    @cvar EX_CONFIG: Configuration error.
+    @type EX_CONFIG: L{ValueConstant}
     """
 
     EX_OK          = ValueConstant(Status.EX_OK)

--- a/twisted/application/runner/_exit.py
+++ b/twisted/application/runner/_exit.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.runner.test.test_exit -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
@@ -17,6 +18,9 @@ def exit(status, message=None):
 
     @param status: An exit status.
     @type status: L{int} or L{ValueConstant} from L{ExitStatus}.
+
+    @param message: An options message to print.
+    @type status: L{str}
     """
     if isinstance(status, ValueConstant):
         code = status.value
@@ -36,9 +40,9 @@ def exit(status, message=None):
 
 
 try:
-    import posix as status
+    import posix as Status
 except ImportError:
-    class status(object):
+    class Status(object):
         """
         Object to hang C{EX_*} values off of as a substitute for L{posix}.
         """
@@ -68,19 +72,19 @@ class ExitStatus(Values):
     Standard exit status codes for system programs.
     """
 
-    EX_OK          = ValueConstant(status.EX_OK)
-    EX_USAGE       = ValueConstant(status.EX_USAGE)
-    EX_DATAERR     = ValueConstant(status.EX_DATAERR)
-    EX_NOINPUT     = ValueConstant(status.EX_NOINPUT)
-    EX_NOUSER      = ValueConstant(status.EX_NOUSER)
-    EX_NOHOST      = ValueConstant(status.EX_NOHOST)
-    EX_UNAVAILABLE = ValueConstant(status.EX_UNAVAILABLE)
-    EX_SOFTWARE    = ValueConstant(status.EX_SOFTWARE)
-    EX_OSERR       = ValueConstant(status.EX_OSERR)
-    EX_OSFILE      = ValueConstant(status.EX_OSFILE)
-    EX_CANTCREAT   = ValueConstant(status.EX_CANTCREAT)
-    EX_IOERR       = ValueConstant(status.EX_IOERR)
-    EX_TEMPFAIL    = ValueConstant(status.EX_TEMPFAIL)
-    EX_PROTOCOL    = ValueConstant(status.EX_PROTOCOL)
-    EX_NOPERM      = ValueConstant(status.EX_NOPERM)
-    EX_CONFIG      = ValueConstant(status.EX_CONFIG)
+    EX_OK          = ValueConstant(Status.EX_OK)
+    EX_USAGE       = ValueConstant(Status.EX_USAGE)
+    EX_DATAERR     = ValueConstant(Status.EX_DATAERR)
+    EX_NOINPUT     = ValueConstant(Status.EX_NOINPUT)
+    EX_NOUSER      = ValueConstant(Status.EX_NOUSER)
+    EX_NOHOST      = ValueConstant(Status.EX_NOHOST)
+    EX_UNAVAILABLE = ValueConstant(Status.EX_UNAVAILABLE)
+    EX_SOFTWARE    = ValueConstant(Status.EX_SOFTWARE)
+    EX_OSERR       = ValueConstant(Status.EX_OSERR)
+    EX_OSFILE      = ValueConstant(Status.EX_OSFILE)
+    EX_CANTCREAT   = ValueConstant(Status.EX_CANTCREAT)
+    EX_IOERR       = ValueConstant(Status.EX_IOERR)
+    EX_TEMPFAIL    = ValueConstant(Status.EX_TEMPFAIL)
+    EX_PROTOCOL    = ValueConstant(Status.EX_PROTOCOL)
+    EX_NOPERM      = ValueConstant(Status.EX_NOPERM)
+    EX_CONFIG      = ValueConstant(Status.EX_CONFIG)

--- a/twisted/application/runner/_exit.py
+++ b/twisted/application/runner/_exit.py
@@ -1,0 +1,86 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+System exit support.
+"""
+
+import sys
+
+from twisted.python.constants import Values, ValueConstant
+
+
+
+def exit(status, message=None):
+    """
+    Exit the python interpreter with an optional message.
+
+    @param status: An exit status.
+    @type status: L{int} or L{ValueConstant} from L{ExitStatus}.
+    """
+    if isinstance(status, ValueConstant):
+        code = status.value
+    else:
+        code = int(status)
+
+    if message:
+        if code == 0:
+            out = sys.stdout
+        else:
+            out = sys.stderr
+        out.write(message)
+        out.write("\n")
+
+    sys.exit(code)
+
+
+
+try:
+    import posix as status
+except ImportError:
+    class status(object):
+        """
+        Object to hang C{EX_*} values off of as a substitute for L{posix}.
+        """
+        EX__BASE = 64
+
+        EX_OK          = 0
+        EX_USAGE       = EX__BASE
+        EX_DATAERR     = EX__BASE + 1
+        EX_NOINPUT     = EX__BASE + 2
+        EX_NOUSER      = EX__BASE + 3
+        EX_NOHOST      = EX__BASE + 4
+        EX_UNAVAILABLE = EX__BASE + 5
+        EX_SOFTWARE    = EX__BASE + 6
+        EX_OSERR       = EX__BASE + 7
+        EX_OSFILE      = EX__BASE + 8
+        EX_CANTCREAT   = EX__BASE + 9
+        EX_IOERR       = EX__BASE + 10
+        EX_TEMPFAIL    = EX__BASE + 11
+        EX_PROTOCOL    = EX__BASE + 12
+        EX_NOPERM      = EX__BASE + 13
+        EX_CONFIG      = EX__BASE + 14
+
+
+
+class ExitStatus(Values):
+    """
+    Standard exit status codes for system programs.
+    """
+
+    EX_OK          = ValueConstant(status.EX_OK)
+    EX_USAGE       = ValueConstant(status.EX_USAGE)
+    EX_DATAERR     = ValueConstant(status.EX_DATAERR)
+    EX_NOINPUT     = ValueConstant(status.EX_NOINPUT)
+    EX_NOUSER      = ValueConstant(status.EX_NOUSER)
+    EX_NOHOST      = ValueConstant(status.EX_NOHOST)
+    EX_UNAVAILABLE = ValueConstant(status.EX_UNAVAILABLE)
+    EX_SOFTWARE    = ValueConstant(status.EX_SOFTWARE)
+    EX_OSERR       = ValueConstant(status.EX_OSERR)
+    EX_OSFILE      = ValueConstant(status.EX_OSFILE)
+    EX_CANTCREAT   = ValueConstant(status.EX_CANTCREAT)
+    EX_IOERR       = ValueConstant(status.EX_IOERR)
+    EX_TEMPFAIL    = ValueConstant(status.EX_TEMPFAIL)
+    EX_PROTOCOL    = ValueConstant(status.EX_PROTOCOL)
+    EX_NOPERM      = ValueConstant(status.EX_NOPERM)
+    EX_CONFIG      = ValueConstant(status.EX_CONFIG)

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -15,14 +15,10 @@ from signal import SIGTERM
 from os import getpid, kill
 
 from twisted.python.constants import Names, NamedConstant
-# from twisted.python.constants import Values, ValueConstant
-# from twisted.python.usage import Options, UsageError
-# from twisted.python.filepath import FilePath
 from twisted.logger import (
-    globalLogBeginner, textFileLogObserver,  # jsonFileLogObserver,
+    globalLogBeginner, textFileLogObserver,
     FilteringLogObserver, LogLevelFilterPredicate,
-    LogLevel,  # InvalidLogLevelError,
-    Logger,
+    LogLevel, Logger,
 )
 from twisted.internet import default as defaultReactor
 from ._exit import exit, ExitStatus

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -44,13 +44,15 @@ class Runner(object):
     def run(self):
         """
         Run this command.
-        Equivalent to:
+        Equivalent to::
+
             self.killIfRequested()
             self.writePIDFile()
             self.startLogging()
             self.startReactor()
             self.reactorExited()
             self.removePIDFile()
+
         Additional steps may be added over time, but the order won't change.
         """
         self.killIfRequested()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -1,0 +1,204 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Twisted application runner.
+"""
+
+__all__ = [
+    "Runner",
+    "RunnerOptions",
+]
+
+from sys import stderr
+from signal import SIGTERM
+from os import getpid, kill
+
+from twisted.python.constants import Names, NamedConstant
+# from twisted.python.constants import Values, ValueConstant
+# from twisted.python.usage import Options, UsageError
+# from twisted.python.filepath import FilePath
+from twisted.logger import (
+    globalLogBeginner, textFileLogObserver,  # jsonFileLogObserver,
+    FilteringLogObserver, LogLevelFilterPredicate,
+    LogLevel,  # InvalidLogLevelError,
+    Logger,
+)
+from ._exit import exit, ExitStatus
+
+
+
+class Runner(object):
+    """
+    Twisted application runner.
+    """
+
+    log = Logger()
+
+
+    def __init__(self, options):
+        """
+        @param options: Configuration options for this runner.
+        @type options: mapping
+        """
+        self.options = options
+
+
+    def execute(self):
+        """
+        Execute this command.
+        Equivalent to:
+            self.killIfRequested()
+            self.writePIDFile()
+            self.startLogging()
+            self.startReactor()
+            self.reactorExited()
+            self.removePIDFile()
+        """
+        self.killIfRequested()
+        self.writePIDFile()
+        self.startLogging()
+        self.startReactor()
+        self.reactorExited()
+        self.removePIDFile()
+
+
+    def killIfRequested(self):
+        """
+        Kill a running instance of this application if L{RunnerOptions.kill} is
+        specified and L{True} in L{self.options}.
+        This requires that L{RunnerOptions.pidFilePath} also be specified;
+        exit with L{ExitStatus.EX_USAGE} if kill is requested with no PID file.
+        """
+        pidFilePath = self.options.get(RunnerOptions.pidFilePath)
+
+        if self.options.get(RunnerOptions.kill, False):
+            if pidFilePath is None:
+                exit(ExitStatus.EX_USAGE, "No PID file specified")
+                return  # When testing, patched exit doesn't exit
+            else:
+                pid = ""
+                try:
+                    for pid in pidFilePath.open():
+                        break
+                except (IOError, OSError):
+                    exit(ExitStatus.EX_DATAERR, "Unable to read pid file.")
+                    return  # When testing, patched exit doesn't exit
+                try:
+                    pid = int(pid)
+                except ValueError:
+                    exit(ExitStatus.EX_DATAERR, "Invalid pid file.")
+                    return  # When testing, patched exit doesn't exit
+
+            self.startLogging()
+            self.log.info("Terminating process: {pid}", pid=pid)
+
+            kill(pid, SIGTERM)
+
+            exit(ExitStatus.EX_OK)
+            return  # When testing, patched exit doesn't exit
+
+
+    def writePIDFile(self):
+        """
+        Write a PID file for this application if L{RunnerOptions.pidFilePath}
+        is specified in L{self.options}.
+        """
+        pidFilePath = self.options.get(RunnerOptions.pidFilePath)
+        if pidFilePath is not None:
+            pid = getpid()
+            pidFilePath.setContent(u"{}\n".format(pid).encode("utf-8"))
+
+
+    def removePIDFile(self):
+        """
+        Remove the PID file for this application if L{RunnerOptions.pidFilePath}
+        is specified in L{self.options}.
+        """
+        pidFilePath = self.options.get(RunnerOptions.pidFilePath)
+        if pidFilePath is not None:
+            pidFilePath.remove()
+
+
+    def startLogging(self):
+        """
+        Start the L{twisted.logging} system.
+        """
+        logFile = self.options.get(RunnerOptions.logFile, stderr)
+
+        fileLogObserverFactory = self.options.get(
+            RunnerOptions.fileLogObserverFactory, textFileLogObserver
+        )
+
+        fileLogObserver = fileLogObserverFactory(logFile)
+
+        logLevelPredicate = LogLevelFilterPredicate(
+            defaultLogLevel=self.options.get(
+                RunnerOptions.defaultLogLevel, LogLevel.info
+            )
+        )
+
+        filteringObserver = FilteringLogObserver(
+            fileLogObserver, [logLevelPredicate]
+        )
+
+        globalLogBeginner.beginLoggingTo([filteringObserver])
+
+
+    def startReactor(self):
+        """
+        Register L{self.whenRunning} with the reactor so that it is called once
+        the reactor is running and start the reactor.
+        If L{RunnerOptions.reactor} is specified in L{self.options}, use that
+        reactor; otherwise use the default reactor.
+        """
+        reactor = self.options.get(RunnerOptions.reactor)
+        if reactor is None:
+            from twisted.internet import reactor
+            self.options[RunnerOptions.reactor] = reactor
+
+        reactor.callWhenRunning(self.whenRunning)
+
+        self.log.info("Starting reactor...")
+        reactor.run()
+
+
+    def whenRunning(self):
+        """
+        If L{RunnerOptions.whenRunning} is specified in L{self.options}, call
+        it.
+
+        @note: This method is called when the reactor is running.
+        """
+        whenRunning = self.options.get(RunnerOptions.whenRunning)
+        if whenRunning is not None:
+            whenRunning(self.options)
+
+
+    def reactorExited(self):
+        """
+        If L{RunnerOptions.reactorExited} is specified in L{self.options}, call
+        it.
+
+        @note: This method is called after the reactor has exited.
+        """
+        reactorExited = self.options.get(RunnerOptions.reactorExited)
+        if reactorExited is not None:
+            reactorExited(self.options)
+
+
+
+class RunnerOptions(Names):
+    """
+    Names for options recognized by L{Runner}.
+    """
+
+    reactor                = NamedConstant()
+    pidFilePath            = NamedConstant()
+    kill                   = NamedConstant()
+    logFile                = NamedConstant()
+    logFileFormat          = NamedConstant()
+    defaultLogLevel        = NamedConstant()
+    fileLogObserverFactory = NamedConstant()
+    whenRunning            = NamedConstant()
+    reactorExited          = NamedConstant()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -45,9 +45,9 @@ class Runner(object):
         self.options = options
 
 
-    def execute(self):
+    def run(self):
         """
-        Execute this command.
+        Run this command.
         Equivalent to:
             self.killIfRequested()
             self.writePIDFile()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -55,6 +55,7 @@ class Runner(object):
             self.startReactor()
             self.reactorExited()
             self.removePIDFile()
+        Additional steps may be added over time, but the order won't change.
         """
         self.killIfRequested()
         self.writePIDFile()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -82,13 +82,13 @@ class Runner(object):
                 try:
                     for pid in pidFilePath.open():
                         break
-                except (IOError, OSError):
-                    exit(ExitStatus.EX_DATAERR, "Unable to read pid file.")
+                except EnvironmentError:
+                    exit(ExitStatus.EX_IOERR, "Unable to read PID file.")
                     return  # When testing, patched exit doesn't exit
                 try:
                     pid = int(pid)
                 except ValueError:
-                    exit(ExitStatus.EX_DATAERR, "Invalid pid file.")
+                    exit(ExitStatus.EX_DATAERR, "Invalid PID file.")
                     return  # When testing, patched exit doesn't exit
 
             self.startLogging()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -24,6 +24,7 @@ from twisted.logger import (
     LogLevel,  # InvalidLogLevelError,
     Logger,
 )
+from twisted.internet import reactor as defaultReactor
 from ._exit import exit, ExitStatus
 
 
@@ -154,7 +155,8 @@ class Runner(object):
         """
         reactor = self.options.get(RunnerOptions.reactor)
         if reactor is None:
-            from twisted.internet import reactor
+            reactor = defaultReactor
+            reactor.install()
             self.options[RunnerOptions.reactor] = reactor
 
         reactor.callWhenRunning(self.whenRunning)

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -67,7 +67,7 @@ class Runner(object):
     def killIfRequested(self):
         """
         Kill a running instance of this application if L{RunnerOptions.kill} is
-        specified and L{True} in L{self.options}.
+        specified and L{True} in C{self.options}.
         This requires that L{RunnerOptions.pidFilePath} also be specified;
         exit with L{ExitStatus.EX_USAGE} if kill is requested with no PID file.
         """
@@ -103,7 +103,7 @@ class Runner(object):
     def writePIDFile(self):
         """
         Write a PID file for this application if L{RunnerOptions.pidFilePath}
-        is specified in L{self.options}.
+        is specified in C{self.options}.
         """
         pidFilePath = self.options.get(RunnerOptions.pidFilePath)
         if pidFilePath is not None:
@@ -114,7 +114,7 @@ class Runner(object):
     def removePIDFile(self):
         """
         Remove the PID file for this application if L{RunnerOptions.pidFilePath}
-        is specified in L{self.options}.
+        is specified in C{self.options}.
         """
         pidFilePath = self.options.get(RunnerOptions.pidFilePath)
         if pidFilePath is not None:
@@ -123,7 +123,7 @@ class Runner(object):
 
     def startLogging(self):
         """
-        Start the L{twisted.logging} system.
+        Start the L{twisted.logger} logging system.
         """
         logFile = self.options.get(RunnerOptions.logFile, stderr)
 
@@ -148,9 +148,9 @@ class Runner(object):
 
     def startReactor(self):
         """
-        Register L{self.whenRunning} with the reactor so that it is called once
+        Register C{self.whenRunning} with the reactor so that it is called once
         the reactor is running and start the reactor.
-        If L{RunnerOptions.reactor} is specified in L{self.options}, use that
+        If L{RunnerOptions.reactor} is specified in C{self.options}, use that
         reactor; otherwise use the default reactor.
         """
         reactor = self.options.get(RunnerOptions.reactor)
@@ -167,7 +167,7 @@ class Runner(object):
 
     def whenRunning(self):
         """
-        If L{RunnerOptions.whenRunning} is specified in L{self.options}, call
+        If L{RunnerOptions.whenRunning} is specified in C{self.options}, call
         it.
 
         @note: This method is called when the reactor is running.
@@ -179,7 +179,7 @@ class Runner(object):
 
     def reactorExited(self):
         """
-        If L{RunnerOptions.reactorExited} is specified in L{self.options}, call
+        If L{RunnerOptions.reactorExited} is specified in C{self.options}, call
         it.
 
         @note: This method is called after the reactor has exited.
@@ -198,40 +198,40 @@ class RunnerOptions(Names):
 
     @cvar reactor: The reactor to start.
         Corresponding value: L{IReactorCore}.
-    @ctype reactor: L{NamedConstant}
+    @type reactor: L{NamedConstant}
 
     @cvar pidFilePath: The path to the PID file.
         Corresponding value: L{IFilePath}.
-    @ctype pidFilePath: L{NamedConstant}
+    @type pidFilePath: L{NamedConstant}
 
     @cvar kill: Whether this runner should kill an existing running instance.
         Corresponding value: L{bool}.
-    @ctype kill: L{NamedConstant}
+    @type kill: L{NamedConstant}
 
     @cvar defaultLogLevel: The default log level to start the logging system
         with.
         Corresponding value: L{NamedConstant} from L{LogLevel}.
-    @ctype defaultLogLevel: L{NamedConstant}
+    @type defaultLogLevel: L{NamedConstant}
 
     @cvar logFile: A file stream to write logging output to.
         Corresponding value: writable file like object.
-    @ctype logFile: L{NamedConstant}
+    @type logFile: L{NamedConstant}
 
     @cvar fileLogObserverFactory: What file log observer to use when starting
         the logging system.
         Corresponding value: callable that returns a
         L{twisted.logger.FileLogObserver}
-    @ctype fileLogObserverFactory: L{NamedConstant}
+    @type fileLogObserverFactory: L{NamedConstant}
 
     @cvar whenRunning: Hook to call when the reactor is running.
         This can be considered the Twisted equivalent to C{main()}.
         Corresponding value: callable that takes the options mapping given to
         the runner as an argument.
-    @ctype whenRunning: L{NamedConstant}
+    @type whenRunning: L{NamedConstant}
 
     @cvar reactorExited: Hook to call when the reactor has exited.
         Corresponding value: callable that takes an empty arguments list
-    @ctype reactorExited: L{NamedConstant}
+    @type reactorExited: L{NamedConstant}
     """
 
     reactor                = NamedConstant()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -225,7 +225,8 @@ class RunnerOptions(Names):
 
     @cvar whenRunning: Hook to call when the reactor is running.
         This can be considered the Twisted equivalent to C{main()}.
-        Corresponding value: callable that takes an empty arguments list
+        Corresponding value: callable that takes the options mapping given to
+        the runner as an argument.
     @ctype whenRunning: L{NamedConstant}
 
     @cvar reactorExited: Hook to call when the reactor has exited.

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -24,7 +24,7 @@ from twisted.logger import (
     LogLevel,  # InvalidLogLevelError,
     Logger,
 )
-from twisted.internet import reactor as defaultReactor
+from twisted.internet import default as defaultReactor
 from ._exit import exit, ExitStatus
 
 

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.runner.test.test_runner -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -191,14 +191,51 @@ class Runner(object):
 class RunnerOptions(Names):
     """
     Names for options recognized by L{Runner}.
+    These are meant to be used as keys in the options given to L{Runner}, with
+    corresponding values as noted below.
+
+    @cvar reactor: The reactor to start.
+        Corresponding value: L{IReactorCore}.
+    @ctype reactor: L{NamedConstant}
+
+    @cvar pidFilePath: The path to the PID file.
+        Corresponding value: L{IFilePath}.
+    @ctype pidFilePath: L{NamedConstant}
+
+    @cvar kill: Whether this runner should kill an existing running instance.
+        Corresponding value: L{bool}.
+    @ctype kill: L{NamedConstant}
+
+    @cvar defaultLogLevel: The default log level to start the logging system
+        with.
+        Corresponding value: L{NamedConstant} from L{LogLevel}.
+    @ctype defaultLogLevel: L{NamedConstant}
+
+    @cvar logFile: A file stream to write logging output to.
+        Corresponding value: writable file like object.
+    @ctype logFile: L{NamedConstant}
+
+    @cvar fileLogObserverFactory: What file log observer to use when starting
+        the logging system.
+        Corresponding value: callable that returns a
+        L{twisted.logger.FileLogObserver}
+    @ctype fileLogObserverFactory: L{NamedConstant}
+
+    @cvar whenRunning: Hook to call when the reactor is running.
+        This can be considered the Twisted equivalent to C{main()}.
+        Corresponding value: callable that takes an empty arguments list
+    @ctype whenRunning: L{NamedConstant}
+
+    @cvar reactorExited: Hook to call when the reactor has exited.
+        Corresponding value: callable that takes an empty arguments list
+    @ctype reactorExited: L{NamedConstant}
     """
 
     reactor                = NamedConstant()
     pidFilePath            = NamedConstant()
     kill                   = NamedConstant()
-    logFile                = NamedConstant()
-    logFileFormat          = NamedConstant()
     defaultLogLevel        = NamedConstant()
+    logFile                = NamedConstant()
     fileLogObserverFactory = NamedConstant()
     whenRunning            = NamedConstant()
     reactorExited          = NamedConstant()

--- a/twisted/application/runner/_runner.py
+++ b/twisted/application/runner/_runner.py
@@ -37,7 +37,7 @@ class Runner(object):
     def __init__(self, options):
         """
         @param options: Configuration options for this runner.
-        @type options: mapping
+        @type options: mapping of L{RunnerOptions} to values
         """
         self.options = options
 

--- a/twisted/application/runner/test/__init__.py
+++ b/twisted/application/runner/test/__init__.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.runner.test -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/runner/test/__init__.py
+++ b/twisted/application/runner/test/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.application.runner}.
+"""

--- a/twisted/application/runner/test/test_exit.py
+++ b/twisted/application/runner/test/test_exit.py
@@ -1,0 +1,64 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{ims.tx.usage._exit}.
+"""
+
+import sys
+
+from .._exit import exit, ExitStatus
+
+import twisted.trial.unittest
+
+
+
+class ExitTests(twisted.trial.unittest.TestCase):
+    """
+    Tests for L{exit}.
+    """
+
+    def setUp(self):
+        self.patch(sys, "exit", self.exit)
+        self.exitStatus = None
+
+
+    def exit(self, status):
+        assert self.exitStatus is None
+        self.exitStatus = status
+
+
+    def test_exitStatusInt(self):
+        """
+        L{exit} given an L{int} status code will pass it to L{sys.exit}.
+        """
+        status = 1234
+        exit(status)
+        self.assertEqual(self.exitStatus, status)
+
+
+    def test_exitStatusStringNotInt(self):
+        """
+        L{exit} given a L{str} status code that isn't a string integer raises
+        L{ValueError}.
+        """
+        self.assertRaises(ValueError, exit, "foo")
+
+
+    def test_exitStatusStringInt(self):
+        """
+        L{exit} given a L{str} status code that is a string integer passes the
+        corresponding L{int} to L{sys.exit}.
+        """
+        exit("1234")
+        self.assertEqual(self.exitStatus, 1234)
+
+
+    def test_exitConstant(self):
+        """
+        L{exit} given a L{ValueConstant} status code passes the corresponding
+        value to L{sys.exit}.
+        """
+        status = ExitStatus.EX_CONFIG
+        exit(status)
+        self.assertEqual(self.exitStatus, status.value)

--- a/twisted/application/runner/test/test_exit.py
+++ b/twisted/application/runner/test/test_exit.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Tests for L{ims.tx.usage._exit}.
+Tests for L{twisted.application.runner._exit}.
 """
 
 import sys
@@ -19,13 +19,8 @@ class ExitTests(twisted.trial.unittest.TestCase):
     """
 
     def setUp(self):
+        self.exit = DummyExit()
         self.patch(sys, "exit", self.exit)
-        self.exitStatus = None
-
-
-    def exit(self, status):
-        assert self.exitStatus is None
-        self.exitStatus = status
 
 
     def test_exitStatusInt(self):
@@ -34,7 +29,7 @@ class ExitTests(twisted.trial.unittest.TestCase):
         """
         status = 1234
         exit(status)
-        self.assertEqual(self.exitStatus, status)
+        self.assertEqual(self.exit.arg, status)
 
 
     def test_exitStatusStringNotInt(self):
@@ -51,7 +46,7 @@ class ExitTests(twisted.trial.unittest.TestCase):
         corresponding L{int} to L{sys.exit}.
         """
         exit("1234")
-        self.assertEqual(self.exitStatus, 1234)
+        self.assertEqual(self.exit.arg, 1234)
 
 
     def test_exitConstant(self):
@@ -61,4 +56,21 @@ class ExitTests(twisted.trial.unittest.TestCase):
         """
         status = ExitStatus.EX_CONFIG
         exit(status)
-        self.assertEqual(self.exitStatus, status.value)
+        self.assertEqual(self.exit.arg, status.value)
+
+
+
+class DummyExit(object):
+    """
+    Mock for L{sys.exit} that remembers whether it's been called and, if it has,
+    what argument it was given.
+    """
+    def __init__(self):
+        self.exited = False
+
+
+    def __call__(self, arg=None):
+        assert not self.exited
+
+        self.arg    = arg
+        self.exited = True

--- a/twisted/application/runner/test/test_exit.py
+++ b/twisted/application/runner/test/test_exit.py
@@ -61,7 +61,7 @@ class ExitTests(twisted.trial.unittest.TestCase):
 
 class DummyExit(object):
     """
-    Mock for L{sys.exit} that remembers whether it's been called and, if it has,
+    Stub for L{sys.exit} that remembers whether it's been called and, if it has,
     what argument it was given.
     """
     def __init__(self):

--- a/twisted/application/runner/test/test_exit.py
+++ b/twisted/application/runner/test/test_exit.py
@@ -5,6 +5,7 @@
 Tests for L{twisted.application.runner._exit}.
 """
 
+from io import BytesIO
 from ...runner import _exit
 from .._exit import exit, ExitStatus
 
@@ -58,11 +59,39 @@ class ExitTests(twisted.trial.unittest.TestCase):
         self.assertEqual(self.exit.arg, status.value)
 
 
+    def test_exitMessageZero(self):
+        """
+        L{exit} given a status code of zero (C{0}) writes the given message to
+        standard output.
+        """
+        out = BytesIO()
+        self.patch(_exit, "stdout", out)
+
+        message = b"Hello, world."
+        exit(0, message)
+
+        self.assertEqual(out.getvalue(), b"{}\n".format(message))
+
+
+    def test_exitMessageNonZero(self):
+        """
+        L{exit} given a non-zero status code writes the given message to
+        standard error.
+        """
+        out = BytesIO()
+        self.patch(_exit, "stderr", out)
+
+        message = b"Hello, world."
+        exit(64, message)
+
+        self.assertEqual(out.getvalue(), b"{}\n".format(message))
+
+
 
 class DummyExit(object):
     """
-    Stub for L{sys.exit} that remembers whether it's been called and, if it has,
-    what argument it was given.
+    Stub for L{sys.exit} that remembers whether it's been called and, if it
+    has, what argument it was given.
     """
     def __init__(self):
         self.exited = False

--- a/twisted/application/runner/test/test_exit.py
+++ b/twisted/application/runner/test/test_exit.py
@@ -5,8 +5,7 @@
 Tests for L{twisted.application.runner._exit}.
 """
 
-import sys
-
+from ...runner import _exit
 from .._exit import exit, ExitStatus
 
 import twisted.trial.unittest
@@ -20,7 +19,7 @@ class ExitTests(twisted.trial.unittest.TestCase):
 
     def setUp(self):
         self.exit = DummyExit()
-        self.patch(sys, "exit", self.exit)
+        self.patch(_exit, "sysexit", self.exit)
 
 
     def test_exitStatusInt(self):

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -405,4 +405,3 @@ class DummyWarningsModule(object):
         @param args: ignored.
         @param kwargs: ignored.
         """
-        pass

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -8,13 +8,10 @@ Tests for L{twisted.application.runner._runner}.
 from signal import SIGTERM
 from io import BytesIO
 
-from zope.interface import implementer
-
-from twisted.python.filepath import IFilePath
+from twisted.python.filepath import FilePath
 from twisted.logger import (
     LogLevel, LogPublisher, LogBeginner,
-    jsonFileLogObserver, FileLogObserver,
-    FilteringLogObserver, LogLevelFilterPredicate,
+    FileLogObserver, FilteringLogObserver, LogLevelFilterPredicate,
 )
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -353,8 +350,7 @@ class DummyKill(object):
 
 
 
-@implementer(IFilePath)
-class DummyFilePath(object):
+class DummyFilePath(FilePath):
     """
     Stub for L{twisted.python.filepath.FilePath} which returns a stream
     containing the given data when opened.

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -185,14 +185,62 @@ class CommandTests(twisted.trial.unittest.TestCase):
         self.assertTrue(reactor.hasRun)
 
 
-    def test_whenRunning(self):
-        raise NotImplementedError()
-    test_whenRunning.todo = "unimplemented"
+    def test_startReactorWithWhenRunning(self):
+        """
+        L{Runner.startReactor} with L{RunnerOptions.whenRunning} ensures that
+        the given callable is called with the runner's options when the reactor
+        is running.
+        """
+        optionsSeen = []
+
+        def txmain(options):
+            optionsSeen.append(options)
+
+        options = {
+            RunnerOptions.reactor: MemoryReactor(),
+            RunnerOptions.whenRunning: txmain,
+        }
+        runner = Runner(options)
+        runner.startReactor()
+
+        self.assertEqual(len(optionsSeen), 1)
+        self.assertIdentical(optionsSeen[0], options)
 
 
-    def test_reactorExited(self):
-        raise NotImplementedError()
-    test_reactorExited.todo = "unimplemented"
+    def test_whenRunningWithWhenRunning(self):
+        """
+        L{Runner.whenRunning} with L{RunnerOptions.whenRunning} calls the given
+        callable with the runner's options.
+        """
+        optionsSeen = []
+
+        def txmain(options):
+            optionsSeen.append(options)
+
+        options = {RunnerOptions.whenRunning: txmain}
+        runner = Runner(options)
+        runner.whenRunning()
+
+        self.assertEqual(len(optionsSeen), 1)
+        self.assertIdentical(optionsSeen[0], options)
+
+
+    def test_reactorExitedWithReactorExited(self):
+        """
+        L{Runner.reactorExited} with L{RunnerOptions.reactorExited} calls the
+        given callable with the runner's options.
+        """
+        optionsSeen = []
+
+        def exited(options):
+            optionsSeen.append(options)
+
+        options = {RunnerOptions.reactorExited: exited}
+        runner = Runner(options)
+        runner.reactorExited()
+
+        self.assertEqual(len(optionsSeen), 1)
+        self.assertIdentical(optionsSeen[0], options)
 
 
 

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -128,16 +128,6 @@ class CommandTests(twisted.trial.unittest.TestCase):
         self.assertIdentical(self.exit.message, None)
 
 
-    def test_writePIDFileWithoutPIDFile(self):
-        """
-        L{Runner.writePIDFile} without L{RunnerOptions.pidFilePath} doesn't
-        write a PID file.
-        """
-        raise NotImplementedError()
-
-    test_writePIDFileWithoutPIDFile.todo = "?"
-
-
     def test_writePIDFileWithPIDFile(self):
         """
         L{Runner.writePIDFile} with L{RunnerOptions.pidFilePath} writes a PID
@@ -150,16 +140,6 @@ class CommandTests(twisted.trial.unittest.TestCase):
         runner.writePIDFile()
 
         self.assertEqual(pidFilePath.getContent(), self.pidFileContent)
-
-
-    def test_removePIDFileWithoutPIDFile(self):
-        """
-        L{Runner.removePIDFile} without L{RunnerOptions.pidFilePath} doesn't
-        remove the PID file.
-        """
-        raise NotImplementedError()
-
-    test_removePIDFileWithoutPIDFile.todo = "?"
 
 
     def test_removePIDFileWithPIDFile(self):

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -163,9 +163,15 @@ class CommandTests(twisted.trial.unittest.TestCase):
         L{Runner.startReactor} without L{RunnerOptions.reactor} runs the default
         reactor.
         """
-        raise NotImplementedError()
+        # Patch defaultReactor
+        reactor = MemoryReactor()
+        self.patch(_runner, "defaultReactor", reactor)
 
-    test_startReactorWithoutReactor.todo = "unimplemented"
+        runner = Runner({})
+        runner.startReactor()
+
+        self.assertTrue(reactor.hasInstalled)
+        self.assertTrue(reactor.hasRun)
 
 
     def test_startReactorWithReactor(self):

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -1,0 +1,283 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.application.runner._runner}.
+"""
+
+from signal import SIGTERM
+from io import BytesIO
+
+from twisted.logger import LogPublisher, LogBeginner
+
+from ...runner import _runner
+from .._exit import ExitStatus
+from .._runner import Runner, RunnerOptions
+
+import twisted.trial.unittest
+
+
+
+class CommandTests(twisted.trial.unittest.TestCase):
+    """
+    Tests for L{Command}.
+    """
+
+    def setUp(self):
+        # Patch exit and kill so we can capture usage and prevent actual exits
+        # and kills.
+
+        self.exit = DummyExit()
+        self.kill = DummyKill()
+
+        self.patch(_runner, "exit", self.exit)
+        self.patch(_runner, "kill", self.kill)
+
+        # Patch getpid so we get a known result
+
+        self.pid = 1337
+        self.pidFileContent = u"{}\n".format(self.pid).encode("utf-8")
+        self.patch(_runner, "getpid", lambda: self.pid)
+
+        # Patch globalLogBeginner so that we aren't trying to install multiple
+        # global log observers.
+
+        self.stdout = BytesIO()
+        self.stderr = BytesIO()
+        self.stdio = DummyStandardIO(self.stdout, self.stderr)
+        self.warnings = DummyWarningsModule()
+
+        self.globalLogPublisher = LogPublisher()
+        self.globalLogBeginner = LogBeginner(
+            self.globalLogPublisher,
+            self.stdio.stderr, self.stdio,
+            self.warnings,
+        )
+
+        self.patch(_runner, "stderr", self.stderr)
+        self.patch(_runner, "globalLogBeginner", self.globalLogBeginner)
+
+
+    def test_execute(self):
+        """
+        L{Runner.execute} calls the documented methods in order.
+        """
+        called = []
+
+        methodNames = [
+            "killIfRequested",
+            "writePIDFile",
+            "startLogging",
+            "startReactor",
+            "reactorExited",
+            "removePIDFile",
+        ]
+
+        for name in methodNames:
+            self.patch(
+                Runner, name, lambda self, name=name: called.append(name)
+            )
+
+        runner = Runner({})
+        runner.execute()
+
+        self.assertEqual(called, methodNames)
+
+
+    def test_killNotRequested(self):
+        """
+        L{Runner.killIfRequested} without L{RunnerOptions.kill} doesn't exit
+        and doesn't indiscriminately murder anyone.
+        """
+        runner = Runner({})
+        runner.killIfRequested()
+
+        self.assertEqual(self.kill.calls, [])
+        self.assertFalse(self.exit.exited)
+
+
+    def test_killRequestedWithoutPIDFile(self):
+        """
+        L{Runner.killIfRequested} with L{RunnerOptions.kill} but without
+        L{RunnerOptions.pidFilePath}, exits with L{ExitStatus.EX_USAGE} and
+        the expected message, and also doesn't indiscriminately murder anyone.
+        """
+        runner = Runner({RunnerOptions.kill: True})
+        runner.killIfRequested()
+
+        self.assertEqual(self.kill.calls, [])
+        self.assertEqual(self.exit.status, ExitStatus.EX_USAGE)
+        self.assertEqual(self.exit.message, "No PID file specified")
+
+
+    def test_killRequestedWithPIDFile(self):
+        """
+        L{Runner.killIfRequested} with both L{RunnerOptions.kill} and
+        L{RunnerOptions.pidFilePath} performs a targeted killing of the
+        appropriate process.
+        """
+        pidFilePath = DummyFilePath(self.pidFileContent)
+        runner = Runner({
+            RunnerOptions.kill: True,
+            RunnerOptions.pidFilePath: pidFilePath,
+        })
+        runner.killIfRequested()
+
+        self.assertEqual(self.kill.calls, [(self.pid, SIGTERM)])
+        self.assertEqual(self.exit.status, ExitStatus.EX_OK)
+        self.assertIdentical(self.exit.message, None)
+
+
+    def test_writePIDFileWithoutPIDFile(self):
+        """
+        L{Runner.writePIDFile} without L{RunnerOptions.pidFilePath} doesn't
+        write a PID file.
+        """
+        raise NotImplementedError()
+
+    test_writePIDFileWithoutPIDFile.todo = "?"
+
+
+    def test_writePIDFileWithPIDFile(self):
+        """
+        L{Runner.writePIDFile} with L{RunnerOptions.pidFilePath} writes a PID
+        file.
+        """
+        pidFilePath = DummyFilePath()
+        runner = Runner({
+            RunnerOptions.pidFilePath: pidFilePath,
+        })
+        runner.writePIDFile()
+
+        self.assertEqual(pidFilePath.getContent(), self.pidFileContent)
+
+
+    def test_removePIDFileWithoutPIDFile(self):
+        """
+        L{Runner.removePIDFile} without L{RunnerOptions.pidFilePath} doesn't
+        remove the PID file.
+        """
+        raise NotImplementedError()
+
+    test_removePIDFileWithoutPIDFile.todo = "?"
+
+
+    def test_removePIDFileWithPIDFile(self):
+        """
+        L{Runner.removePIDFile} with L{RunnerOptions.pidFilePath} removes the
+        PID file.
+        """
+        pidFilePath = DummyFilePath()
+        runner = Runner({
+            RunnerOptions.pidFilePath: pidFilePath,
+        })
+        runner.removePIDFile()
+
+        self.assertFalse(pidFilePath.exists())
+
+
+    def test_startLogging(self):
+        raise NotImplementedError()
+    test_startLogging.todo = "unimplemented"
+
+
+    def test_startReactor(self):
+        raise NotImplementedError()
+    test_startReactor.todo = "unimplemented"
+
+
+    def test_whenRunning(self):
+        raise NotImplementedError()
+    test_whenRunning.todo = "unimplemented"
+
+
+    def test_reactorExited(self):
+        raise NotImplementedError()
+    test_reactorExited.todo = "unimplemented"
+
+
+
+class DummyExit(object):
+    """
+    Stub for L{exit} that remembers whether it's been called and, if it has,
+    what arguments it was given.
+    """
+
+    def __init__(self):
+        self.exited = False
+
+
+    def __call__(self, status, message=None):
+        assert not self.exited
+
+        self.status  = status
+        self.message = message
+        self.exited  = True
+
+
+
+class DummyKill(object):
+    """
+    Stub for L{os.kill} that remembers whether it's been called and, if it has,
+    what arguments it was given.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+
+    def __call__(self, pid, sig):
+        self.calls.append((pid, sig))
+
+
+
+class DummyFilePath(object):
+    """
+    Stub for L{twisted.python.filepath.FilePath} which returns a stream
+    containing the given data when opened.
+    """
+
+    def __init__(self, content=b""):
+        self.setContent(content)
+
+
+    def open(self, mode="r"):
+        return BytesIO(self._content)
+
+
+    def setContent(self, content):
+        self._exits = True
+        self._content = content
+
+
+    def getContent(self):
+        return self._content
+
+
+    def remove(self):
+        self._exits = False
+
+
+    def exists(self):
+        return self._exits
+
+
+
+class DummyStandardIO(object):
+    """
+    Stub for L{sys} which provides L{BytesIO} streams as stdout and stderr.
+    """
+
+    def __init__(self, stdout, stderr):
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+
+class DummyWarningsModule(object):
+    """
+    Stub for L{warnings} which provides a C{showwarning} method that is a no-op.
+    """
+
+    def showwarning(*args, **kwargs):
+        pass

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -150,6 +150,23 @@ class CommandTests(twisted.trial.unittest.TestCase):
         self.assertEqual(self.exit.message, "Unable to read PID file.")
 
 
+    def test_killRequestedWithPIDFileEmpty(self):
+        """
+        L{Runner.killIfRequested} with both L{RunnerOptions.kill} and a
+        L{RunnerOptions.pidFilePath} containing no value exits with
+        L{ExitStatus.EX_DATAERR}.
+        """
+        pidFilePath = DummyFilePath(b"")
+        runner = Runner({
+            RunnerOptions.kill: True,
+            RunnerOptions.pidFilePath: pidFilePath,
+        })
+        runner.killIfRequested()
+
+        self.assertEqual(self.exit.status, ExitStatus.EX_DATAERR)
+        self.assertEqual(self.exit.message, "Invalid PID file.")
+
+
     def test_killRequestedWithPIDFileNotAnInt(self):
         """
         L{Runner.killIfRequested} with both L{RunnerOptions.kill} and a

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -9,6 +9,7 @@ from signal import SIGTERM
 from io import BytesIO
 
 from twisted.logger import LogPublisher, LogBeginner
+from twisted.test.proto_helpers import MemoryReactor
 
 from ...runner import _runner
 from .._exit import ExitStatus
@@ -134,9 +135,7 @@ class CommandTests(twisted.trial.unittest.TestCase):
         file.
         """
         pidFilePath = DummyFilePath()
-        runner = Runner({
-            RunnerOptions.pidFilePath: pidFilePath,
-        })
+        runner = Runner({RunnerOptions.pidFilePath: pidFilePath})
         runner.writePIDFile()
 
         self.assertEqual(pidFilePath.getContent(), self.pidFileContent)
@@ -148,9 +147,7 @@ class CommandTests(twisted.trial.unittest.TestCase):
         PID file.
         """
         pidFilePath = DummyFilePath()
-        runner = Runner({
-            RunnerOptions.pidFilePath: pidFilePath,
-        })
+        runner = Runner({RunnerOptions.pidFilePath: pidFilePath})
         runner.removePIDFile()
 
         self.assertFalse(pidFilePath.exists())
@@ -161,9 +158,25 @@ class CommandTests(twisted.trial.unittest.TestCase):
     test_startLogging.todo = "unimplemented"
 
 
-    def test_startReactor(self):
+    def test_startReactorWithoutReactor(self):
+        """
+        L{Runner.startReactor} without L{RunnerOptions.reactor} runs the default
+        reactor.
+        """
         raise NotImplementedError()
-    test_startReactor.todo = "unimplemented"
+
+    test_startReactorWithoutReactor.todo = "unimplemented"
+
+
+    def test_startReactorWithReactor(self):
+        """
+        L{Runner.startReactor} with L{RunnerOptions.reactor} runs that reactor.
+        """
+        reactor = MemoryReactor()
+        runner = Runner({RunnerOptions.reactor: reactor})
+        runner.startReactor()
+
+        self.assertTrue(reactor.hasRun)
 
 
     def test_whenRunning(self):

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -8,6 +8,9 @@ Tests for L{twisted.application.runner._runner}.
 from signal import SIGTERM
 from io import BytesIO
 
+from zope.interface import implements
+
+from twisted.python.filepath import IFilePath
 from twisted.logger import LogPublisher, LogBeginner
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -278,6 +281,7 @@ class DummyKill(object):
 
 
 
+@implements(IFilePath)
 class DummyFilePath(object):
     """
     Stub for L{twisted.python.filepath.FilePath} which returns a stream
@@ -327,4 +331,10 @@ class DummyWarningsModule(object):
     """
 
     def showwarning(*args, **kwargs):
+        """
+        Do nothing.
+
+        @param args: ignored.
+        @param kwargs: ignored.
+        """
         pass

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -133,6 +133,23 @@ class CommandTests(twisted.trial.unittest.TestCase):
         self.assertIdentical(self.exit.message, None)
 
 
+    def test_killRequestedWithPIDFileNotAnInt(self):
+        """
+        L{Runner.killIfRequested} with both L{RunnerOptions.kill} and
+        a L{RunnerOptions.pidFilePath} containing a non-integer value exits
+        with L{ExitStatus.EX_DATAERR}.
+        """
+        pidFilePath = DummyFilePath(b"** totally not a number, dude **")
+        runner = Runner({
+            RunnerOptions.kill: True,
+            RunnerOptions.pidFilePath: pidFilePath,
+        })
+        runner.killIfRequested()
+
+        self.assertEqual(self.exit.status, ExitStatus.EX_DATAERR)
+        self.assertEqual(self.exit.message, "Invalid pid file.")
+
+
     def test_writePIDFileWithPIDFile(self):
         """
         L{Runner.writePIDFile} with L{RunnerOptions.pidFilePath} writes a PID

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -41,7 +41,7 @@ class CommandTests(twisted.trial.unittest.TestCase):
         # Patch getpid so we get a known result
 
         self.pid = 1337
-        self.pidFileContent = u"{}\n".format(self.pid).encode("utf-8")
+        self.pidFileContent = b"{}\n".format(self.pid)
         self.patch(_runner, "getpid", lambda: self.pid)
 
         # Patch globalLogBeginner so that we aren't trying to install multiple

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -59,9 +59,9 @@ class CommandTests(twisted.trial.unittest.TestCase):
         self.patch(_runner, "globalLogBeginner", self.globalLogBeginner)
 
 
-    def test_execute(self):
+    def test_run(self):
         """
-        L{Runner.execute} calls the documented methods in order.
+        L{Runner.run} calls the documented methods in order.
         """
         called = []
 
@@ -80,7 +80,7 @@ class CommandTests(twisted.trial.unittest.TestCase):
             )
 
         runner = Runner({})
-        runner.execute()
+        runner.run()
 
         self.assertEqual(called, methodNames)
 

--- a/twisted/application/runner/test/test_runner.py
+++ b/twisted/application/runner/test/test_runner.py
@@ -8,7 +8,7 @@ Tests for L{twisted.application.runner._runner}.
 from signal import SIGTERM
 from io import BytesIO
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python.filepath import IFilePath
 from twisted.logger import LogPublisher, LogBeginner
@@ -281,7 +281,7 @@ class DummyKill(object):
 
 
 
-@implements(IFilePath)
+@implementer(IFilePath)
 class DummyFilePath(object):
     """
     Stub for L{twisted.python.filepath.FilePath} which returns a stream

--- a/twisted/application/twist/__init__.py
+++ b/twisted/application/twist/__init__.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.twist.test -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/twist/__init__.py
+++ b/twisted/application/twist/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+C{twist} command line tool.
+"""
+
+__all__ = [
+    "Twist",
+]
+
+from _twist import Twist

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -9,6 +9,7 @@ from operator import attrgetter
 
 from twisted.copyright import version
 from twisted.python.usage import Options
+from twisted.python.filepath import FilePath
 from ..reactors import installReactor, NoSuchReactor, getReactorTypes
 from ..runner import exit, ExitStatus
 
@@ -61,6 +62,13 @@ class TwistOptions(Options):
             self["reactor"] = installReactor(name)
         except NoSuchReactor:
             exit(ExitStatus.EX_CONFIG, "Unknown reactor: {}".format(name))
+
+
+    def opt_pidfile(self, path):
+        """
+        The path to the PID file.
+        """
+        self["pidFilePath"] = FilePath(path)
 
 
     def parseArgs(self):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -113,7 +113,7 @@ class TwistOptions(Options):
             self["logFile"] = openFile(fileName, "a")
         except EnvironmentError as e:
             exit(
-                ExitStatus.EX_CANTCREAT,
+                ExitStatus.EX_IOERR,
                 "Unable to open log file {!r}: {}".format(fileName, e)
             )
 

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -9,6 +9,7 @@ from sys import stdout
 
 from operator import attrgetter
 
+from twisted.copyright import version
 from twisted.python.usage import Options
 from ..reactors import installReactor, NoSuchReactor, getReactorTypes
 from ..runner import exit, ExitStatus
@@ -24,6 +25,13 @@ class TwistOptions(Options):
         Options.__init__(self)
 
         self["reactorName"] = "default"
+
+
+    def opt_version(self):
+        """
+        Print version and exit.
+        """
+        exit(ExitStatus.EX_OK, "{}".format(version))
 
 
     def opt_reactor(self, name):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 from textwrap import dedent
 
 from twisted.copyright import version
-from twisted.python.usage import Options
+from twisted.python.usage import Options, UsageError
 from twisted.logger import (
     LogLevel, InvalidLogLevelError,
     textFileLogObserver, jsonFileLogObserver,
@@ -75,7 +75,7 @@ class TwistOptions(Options):
         try:
             self["reactor"] = installReactor(name)
         except NoSuchReactor:
-            exit(ExitStatus.EX_CONFIG, "Unknown reactor: {}".format(name))
+            raise UsageError("Unknown reactor: {}".format(name))
 
 
     def opt_log_level(self, levelName):
@@ -86,10 +86,7 @@ class TwistOptions(Options):
         try:
             self["logLevel"] = LogLevel.levelWithName(levelName)
         except InvalidLogLevelError:
-            exit(
-                ExitStatus.EX_CONFIG,
-                "Invalid log level: {}".format(levelName)
-            )
+            raise UsageError("Invalid log level: {}".format(levelName))
 
     opt_log_level.__doc__ = dedent(opt_log_level.__doc__).format(
         options=", ".join(
@@ -133,10 +130,7 @@ class TwistOptions(Options):
         elif format == "json":
             self["fileLogObserverFactory"] = jsonFileLogObserver
         else:
-            exit(
-                ExitStatus.EX_CONFIG,
-                "Invalid log format: {}".format(format)
-            )
+            raise UsageError("Invalid log format: {}".format(format))
         self["logFormat"] = format
 
     opt_log_format.__doc__ = dedent(opt_log_format.__doc__)
@@ -184,4 +178,4 @@ class TwistOptions(Options):
         Options.postOptions(self)
 
         if self.subCommand is None:
-            exit(ExitStatus.EX_USAGE, "No plugin specified.")
+            raise UsageError("No plugin specified.")

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -7,7 +7,6 @@ Command line options for C{twist}.
 
 from sys import stdout, stderr
 from os import isatty
-from operator import attrgetter
 from textwrap import dedent
 
 from twisted.copyright import version

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -1,0 +1,61 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Command line options for C{twist}.
+"""
+
+from sys import stdout
+
+from operator import attrgetter
+
+from twisted.python.usage import Options
+from ..reactors import installReactor, NoSuchReactor, getReactorTypes
+from ..runner import exit, ExitStatus
+
+
+
+class TwistOptions(Options):
+    """
+    Command line options for C{twist}.
+    """
+
+    def __init__(self):
+        Options.__init__(self)
+
+        self["reactorName"] = "default"
+
+
+    def opt_reactor(self, name):
+        """
+        The name of the reactor to use.
+        """
+        self["reactorName"] = name
+
+
+    def opt_list_reactors(self):
+        """
+        List available reactors.
+        """
+        reactorTypes = sorted(getReactorTypes(), key=attrgetter("shortName"))
+        stdout.write("Available reactors:\n")
+        for reactorType in reactorTypes:
+            stdout.write(
+                "    {rt.shortName:10} {rt.description}\n"
+                .format(rt=reactorType)
+            )
+        exit(ExitStatus.EX_OK)
+
+
+    def installReactor(self):
+        name = self["reactorName"]
+        try:
+            self["reactor"] = installReactor(name)
+        except NoSuchReactor:
+            exit(ExitStatus.EX_CONFIG, "Unknown reactor: {}".format(name))
+
+
+    def parseArgs(self):
+        self.installReactor()
+
+        Options.parseArgs(self)

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -18,7 +18,7 @@ from twisted.logger import (
 from twisted.plugin import getPlugins
 
 from ..reactors import installReactor, NoSuchReactor, getReactorTypes
-from ..runner import exit, ExitStatus
+from ..runner._exit import exit, ExitStatus
 from ..service import IServiceMaker
 
 openFile = open

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.twist.test.test_options -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -77,7 +77,7 @@ class TwistOptions(Options):
             self["logLevel"] = LogLevel.levelWithName(levelName)
         except InvalidLogLevelError:
             exit(
-                ExitStatus.EX_USAGE,
+                ExitStatus.EX_CONFIG,
                 "Invalid log level: {}".format(levelName)
             )
 
@@ -124,7 +124,7 @@ class TwistOptions(Options):
             self["fileLogObserverFactory"] = jsonFileLogObserver
         else:
             exit(
-                ExitStatus.EX_USAGE,
+                ExitStatus.EX_CONFIG,
                 "Invalid log format: {}".format(format)
             )
         self["logFormat"] = format

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -145,7 +145,7 @@ class TwistOptions(Options):
         if "fileLogObserverFactory" not in self:
             logFile = self["logFile"]
 
-            if hasattr(logFile, "fileno") and isatty(logFile.fileno()):
+            if hasattr(logFile, "isatty") and logFile.isatty():
                 self["fileLogObserverFactory"] = textFileLogObserver
                 self["logFormat"] = "text"
             else:

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -139,8 +139,8 @@ class TwistOptions(Options):
 
     def selectDefaultLogObserver(self):
         """
-        Set the L{fileLogObserverFactory} to the default appropriate for the
-        chosen L{logFile}.
+        Set C{fileLogObserverFactory} to the default appropriate for the
+        chosen C{logFile}.
         """
         if "fileLogObserverFactory" not in self:
             logFile = self["logFile"]

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -5,8 +5,6 @@
 Command line options for C{twist}.
 """
 
-from sys import stdout
-
 from operator import attrgetter
 
 from twisted.copyright import version
@@ -46,13 +44,15 @@ class TwistOptions(Options):
         List available reactors.
         """
         reactorTypes = sorted(getReactorTypes(), key=attrgetter("shortName"))
-        stdout.write("Available reactors:\n")
+
+        info = ["Available reactors:"]
+
         for reactorType in reactorTypes:
-            stdout.write(
-                "    {rt.shortName:10} {rt.description}\n"
+            info.append(
+                "    {rt.shortName:10} {rt.description}"
                 .format(rt=reactorType)
             )
-        exit(ExitStatus.EX_OK)
+        exit(ExitStatus.EX_OK, "\n".join(info))
 
 
     def installReactor(self):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -10,7 +10,10 @@ from textwrap import dedent
 
 from twisted.copyright import version
 from twisted.python.usage import Options
-from twisted.logger import LogLevel, InvalidLogLevelError
+from twisted.logger import (
+    LogLevel, InvalidLogLevelError,
+    textFileLogObserver, jsonFileLogObserver,
+)
 from ..reactors import installReactor, NoSuchReactor, getReactorTypes
 from ..runner import exit, ExitStatus
 
@@ -29,6 +32,7 @@ class TwistOptions(Options):
 
         self["reactorName"] = "default"
         self["logLevel"] = self.defaultLogLevel
+        self["logFile"] = stdout
 
 
     def opt_version(self):
@@ -100,6 +104,26 @@ class TwistOptions(Options):
                 ExitStatus.EX_CANTCREAT,
                 "Unable to open log file {!r}: {}".format(fileName, e)
             )
+
+
+    def opt_log_format(self, format):
+        """
+        Set log file format to one of: (text, json).
+
+        (default: text for stdout/stderr, otherwise json)
+        """
+        format = format.lower()
+
+        if format == "text":
+            self["fileLogObserverFactory"] = textFileLogObserver
+        elif format == "json":
+            self["fileLogObserverFactory"] = jsonFileLogObserver
+        else:
+            exit(
+                ExitStatus.EX_USAGE,
+                "Invalid log format: {}".format(format)
+            )
+        self["logFormat"] = format
 
 
     def parseArgs(self):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -164,9 +164,9 @@ class TwistOptions(Options):
     @property
     def subCommands(self):
         plugins = sorted(getPlugins(IServiceMaker), key=attrgetter("tapname"))
-        self.loadedPlugins = {}
+        self["loadedPlugins"] = {}
         for plugin in plugins:
-            self.loadedPlugins[plugin.tapname] = plugin
+            self["loadedPlugins"][plugin.tapname] = plugin
             yield (
                 plugin.tapname,
                 None,

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -146,14 +146,8 @@ class TwistOptions(Options):
                 self["fileLogObserverFactory"] = jsonFileLogObserver
 
 
-    def parseArgs(self):
-        try:
-            self.installReactor()
-            self.selectDefaultLogObserver()
-        except Exception as e:
-            exit(
-                ExitStatus.EX_SOFTWARE,
-                "Unexpected error parsing arguments: {}".format(e)
-            )
+    def postOptions(self):
+        self.installReactor()
+        self.selectDefaultLogObserver()
 
-        Options.parseArgs(self)
+

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -22,6 +22,8 @@ from ..reactors import installReactor, NoSuchReactor, getReactorTypes
 from ..runner import exit, ExitStatus
 from ..service import IServiceMaker
 
+openFile = open
+
 
 
 class TwistOptions(Options):
@@ -109,7 +111,7 @@ class TwistOptions(Options):
             return
 
         try:
-            self["logFile"] = open(fileName, "a")
+            self["logFile"] = openFile(fileName, "a")
         except EnvironmentError as e:
             exit(
                 ExitStatus.EX_CANTCREAT,
@@ -146,8 +148,10 @@ class TwistOptions(Options):
 
             if hasattr(logFile, "fileno") and isatty(logFile.fileno()):
                 self["fileLogObserverFactory"] = textFileLogObserver
+                self["logFormat"] = "text"
             else:
                 self["fileLogObserverFactory"] = jsonFileLogObserver
+                self["logFormat"] = "json"
 
 
     def parseOptions(self, options=None):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -27,7 +27,7 @@ class TwistOptions(Options):
         Options.__init__(self)
 
         self["reactorName"] = "default"
-        self["logLevel"]    = self.defaultLogLevel
+        self["logLevel"] = self.defaultLogLevel
 
 
     def opt_version(self):
@@ -45,7 +45,9 @@ class TwistOptions(Options):
         self["reactorName"] = name
 
     opt_reactor.__doc__ = dedent(opt_reactor.__doc__).format(
-        options=", ".join(rt.shortName for rt in getReactorTypes()),
+        options=", ".join(
+            '"{}"'.format(rt.shortName) for rt in getReactorTypes()
+        ),
     )
 
 
@@ -60,7 +62,7 @@ class TwistOptions(Options):
     def opt_log_level(self, levelName):
         """
         Set default log level.
-        (options: {options}; default: {default})
+        (options: {options}; default: "{default}")
         """
         try:
             self["logLevel"] = LogLevel.levelWithName(levelName)
@@ -71,7 +73,9 @@ class TwistOptions(Options):
             )
 
     opt_log_level.__doc__ = dedent(opt_log_level.__doc__).format(
-        options=", ".join(l.name for l in LogLevel.iterconstants()),
+        options=", ".join(
+            '"{}"'.format(l.name) for l in LogLevel.iterconstants()
+        ),
         default=defaultLogLevel.name,
     )
 

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -137,12 +137,13 @@ class TwistOptions(Options):
         Set the L{fileLogObserverFactory} to the default appropriate for the
         chosen L{logFile}.
         """
-        logFile = self["logFile"]
+        if "fileLogObserverFactory" not in self:
+            logFile = self["logFile"]
 
-        if hasattr(logFile, "fileno") and isatty(logFile.fileno()):
-            self["fileLogObserverFactory"] = textFileLogObserver
-        else:
-            self["fileLogObserverFactory"] = jsonFileLogObserver
+            if hasattr(logFile, "fileno") and isatty(logFile.fileno()):
+                self["fileLogObserverFactory"] = textFileLogObserver
+            else:
+                self["fileLogObserverFactory"] = jsonFileLogObserver
 
 
     def parseArgs(self):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -6,7 +6,6 @@ Command line options for C{twist}.
 """
 
 from sys import stdout, stderr
-from os import isatty
 from textwrap import dedent
 
 from twisted.copyright import version

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -5,6 +5,7 @@
 Command line options for C{twist}.
 """
 
+from sys import stdout, stderr
 from textwrap import dedent
 
 from twisted.copyright import version
@@ -78,6 +79,27 @@ class TwistOptions(Options):
         ),
         default=defaultLogLevel.name,
     )
+
+
+    def opt_log_file(self, fileName):
+        """
+        Log to file. ("-" for stdout, "+" for stderr; default: "-")
+        """
+        if fileName == "-":
+            self["logFile"] = stdout
+            return
+
+        if fileName == "+":
+            self["logFile"] = stderr
+            return
+
+        try:
+            self["logFile"] = open(fileName, "a")
+        except EnvironmentError as e:
+            exit(
+                ExitStatus.EX_CANTCREAT,
+                "Unable to open log file {!r}: {}".format(fileName, e)
+            )
 
 
     def parseArgs(self):

--- a/twisted/application/twist/_options.py
+++ b/twisted/application/twist/_options.py
@@ -162,11 +162,21 @@ class TwistOptions(Options):
 
 
     @property
+    def plugins(self):
+        if "plugins" not in self:
+            plugins = {}
+            for plugin in getPlugins(IServiceMaker):
+                plugins[plugin.tapname] = plugin
+            self["plugins"] = plugins
+
+        return self["plugins"]
+
+
+    @property
     def subCommands(self):
-        plugins = sorted(getPlugins(IServiceMaker), key=attrgetter("tapname"))
-        self["loadedPlugins"] = {}
-        for plugin in plugins:
-            self["loadedPlugins"][plugin.tapname] = plugin
+        plugins = self.plugins
+        for name in sorted(plugins):
+            plugin = plugins[name]
             yield (
                 plugin.tapname,
                 None,

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.twist.test.test_twist -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -68,10 +68,13 @@ class Twist(object):
 
         ################# END DELETE THIS #################
 
-        runnerOptions[RunnerOptions.defaultLogLevel] = twistOptions["logLevel"]
-        runnerOptions[RunnerOptions.logFile] = twistOptions["logFile"]
+        for runnerOpt, twistOpt in (
+            (RunnerOptions.defaultLogLevel, "logLevel"),
+            (RunnerOptions.logFile, "logFile"),
+            (RunnerOptions.fileLogObserverFactory, "fileLogObserverFactory"),
+        ):
+            runnerOptions[runnerOpt] = twistOptions[twistOpt]
 
-        # RunnerOptions.fileLogObserverFactory
         # RunnerOptions.whenRunning
         # RunnerOptions.reactorExited
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -88,7 +88,7 @@ class Twist(object):
 
         reactor = twistOptions["reactor"]
         service = cls.service(
-            plugin=twistOptions.loadedPlugins[twistOptions.subCommand],
+            plugin=twistOptions["loadedPlugins"][twistOptions.subCommand],
             options=twistOptions.subOptions,
         )
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -69,10 +69,8 @@ class Twist(object):
         ################# END DELETE THIS #################
 
         runnerOptions[RunnerOptions.defaultLogLevel] = twistOptions["logLevel"]
+        runnerOptions[RunnerOptions.logFile] = twistOptions["logFile"]
 
-
-        # RunnerOptions.defaultLogLevel
-        # RunnerOptions.logFile
         # RunnerOptions.fileLogObserverFactory
         # RunnerOptions.whenRunning
         # RunnerOptions.reactorExited

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -77,8 +77,8 @@ class Twist(object):
 
 
     @staticmethod
-    def run(options):
-        runner = Runner(options)
+    def run(runnerOptions):
+        runner = Runner(runnerOptions)
         runner.run()
 
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -84,16 +84,16 @@ class Twist(object):
 
     @classmethod
     def main(cls, argv=sys.argv):
-        twistOptions = cls.options(argv)
+        options = cls.options(argv)
 
-        reactor = twistOptions["reactor"]
+        reactor = options["reactor"]
         service = cls.service(
-            plugin=twistOptions.plugins[twistOptions.subCommand],
-            options=twistOptions.subOptions,
+            plugin=options.plugins[options.subCommand],
+            options=options.subOptions,
         )
 
         cls.startService(reactor, service)
-        cls.run(cls.runnerOptions(twistOptions))
+        cls.run(cls.runnerOptions(options))
 
 
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -88,12 +88,11 @@ class Twist(object):
 
         reactor = twistOptions["reactor"]
         service = cls.service(
-            plugin=twistOptions["loadedPlugins"][twistOptions.subCommand],
+            plugin=twistOptions.plugins[twistOptions.subCommand],
             options=twistOptions.subOptions,
         )
 
         cls.startService(reactor, service)
-
         cls.run(cls.runnerOptions(twistOptions))
 
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -49,7 +49,7 @@ class Twist(object):
     @staticmethod
     def startService(reactor, service):
         # Start the service
-        service.privilegedStartService()
+        service.startService()
 
         # Ask the reactor to stop the service before shutting down
         reactor.addSystemEventTrigger(

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -61,10 +61,7 @@ class Twist(object):
 
             cls.log.info("Waiting...")
 
-        runnerOptions.update({
-            RunnerOptions.logFile: sys.stdout,
-            RunnerOptions.whenRunning: whenRunning,
-        })
+        runnerOptions[RunnerOptions.whenRunning] = whenRunning
 
         ################# END DELETE THIS #################
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-C{twist} command line tool.
+Run a Twisted application.
 """
 
 import sys
@@ -16,7 +16,7 @@ from ._options import TwistOptions
 
 class Twist(object):
     """
-    C{twist} command line tool.
+    Run a Twisted application.
     """
 
     @classmethod

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -10,7 +10,8 @@ import sys
 
 from twisted.python.usage import UsageError
 from ..service import Application, IService
-from ..runner import Runner, RunnerOptions, exit, ExitStatus
+from ..runner._exit import exit, ExitStatus
+from ..runner._runner import Runner, RunnerOptions
 from ._options import TwistOptions
 
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -40,18 +40,18 @@ class Twist(object):
         def whenRunning(options):
             from twisted.internet import reactor
 
-            cls.log.info(
+            cls.log.debug(
                 "Reactor is running: {reactor}",
                 reactor=reactor,
             )
 
-            try:
-                cls.log.info(
-                    "PID file: {fp.path}",
-                    fp=options[RunnerOptions.pidFilePath],
-                )
-            except KeyError:
-                pass
+            # try:
+            #     cls.log.info(
+            #         "PID file: {fp.path}",
+            #         fp=options[RunnerOptions.pidFilePath],
+            #     )
+            # except KeyError:
+            #     pass
 
             def stop():
                 cls.log.info("Stopping reactor...")
@@ -61,20 +61,16 @@ class Twist(object):
 
             cls.log.info("Waiting...")
 
-        ################# END DELETE THIS #################
-
-        runnerOptions = {
-            RunnerOptions.reactor: twistOptions["reactor"],
-
+        runnerOptions.update({
             RunnerOptions.logFile: sys.stdout,
             RunnerOptions.whenRunning: whenRunning,
-        }
+        })
 
-        pidFilePath = twistOptions.get("pidFilePath")
-        if pidFilePath is not None:
-            runnerOptions[RunnerOptions.pidFilePath] = pidFilePath
+        ################# END DELETE THIS #################
 
-        # RunnerOptions.kill
+        runnerOptions[RunnerOptions.defaultLogLevel] = twistOptions["logLevel"]
+
+
         # RunnerOptions.defaultLogLevel
         # RunnerOptions.logFile
         # RunnerOptions.fileLogObserverFactory

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -23,6 +23,12 @@ class Twist(object):
     def options(argv):
         """
         Parse command line options.
+
+        @param argv: Command line arguments.
+        @type argv: L{list}
+
+        @return: The parsed options.
+        @rtype: L{TwistOptions}
         """
         options = TwistOptions()
 
@@ -38,6 +44,16 @@ class Twist(object):
     def service(plugin, options):
         """
         Create the application service.
+
+        @param plugin: The name of the plugin that implements the service
+            application to run.
+        @type plugin: L{str}
+
+        @param options: Options to pass to the application.
+        @type options: L{twisted.python.usage.Options}
+
+        @return: The created application service.
+        @rtype: L{IService}
         """
         service = plugin.makeService(options)
         application = Application(plugin.tapname)
@@ -48,7 +64,15 @@ class Twist(object):
 
     @staticmethod
     def startService(reactor, service):
-        # Start the service
+        """
+        Start the application service.
+
+        @param reactor: The reactor to run the service with.
+        @type reactor: L{twisted.internet.interfaces.IReactorCore}
+
+        @param service: The application service to run.
+        @type service: L{IService}
+        """
         service.startService()
 
         # Ask the reactor to stop the service before shutting down
@@ -62,6 +86,12 @@ class Twist(object):
         """
         Take options obtained from command line and configure options for the
         application runner.
+
+        @param twistOptions: Command line options to convert to runner options.
+        @type twistOptions: L{TwistOptions}
+
+        @return: The corresponding runner options.
+        @rtype: L{RunnerOptions}
         """
         runnerOptions = {}
 
@@ -78,12 +108,25 @@ class Twist(object):
 
     @staticmethod
     def run(runnerOptions):
+        """
+        Run the application service.
+
+        @param runnerOptions: Options to pass to the runner.
+        @type runnerOptions: L{RunnerOptions}
+        """
         runner = Runner(runnerOptions)
         runner.run()
 
 
     @classmethod
     def main(cls, argv=sys.argv):
+        """
+        Executable entry point for L{Twist}.
+        Processes options and run a twisted reactor with a service.
+
+        @param argv: Command line arguments.
+        @type argv: L{list}
+        """
         options = cls.options(argv)
 
         reactor = options["reactor"]

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -19,54 +19,82 @@ class Twist(object):
     Run a Twisted application.
     """
 
-    @classmethod
-    def main(cls, argv=sys.argv):
-
-        # Parse command line
-
-        twistOptions = TwistOptions()
+    @staticmethod
+    def options(argv):
+        """
+        Parse command line options.
+        """
+        options = TwistOptions()
 
         try:
-            twistOptions.parseOptions(argv[1:])
+            options.parseOptions(argv[1:])
         except UsageError as e:
-            exit(ExitStatus.EX_USAGE, "Error: {}\n\n{}".format(e, twistOptions))
+            exit(ExitStatus.EX_USAGE, "Error: {}\n\n{}".format(e, options))
 
-        # Configure the runner based on the command line options
+        return options
 
-        reactor = twistOptions["reactor"]
 
-        runnerOptions = {
-            RunnerOptions.reactor: reactor,
-        }
+    @staticmethod
+    def service(plugin, options):
+        """
+        Create the application service.
+        """
+        service = plugin.makeService(options)
+        application = Application(plugin.tapname)
+        service.setServiceParent(application)
+
+        return IService(application)
+
+
+    @staticmethod
+    def startService(reactor, service):
+        # Start the service
+        service.privilegedStartService()
+
+        # Ask the reactor to stop the service before shutting down
+        reactor.addSystemEventTrigger(
+            "before", "shutdown", service.stopService
+        )
+
+
+    @staticmethod
+    def runnerOptions(twistOptions):
+        """
+        Take options obtained from command line and configure options for the
+        application runner.
+        """
+        runnerOptions = {}
 
         for runnerOpt, twistOpt in (
+            (RunnerOptions.reactor, "reactor"),
             (RunnerOptions.defaultLogLevel, "logLevel"),
             (RunnerOptions.logFile, "logFile"),
             (RunnerOptions.fileLogObserverFactory, "fileLogObserverFactory"),
         ):
             runnerOptions[runnerOpt] = twistOptions[twistOpt]
 
-        # Set up application service
+        return runnerOptions
 
-        plugin = twistOptions.loadedPlugins[twistOptions.subCommand]
-        service = plugin.makeService(twistOptions.subOptions)
-        application = Application(plugin.tapname)
-        service.setServiceParent(application)
 
-        # Start the service
+    @staticmethod
+    def run(options):
+        runner = Runner(options)
+        runner.run()
 
-        IService(application).privilegedStartService()
 
-        # Ask the reactor to stop the service before shutting down
+    @classmethod
+    def main(cls, argv=sys.argv):
+        twistOptions = cls.options(argv)
 
-        reactor.addSystemEventTrigger(
-            "before", "shutdown", IService(application).stopService
+        reactor = twistOptions["reactor"]
+        service = cls.service(
+            plugin=twistOptions.loadedPlugins[twistOptions.subCommand],
+            options=twistOptions.subOptions,
         )
 
-        # Instantiate and run the runner
+        cls.startService(reactor, service)
 
-        runner = Runner(runnerOptions)
-        runner.run()
+        cls.run(cls.runnerOptions(twistOptions))
 
 
 

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -1,0 +1,52 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+C{twist} command line tool.
+"""
+
+import sys
+
+from twisted.python.usage import UsageError
+from twisted.logger import Logger
+from ..runner import Runner, RunnerOptions, exit, ExitStatus
+from ._options import TwistOptions
+
+
+
+class Twist(object):
+    """
+    C{twist} command line tool.
+    """
+
+    log = Logger()
+
+
+    @classmethod
+    def main(cls, argv=sys.argv):
+        options = TwistOptions()
+
+        try:
+            options.parseOptions(argv[1:])
+        except UsageError as e:
+            exit(ExitStatus.EX_USAGE, "Error: {}\n\n{}".format(e, options))
+
+        def whenRunning(options):
+            from twisted.internet import reactor
+
+            cls.log.info("Reactor is running: {}".format(reactor))
+            cls.log.info("Stopping reactor...")
+            reactor.stop()
+
+        runner = Runner({
+            RunnerOptions.reactor: options["reactor"],
+            RunnerOptions.logFile: sys.stdout,
+            RunnerOptions.whenRunning: whenRunning,
+        })
+
+        runner.run()
+
+
+
+if __name__ == "__main__":
+    Twist.main()

--- a/twisted/application/twist/_twist.py
+++ b/twisted/application/twist/_twist.py
@@ -138,8 +138,3 @@ class Twist(object):
 
         cls.startService(reactor, service)
         cls.run(cls.runnerOptions(options))
-
-
-
-if __name__ == "__main__":
-    Twist.main()

--- a/twisted/application/twist/test/__init__.py
+++ b/twisted/application/twist/test/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.application.twist}.
+"""

--- a/twisted/application/twist/test/__init__.py
+++ b/twisted/application/twist/test/__init__.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: twisted.application.twist.test -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/twisted/application/twist/test/test_options.py
+++ b/twisted/application/twist/test/test_options.py
@@ -215,6 +215,13 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         L{TwistOptions.selectDefaultLogObserver} will not override an already
         selected observer.
         """
+        class TTYFile(object):
+            def isatty(self):
+                return True
+
+        # stdout may not be a tty, so let's make sure it thinks it is
+        self.patch(_options, "stdout", TTYFile())
+
         options = TwistOptions()
         options.opt_log_file("-")  # stdout, a tty
         options.selectDefaultLogObserver()

--- a/twisted/application/twist/test/test_options.py
+++ b/twisted/application/twist/test/test_options.py
@@ -27,12 +27,17 @@ class OptionsTests(twisted.trial.unittest.TestCase):
     """
 
     def patchExit(self):
-        # Patch exit so we can capture usage and prevent actual exits.
+        """
+        Patch L{_twist.exit} so we can capture usage and prevent actual exits.
+        """
         self.exit = DummyExit()
         self.patch(_options, "exit", self.exit)
 
 
     def patchOpen(self):
+        """
+        Patch L{_options.open} so we can capture usage and prevent actual opens.
+        """
         self.opened = []
 
         def fakeOpen(name, mode=None):
@@ -43,6 +48,10 @@ class OptionsTests(twisted.trial.unittest.TestCase):
 
 
     def patchInstallReactor(self):
+        """
+        Patch C{_options.installReactor} so we can capture usage and prevent
+        actual installs.
+        """
         self.installedReactors = {}
 
         def installReactor(name):
@@ -122,6 +131,12 @@ class OptionsTests(twisted.trial.unittest.TestCase):
 
 
     def _testLogFile(self, name, expectedStream):
+        """
+        Set log file name and check the selected output stream.
+
+        @param name: The name of the file.
+        @param expectedStream: The expected stream.
+        """
         options = TwistOptions()
         options.opt_log_file(name)
 
@@ -155,6 +170,12 @@ class OptionsTests(twisted.trial.unittest.TestCase):
 
 
     def _testLogFormat(self, format, expectedObserver):
+        """
+        Set log file format and check the selected observer.
+
+        @param format: The format of the file.
+        @param expectedObserver: The expected observer.
+        """
         options = TwistOptions()
         options.opt_log_format(format)
 

--- a/twisted/application/twist/test/test_options.py
+++ b/twisted/application/twist/test/test_options.py
@@ -1,0 +1,295 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.application.runner._runner}.
+"""
+
+from sys import stdout, stderr
+
+from twisted.copyright import version
+from twisted.python.usage import UsageError
+from twisted.logger import LogLevel, textFileLogObserver, jsonFileLogObserver
+from ...service import ServiceMaker
+from ...runner import ExitStatus
+from ...runner.test.test_runner import DummyExit
+from ...twist import _options
+from .._options import TwistOptions
+
+import twisted.trial.unittest
+
+
+
+class OptionsTests(twisted.trial.unittest.TestCase):
+    """
+    Tests for L{TwistOptions}.
+    """
+
+    def patchExit(self):
+        # Patch exit so we can capture usage and prevent actual exits.
+        self.exit = DummyExit()
+        self.patch(_options, "exit", self.exit)
+
+
+    def patchOpen(self):
+        self.opened = []
+
+        def fakeOpen(name, mode=None):
+            self.opened.append((name, mode))
+            return NotImplemented
+
+        self.patch(_options, "openFile", fakeOpen)
+
+
+    def test_synopsis(self):
+        """
+        L{TwistOptions.getSynopsis} appends arguments.
+        """
+        options = TwistOptions()
+
+        self.assertTrue(
+            options.getSynopsis().endswith(" plugin [plugin_options]")
+        )
+
+
+    def test_version(self):
+        """
+        L{TwistOptions.opt_version} exits with L{ExitStatus.EX_OK} and prints
+        the version.
+        """
+        self.patchExit()
+
+        options = TwistOptions()
+        options.opt_version()
+
+        self.assertEquals(self.exit.status, ExitStatus.EX_OK)
+        self.assertEquals(self.exit.message, version)
+
+
+    def test_reactor(self):
+        """
+        L{TwistOptions.opt_reactor} sets the reactor name.
+        """
+        options = TwistOptions()
+        options.opt_reactor("fission")
+
+        self.assertEquals(options["reactorName"], "fission")
+
+
+    def test_installReactor(self):
+        """
+        L{TwistOptions.installReactor} installs the chosen reactor.
+        """
+        # Patch installReactor so we can capture usage and prevent installation.
+        installed = []
+        self.patch(
+            _options, "installReactor", lambda name: installed.append(name)
+        )
+
+        options = TwistOptions()
+        options.opt_reactor("fusion")
+        options.installReactor()
+
+        self.assertEqual(installed, ["fusion"])
+
+
+    def test_logLevelValid(self):
+        """
+        L{TwistOptions.opt_log_level} sets the corresponding log level.
+        """
+        options = TwistOptions()
+        options.opt_log_level("warn")
+
+        self.assertIdentical(options["logLevel"], LogLevel.warn)
+
+
+    def test_logLevelInvalid(self):
+        """
+        L{TwistOptions.opt_log_level} with an invalid log level name raises
+        UsageError.
+        """
+        options = TwistOptions()
+
+        self.assertRaises(UsageError, options.opt_log_level, "cheese")
+
+
+    def _testLogFile(self, name, expectedStream):
+        options = TwistOptions()
+        options.opt_log_file(name)
+
+        self.assertIdentical(options["logFile"], expectedStream)
+
+
+    def test_logFileStdout(self):
+        """
+        L{TwistOptions.opt_log_file} given C{"-"} as a file name uses stdout.
+        """
+        self._testLogFile("-", stdout)
+
+
+    def test_logFileStderr(self):
+        """
+        L{TwistOptions.opt_log_file} given C{"+"} as a file name uses stderr.
+        """
+        self._testLogFile("+", stderr)
+
+
+    def test_logFileNamed(self):
+        """
+        L{TwistOptions.opt_log_file} opens the given file name in append mode.
+        """
+        self.patchOpen()
+
+        options = TwistOptions()
+        options.opt_log_file("mylog")
+
+        self.assertEqual([("mylog", "a")], self.opened)
+
+
+    def _testLogFormat(self, format, expectedObserver):
+        options = TwistOptions()
+        options.opt_log_format(format)
+
+        self.assertIdentical(
+            options["fileLogObserverFactory"], expectedObserver
+        )
+        self.assertEqual(options["logFormat"], format)
+
+
+    def test_logFormatText(self):
+        """
+        L{TwistOptions.opt_log_format} given C{"text"} uses a
+        L{textFileLogObserver}.
+        """
+        self._testLogFormat("text", textFileLogObserver)
+
+
+    def test_logFormatJSON(self):
+        """
+        L{TwistOptions.opt_log_format} given C{"text"} uses a
+        L{textFileLogObserver}.
+        """
+        self._testLogFormat("json", jsonFileLogObserver)
+
+
+    def test_logFormatInvalid(self):
+        """
+        L{TwistOptions.opt_log_format} given an invalid format name raises
+        L{UsageError}.
+        """
+        options = TwistOptions()
+
+        self.assertRaises(UsageError, options.opt_log_format, "frommage")
+
+
+    def test_selectDefaultLogObserverNoOverride(self):
+        """
+        L{TwistOptions.selectDefaultLogObserver} will not override an already
+        selected observer.
+        """
+        self.patchOpen()
+
+        options = TwistOptions()
+        options.opt_log_format("text")  # Ask for text
+        options.opt_log_file("queso")   # File, not a tty
+        options.selectDefaultLogObserver()
+
+        # Because we didn't select a file that is a tty, the default is JSON,
+        # but since we asked for text, we should get text.
+        self.assertIdentical(
+            options["fileLogObserverFactory"], textFileLogObserver
+        )
+        self.assertEqual(options["logFormat"], "text")
+
+
+    def test_selectDefaultLogObserverDefaultWithTTY(self):
+        """
+        L{TwistOptions.selectDefaultLogObserver} will not override an already
+        selected observer.
+        """
+        options = TwistOptions()
+        options.opt_log_file("-")  # stdout, a tty
+        options.selectDefaultLogObserver()
+
+        self.assertIdentical(
+            options["fileLogObserverFactory"], textFileLogObserver
+        )
+        self.assertEqual(options["logFormat"], "text")
+
+
+    def test_selectDefaultLogObserverDefaultWithoutTTY(self):
+        """
+        L{TwistOptions.selectDefaultLogObserver} will not override an already
+        selected observer.
+        """
+        self.patchOpen()
+
+        options = TwistOptions()
+        options.opt_log_file("queso")  # File, not a tty
+        options.selectDefaultLogObserver()
+
+        self.assertIdentical(
+            options["fileLogObserverFactory"], jsonFileLogObserver
+        )
+        self.assertEqual(options["logFormat"], "json")
+
+
+    def test_pluginsType(self):
+        """
+        L{TwistOptions.plugins} is a mapping of available plug-ins.
+        """
+        options = TwistOptions()
+        plugins = options.plugins
+
+        for name in plugins:
+            self.assertIsInstance(name, str)
+            self.assertIsInstance(plugins[name], ServiceMaker)
+
+
+    def test_pluginsIncludeWeb(self):
+        """
+        L{TwistOptions.plugins} includes a C{"web"} plug-in.
+        This is an attempt to verify that something we expect to be in the list
+        is in there without enumerating all of the built-in plug-ins.
+        """
+        options = TwistOptions()
+
+        self.assertIn("web", options.plugins)
+
+
+    def test_subCommandsType(self):
+        """
+        L{TwistOptions.subCommands} is an iterable of tuples as expected by
+        L{twisted.python.usage.Options}.
+        """
+        options = TwistOptions()
+
+        for name, shortcut, parser, doc in options.subCommands:
+            self.assertIsInstance(name, str)
+            self.assertIdentical(shortcut, None)
+            self.assertTrue(callable(parser))
+            self.assertIsInstance(doc, str)
+
+
+    def test_subCommandsIncludeWeb(self):
+        """
+        L{TwistOptions.subCommands} includes a sub-command for every plug-in.
+        """
+        options = TwistOptions()
+
+        plugins = set(options.plugins)
+        subCommands = set(
+            name for name, shortcut, parser, doc in options.subCommands
+        )
+
+        self.assertEqual(subCommands, plugins)
+
+
+    def test_postOptionsNoSubCommand(self):
+        """
+        L{TwistOptions.postOptions} raises L{UsageError} is it has no
+        sub-command.
+        """
+        options = TwistOptions()
+
+        self.assertRaises(UsageError, options.postOptions)

--- a/twisted/application/twist/test/test_options.py
+++ b/twisted/application/twist/test/test_options.py
@@ -13,7 +13,7 @@ from twisted.logger import LogLevel, textFileLogObserver, jsonFileLogObserver
 from twisted.test.proto_helpers import MemoryReactor
 from ...reactors import NoSuchReactor
 from ...service import ServiceMaker
-from ...runner import ExitStatus
+from ...runner._exit import ExitStatus
 from ...runner.test.test_runner import DummyExit
 from ...twist import _options
 from .._options import TwistOptions

--- a/twisted/application/twist/test/test_options.py
+++ b/twisted/application/twist/test/test_options.py
@@ -11,6 +11,7 @@ from twisted.copyright import version
 from twisted.python.usage import UsageError
 from twisted.logger import LogLevel, textFileLogObserver, jsonFileLogObserver
 from twisted.test.proto_helpers import MemoryReactor
+from ...reactors import NoSuchReactor
 from ...service import ServiceMaker
 from ...runner import ExitStatus
 from ...runner.test.test_runner import DummyExit
@@ -55,6 +56,9 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         self.installedReactors = {}
 
         def installReactor(name):
+            if name != "fusion":
+                raise NoSuchReactor()
+
             reactor = MemoryReactor()
             self.installedReactors[name] = reactor
             return reactor
@@ -108,6 +112,19 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         options.installReactor()
 
         self.assertEqual(set(self.installedReactors), set(["fusion"]))
+
+
+    def test_installReactorBogus(self):
+        """
+        L{TwistOptions.installReactor} raises UsageError if an unknown reactor
+        is specified.
+        """
+        self.patchInstallReactor()
+
+        options = TwistOptions()
+        options.opt_reactor("coal")
+
+        self.assertRaises(UsageError, options.installReactor)
 
 
     def test_logLevelValid(self):

--- a/twisted/application/twist/test/test_twist.py
+++ b/twisted/application/twist/test/test_twist.py
@@ -7,7 +7,7 @@ Tests for L{twisted.application.twist._twist}.
 
 from sys import stdout
 
-from twisted.logger import LogLevel, textFileLogObserver
+from twisted.logger import LogLevel, jsonFileLogObserver
 from twisted.test.proto_helpers import MemoryReactor
 from ...service import IService, MultiService
 from ...runner import ExitStatus, Runner, RunnerOptions
@@ -118,7 +118,9 @@ class TwistTests(twisted.trial.unittest.TestCase):
         L{Twist.runnerOptions} translates L{TwistOptions} to a L{RunnerOptions}
         map.
         """
-        options = Twist.options(["twist", "--reactor", "default", "web"])
+        options = Twist.options([
+            "twist", "--reactor=default", "--log-format=json", "web"
+        ])
 
         self.assertEqual(
             Twist.runnerOptions(options),
@@ -126,7 +128,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
                 RunnerOptions.reactor: self.installedReactors["default"],
                 RunnerOptions.defaultLogLevel: LogLevel.info,
                 RunnerOptions.logFile: stdout,
-                RunnerOptions.fileLogObserverFactory: textFileLogObserver,
+                RunnerOptions.fileLogObserverFactory: jsonFileLogObserver,
             }
         )
 
@@ -168,7 +170,9 @@ class TwistTests(twisted.trial.unittest.TestCase):
 
         self.patch(_twist, "Runner", Runner)
 
-        Twist.main(["twist", "--reactor", "default", "web"])
+        Twist.main([
+            "twist", "--reactor=default", "--log-format=json", "web"
+        ])
 
         self.assertEqual(len(self.serviceStarts), 1)
         self.assertEqual(len(runners), 1)
@@ -178,7 +182,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
                 RunnerOptions.reactor: self.installedReactors["default"],
                 RunnerOptions.defaultLogLevel: LogLevel.info,
                 RunnerOptions.logFile: stdout,
-                RunnerOptions.fileLogObserverFactory: textFileLogObserver,
+                RunnerOptions.fileLogObserverFactory: jsonFileLogObserver,
             }
         )
         self.assertEqual(runners[0].runs, 1)

--- a/twisted/application/twist/test/test_twist.py
+++ b/twisted/application/twist/test/test_twist.py
@@ -10,7 +10,8 @@ from sys import stdout
 from twisted.logger import LogLevel, jsonFileLogObserver
 from twisted.test.proto_helpers import MemoryReactor
 from ...service import IService, MultiService
-from ...runner import ExitStatus, Runner, RunnerOptions
+from ...runner._exit import ExitStatus
+from ...runner._runner import Runner, RunnerOptions
 from ...runner.test.test_runner import DummyExit
 from ...twist import _options, _twist
 from .._options import TwistOptions

--- a/twisted/application/twist/test/test_twist.py
+++ b/twisted/application/twist/test/test_twist.py
@@ -1,0 +1,131 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.application.twist._twist}.
+"""
+
+from sys import stdout
+
+from twisted.logger import LogLevel, textFileLogObserver
+from twisted.test.proto_helpers import MemoryReactor
+from ...service import IService
+from ...runner import ExitStatus, Runner, RunnerOptions
+from ...runner.test.test_runner import DummyExit
+from ...twist import _options, _twist
+from .._options import TwistOptions
+from .._twist import Twist
+
+import twisted.trial.unittest
+
+
+
+class TwistTests(twisted.trial.unittest.TestCase):
+    """
+    Tests for L{Twist}.
+    """
+
+    def setUp(self):
+        self.patchInstallReactor()
+
+
+    def patchExit(self):
+        # Patch exit so we can capture usage and prevent actual exits.
+        self.exit = DummyExit()
+        self.patch(_twist, "exit", self.exit)
+
+
+    def patchInstallReactor(self):
+        self.installedReactors = {}
+
+        def installReactor(name):
+            reactor = MemoryReactor()
+            self.installedReactors[name] = reactor
+            return reactor
+
+        self.patch(_options, "installReactor", installReactor)
+
+
+    def test_optionsValidArguments(self):
+        """
+        L{Twist.options} given valid arguments returns options.
+        """
+        options = Twist.options(["twist", "web"])
+
+        self.assertIsInstance(options, TwistOptions)
+
+
+    def test_optionsInvalidArguments(self):
+        """
+        L{Twist.options} given invalid arguments exits with
+        L{ExitStatus.EX_USAGE} and an error/usage message.
+        """
+        self.patchExit()
+
+        Twist.options(["twist", "--bogus-bagels"])
+
+        self.assertIdentical(self.exit.status, ExitStatus.EX_USAGE)
+        self.assertTrue(self.exit.message.startswith("Error: "))
+        self.assertTrue(self.exit.message.endswith(
+            "\n\n{}".format(TwistOptions())
+        ))
+
+
+    def test_service(self):
+        """
+        L{Twist.service} returns an L{IService}.
+        """
+        options = TwistOptions()
+        options.parseOptions(["web"])  # web should exist
+
+        service = Twist.service(options.plugins["web"], options.subOptions)
+        self.assertTrue(IService.providedBy(service))
+
+
+    def test_startService(self):
+        raise NotImplementedError()
+    test_startService.todo = "unimplemented"
+
+
+    def test_runnerOptions(self):
+        """
+        L{Twist.runnerOptions} translates L{TwistOptions} to a L{RunnerOptions}
+        map.
+        """
+        options = Twist.options([
+            "twist",
+            "--reactor", "default",
+            "web"
+        ])
+
+        self.assertEqual(
+            Twist.runnerOptions(options),
+            {
+                RunnerOptions.reactor: self.installedReactors["default"],
+                RunnerOptions.defaultLogLevel: LogLevel.info,
+                RunnerOptions.logFile: stdout,
+                RunnerOptions.fileLogObserverFactory: textFileLogObserver,
+            }
+        )
+
+
+    def test_run(self):
+        """
+        L{Twist.run} run the runner with the given options.
+        """
+        options = TwistOptions()
+        runner = Runner(options)
+
+        optionsSeen = []
+
+        self.patch(Runner, "run", lambda self: optionsSeen.append(self.options))
+
+        runner.run()
+
+        self.assertEqual(len(optionsSeen), 1)
+        self.assertIdentical(optionsSeen[0], options)
+
+
+    def test_mainRunner(self):
+        raise NotImplementedError()
+    test_mainRunner.todo = "unimplemented"

--- a/twisted/application/twist/test/test_twist.py
+++ b/twisted/application/twist/test/test_twist.py
@@ -30,12 +30,18 @@ class TwistTests(twisted.trial.unittest.TestCase):
 
 
     def patchExit(self):
-        # Patch exit so we can capture usage and prevent actual exits.
+        """
+        Patch L{_twist.exit} so we can capture usage and prevent actual exits.
+        """
         self.exit = DummyExit()
         self.patch(_twist, "exit", self.exit)
 
 
     def patchInstallReactor(self):
+        """
+        Patch C{_options.installReactor} so we can capture usage and prevent
+        actual installs.
+        """
         self.installedReactors = {}
 
         def installReactor(name):
@@ -47,6 +53,10 @@ class TwistTests(twisted.trial.unittest.TestCase):
 
 
     def patchStartService(self):
+        """
+        Patch L{MultiService.startService} so we can capture usage and prevent
+        actual starts.
+        """
         self.serviceStarts = []
 
         def startService(service):
@@ -142,7 +152,9 @@ class TwistTests(twisted.trial.unittest.TestCase):
 
         optionsSeen = []
 
-        self.patch(Runner, "run", lambda self: optionsSeen.append(self.options))
+        self.patch(
+            Runner, "run", lambda self: optionsSeen.append(self.options)
+        )
 
         runner.run()
 

--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -422,6 +422,8 @@ class MemoryReactor(object):
         """
         Initialize the tracking lists.
         """
+        self.hasInstalled = False
+
         self.running = False
         self.hasRun = True
         self.hasStopped = True
@@ -441,6 +443,13 @@ class MemoryReactor(object):
 
         self.readers = set()
         self.writers = set()
+
+
+    def install(self):
+        """
+        Fake install callable to emulate reactor module installation.
+        """
+        self.hasInstalled = True
 
 
     def resolve(self, name, timeout=10):

--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -387,34 +387,54 @@ class MemoryReactor(object):
     much that's useful yet.  It accepts TCP connection setup attempts, but
     they will never succeed.
 
-    @ivar tcpClients: a list that keeps track of connection attempts (ie, calls
-        to C{connectTCP}).
-    @type tcpClients: C{list}
+    @ivar hasInstalled: Keeps track of whether this reactor has been installed.
+    @type hasInstalled: L{bool}
 
-    @ivar tcpServers: a list that keeps track of server listen attempts (ie,
-        calls to C{listenTCP}).
-    @type tcpServers: C{list}
+    @ivar running: Keeps track of whether this reactor is running.
+    @type running: L{bool}
 
-    @ivar sslClients: a list that keeps track of connection attempts (ie,
-        calls to C{connectSSL}).
-    @type sslClients: C{list}
+    @ivar hasStopped: Keeps track of whether this reactor has been stopped.
+    @type hasStopped: L{bool}
 
-    @ivar sslServers: a list that keeps track of server listen attempts (ie,
-        calls to C{listenSSL}).
-    @type sslServers: C{list}
+    @ivar hasCrashed: Keeps track of whether this reactor has crashed.
+    @type hasCrashed: L{bool}
 
-    @ivar unixClients: a list that keeps track of connection attempts (ie,
-        calls to C{connectUNIX}).
-    @type unixClients: C{list}
+    @ivar whenRunningHooks: Keeps track of hooks registered with
+        C{callWhenRunning}.
+    @type whenRunningHooks: L{list}
 
-    @ivar unixServers: a list that keeps track of server listen attempts (ie,
-        calls to C{listenUNIX}).
-    @type unixServers: C{list}
+    @ivar triggers: Keeps track of hooks registered with
+        C{addSystemEventTrigger}.
+    @type triggers: L{dict}
 
-    @ivar adoptedPorts: a list that keeps track of server listen attempts (ie,
-        calls to C{adoptStreamPort}).
+    @ivar tcpClients: Keeps track of connection attempts (ie, calls to
+        C{connectTCP}).
+    @type tcpClients: L{list}
 
-    @ivar adoptedStreamConnections: a list that keeps track of stream-oriented
+    @ivar tcpServers: Keeps track of server listen attempts (ie, calls to
+        C{listenTCP}).
+    @type tcpServers: L{list}
+
+    @ivar sslClients: Keeps track of connection attempts (ie, calls to
+        C{connectSSL}).
+    @type sslClients: L{list}
+
+    @ivar sslServers: Keeps track of server listen attempts (ie, calls to
+        C{listenSSL}).
+    @type sslServers: L{list}
+
+    @ivar unixClients: Keeps track of connection attempts (ie, calls to
+        C{connectUNIX}).
+    @type unixClients: L{list}
+
+    @ivar unixServers: Keeps track of server listen attempts (ie, calls to
+        C{listenUNIX}).
+    @type unixServers: L{list}
+
+    @ivar adoptedPorts: Keeps track of server listen attempts (ie, calls to
+        C{adoptStreamPort}).
+
+    @ivar adoptedStreamConnections: Keeps track of stream-oriented
         connections added using C{adoptStreamConnection}.
     """
 
@@ -561,8 +581,9 @@ class MemoryReactor(object):
 
         @see: L{twisted.internet.interfaces.IReactorSocket.adoptStreamConnection}
         """
-        self.adoptedStreamConnections.append((
-                fileDescriptor, addressFamily, factory))
+        self.adoptedStreamConnections.append(
+            (fileDescriptor, addressFamily, factory)
+        )
 
 
     def adoptDatagramPort(self, fileno, addressFamily, protocol,

--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -483,10 +483,10 @@ class MemoryReactor(object):
     def run(self):
         """
         Fake L{IReactorCore.run}.
-        Sets L{self.running} to L{True}, runs all of the hooks passed to
-        L{self.callWhenRunning}, then calls L{self.stop} to simulate a request
+        Sets C{self.running} to L{True}, runs all of the hooks passed to
+        C{self.callWhenRunning}, then calls C{self.stop} to simulate a request
         to stop the reactor.
-        Sets L{self.hasRun} to L{True}.
+        Sets C{self.hasRun} to L{True}.
         """
         assert self.running is False
         self.running = True
@@ -502,8 +502,8 @@ class MemoryReactor(object):
     def stop(self):
         """
         Fake L{IReactorCore.run}.
-        Sets L{self.running} to L{False}.
-        Sets L{self.hasStopped} to L{True}.
+        Sets C{self.running} to L{False}.
+        Sets C{self.hasStopped} to L{True}.
         """
         self.running = False
         self.hasStopped = True
@@ -512,8 +512,8 @@ class MemoryReactor(object):
     def crash(self):
         """
         Fake L{IReactorCore.crash}.
-        Sets L{self.running} to L{None}, because that feels crashy.
-        Sets L{self.hasCrashed} to L{True}.
+        Sets C{self.running} to L{None}, because that feels crashy.
+        Sets C{self.hasCrashed} to L{True}.
         """
         self.running = None
         self.hasCrashed = True
@@ -554,7 +554,7 @@ class MemoryReactor(object):
     def callWhenRunning(self, callable, *args, **kw):
         """
         Fake L{IReactorCore.callWhenRunning}.
-        Keeps a list of invocations to make in L{self.whenRunningHooks}.
+        Keeps a list of invocations to make in C{self.whenRunningHooks}.
         """
         self.whenRunningHooks.append((callable, args, kw))
 

--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -430,6 +430,7 @@ class MemoryReactor(object):
         self.hasCrashed = True
 
         self.whenRunningHooks = []
+        self.triggers = {}
 
         self.tcpClients = []
         self.tcpServers = []
@@ -514,9 +515,13 @@ class MemoryReactor(object):
 
     def addSystemEventTrigger(self, phase, eventType, callable, *args, **kw):
         """
-        Not implemented; raises L{NotImplementedError}.
+        Fake L{IReactorCore.run}.
+        Keep track of trigger by appending it to
+        self.triggers[phase][eventType].
         """
-        raise NotImplementedError()
+        phaseTriggers = self.triggers.setdefault(phase, {})
+        eventTypeTriggers = phaseTriggers.setdefault(eventType, [])
+        eventTypeTriggers.append((callable, args, kw))
 
 
     def removeSystemEventTrigger(self, triggerID):

--- a/twisted/test/proto_helpers.py
+++ b/twisted/test/proto_helpers.py
@@ -581,9 +581,8 @@ class MemoryReactor(object):
 
         @see: L{twisted.internet.interfaces.IReactorSocket.adoptStreamConnection}
         """
-        self.adoptedStreamConnections.append(
-            (fileDescriptor, addressFamily, factory)
-        )
+        self.adoptedStreamConnections.append((
+                fileDescriptor, addressFamily, factory))
 
 
     def adoptDatagramPort(self, fileno, addressFamily, protocol,

--- a/twisted/topfiles/5705.feature
+++ b/twisted/topfiles/5705.feature
@@ -1,0 +1,2 @@
+Add twisted.application.twist, meant to eventually replace twistd with a simpler interface.
+Add twisted.application.runner API, currently private, which twist is built on.


### PR DESCRIPTION
Introduce new command line runner for Twisted: `twist`: https://twistedmatrix.com/trac/ticket/5705.

```
Usage: twist [options] plugin [plugin_options]
Options:
      --log-level=   Set default log level. (options: "debug", "info", "warn",
                     "error", "critical"; default: "info")
      --help         Display this help and exit.
      --version      Print version and exit.
      --log-format=  Log file format. (options: "text", "json"; default: "text"
                     if the log file is a tty, otherwise "json")
      --log-file=    Log to file. ("-" for stdout, "+" for stderr; default: "-")
      --reactor=     The name of the reactor to use. (options: "win32", "gi",
                     "kqueue", "poll", "iocp", "select", "epoll", "gtk2",
                     "gtk3", "wx", "default", "cf", "glib2")

Run a Twisted application.
Commands:
    conch            A Conch SSH service.
    dns              A domain name server.
    ftp              An FTP server.
    inetd            An inetd(8) replacement.
    mail             An email service
    manhole          An interactive remote debugger service accessible via
                     telnet and ssh and providing syntax coloring and basic line
                     editing functionality.
    news             A news server.
    portforward      A simple port-forwarder.
    procmon          A process watchdog / supervisor
    socks            A SOCKSv4 proxy service.
    web              A general-purpose web server which can serve from a
                     filesystem or application resource.
    words            A modern words server
    xmpp-router      An XMPP Router server
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/twisted/134)

<!-- Reviewable:end -->
