### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/words

### DIFF
--- a/twisted/words/im/ircsupport.py
+++ b/twisted/words/im/ircsupport.py
@@ -12,7 +12,7 @@ from twisted.words.im.locals import ONLINE
 from twisted.internet import defer, reactor, protocol
 from twisted.internet.defer import succeed
 from twisted.words.im import basesupport, interfaces, locals
-from zope.interface import implements
+from zope.interface import implementer
 
 
 class IRCPerson(basesupport.AbstractPerson):
@@ -44,10 +44,8 @@ class IRCPerson(basesupport.AbstractPerson):
                 self.account.client.msg(self.name, line)
         return succeed(text)
 
+@implementer(interfaces.IGroup)
 class IRCGroup(basesupport.AbstractGroup):
-
-    implements(interfaces.IGroup)
-
     def imgroup_testAction(self):
         pass
 
@@ -241,8 +239,8 @@ class IRCProto(basesupport.AbstractClientMixin, irc.IRCClient):
         self.join(name)
         self.getGroupConversation(name)
 
+@implementer(interfaces.IAccount)
 class IRCAccount(basesupport.AbstractAccount):
-    implements(interfaces.IAccount)
     gatewayType = "IRC"
 
     _groupFactory = IRCGroup

--- a/twisted/words/im/pbsupport.py
+++ b/twisted/words/im/pbsupport.py
@@ -17,7 +17,7 @@ from twisted.spread import pb
 from twisted.words.im.locals import ONLINE, OFFLINE, AWAY
 
 from twisted.words.im import basesupport, interfaces
-from zope.interface import implements
+from zope.interface import implementer
 
 
 class TwistedWordsPerson(basesupport.AbstractPerson):
@@ -53,8 +53,8 @@ class TwistedWordsPerson(basesupport.AbstractPerson):
         self.status = status
         self.chat.getContactsList().setContactStatus(self)
 
+@implementer(interfaces.IGroup)
 class TwistedWordsGroup(basesupport.AbstractGroup):
-    implements(interfaces.IGroup)
     def __init__(self, name, wordsClient):
         basesupport.AbstractGroup.__init__(self, name, wordsClient)
         self.joined = 0
@@ -182,8 +182,8 @@ pbFrontEnds = {
     }
 
 
+@implementer(interfaces.IAccount)
 class PBAccount(basesupport.AbstractAccount):
-    implements(interfaces.IAccount)
     gatewayType = "PB"
     _groupFactory = TwistedWordsGroup
     _personFactory = TwistedWordsPerson

--- a/twisted/words/protocols/jabber/component.py
+++ b/twisted/words/protocols/jabber/component.py
@@ -18,7 +18,7 @@ ServiceManager connects to the Jabber server and is responsible for the
 corresponding XML stream.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 from twisted.internet import defer
@@ -195,12 +195,11 @@ class ListenComponentAuthenticator(xmlstream.ListenAuthenticator):
 
 
 
+@implementer(ijabber.IService)
 class Service(service.Service):
     """
     External server-side component service.
     """
-
-    implements(ijabber.IService)
 
     def componentConnected(self, xs):
         pass

--- a/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -10,7 +10,7 @@ Protocol agnostic implementations of SASL authentication mechanisms.
 import binascii, random, time, os
 from hashlib import md5
 
-from zope.interface import Interface, Attribute, implements
+from zope.interface import Interface, Attribute, implementer
 
 
 class ISASLMechanism(Interface):
@@ -37,13 +37,13 @@ class ISASLMechanism(Interface):
 
 
 
+@implementer(ISASLMechanism)
 class Anonymous(object):
     """
     Implements the ANONYMOUS SASL authentication mechanism.
 
     This mechanism is defined in RFC 2245.
     """
-    implements(ISASLMechanism)
     name = 'ANONYMOUS'
 
     def getInitialResponse(self):
@@ -51,14 +51,13 @@ class Anonymous(object):
 
 
 
+@implementer(ISASLMechanism)
 class Plain(object):
     """
     Implements the PLAIN SASL authentication mechanism.
 
     The PLAIN SASL authentication mechanism is defined in RFC 2595.
     """
-    implements(ISASLMechanism)
-
     name = 'PLAIN'
 
     def __init__(self, authzid, authcid, password):
@@ -74,14 +73,13 @@ class Plain(object):
 
 
 
+@implementer(ISASLMechanism)
 class DigestMD5(object):
     """
     Implements the DIGEST-MD5 SASL authentication mechanism.
 
     The DIGEST-MD5 SASL authentication mechanism is defined in RFC 2831.
     """
-    implements(ISASLMechanism)
-
     name = 'DIGEST-MD5'
 
     def __init__(self, serv_type, host, serv_name, username, password):

--- a/twisted/words/protocols/jabber/xmlstream.py
+++ b/twisted/words/protocols/jabber/xmlstream.py
@@ -12,7 +12,7 @@ Stanzas.
 """
 
 from hashlib import sha1
-from zope.interface import directlyProvides, implements
+from zope.interface import directlyProvides, implementer
 
 from twisted.internet import defer, protocol
 from twisted.internet.error import ConnectionLost
@@ -291,6 +291,7 @@ class FeatureNotAdvertized(Exception):
 
 
 
+@implementer(ijabber.IInitiatingInitializer)
 class BaseFeatureInitiatingInitializer(object):
     """
     Base class for initializers with a stream feature.
@@ -304,8 +305,6 @@ class BaseFeatureInitiatingInitializer(object):
                     by the receiving entity.
     @type required: C{bool}
     """
-
-    implements(ijabber.IInitiatingInitializer)
 
     feature = None
     required = False
@@ -863,6 +862,7 @@ def toResponse(stanza, stanzaType=None):
 
 
 
+@implementer(ijabber.IXMPPHandler)
 class XMPPHandler(object):
     """
     XMPP protocol handler.
@@ -870,8 +870,6 @@ class XMPPHandler(object):
     Classes derived from this class implement (part of) one or more XMPP
     extension protocols, and are referred to as a subprotocol implementation.
     """
-
-    implements(ijabber.IXMPPHandler)
 
     def __init__(self):
         self.parent = None
@@ -939,6 +937,7 @@ class XMPPHandler(object):
 
 
 
+@implementer(ijabber.IXMPPHandlerCollection)
 class XMPPHandlerCollection(object):
     """
     Collection of XMPP subprotocol handlers.
@@ -950,9 +949,6 @@ class XMPPHandlerCollection(object):
     @type handlers: C{list} of objects providing
                       L{IXMPPHandler}
     """
-
-    implements(ijabber.IXMPPHandlerCollection)
-
     def __init__(self):
         self.handlers = []
 

--- a/twisted/words/protocols/jabber/xmpp_stringprep.py
+++ b/twisted/words/protocols/jabber/xmpp_stringprep.py
@@ -12,7 +12,7 @@ from unicodedata import ucd_3_2_0 as unicodedata
 from twisted.python.versions import Version
 from twisted.python.deprecate import deprecatedModuleAttribute
 
-from zope.interface import Interface, implements
+from zope.interface import Interface, implementer
 
 
 crippled = False
@@ -48,19 +48,15 @@ class IMappingTable(Interface):
 
 
 
+@implementer(ILookupTable)
 class LookupTableFromFunction:
-
-    implements(ILookupTable)
-
     def __init__(self, in_table_function):
         self.lookup = in_table_function
 
 
 
+@implementer(ILookupTable)
 class LookupTable:
-
-    implements(ILookupTable)
-
     def __init__(self, table):
         self._table = table
 
@@ -69,19 +65,15 @@ class LookupTable:
 
 
 
+@implementer(IMappingTable)
 class MappingTableFromFunction:
-
-    implements(IMappingTable)
-
     def __init__(self, map_table_function):
         self.map = map_table_function
 
 
 
+@implementer(IMappingTable)
 class EmptyMappingTable:
-
-    implements(IMappingTable)
-
     def __init__(self, in_table_function):
         self._in_table_function = in_table_function
 

--- a/twisted/words/service.py
+++ b/twisted/words/service.py
@@ -29,7 +29,7 @@ How does this thing work?
 
 from time import time, ctime
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.words import iwords, ewords
 
@@ -42,9 +42,8 @@ from twisted.python import log, failure, reflect
 from twisted import copyright
 
 
+@implementer(iwords.IGroup)
 class Group(object):
-    implements(iwords.IGroup)
-
     def __init__(self, name):
         self.name = name
         self.users = {}
@@ -128,9 +127,8 @@ class Group(object):
         return iter(self.users.values())
 
 
+@implementer(iwords.IUser)
 class User(object):
-    implements(iwords.IUser)
-
     realm = None
     mind = None
 
@@ -177,12 +175,11 @@ class User(object):
 NICKSERV = 'NickServ!NickServ@services'
 
 
+@implementer(iwords.IChatClient)
 class IRCUser(irc.IRC):
     """
     Protocol instance representing an IRC user connected to the server.
     """
-    implements(iwords.IChatClient)
-
     # A list of IGroups in which I am participating
     groups = None
 
@@ -912,9 +909,8 @@ class PBMind(pb.Referenceable):
         pass
 
 
+@implementer(iwords.IChatClient)
 class PBMindReference(pb.RemoteReference):
-    implements(iwords.IChatClient)
-
     def receive(self, sender, recipient, message):
         if iwords.IGroup.providedBy(recipient):
             rec = PBGroup(self.realm, self.avatar, recipient)
@@ -971,9 +967,8 @@ class PBGroup(pb.Referenceable):
         return self.avatar.send(self.group, message)
 
 
+@implementer(iwords.IGroup)
 class PBGroupReference(pb.RemoteReference):
-    implements(iwords.IGroup)
-
     def unjellyFor(self, unjellier, unjellyList):
         clsName, name, ref = unjellyList
         self.name = name.decode('utf-8')
@@ -996,9 +991,8 @@ class PBUser(pb.Referenceable):
         return hash((self.realm.name, self.avatar.name, self.user.name))
 
 
+@implementer(iwords.IChatClient)
 class ChatAvatar(pb.Referenceable):
-    implements(iwords.IChatClient)
-
     def __init__(self, avatar):
         self.avatar = avatar
 
@@ -1033,9 +1027,8 @@ class AvatarReference(pb.RemoteReference):
 pb.setUnjellyableForClass(ChatAvatar, AvatarReference)
 
 
+@implementer(portal.IRealm, iwords.IChatService)
 class WordsRealm(object):
-    implements(portal.IRealm, iwords.IChatService)
-
     _encoding = 'utf-8'
 
     def __init__(self, name):

--- a/twisted/words/test/test_jabbersasl.py
+++ b/twisted/words/test/test_jabbersasl.py
@@ -1,7 +1,7 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet import defer
 from twisted.trial import unittest
 from twisted.words.protocols.jabber import sasl, sasl_mechanisms, xmlstream, jid
@@ -9,6 +9,7 @@ from twisted.words.xish import domish
 
 NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl'
 
+@implementer(sasl_mechanisms.ISASLMechanism)
 class DummySASLMechanism(object):
     """
     Dummy SASL mechanism.
@@ -22,9 +23,6 @@ class DummySASLMechanism(object):
                            via C{getInitialResponse} or C{None}.
     @type initialResponse: C{unicode}
     """
-
-    implements(sasl_mechanisms.ISASLMechanism)
-
     challenge = None
     name = "DUMMY"
 

--- a/twisted/words/xish/domish.py
+++ b/twisted/words/xish/domish.py
@@ -12,7 +12,7 @@ for use in streaming XML applications.
 
 import types
 
-from zope.interface import implements, Interface, Attribute
+from zope.interface import implementer, Interface, Attribute
 
 def _splitPrefix(name):
     """ Internal method for splitting a prefixed Element name into its
@@ -284,6 +284,7 @@ class IElement(Interface):
         @type node: C{unicode} or object implementing L{IElement}
         """
 
+@implementer(IElement)
 class Element(object):
     """ Represents an XML element node.
 
@@ -382,9 +383,6 @@ class Element(object):
                          element. The key is the prefix to bind the
                          namespace uri to.
     """
-
-    implements(IElement)
-
     _idCounter = 0
 
     def __init__(self, qname, defaultUri=None, attribs=None,


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8425

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
