### PR TITLE
Do not check for topfiles if current git HEAD has no diffs from trunk (#8417)

### DIFF
--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -1081,12 +1081,14 @@ class CheckTopfileScript(object):
         branch = runCommand([b"git", b"rev-parse", b"--abbrev-ref",  "HEAD"],
                             cwd=location).strip()
 
-        if branch == "trunk":
-            self._print("On trunk, no need to look at this.")
+        r = runCommand([b"git", b"diff", b"--name-only", b"origin/trunk..."],
+                       cwd=location).strip()
+
+        if not r:
+            self._print(
+                "On trunk or no diffs from trunk; no need to look at this.")
             sys.exit(0)
 
-        r = runCommand([b"git", b"diff", b"--name-only", b"origin/trunk..."],
-                       cwd=location)
         files = r.strip().split(os.linesep)
 
         self._print("Looking at these files:")

--- a/twisted/python/test/test_release.py
+++ b/twisted/python/test/test_release.py
@@ -1792,7 +1792,7 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
         self.assertEqual(e.exception.args,
                          ("Must specify one argument: the Twisted checkout",))
 
-    def test_diff_from_from_trunk_no_topfiles(self):
+    def test_diffFromTrunkNoTopfiles(self):
         """
         If there are changes from trunk, then there should also be a topfile.
         """
@@ -1815,7 +1815,7 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
         self.assertEqual(logs[-1], "No topfile found. Have you committed it?")
 
 
-    def test_no_change_from_trunk(self):
+    def test_noChangeFromTrunk(self):
         """
         If there are no changes from trunk, then no need to check the topfiles
         """

--- a/twisted/python/test/test_release.py
+++ b/twisted/python/test/test_release.py
@@ -1792,12 +1792,18 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
         self.assertEqual(e.exception.args,
                          ("Must specify one argument: the Twisted checkout",))
 
-
-    def test_nothing(self):
+    def test_diff_from_from_trunk_no_topfiles(self):
         """
-        No topfiles means a failure.
+        If there are changes from trunk, then there should also be a topfile.
         """
         runCommand(["git", "checkout", "-b", "mypatch"],
+                   cwd=self.repo.path)
+        somefile = self.repo.child("somefile")
+        somefile.setContent(b"change")
+
+        runCommand(["git", "add", somefile.path, somefile.path],
+                   cwd=self.repo.path)
+        runCommand(["git", "commit", "-m", "some file"],
                    cwd=self.repo.path)
 
         logs = []
@@ -1807,6 +1813,24 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
 
         self.assertEqual(e.exception.args, (1,))
         self.assertEqual(logs[-1], "No topfile found. Have you committed it?")
+
+
+    def test_no_change_from_trunk(self):
+        """
+        If there are no changes from trunk, then no need to check the topfiles
+        """
+        runCommand(["git", "checkout", "-b", "mypatch"],
+                   cwd=self.repo.path)
+
+        logs = []
+
+        with self.assertRaises(SystemExit) as e:
+            CheckTopfileScript(logs.append).main([self.repo.path])
+
+        self.assertEqual(e.exception.args, (0,))
+        self.assertEqual(
+            logs[-1],
+            "On trunk or no diffs from trunk; no need to look at this.")
 
 
     def test_trunk(self):
@@ -1819,14 +1843,25 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
             CheckTopfileScript(logs.append).main([self.repo.path])
 
         self.assertEqual(e.exception.args, (0,))
-        self.assertEqual(logs[-1], "On trunk, no need to look at this.")
+        self.assertEqual(
+            logs[-1],
+            "On trunk or no diffs from trunk; no need to look at this.")
 
 
     def test_release(self):
         """
-        Running it on a release branch returns green if there is no topfiles.
+        Running it on a release branch returns green if there is no topfiles
+        even if there are changes.
         """
         runCommand(["git", "checkout", "-b", "release-16.11111-9001"],
+                   cwd=self.repo.path)
+
+        somefile = self.repo.child("somefile")
+        somefile.setContent(b"change")
+
+        runCommand(["git", "add", somefile.path, somefile.path],
+                   cwd=self.repo.path)
+        runCommand(["git", "commit", "-m", "some file"],
                    cwd=self.repo.path)
 
         logs = []
@@ -1898,7 +1933,8 @@ class CheckTopfileScriptTests(ExternalTempdirTestCase):
 
     def test_topfileAdded(self):
         """
-        Running it on a branch with a fragment added returns green.
+        Running it on a branch with a fragment in the topfiles dir added
+        returns green.
         """
         runCommand(["git", "checkout", "-b", "quotefile"],
                    cwd=self.repo.path)


### PR DESCRIPTION
This hopefully fixes http://twistedmatrix.com/trac/ticket/8417.

Travis-CI builds commits, probably with detached heads, so the branch isn't `trunk` even if it is testing the latest merge to `trunk`.  (for instance, see https://travis-ci.org/twisted/twisted/jobs/135185494)

So just modify the check so that if there is no diff from origin/head, we don't check for topfiles.  This should allow PRs from forks to also succeed, I think.

I tested the check manually before committing, so that I was on a different branch but there was no (committed) change from origin/trunk, and the checker did not seem to error.
