### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/cred

### DIFF
--- a/twisted/cred/credentials.py
+++ b/twisted/cred/credentials.py
@@ -34,7 +34,7 @@ class ICredentials(Interface):
     I check credentials.
 
     Implementors _must_ specify which sub-interfaces of ICredentials
-    to which it conforms, using zope.interface.implements().
+    to which it conforms, using @zope.interface.implementer().
     """
 
 


### PR DESCRIPTION
See:
http://twistedmatrix.com/trac/ticket/8434

In docstring, remove reference to deprecated zope.interface.implements()

Replace with reference to @zope.interface.implementer()
