### PR TITLE
Fix setting SecondaryAuthority.transferring state

### DIFF
--- a/src/twisted/names/secondary.py
+++ b/src/twisted/names/secondary.py
@@ -141,7 +141,7 @@ class SecondaryAuthority(FileAuthority):
     def transfer(self):
         if self.transferring:
             return
-        self.transfering = True
+        self.transferring = True
 
         reactor = self._reactor
         if reactor is None:
@@ -185,6 +185,6 @@ class SecondaryAuthority(FileAuthority):
 
 
     def _ebTransferred(self, failure):
-        self.transferred = False
+        self.transferring = False
         log.msg("Transferring %s from %s failed after zone transfer" % (self.domain, self.primary))
         log.err(failure)


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8594

I could not get the following description past the Trac spam checker, so I'm describing the issue here.

The flag variable to track the state whether SecondaryAuthority is currently transferring is named `transferring`.

However, as of current trunk, there are two apparent issues in setting the state:
- `transfer()` sets `self.transfering` (one "r" too few)
- `_ebTransferred()` sets `self.transferred` ("...rred" vs "...rring")

Test coverage is currently zero for SecondaryAuthority, and I'm not actually using it for anything (just noticed this as part of my misspellings check), so I won't be working on test cases/coverage for this but will leave doing that to someone else interested if it's required.
