### PR TITLE
Replace sys.maxint (which is gone in Python 3) with sys.maxsize in twisted/spread

### DIFF
--- a/twisted/spread/flavors.py
+++ b/twisted/spread/flavors.py
@@ -467,7 +467,7 @@ class RemoteCache(RemoteCopy, Serializable):
     def __hash__(self):
         """Hash me.
         """
-        return int(id(self.__dict__) % sys.maxint)
+        return int(id(self.__dict__) % sys.maxsize)
 
     broker = None
     luid = None


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8444
