### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in docs/core/examples

### DIFF
--- a/docs/core/examples/cred.py
+++ b/docs/core/examples/cred.py
@@ -5,7 +5,7 @@
 
 
 import sys
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.protocols import basic
 from twisted.internet import protocol
@@ -23,27 +23,24 @@ class IProtocolUser(Interface):
     def logout():
         """Cleanup per-login resources allocated to this avatar"""
 
+@implementer(IProtocolUser)
 class AnonymousUser:
-    implements(IProtocolUser)
-    
     def getPrivileges(self):
         return [1, 2, 3]
 
     def logout(self):
         print "Cleaning up anonymous user resources"
 
+@implementer(IProtocolUser)
 class RegularUser:
-    implements(IProtocolUser)
-    
     def getPrivileges(self):
         return [1, 2, 3, 5, 6]
 
     def logout(self):
         print "Cleaning up regular user resources"
 
+@implementer(IProtocolUser)
 class Administrator:
-    implements(IProtocolUser)
-    
     def getPrivileges(self):
         return range(50)
 
@@ -127,9 +124,8 @@ class ServerFactory(protocol.ServerFactory):
         p.portal = self.portal
         return p
 
+@implementer(portal.IRealm)
 class Realm:
-    implements(portal.IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         if IProtocolUser in interfaces:
             if avatarId == checkers.ANONYMOUS:

--- a/docs/core/examples/dbcred.py
+++ b/docs/core/examples/dbcred.py
@@ -13,16 +13,15 @@ from twisted.cred.credentials import IUsernameHashedPassword, IUsernamePassword
 from twisted.cred.checkers import ICredentialsChecker
 from twisted.internet.defer import Deferred
 
-from zope.interface import implements
+from zope.interface import implementer
 
 
+@implementer(ICredentialsChecker)
 class DBCredentialsChecker(object):
     """
     This class checks the credentials of incoming connections
     against a user table in a database.
     """
-    implements(ICredentialsChecker)
-
     def __init__(self, runQuery,
         query="SELECT username, password FROM user WHERE username = %s",
         customCheckFunc=None, caseSensitivePasswords=True):

--- a/docs/core/examples/pbbenchserver.py
+++ b/docs/core/examples/pbbenchserver.py
@@ -4,7 +4,7 @@
 
 """Server for PB benchmark."""
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.spread import pb
 from twisted.internet import reactor
@@ -28,9 +28,8 @@ class PBBenchPerspective(pb.Avatar):
         return ['a', 1, 1l, 1.0, [], ()]
 
 
+@implementer(IRealm)
 class SimpleRealm:
-    implements(IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         if pb.IPerspective in interfaces:
             p = PBBenchPerspective()

--- a/docs/core/examples/pbecho.py
+++ b/docs/core/examples/pbecho.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
     from pbecho import main
     raise SystemExit(main())
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.spread import pb
 from twisted.cred.portal import IRealm
@@ -28,9 +28,8 @@ class SimplePerspective(pb.Avatar):
         print self, "logged out"
 
 
+@implementer(IRealm)
 class SimpleRealm:
-    implements(IRealm)
-
     def requestAvatar(self, avatarId, mind, *interfaces):
         if pb.IPerspective in interfaces:
             avatar = SimplePerspective()

--- a/docs/core/examples/recvfd.py
+++ b/docs/core/examples/recvfd.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
 
 import os, sys
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python.log import startLogging
 from twisted.python.filepath import FilePath
@@ -32,8 +32,8 @@ from twisted.protocols.basic import LineOnlyReceiver
 from twisted.internet.endpoints import UNIXClientEndpoint
 from twisted.internet import reactor
 
+@implementer(IFileDescriptorReceiver)
 class ReceiveFDProtocol(LineOnlyReceiver):
-    implements(IFileDescriptorReceiver)
 
     descriptor = None
 

--- a/docs/core/examples/streaming.py
+++ b/docs/core/examples/streaming.py
@@ -13,19 +13,18 @@ and finally closes the connection.
 from sys import stdout
 from random import randrange
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python.log import startLogging
 from twisted.internet import interfaces, reactor
 from twisted.internet.protocol import Factory
 from twisted.protocols.basic import LineReceiver
 
 
+@implementer(interfaces.IPushProducer)
 class Producer(object):
     """
     Send back the requested number of random integers to the client.
     """
-
-    implements(interfaces.IPushProducer)
 
     def __init__(self, proto, count):
         self._proto = proto


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8438

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
