### PR TITLE
Improper epytext removed from twisted.words.protocols.jabber.sasl_mechanisms

### DIFF
--- a/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -69,7 +69,7 @@ class Plain(object):
         @param authzid: The authorization identity.
         @type authzid: L{unicode}
 
-        @param authcid; The authentication identity.
+        @param authcid: The authentication identity.
         @type authcid: L{unicode}
 
         @param password: The plain-text password.


### PR DESCRIPTION
See: https://twistedmatrix.com/trac/ticket/8510
