### PR TITLE
Add an event that fires when TLS handshakes are complete.

### DIFF
--- a/twisted/internet/_sslverify.py
+++ b/twisted/internet/_sslverify.py
@@ -1284,8 +1284,7 @@ def _handshakeCompletionInfoCallback(connection, where, ret):
     # Is that going to be a problem? Investigate.
     if where & SSL_CB_HANDSHAKE_DONE:
         transport = connection.get_app_data()
-        if IHandshakeListener.providedBy(transport):
-            transport.handshakeCompleted()
+        transport.handshakeCompleted()
 
 
 

--- a/twisted/internet/_sslverify.py
+++ b/twisted/internet/_sslverify.py
@@ -209,7 +209,8 @@ from zope.interface import Interface, implementer
 from twisted.internet.defer import Deferred
 from twisted.internet.error import VerifyError, CertificateError
 from twisted.internet.interfaces import (
-    IAcceptableCiphers, ICipher, IOpenSSLClientConnectionCreator
+    IAcceptableCiphers, ICipher, IOpenSSLClientConnectionCreator,
+    IHandshakeListener
 )
 
 from twisted.python import reflect, util
@@ -1255,6 +1256,23 @@ class ClientTLSOptions(object):
                 f = Failure()
                 transport = connection.get_app_data()
                 transport.failVerification(f)
+
+
+
+def _handshakeCompletionInfoCallback(connection, where, ret):
+    """
+    U{info_callback
+    <http://pythonhosted.org/pyOpenSSL/api/ssl.html#OpenSSL.SSL.Context.set_info_callback>
+    } for pyOpenSSL that notifies the transport on handshake completion if
+    the transport implements L{IHandshakeListener}.
+    """
+    # TODO: Are we at any risk dispatching this callback from inside the
+    # OpenSSL info callback? For example, what if this triggers a write?
+    # Is that going to be a problem? Investigate.
+    if where & SSL_CB_HANDSHAKE_DONE:
+        transport = connection.get_app_data()
+        if IHandshakeListener.providedBy(transport):
+            transport.handshakeCompleted()
 
 
 

--- a/twisted/internet/endpoints.py
+++ b/twisted/internet/endpoints.py
@@ -85,7 +85,8 @@ class _WrappingProtocol(Protocol):
         self._wrappedProtocol = wrappedProtocol
 
         for iface in [interfaces.IHalfCloseableProtocol,
-                      interfaces.IFileDescriptorReceiver]:
+                      interfaces.IFileDescriptorReceiver,
+                      interfaces.IHandshakeListener]:
             if iface.providedBy(self._wrappedProtocol):
                 directlyProvides(self, iface)
 
@@ -143,6 +144,14 @@ class _WrappingProtocol(Protocol):
         C{self._wrappedProtocol}
         """
         self._wrappedProtocol.writeConnectionLost()
+
+
+    def handshakeCompleted(self):
+        """
+        Proxy L{IHandshakeListener.handshakeCompleted} to our
+        C{self._wrappedProtocol}
+        """
+        self._wrappedProtocol.handshakeCompleted()
 
 
 

--- a/twisted/internet/interfaces.py
+++ b/twisted/internet/interfaces.py
@@ -1946,6 +1946,33 @@ class IHalfCloseableProtocol(Interface):
 
 
 
+class IHandshakeListener(Interface):
+    """
+    An interface implemented by a L{IProtocol} to indicate that it would like
+    to be notified when TLS handshakes complete when run over a TLS-based
+    transport.
+
+    This interface is only guaranteed to be called when run over a TLS-based
+    transport: non TLS-based transports will not respect this interface.
+    """
+
+    def handshakeCompleted():
+        """
+        Notification of the TLS handshake being completed.
+
+        This notification fires when OpenSSL has completed the TLS handshake.
+        At this point the TLS connection is established, and the protocol can
+        interrogate its transport (usually an L{ISSLTransport}) for details of
+        the TLS connection.
+
+        This notification *also* fires whenever the TLS session is
+        renegotiated. As a result, protocols that have certain minimum security
+        requirements should implement this interface to ensure that they are
+        able to re-evaluate the security of the TLS session if it changes.
+        """
+
+
+
 class IFileDescriptorReceiver(Interface):
     """
     Protocols may implement L{IFileDescriptorReceiver} to receive file

--- a/twisted/protocols/tls.py
+++ b/twisted/protocols/tls.py
@@ -214,7 +214,7 @@ class _ProducerMembrane(object):
 
 
 
-@implementer(ISystemHandle, INegotiated, IHandshakeListener)
+@implementer(ISystemHandle, INegotiated)
 class TLSMemoryBIOProtocol(ProtocolWrapper):
     """
     L{TLSMemoryBIOProtocol} is a protocol wrapper which uses OpenSSL via a

--- a/twisted/topfiles/6024.feature
+++ b/twisted/topfiles/6024.feature
@@ -1,0 +1,1 @@
+The new interface IHandshakeListener that can be implemented by any Protocol provides a callback that is called when the TLS handshake has been completed, allowing Protocols to make decisions about the TLS configuration before application data is sent.


### PR DESCRIPTION
This pull request is related to [Twisted issue #6024](https://twistedmatrix.com/trac/ticket/6024).

This change adds a new interface, currently tentatively called `IHandshakeListener`, that may be implemented by an `IProtocol` that wants to support being notified of TLS handshake completion. Protocols that implement this interface will define a `handshakeCompleted` method that will be called when OpenSSL informs Twisted that the TLS handshake has been completed.

This change is unfortunately quite broad-reaching, because there are several proxy objects involved in the call chain that need to be updated to handle this interface appropriately.

This change also updates `test_tls.py` to take advantage of the new interface. Previously, `test_tls.py` would set its own info callback handlers that it used to fire deferreds when the handshake was complete. Now, it uses the interface defined here to achieve the same functionality. This has the neat side effect of getting pretty good test coverage of the interface.
