### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/test

### DIFF
--- a/twisted/test/crash_test_dummy.py
+++ b/twisted/test/crash_test_dummy.py
@@ -4,7 +4,7 @@
 
 
 from twisted.python import components
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 def foo():
     return 2
@@ -24,9 +24,8 @@ class XComponent(components.Componentized):
 class IX(Interface):
     pass
 
+@implementer(IX)
 class XA(components.Adapter):
-    implements(IX)
-
     def method(self):
         # Kick start :(
         pass

--- a/twisted/test/test_ftp.py
+++ b/twisted/test/test_ftp.py
@@ -10,7 +10,7 @@ import errno
 from StringIO import StringIO
 import getpass
 
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface.verify import verifyClass
 
 from twisted.trial import unittest
@@ -3288,6 +3288,7 @@ class FTPShellTests(unittest.TestCase, IFTPShellTestsMixin):
 
 
 
+@implementer(IConsumer)
 class TestConsumer(object):
     """
     A simple consumer for tests. It only works with non-streaming producers.
@@ -3296,7 +3297,6 @@ class TestConsumer(object):
         L{twisted.internet.interfaces.IPullProducer}.
     """
 
-    implements(IConsumer)
     producer = None
 
     def registerProducer(self, producer, streaming):
@@ -3453,8 +3453,8 @@ class FTPReadWriteTests(unittest.TestCase, IReadWriteTestsMixin):
 
 
 
+@implementer(ftp.IWriteFile)
 class CloseTestWriter:
-    implements(ftp.IWriteFile)
     closeStarted = False
     def receive(self):
         self.s = StringIO()

--- a/twisted/test/test_pb.py
+++ b/twisted/test/test_pb.py
@@ -14,7 +14,7 @@ only specific tests for old API.
 import sys, os, time, gc, weakref
 
 from cStringIO import StringIO
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.trial import unittest
 from twisted.spread import pb, util, publish, jelly
@@ -44,9 +44,8 @@ class DummyPerspective(pb.Avatar):
 
 
 
+@implementer(portal.IRealm)
 class DummyRealm(object):
-    implements(portal.IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         for iface in interfaces:
             if iface is pb.IPerspective:
@@ -1062,6 +1061,7 @@ class LocalRemoteTest(util.LocalAsRemote):
 
 
 
+@implementer(pb.IPerspective)
 class MyPerspective(pb.Avatar):
     """
     @ivar loggedIn: set to C{True} when the avatar is logged in.
@@ -1070,8 +1070,6 @@ class MyPerspective(pb.Avatar):
     @ivar loggedOut: set to C{True} when the avatar is logged out.
     @type loggedOut: C{bool}
     """
-    implements(pb.IPerspective)
-
     loggedIn = loggedOut = False
 
     def __init__(self, avatarId):
@@ -1630,9 +1628,8 @@ class NewCredTests(unittest.TestCase):
 
 
 
+@implementer(pb.IPerspective)
 class NonSubclassingPerspective:
-    implements(pb.IPerspective)
-
     def __init__(self, avatarId):
         pass
 
@@ -1703,6 +1700,7 @@ class IForwarded(Interface):
         """
 
 
+@implementer(IForwarded)
 class Forwarded:
     """
     Test implementation of L{IForwarded}.
@@ -1712,7 +1710,6 @@ class Forwarded:
     @ivar unforwarded: set if C{dontForwardMe} is called.
     @type unforwarded: C{bool}
     """
-    implements(IForwarded)
     forwarded = False
     unforwarded = False
 

--- a/twisted/test/test_sip.py
+++ b/twisted/test/test_sip.py
@@ -14,7 +14,7 @@ from twisted.test import proto_helpers
 
 from twisted import cred
 
-from zope.interface import implements
+from zope.interface import implementer
 
 
 # request, prefixed by random CRLFs
@@ -419,13 +419,13 @@ class ParseTests(unittest.TestCase):
             self.assertEqual(gparams, params)
 
 
+@implementer(sip.ILocator)
 class DummyLocator:
-    implements(sip.ILocator)
     def getAddress(self, logicalURL):
         return defer.succeed(sip.URL("server.com", port=5060))
 
+@implementer(sip.ILocator)
 class FailingLocator:
-    implements(sip.ILocator)
     def getAddress(self, logicalURL):
         return defer.fail(LookupError())
 


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8426

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
