### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/internet

### DIFF
--- a/twisted/internet/cfreactor.py
+++ b/twisted/internet/cfreactor.py
@@ -17,7 +17,7 @@ __all__ = [
 
 import sys
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet.interfaces import IReactorFDSet
 from twisted.internet.posixbase import PosixReactorBase, _Waker
@@ -72,6 +72,7 @@ class _WakerPlus(_Waker):
 
 
 
+@implementer(IReactorFDSet)
 class CFReactor(PosixReactorBase):
     """
     The CoreFoundation reactor.
@@ -109,9 +110,6 @@ class CFReactor(PosixReactorBase):
         run loop to run Twisted callLater calls, this is a reference to it.
         Otherwise, it is C{None}
     """
-
-    implements(IReactorFDSet)
-
     def __init__(self, runLoop=None, runner=None):
         self._fdmap = {}
         self._idmap = {}


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8433

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
