### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in docs/web

### DIFF
--- a/docs/web/examples/webguard.py
+++ b/docs/web/examples/webguard.py
@@ -13,7 +13,7 @@ password. See the code in main() to get the correct username & password!
 
 import sys
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python import log
 from twisted.internet import reactor
@@ -36,13 +36,12 @@ class GuardedResource(resource.Resource):
 
 
 
+@implementer(IRealm)
 class SimpleRealm(object):
     """
     A realm which gives out L{GuardedResource} instances for authenticated
     users.
     """
-    implements(IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         if resource.IResource in interfaces:
             return resource.IResource, GuardedResource(), lambda: None

--- a/docs/web/howto/listings/client/stringprod.py
+++ b/docs/web/howto/listings/client/stringprod.py
@@ -1,11 +1,10 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet.defer import succeed
 from twisted.web.iweb import IBodyProducer
 
+@implementer(IBodyProducer)
 class StringProducer(object):
-    implements(IBodyProducer)
-
     def __init__(self, body):
         self.body = body
         self.length = len(body)

--- a/docs/web/howto/web-in-60/http-auth.rst
+++ b/docs/web/howto/web-in-60/http-auth.rst
@@ -69,13 +69,13 @@ later.
 .. code-block:: python
 
     
-    from zope.interface import implements
+    from zope.interface import implementer
     
     from twisted.cred.portal import IRealm
     from twisted.web.static import File
     
+    implementer(IRealm)
     class PublicHTMLRealm(object):
-        implements(IRealm)
 
 
 
@@ -266,7 +266,7 @@ conventional style):
     
     cache()
     
-    from zope.interface import implements
+    from zope.interface import implementer
     
     from twisted.cred.portal import IRealm, Portal
     from twisted.cred.checkers import FilePasswordDB
@@ -274,9 +274,8 @@ conventional style):
     from twisted.web.resource import IResource
     from twisted.web.guard import HTTPAuthSessionWrapper, DigestCredentialFactory
     
+    @implementer(IRealm)
     class PublicHTMLRealm(object):
-        implements(IRealm)
-    
         def requestAvatar(self, avatarId, mind, *interfaces):
             if IResource in interfaces:
                 return (IResource, File("/home/%s/public_html" % (avatarId,)), lambda: None)

--- a/docs/web/howto/web-in-60/http-auth.rst
+++ b/docs/web/howto/web-in-60/http-auth.rst
@@ -74,7 +74,7 @@ later.
     from twisted.cred.portal import IRealm
     from twisted.web.static import File
     
-    implementer(IRealm)
+    @implementer(IRealm)
     class PublicHTMLRealm(object):
 
 

--- a/docs/web/howto/web-in-60/session-store.rst
+++ b/docs/web/howto/web-in-60/session-store.rst
@@ -37,14 +37,14 @@ example:
 .. code-block:: console
 
     
-    >>> from zope.interface import Interface, Attribute, implements
+    >>> from zope.interface import Interface, Attribute, implementer
     >>> from twisted.python.components import registerAdapter
     >>> from twisted.web.server import Session
     >>> class ICounter(Interface):
     ...     value = Attribute("An int value which counts up once per page view.")
     ...
-    >>> class Counter(object):
-    ...     implements(ICounter)
+    >>> @implementer(ICounter)
+    ... class Counter(object):
     ...     def __init__(self, session):
     ...         self.value = 0
     ...
@@ -151,7 +151,7 @@ based on this example:
     
     cache()
     
-    from zope.interface import Interface, Attribute, implements
+    from zope.interface import Interface, Attribute, implementer
     from twisted.python.components import registerAdapter
     from twisted.web.server import Session
     from twisted.web.resource import Resource
@@ -159,8 +159,8 @@ based on this example:
     class ICounter(Interface):
         value = Attribute("An int value which counts up once per page view.")
     
+    @implementer(ICounter)
     class Counter(object):
-        implements(ICounter)
         def __init__(self, session):
             self.value = 0
     


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8435

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
