### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/names

### DIFF
--- a/twisted/names/srvconnect.py
+++ b/twisted/names/srvconnect.py
@@ -4,7 +4,7 @@
 
 from functools import reduce
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import error, interfaces
 from twisted.names import client, dns
@@ -31,11 +31,9 @@ class _SRVConnector_ClientFactoryWrapper:
 
 
 
+@implementer(interfaces.IConnector)
 class SRVConnector:
     """A connector that looks up DNS SRV records. See RFC2782."""
-
-    implements(interfaces.IConnector)
-
     stopAfterDNS=0
 
     def __init__(self, reactor, service, domain, factory,


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8431

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
