### PR TITLE
When binding to an IPv6 Socket, set IPv6 Only

### DIFF
--- a/twisted/internet/tcp.py
+++ b/twisted/internet/tcp.py
@@ -962,6 +962,8 @@ class Port(base.BasePort, _SocketCloser):
         s = base.BasePort.createInternetSocket(self)
         if platformType == "posix" and sys.platform != "cygwin":
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if self.addressFamily == socket.AF_INET6 and hasattr(socket, "IPV6_V6ONLY"):
+            s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
         return s
 
 


### PR DESCRIPTION
Without this, you can't bind to all IPv4 interfaces _and_ all IPv6 interfaces because IPv6 will attempt to bind to all the IPv4 interfaces too... for reasons I don't really know why it would do that.

Literally no idea how to test this, since this method doesn't seem to have any tests as it is.
