### PR TITLE
Use higher version of zope.interface when using Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ def main(args):
     if os.path.exists('twisted'):
         sys.path.insert(0, '.')
 
-    requirements = ["zope.interface >= 3.6.0"]
+    if sys.version_info[0] >= 3:
+        requirements = ["zope.interface >= 4.0.2"]
+    else:
+        requirements = ["zope.interface >= 3.6.0"]
 
     from twisted.python.dist import (
         STATIC_PACKAGE_METADATA, getExtensions, getScripts,


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8446

To test this patch fully, you need to comment out these lines in setup.py:

```
    # On Python 3, use setup3.py until Python 3 port is done:
    if sys.version_info[0] > 2:
        import setup3
        setup3.main()
        return
```

This patch is meant to facilitate aggressive testing of porting to Python3.
The existing setup.py will still use zope.interface >= 3.6.0 on Python2.
