### PR TITLE
Delete testPartial() from test_webclient.py, which has been skipped since 2004

### DIFF
--- a/twisted/web/test/test_webclient.py
+++ b/twisted/web/test/test_webclient.py
@@ -688,33 +688,6 @@ class WebClientTests(unittest.TestCase):
         return d
 
 
-    def testPartial(self):
-        name = self.mktemp()
-        f = open(name, "wb")
-        f.write(b"abcd")
-        f.close()
-
-        partialDownload = [(True, b"abcd456789"),
-                           (True, b"abcd456789"),
-                           (False, b"0123456789")]
-
-        d = defer.succeed(None)
-        for (partial, expectedData) in partialDownload:
-            d.addCallback(self._cbRunPartial, name, partial)
-            d.addCallback(self._cbPartialTest, expectedData, name)
-
-        return d
-
-    testPartial.skip = "Cannot test until webserver can serve partial data properly"
-
-    def _cbRunPartial(self, ignored, name, partial):
-        return client.downloadPage(self.getURL("file"), name, supportPartial=partial)
-
-    def _cbPartialTest(self, ignored, expectedData, filename):
-        bytes = file(filename, "rb").read()
-        self.assertEqual(bytes, expectedData)
-
-
     def test_downloadTimeout(self):
         """
         If the timeout indicated by the C{timeout} parameter to


### PR DESCRIPTION
See:
https://twistedmatrix.com/trac/ticket/8530
