### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/news

### DIFF
--- a/twisted/news/database.py
+++ b/twisted/news/database.py
@@ -12,7 +12,7 @@ import StringIO
 from hashlib import md5
 from email.Message import Message
 from email.Generator import Generator
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.news.nntp import NNTPError
 from twisted.mail import smtp
@@ -279,6 +279,7 @@ class _ModerationMixin:
 
 
 
+@implementer(INewsStorage)
 class PickleStorage(_ModerationMixin):
     """
     A trivial NewsStorage implementation using pickles
@@ -286,9 +287,6 @@ class PickleStorage(_ModerationMixin):
     Contains numerous flaws and is generally unsuitable for any
     real applications.  Consider yourself warned!
     """
-
-    implements(INewsStorage)
-
     sharedDBs = {}
 
     def __init__(self, filename, groups=None, moderators=(),
@@ -498,13 +496,11 @@ class Group:
         self.articles = {}
 
 
+@implementer(INewsStorage)
 class NewsShelf(_ModerationMixin):
     """
     A NewStorage implementation using Twisted's dirdbm persistence module.
     """
-
-    implements(INewsStorage)
-
     def __init__(self, mailhost, path, sender=None):
         """
         @param mailhost: A C{str} giving the mail exchange host which will
@@ -732,13 +728,11 @@ class NewsShelf(_ModerationMixin):
             return defer.succeed((index, a.getHeader('Message-ID'), StringIO.StringIO(a.body)))
 
 
+@implementer(INewsStorage)
 class NewsStorageAugmentation:
     """
     A NewsStorage implementation using Twisted's asynchronous DB-API
     """
-
-    implements(INewsStorage)
-
     schema = """
 
     CREATE TABLE groups (


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8430

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
