### PR TITLE
Fixed fatal signal exit code

### DIFF
--- a/twisted/internet/base.py
+++ b/twisted/internet/base.py
@@ -443,6 +443,13 @@ class ReactorBase(object):
         and C{reactor.stop}.  This should be replaced with an explicit state
         machine.
 
+    @type _lastSignal: None|C{int}|C{bool}
+    @ivar _lastSignal: Indicates the latest fatal signal that has been received
+        from the user/OS.  This helps us determine an appropriate exit code
+        when the shutdown is complete.  If None, there has not been a fatal
+        signal received.  On Posix systems, it is an int telling us the signal.
+        On non-Posix systems, it is True.
+
     @type _justStopped: C{bool}
     @ivar _justStopped: A flag which is true between the time C{reactor.stop}
         is called and the time the shutdown system event is fired.  This is

--- a/twisted/internet/base.py
+++ b/twisted/internet/base.py
@@ -1238,4 +1238,6 @@ class _SignalReactorMixin(object):
                     exit(128 + code)
                 log.msg('Main loop terminated.')
 
+
+
 __all__ = []

--- a/twisted/topfiles/8477.bugfix
+++ b/twisted/topfiles/8477.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.base now exits with an appropriate fatal signal status code if a fatal signal is received

--- a/twisted/topfiles/8477.bugfix
+++ b/twisted/topfiles/8477.bugfix
@@ -1,1 +1,1 @@
-twisted.internet.base now exits with an appropriate fatal signal status code if a fatal signal is received
+twisted.internet now exits with an appropriate status code if killed with a SIGTERM, SIGINT or SIGBREAK


### PR DESCRIPTION
Previously whenever the process would catch a fatal signal, SIGINT, SIGTERM or SIGBREAK, it would exit(0) which is 100% wrong.

Processes must `exit(128+signal_code)` in order to properly inform the OS that it died because of a signal, and also communicate which signal killed the process.

This is important, for example, when one needs to make sure that a process is always running, so one wraps it in a parent process that restarts the child whenever it dies unexpectedly.  The parent needs to know that the process died from a SIGTERM (e.g. the OS is explicitly shutting it down) so that it doesn't keep restarting it when it shouldn't.

This patch fixes the problem.

I was not able to get the test suite working, it's a beast!  But I was able to manually test and this code is working as expected.

Test method:
- Start process
  - `kill -INT $pid`
  - Verify exit code is 130 (e.g. 128 + 2)
- Start process
  - `kill -TERM $pid`
  - Verify exit code is 143 (e.g. 128 + 15)
- Start process
  - `kill -KILL $pid`
  - Verify exit code is 137 (e.g. 128 + 9)
  - NOTE: This behavior is unchanged.  Since you cannot catch KILL signals, the buggy code was not erroneously exiting with code `0`.  This illustrates the proper way to exit from fatal signals.
