### PR TITLE
Replace thread.get_ident() with twisted.python.threadable.getThreadID()

### DIFF
--- a/twisted/enterprise/adbapi.py
+++ b/twisted/enterprise/adbapi.py
@@ -238,9 +238,9 @@ class ConnectionPool:
 
         # These are optional so import them here
         from twisted.python import threadpool
-        import thread
+        from twisted.python import threadable
 
-        self.threadID = thread.get_ident
+        self.threadID = threadable.getThreadID
         self.threadpool = threadpool.ThreadPool(self.min, self.max)
         self.startID = self._reactor.callWhenRunning(self._start)
 


### PR DESCRIPTION
Moved from: https://github.com/twisted/twisted/pull/74

See: http://twistedmatrix.com/trac/ticket/8421

`import thread` is deprecated in Python2, and results in an error in Python3.  The deprecation is documented here:
https://www.python.org/dev/peps/pep-3108/#thread-deprecation

Developers are encouraged to use `import threading` instead.
Instead of doing that, I imported twisted.python.threadable and used twisted.python.threadable.getThreadID()
