### PR TITLE
Restore timeouts to the HTTP/1.1 server.

### DIFF
--- a/twisted/web/http.py
+++ b/twisted/web/http.py
@@ -2242,6 +2242,7 @@ class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):
     _requestFactory = Request
     _factory = None
     _site = None
+    _timeOut = None
 
 
     @property
@@ -2283,6 +2284,17 @@ class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):
         self._channel.site = value
 
 
+    @property
+    def timeOut(self):
+        return self._channel.timeOut
+
+
+    @timeOut.setter
+    def timeOut(self, value):
+        self._timeOut = value
+        self._channel.timeOut = value
+
+
     def dataReceived(self, data):
         """
         A override of L{IProtocol.dataReceived} that checks what protocol we're
@@ -2307,6 +2319,7 @@ class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):
                 self._channel.requestFactory = self._requestFactory
                 self._channel.site = self._site
                 self._channel.factory = self._factory
+                self._channel.timeOut = self._timeOut
                 self._channel.makeConnection(transport)
             else:
                 # Only HTTP/2 and HTTP/1.1 are supported right now.

--- a/twisted/web/http.py
+++ b/twisted/web/http.py
@@ -2237,6 +2237,9 @@ class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):
 
     @ivar _factory: A reference to the creating L{HTTPFactory} object.
     @type _factory: L{HTTPFactory}
+
+    @ivar _timeOut: A timeout value to pass to the backing channel.
+    @type _timeOut: L{int} or L{None}
     """
     _negotiatedProtocol = None
     _requestFactory = Request

--- a/twisted/web/test/test_http.py
+++ b/twisted/web/test/test_http.py
@@ -2485,7 +2485,6 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
         # This is a terrible violation of the abstraction later of
         # _genericHTTPChannelProtocol, but we need to do it because
         # policies.TimeoutMixin doesn't accept a reactor on the object.
-        # Maybe we should fix this?
         protocol._channel.callLater = clock.callLater
         protocol.makeConnection(transport)
         protocol.dataReceived(b'POST / HTTP/1.0\r\nContent-Length: 2\r\n\r\n')

--- a/twisted/web/test/test_http.py
+++ b/twisted/web/test/test_http.py
@@ -2446,6 +2446,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
         message.
         """
         factory = http.HTTPFactory()
+        factory.timeOut = None
         factory._logDateTime = "sometime"
         factory._logDateTimeCall = True
         factory.startFactory()

--- a/twisted/web/test/test_http.py
+++ b/twisted/web/test/test_http.py
@@ -2470,6 +2470,30 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
                       factory.logFile.getvalue())
 
 
+    def test_requestBodyTimeoutFromFactory(self):
+        """
+        L{HTTPChannel} timeouts whenever data from a request body is not
+        delivered to it in time, even when it gets built from a L{HTTPFactory}.
+        """
+        clock = Clock()
+        factory = http.HTTPFactory(timeout=100, reactor=clock)
+        factory.startFactory()
+        protocol = factory.buildProtocol(None)
+        transport = StringTransport()
+
+        # This is a terrible violation of the abstraction later of
+        # _genericHTTPChannelProtocol, but we need to do it because
+        # policies.TimeoutMixin doesn't accept a reactor on the object.
+        # Maybe we should fix this?
+        protocol._channel.callLater = clock.callLater
+        protocol.makeConnection(transport)
+        protocol.dataReceived(b'POST / HTTP/1.0\r\nContent-Length: 2\r\n\r\n')
+        clock.advance(99)
+        self.assertFalse(transport.disconnecting)
+        clock.advance(2)
+        self.assertTrue(transport.disconnecting)
+
+
 
 class MultilineHeadersTests(unittest.TestCase):
     """

--- a/twisted/web/topfiles/8481.bugfix
+++ b/twisted/web/topfiles/8481.bugfix
@@ -1,0 +1,1 @@
+The HTTP server now correctly times connections out. (broken in 16.2)


### PR DESCRIPTION
See [Twisted issue 8481](https://twistedmatrix.com/trac/ticket/8481) for more details.

This restores the timeout in the HTTP/1.1 server that was broken in 16.2 when we released the `_GenericHTTPChannelProtocol`.
