### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in docs/mail

### DIFF
--- a/docs/mail/examples/emailserver.tac
+++ b/docs/mail/examples/emailserver.tac
@@ -8,7 +8,7 @@
 A toy email server.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 from twisted.mail import smtp
@@ -20,9 +20,8 @@ from twisted.cred.portal import Portal
 
 
 
+@implementer(smtp.IMessageDelivery)
 class ConsoleMessageDelivery:
-    implements(smtp.IMessageDelivery)
-    
     def receivedHeader(self, helo, origin, recipients):
         return "Received: ConsoleMessageDelivery"
 
@@ -40,9 +39,8 @@ class ConsoleMessageDelivery:
 
 
 
+@implementer(smtp.IMessage)
 class ConsoleMessage:
-    implements(smtp.IMessage)
-    
     def __init__(self):
         self.lines = []
 
@@ -80,9 +78,8 @@ class ConsoleSMTPFactory(smtp.SMTPFactory):
 
 
 
+@implementer(IRealm)
 class SimpleRealm:
-    implements(IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         if smtp.IMessageDelivery in interfaces:
             return smtp.IMessageDelivery, ConsoleMessageDelivery(), lambda: None

--- a/docs/mail/tutorial/smtpserver/smtpserver-5.tac
+++ b/docs/mail/tutorial/smtpserver/smtpserver-5.tac
@@ -1,5 +1,5 @@
 import os
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 
@@ -12,9 +12,8 @@ smtpServerFactory = protocol.ServerFactory()
 
 from twisted.mail import smtp
 
+@implementer(smtp.IMessage)
 class FileMessage(object):
-    implements(smtp.IMessage)
-
     def __init__(self, fileObj):
         self.fileObj = fileObj
 

--- a/docs/mail/tutorial/smtpserver/smtpserver-6.tac
+++ b/docs/mail/tutorial/smtpserver/smtpserver-6.tac
@@ -1,5 +1,5 @@
 import os
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 
@@ -12,9 +12,8 @@ smtpServerFactory = protocol.ServerFactory()
 
 from twisted.mail import smtp
 
+@implementer(smtp.IMessage)
 class FileMessage(object):
-    implements(smtp.IMessage)
-
     def __init__(self, fileObj):
         self.fileObj = fileObj
 

--- a/docs/mail/tutorial/smtpserver/smtpserver-7.tac
+++ b/docs/mail/tutorial/smtpserver/smtpserver-7.tac
@@ -1,5 +1,5 @@
 import os
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 
@@ -10,9 +10,8 @@ from twisted.internet import protocol, defer
 
 from twisted.mail import smtp
 
+@implementer(smtp.IMessage)
 class FileMessage(object):
-    implements(smtp.IMessage)
-
     def __init__(self, fileObj):
         self.fileObj = fileObj
 
@@ -27,8 +26,8 @@ class FileMessage(object):
         self.fileObj.close()
         os.remove(self.fileObj.name)
 
+@implementer(smtp.IMessageDelivery)
 class TutorialDelivery(object):
-    implements(smtp.IMessageDelivery)
     counter = 0
 
     def validateTo(self, user):

--- a/docs/mail/tutorial/smtpserver/smtpserver-8.tac
+++ b/docs/mail/tutorial/smtpserver/smtpserver-8.tac
@@ -1,5 +1,5 @@
 import os
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 
@@ -10,9 +10,8 @@ from twisted.internet import protocol, defer
 
 from twisted.mail import smtp
 
+@implementer(smtp.IMessage)
 class FileMessage(object):
-    implements(smtp.IMessage)
-
     def __init__(self, fileObj):
         self.fileObj = fileObj
 
@@ -27,8 +26,8 @@ class FileMessage(object):
         self.fileObj.close()
         os.remove(self.fileObj.name)
 
+@implementer(smtp.IMessageDelivery)
 class TutorialDelivery(object):
-    implements(smtp.IMessageDelivery)
     counter = 0
 
     def validateTo(self, user):
@@ -42,9 +41,8 @@ class TutorialDelivery(object):
     def receivedHeader(self, helo, origin, recipients):
         return 'Received: Tutorially.'
 
+@implementer(smtp.IMessageDeliveryFactory)
 class TutorialDeliveryFactory(object):
-    implements(smtp.IMessageDeliveryFactory)
-
     def getMessageDelivery(self):
         return TutorialDelivery()
 


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8436

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
