### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/mail

### DIFF
--- a/twisted/mail/alias.py
+++ b/twisted/mail/alias.py
@@ -19,7 +19,7 @@ from twisted.internet import protocol
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 
 def handle(result, line, filename, lineNo):
@@ -187,6 +187,7 @@ class AliasBase:
 
 
 
+@implementer(IAlias)
 class AddressAlias(AliasBase):
     """
     An alias which translates one email address into another.
@@ -194,8 +195,6 @@ class AddressAlias(AliasBase):
     @type alias : L{Address}
     @ivar alias: The destination address.
     """
-    implements(IAlias)
-
     def __init__(self, alias, *args):
         """
         @type alias: L{Address}, L{User}, L{bytes} or object which can be
@@ -262,6 +261,7 @@ class AddressAlias(AliasBase):
 
 
 
+@implementer(smtp.IMessage)
 class FileWrapper:
     """
     A message receiver which delivers a message to a file.
@@ -273,8 +273,6 @@ class FileWrapper:
     @ivar finalname: The name of the file in which the message should be
         stored.
     """
-    implements(smtp.IMessage)
-
     def __init__(self, filename):
         """
         @type filename: L{bytes}
@@ -337,14 +335,13 @@ class FileWrapper:
 
 
 
+@implementer(IAlias)
 class FileAlias(AliasBase):
     """
     An alias which translates an address to a file.
 
     @ivar filename: See L{__init__}.
     """
-    implements(IAlias)
-
     def __init__(self, filename, *args):
         """
         @type filename: L{bytes}
@@ -387,6 +384,7 @@ class ProcessAliasTimeout(Exception):
 
 
 
+@implementer(smtp.IMessage)
 class MessageWrapper:
     """
     A message receiver which delivers a message to a child process.
@@ -417,8 +415,6 @@ class MessageWrapper:
     @ivar completion: The deferred which will be triggered by the protocol
         when the child process exits.
     """
-    implements(smtp.IMessage)
-
     done = False
 
     completionTimeout = 60
@@ -553,6 +549,7 @@ class ProcessAliasProtocol(protocol.ProcessProtocol):
 
 
 
+@implementer(IAlias)
 class ProcessAlias(AliasBase):
     """
     An alias which is handled by the execution of a program.
@@ -570,8 +567,6 @@ class ProcessAlias(AliasBase):
     @ivar reactor: A reactor which will be used to create and timeout the
         child process.
     """
-    implements(IAlias)
-
     reactor = reactor
 
     def __init__(self, path, *args):
@@ -642,6 +637,7 @@ class ProcessAlias(AliasBase):
 
 
 
+@implementer(smtp.IMessage)
 class MultiWrapper:
     """
     A message receiver which delivers a single message to multiple other
@@ -649,8 +645,6 @@ class MultiWrapper:
 
     @ivar objs: See L{__init__}.
     """
-    implements(smtp.IMessage)
-
     def __init__(self, objs):
         """
         @type objs: L{list} of L{IMessage <smtp.IMessage>} provider
@@ -704,6 +698,7 @@ class MultiWrapper:
 
 
 
+@implementer(IAlias)
 class AliasGroup(AliasBase):
     """
     An alias which points to multiple destination aliases.
@@ -715,8 +710,6 @@ class AliasGroup(AliasBase):
     @type aliases: L{list} of L{AliasBase} which implements L{IAlias}
     @ivar aliases: The destination aliases.
     """
-    implements(IAlias)
-
     processAliasFactory = ProcessAlias
 
     def __init__(self, items, *args):

--- a/twisted/mail/imap4.py
+++ b/twisted/mail/imap4.py
@@ -34,7 +34,7 @@ try:
 except:
     import StringIO
 
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.protocols import basic
 from twisted.protocols import policies
@@ -469,6 +469,7 @@ _nonAtomChars = r'(){%*"\]' + _SP + _CTL
 # This is all the bytes that match the ATOM-CHAR from the grammar in the RFC.
 _atomChars = ''.join(chr(ch) for ch in range(0x100) if chr(ch) not in _nonAtomChars)
 
+@implementer(IMailboxListener)
 class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
     """
     Protocol implementation for an IMAP4rev1 server.
@@ -479,8 +480,6 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         - Selected
         - Logout
     """
-    implements(IMailboxListener)
-
     # Identifier for this server software
     IDENT = 'Twisted IMAP4rev1 Ready'
 
@@ -2206,14 +2205,13 @@ class IllegalServerResponse(IMAP4Exception): pass
 
 TIMEOUT_ERROR = error.TimeoutError()
 
+@implementer(IMailboxListener)
 class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
     """IMAP4 client protocol implementation
 
     @ivar state: A string representing the state the connection is currently
     in.
     """
-    implements(IMailboxListener)
-
     tags = None
     waiting = None
     queued = None
@@ -4435,9 +4433,8 @@ class IClientAuthentication(Interface):
 
 
 
+@implementer(IClientAuthentication)
 class CramMD5ClientAuthenticator:
-    implements(IClientAuthentication)
-
     def __init__(self, user):
         self.user = user
 
@@ -4450,9 +4447,8 @@ class CramMD5ClientAuthenticator:
 
 
 
+@implementer(IClientAuthentication)
 class LOGINAuthenticator:
-    implements(IClientAuthentication)
-
     def __init__(self, user):
         self.user = user
         self.challengeResponse = self.challengeUsername
@@ -4469,9 +4465,8 @@ class LOGINAuthenticator:
         # Respond to something like "Password:"
         return secret
 
+@implementer(IClientAuthentication)
 class PLAINAuthenticator:
-    implements(IClientAuthentication)
-
     def __init__(self, user):
         self.user = user
 
@@ -4689,9 +4684,8 @@ class INamespacePresenter(Interface):
         """
 
 
+@implementer(IAccount, INamespacePresenter)
 class MemoryAccount(object):
-    implements(IAccount, INamespacePresenter)
-
     mailboxes = None
     subscriptions = None
     top_id = 0

--- a/twisted/mail/mail.py
+++ b/twisted/mail/mail.py
@@ -19,7 +19,7 @@ from twisted.mail import protocols, smtp
 
 # System imports
 import os
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 
 class DomainWithDefaultDict:
@@ -432,14 +432,13 @@ class IAliasableDomain(IDomain):
 
 
 
+@implementer(IDomain)
 class BounceDomain:
     """
     A domain with no users.
 
     This can be used to block off a domain.
     """
-    implements(IDomain)
-
     def exists(self, user):
         """
         Raise an exception to indicate that the user does not exist in this
@@ -494,6 +493,7 @@ class BounceDomain:
 
 
 
+@implementer(smtp.IMessage)
 class FileMessage:
     """
     A message receiver which delivers a message to a file.
@@ -502,8 +502,6 @@ class FileMessage:
     @ivar name: See L{__init__}.
     @ivar finalName: See L{__init__}.
     """
-    implements(smtp.IMessage)
-
     def __init__(self, fp, name, finalName):
         """
         @type fp: file-like object

--- a/twisted/mail/pop3.py
+++ b/twisted/mail/pop3.py
@@ -16,7 +16,7 @@ import binascii
 import warnings
 from hashlib import md5
 
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.mail import smtp
 from twisted.protocols import basic
@@ -31,6 +31,7 @@ from twisted import cred
 ##
 ## Authentication
 ##
+@implementer(cred.credentials.IUsernamePassword)
 class APOPCredentials:
     """
     Credentials for use in APOP authentication.
@@ -39,8 +40,6 @@ class APOPCredentials:
     @ivar username: See L{__init__}
     @ivar digest: See L{__init__}
     """
-    implements(cred.credentials.IUsernamePassword)
-
     def __init__(self, magic, username, digest):
         """
         @type magic: L{bytes}
@@ -394,6 +393,7 @@ def formatUIDListResponse(msgs, getUidl):
 
 
 
+@implementer(interfaces.IProducer)
 class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
     """
     A POP3 server protocol.
@@ -449,8 +449,6 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         <cred.credentials.IUsernameHashedPassword>} provider
     @ivar _auth: Authorization credentials.
     """
-    implements(interfaces.IProducer)
-
     magic = None
     _userIs = None
     _onLogout = None
@@ -1498,12 +1496,11 @@ class IMailbox(Interface):
 
 
 
+@implementer(IMailbox)
 class Mailbox:
     """
     A base class for mailboxes.
     """
-    implements(IMailbox)
-
     def listMessages(self, i=None):
         """
         Retrieve the size of a message, or, if none is specified, the size of

--- a/twisted/mail/protocols.py
+++ b/twisted/mail/protocols.py
@@ -21,10 +21,11 @@ from twisted.cred.error import UnauthorizedLogin
 
 from twisted.mail import relay
 
-from zope.interface import implements
+from zope.interface import implementer
 
 
 
+@implementer(smtp.IMessageDelivery)
 class DomainDeliveryBase:
     """
     A base class for message delivery using the domains of a mail service.
@@ -37,8 +38,6 @@ class DomainDeliveryBase:
     @ivar protocolName: The protocol being used to deliver the mail.
         Sub-classes should set this appropriately.
     """
-    implements(smtp.IMessageDelivery)
-
     service = None
     protocolName = None
 

--- a/twisted/mail/smtp.py
+++ b/twisted/mail/smtp.py
@@ -11,7 +11,7 @@ import binascii
 import warnings
 from email.base64MIME import encode as encode_base64
 
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.copyright import longversion
 from twisted.protocols import basic
@@ -1987,9 +1987,8 @@ class LOGINCredentials(_lcredentials):
 
 
 
+@implementer(IClientAuthentication)
 class PLAINAuthenticator:
-    implements(IClientAuthentication)
-
     def __init__(self, user):
         self.user = user
 

--- a/twisted/mail/test/test_imap.py
+++ b/twisted/mail/test/test_imap.py
@@ -19,7 +19,7 @@ import types
 
 from collections import OrderedDict
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.mail.imap4 import MessageSet
 from twisted.mail import imap4
@@ -972,9 +972,8 @@ class IMAP4HelperTests(unittest.TestCase):
                 self.assertEqual(L, expected,
                                   "len(%r) = %r != %r" % (input, L, expected))
 
+@implementer(imap4.IMailboxInfo, imap4.IMailbox, imap4.ICloseableMailbox)
 class SimpleMailbox:
-    implements(imap4.IMailboxInfo, imap4.IMailbox, imap4.ICloseableMailbox)
-
     flags = ('\\Flag1', 'Flag2', '\\AnotherSysFlag', 'LastFlag')
     messages = []
     mUID = 0
@@ -3391,9 +3390,8 @@ class FakeyServer(imap4.IMAP4Server):
     def sendServerGreeting(self):
         pass
 
+@implementer(imap4.IMessage)
 class FakeyMessage(util.FancyStrMixin):
-    implements(imap4.IMessage)
-
     showAttributes = ('headers', 'flags', 'date', 'body', 'uid')
 
     def __init__(self, headers, flags, date, body, uid, subpart):
@@ -4417,9 +4415,8 @@ class DefaultSearchTests(IMAP4HelperMixin, unittest.TestCase):
 
 
 
+@implementer(imap4.ISearchableMailbox)
 class FetchSearchStoreTests(unittest.TestCase, IMAP4HelperMixin):
-    implements(imap4.ISearchableMailbox)
-
     def setUp(self):
         self.expected = self.result = None
         self.server_received_query = None
@@ -4578,9 +4575,8 @@ class FakeMailbox:
         self.args.append((body, flags, date))
         return defer.succeed(None)
 
+@implementer(imap4.IMessageFile)
 class FeaturefulMessage:
-    implements(imap4.IMessageFile)
-
     def getFlags(self):
         return 'flags'
 
@@ -4590,9 +4586,8 @@ class FeaturefulMessage:
     def open(self):
         return StringIO("open")
 
+@implementer(imap4.IMessageCopier)
 class MessageCopierMailbox:
-    implements(imap4.IMessageCopier)
-
     def __init__(self):
         self.msgs = []
 

--- a/twisted/mail/test/test_mail.py
+++ b/twisted/mail/test/test_mail.py
@@ -17,7 +17,7 @@ import time
 from hashlib import md5
 
 from zope.interface.verify import verifyClass
-from zope.interface import Interface, implements
+from zope.interface import Interface, implementer
 
 from twisted.trial import unittest
 from twisted.mail import smtp
@@ -706,12 +706,11 @@ class MaildirDirdbmDomainTests(unittest.TestCase):
 
 
 
+@implementer(mail.mail.IAliasableDomain)
 class StubAliasableDomain(object):
     """
     Minimal testable implementation of IAliasableDomain.
     """
-    implements(mail.mail.IAliasableDomain)
-
     def exists(self, user):
         """
         No test coverage for invocations of this method on domain objects,

--- a/twisted/mail/test/test_pop3.py
+++ b/twisted/mail/test/test_pop3.py
@@ -12,7 +12,7 @@ import itertools
 
 from collections import OrderedDict
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 
@@ -416,9 +416,8 @@ class AnotherPOP3Tests(unittest.TestCase):
         dummy.connectionLost(failure.Failure(Exception("Test harness disconnect")))
 
 
+@implementer(pop3.IServerFactory)
 class TestServerFactory:
-    implements(pop3.IServerFactory)
-
     def cap_IMPLEMENTATION(self):
         return "Test Implementation String"
 

--- a/twisted/mail/test/test_smtp.py
+++ b/twisted/mail/test/test_smtp.py
@@ -6,7 +6,7 @@ Test cases for twisted.mail.smtp module.
 """
 import inspect
 
-from zope.interface import implements, directlyProvides
+from zope.interface import implementer, directlyProvides
 
 from twisted.python.util import LineLog
 from twisted.trial import unittest, util
@@ -50,14 +50,13 @@ def spameater(*spam, **eggs):
 
 
 
+@implementer(smtp.IMessage)
 class BrokenMessage(object):
     """
     L{BrokenMessage} is an L{IMessage} which raises an unexpected exception
     from its C{eomReceived} method.  This is useful for creating a server which
     can be used to test client retry behavior.
     """
-    implements(smtp.IMessage)
-
     def __init__(self, user):
         pass
 
@@ -530,9 +529,8 @@ class AnotherSMTPTests(AnotherTestCase, unittest.TestCase):
 
 
 
+@implementer(cred.checkers.ICredentialsChecker)
 class DummyChecker:
-    implements(cred.checkers.ICredentialsChecker)
-
     users = {
         'testuser': 'testpassword'
     }
@@ -552,13 +550,12 @@ class DummyChecker:
 
 
 
+@implementer(smtp.IMessageDelivery)
 class SimpleDelivery(object):
     """
     L{SimpleDelivery} is a message delivery factory with no interesting
     behavior.
     """
-    implements(smtp.IMessageDelivery)
-
     def __init__(self, messageFactory):
         self._messageFactory = messageFactory
 
@@ -1024,13 +1021,12 @@ class SMTPSenderFactoryRetryTests(unittest.TestCase):
 
 
 
+@implementer(IRealm)
 class SingletonRealm(object):
     """
     Trivial realm implementation which is constructed with an interface and an
     avatar and returns that avatar when asked for that interface.
     """
-    implements(IRealm)
-
     def __init__(self, interface, avatar):
         self.interface = interface
         self.avatar = avatar
@@ -1187,6 +1183,7 @@ class SMTPServerTests(unittest.TestCase):
             '<alice@example.com>: Sender not acceptable\r\n')
 
 
+    @implementer(ICredentialsChecker)
     def test_portalRejectedSenderAddress(self):
         """
         Test that a C{MAIL FROM} command with an address rejected by an
@@ -1197,8 +1194,6 @@ class SMTPServerTests(unittest.TestCase):
             """
             Checker for L{IAnonymous} which rejects authentication attempts.
             """
-            implements(ICredentialsChecker)
-
             credentialInterfaces = (IAnonymous,)
 
             def requestAvatarId(self, credentials):


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8432

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
