### PR TITLE
Revert "Replace sys.maxint (which is gone in Python 3) with sys.maxsize"

### DIFF
--- a/twisted/test/test_banana.py
+++ b/twisted/test/test_banana.py
@@ -177,7 +177,7 @@ class BananaTests(BananaTestBase):
                 for n in (m, -m-1):
                     self.enc.dataReceived(self.encode(n))
                     self.assertEqual(self.result, n)
-                    if n > sys.maxsize or n < -sys.maxsize - 1:
+                    if n > sys.maxint or n < -sys.maxint - 1:
                         self.assertIsInstance(self.result, long)
                     else:
                         self.assertIsInstance(self.result, int)


### PR DESCRIPTION
On Windows 10, 64 bit, Python 2.7
   sys.maxint == 2147483647
   sys.maxsize == 9223372036854775807

Every other platform I tested on has sys.maxint == sys.maxsize

We need to fix this in a better way for Python 3, where sys.maxint is gone, but not break
the test on Python 2 for Windows 64-bit.
