### PR TITLE
Print traceback of original exception for python 2.x

### DIFF
--- a/twisted/__init__.py
+++ b/twisted/__init__.py
@@ -39,6 +39,9 @@ def _checkRequirements():
         raise ImportError(required + ": no module named zope.interface.")
     except:
         # It is installed but not compatible with this version of Python.
+        if version < (3, 0):
+            import traceback
+            traceback.print_exc()
         raise ImportError(required + ".")
     try:
         # Try using the API that we need, which only works right with


### PR DESCRIPTION
Python 2.x doesnt keep track of previous exception what makes debugging difficult.
In my case the real cause of not being able to import twisted was wrong platform.pyc file copied to the sys.path and overriding original platform module.
But raised exception were showing only ImportError.
