### PR TITLE
Do not call sys.exc_clear() on Python 3 in twisted/trial

### DIFF
--- a/twisted/trial/_dist/workertrial.py
+++ b/twisted/trial/_dist/workertrial.py
@@ -85,7 +85,8 @@ def main(_fdopen=os.fdopen):
             r = protocolIn.read(1)
         except IOError as e:
             if e.args[0] == errno.EINTR:
-                sys.exc_clear()
+                if sys.version_info < (3, 0):
+                    sys.exc_clear()
                 continue
             else:
                 raise


### PR DESCRIPTION
Moved from: https://github.com/twisted/twisted/pull/188

https://twistedmatrix.com/trac/ticket/8469
