### PR TITLE
Time out HTTP/2 connections.

### DIFF
--- a/twisted/web/_http2.py
+++ b/twisted/web/_http2.py
@@ -35,9 +35,9 @@ from twisted.internet.interfaces import (
     IProtocol, ITransport, IConsumer, IPushProducer, ISSLTransport
 )
 from twisted.internet.protocol import Protocol
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
 from twisted.protocols.tls import _PullToPush
-from twisted.python import log
 
 
 # This API is currently considered private.
@@ -45,6 +45,8 @@ __all__ = []
 
 
 _END_STREAM_SENTINEL = object()
+
+log = Logger()
 
 
 # Python versions 2.7.3 and older don't have a memoryview object that plays
@@ -189,7 +191,7 @@ class H2Connection(Protocol, TimeoutMixin):
         """
         # In our override of timeoutConnection we deliberately send a GoAway
         # frame *before* we tear the connection down.
-        log.msg("Timing out client: %s" % str(self.transport.getPeer()))
+        log.info("Timing out client {client}", client=self.transport.getPeer())
 
         # Check whether there are open streams. If there are, we're going to
         # want to use the error code PROTOCOL_ERROR. If there aren't, use

--- a/twisted/web/_http2.py
+++ b/twisted/web/_http2.py
@@ -26,6 +26,7 @@ from zope.interface import implementer
 
 import priority
 import h2.connection
+import h2.errors
 import h2.events
 import h2.exceptions
 
@@ -34,7 +35,9 @@ from twisted.internet.interfaces import (
     IProtocol, ITransport, IConsumer, IPushProducer, ISSLTransport
 )
 from twisted.internet.protocol import Protocol
+from twisted.protocols.policies import TimeoutMixin
 from twisted.protocols.tls import _PullToPush
+from twisted.python import log
 
 
 # This API is currently considered private.
@@ -59,7 +62,7 @@ if sys.version_info < (2, 7, 4):
 
 
 @implementer(IProtocol, IPushProducer)
-class H2Connection(Protocol):
+class H2Connection(Protocol, TimeoutMixin):
     """
     A class representing a single HTTP/2 connection.
 
@@ -132,6 +135,7 @@ class H2Connection(Protocol):
         by the L{twisted.web.http._GenericHTTPChannelProtocol} during upgrade
         to HTTP/2.
         """
+        self.setTimeout(self.timeOut)
         self.conn.initiate_connection()
         self.transport.write(self.conn.data_to_send())
 
@@ -143,6 +147,8 @@ class H2Connection(Protocol):
         @param data: The data received from the transport.
         @type data: L{bytes}
         """
+        self.resetTimeout()
+
         try:
             events = self.conn.receive_data(data)
         except h2.exceptions.ProtocolError:
@@ -175,6 +181,34 @@ class H2Connection(Protocol):
             self.transport.write(dataToSend)
 
 
+    def timeoutConnection(self):
+        """
+        Called when the connection has been inactive for C{self.timeOut}
+        seconds. Cleanly tears the connection down, attempting to notify the
+        peer if needed.
+        """
+        # In our override of timeoutConnection we deliberately send a GoAway
+        # frame *before* we tear the connection down.
+        log.msg("Timing out client: %s" % str(self.transport.getPeer()))
+
+        # Check whether there are open streams. If there are, we're going to
+        # want to use the error code PROTOCOL_ERROR. If there aren't, use
+        # NO_ERROR.
+        if (self.conn.open_outbound_streams > 0 or
+                self.conn.open_inbound_streams > 0):
+            error_code = h2.errors.PROTOCOL_ERROR
+        else:
+            error_code = h2.errors.NO_ERROR
+
+        # TODO: We should probably aim to keep track of what the highest
+        # numbered connection ID is that we've processed.
+        self.conn.close_connection(error_code=error_code)
+        self.transport.write(self.conn.data_to_send())
+
+        # We're done, throw the connection away.
+        self.transport.loseConnection()
+
+
     def connectionLost(self, reason):
         """
         Called when the transport connection is lost.
@@ -183,6 +217,7 @@ class H2Connection(Protocol):
         lost, and cleans up all internal state.
         """
         self._stillProducing = False
+        self.setTimeout(None)
 
         for stream in self.streams.values():
             stream.connectionLost(reason)

--- a/twisted/web/test/test_http2.py
+++ b/twisted/web/test/test_http2.py
@@ -2208,35 +2208,35 @@ class HTTP2TimeoutTests(unittest.TestCase):
         # passed a reactor.
         conn.callLater = reactor.callLater
 
-        f = FrameFactory()
-        b = StringTransport()
+        frameFactory = FrameFactory()
+        transport = StringTransport()
         conn.requestFactory = DummyHTTPHandler
 
         # Send the preamble with no request.
-        conn.makeConnection(b)
+        conn.makeConnection(transport)
 
         # one byte at a time, to stress the implementation.
-        for byte in iterbytes(f.preamble()):
+        for byte in iterbytes(frameFactory.preamble()):
             conn.dataReceived(byte)
 
         # Save the preamble.
-        preamble = b.value()
+        preamble = transport.value()
 
         # Advance the clock.
         reactor.advance(99)
 
         # Everything is fine, no extra data got sent.
-        self.assertEqual(preamble, b.value())
-        self.assertFalse(b.disconnecting)
+        self.assertEqual(preamble, transport.value())
+        self.assertFalse(transport.disconnecting)
 
         # Advance the clock.
         reactor.advance(2)
 
         # We disconnected after sending a GoAway frame.
-        self.assertTrue(b.disconnecting)
+        self.assertTrue(transport.disconnecting)
 
         buffer = FrameBuffer()
-        buffer.receiveData(b.value())
+        buffer.receiveData(transport.value())
         frames = list(buffer)
 
         self.assertEqual(len(frames), 2)
@@ -2259,29 +2259,29 @@ class HTTP2TimeoutTests(unittest.TestCase):
         # passed a reactor.
         conn.callLater = reactor.callLater
 
-        f = FrameFactory()
-        b = StringTransport()
+        frameFactory = FrameFactory()
+        transport = StringTransport()
         conn.requestFactory = DummyHTTPHandler
-        conn.makeConnection(b)
+        conn.makeConnection(transport)
 
         # Send one byte of the preamble.
-        for byte in iterbytes(f.preamble()):
+        for byte in iterbytes(frameFactory.preamble()):
             conn.dataReceived(byte)
 
             # Advance the clock.
             reactor.advance(99)
 
             # Everything is fine.
-            self.assertFalse(b.disconnecting)
+            self.assertFalse(transport.disconnecting)
 
         # Advance the clock.
         reactor.advance(2)
 
         # We disconnected after sending a GoAway frame.
-        self.assertTrue(b.disconnecting)
+        self.assertTrue(transport.disconnecting)
 
         buffer = FrameBuffer()
-        buffer.receiveData(b.value())
+        buffer.receiveData(transport.value())
         frames = list(buffer)
 
         self.assertEqual(len(frames), 2)
@@ -2305,15 +2305,15 @@ class HTTP2TimeoutTests(unittest.TestCase):
         # passed a reactor.
         conn.callLater = reactor.callLater
 
-        f = FrameFactory()
-        b = StringTransport()
+        frameFactory = FrameFactory()
+        transport = StringTransport()
         conn.requestFactory = DummyProducerHandler
-        frames = buildRequestFrames(self.getRequestHeaders, [], f)
-        requestBytes = f.preamble()
+        frames = buildRequestFrames(self.getRequestHeaders, [], frameFactory)
+        requestBytes = frameFactory.preamble()
         requestBytes += b''.join(f.serialize() for f in frames)
 
         # Send the preamble with no request.
-        conn.makeConnection(b)
+        conn.makeConnection(transport)
 
         # one byte at a time, to stress the implementation.
         for byte in iterbytes(requestBytes):
@@ -2323,10 +2323,10 @@ class HTTP2TimeoutTests(unittest.TestCase):
         reactor.advance(101)
 
         # We disconnected after sending a GoAway frame.
-        self.assertTrue(b.disconnecting)
+        self.assertTrue(transport.disconnecting)
 
         buffer = FrameBuffer()
-        buffer.receiveData(b.value())
+        buffer.receiveData(transport.value())
         frames = list(buffer)
 
         self.assertEqual(len(frames), 2)
@@ -2349,21 +2349,21 @@ class HTTP2TimeoutTests(unittest.TestCase):
         # passed a reactor.
         conn.callLater = reactor.callLater
 
-        f = FrameFactory()
-        b = StringTransport()
+        frameFactory = FrameFactory()
+        transport = StringTransport()
         conn.requestFactory = DummyProducerHandler
-        frames = buildRequestFrames(self.getRequestHeaders, [], f)
-        requestBytes = f.preamble()
+        frames = buildRequestFrames(self.getRequestHeaders, [], frameFactory)
+        requestBytes = frameFactory.preamble()
         requestBytes += b''.join(f.serialize() for f in frames)
 
         # Send the preamble with no request.
-        conn.makeConnection(b)
+        conn.makeConnection(transport)
 
         # one byte at a time, to stress the implementation.
         for byte in iterbytes(requestBytes):
             conn.dataReceived(byte)
 
-        sentData = b.value()
+        sentData = transport.value()
         oldCallCount = len(reactor.getDelayedCalls())
 
         # Now lose the connection.
@@ -2375,4 +2375,4 @@ class HTTP2TimeoutTests(unittest.TestCase):
 
         # Advancing the clock should do nothing.
         reactor.advance(101)
-        self.assertEqual(b.value(), sentData)
+        self.assertEqual(transport.value(), sentData)

--- a/twisted/web/topfiles/8480.feature
+++ b/twisted/web/topfiles/8480.feature
@@ -1,0 +1,1 @@
+Twisted web HTTP/2 servers now time out HTTP/2 connections in the same manner as HTTP/1.1 connections.


### PR DESCRIPTION
This is a possible solution to [Twisted ticket 8480](https://twistedmatrix.com/trac/ticket/8480).

This patch adds timeouts to the HTTP/2 server connection management code. The timeout for a HTTP/2 connection defaults to being the same as the timeout for a HTTP/1.1 connection. If that interval passes with no data received on the connection, the connection is torn down cleanly with a GOAWAY frame being emitted to signal to the client that the connection has been cleanly terminated.

Please see the Twisted ticket in trac for more discussion of this patch.
