### PR TITLE
Enabling Python 3.5 version.

### DIFF
--- a/twisted/python/dist.py
+++ b/twisted/python/dist.py
@@ -57,6 +57,7 @@ on event-based network programming and multiprotocol integration.
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         ],
     )
 

--- a/twisted/topfiles/8479.misc
+++ b/twisted/topfiles/8479.misc
@@ -1,0 +1,1 @@
+Enabling Python 3.5 version on PyPI.


### PR DESCRIPTION
Since Python 3.5 support has been introduced 8 months ago (https://twistedmatrix.com/trac/ticket/8042) and builds on Travis are already testing this version (e.g. https://travis-ci.org/twisted/twisted/jobs/137033567), I'd like to have this version enabled on PyPI side.
