### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer in twisted/python

### DIFF
--- a/twisted/python/components.py
+++ b/twisted/python/components.py
@@ -9,13 +9,13 @@ Component architecture for Twisted, based on Zope3 components.
 Using the Zope3 API directly is strongly recommended. Everything
 you need is in the top-level of the zope.interface package, e.g.::
 
-   from zope.interface import Interface, implements
+   from zope.interface import Interface, implementer
 
    class IFoo(Interface):
        pass
 
+   @implementer(IFoo)
    class Foo:
-       implements(IFoo)
 
    print IFoo.implementedBy(Foo) # True
    print IFoo.providedBy(Foo()) # True


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8427

zope.interface.implements() was deprecated in Python 2.x, and raises
a hard error in Python 3.x.  I am choosing this example at random,
but here is an example error:

```
Traceback (most recent call last):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 784, in loadByName
    return self.suiteFactory([self.findByName(name, recurse=recurse)])
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/trial/runner.py", line 682, in findByName
    __import__(name)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/test/test_xpath.py", line 7, in <module>
    from twisted.words.xish.domish import Element
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 287, in <module>
    class Element(object):
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/twisted/words/xish/domish.py", line 386, in Element
    implements(IElement)
  File "/Users/crodrigues/twisted3/build/py36-tests-posix/lib/python3.6/site-packages/zope/interface/declarations.py", line 412, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

In the zope.interface 3.6 documentation, it mentions that the
@implementer decorator can be used in Python 2.6 and up: 
https://pypi.python.org/pypi/zope.interface/3.6.0

Barry Warsaw also recommended using the @implementer decorator:

https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html
