### PR TITLE
Remove "python" before invoking tests via "tox -e py35-tests"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ setenv =
    COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
 
 commands =
-    {tests,nomodules}: python {envbindir}/trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose}  {posargs:twisted}
+    {tests,nomodules}: {envbindir}/trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose}  {posargs:twisted}
 
     coverage: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth
     coverage: coverage erase

--- a/twisted/topfiles/8577.bugfix
+++ b/twisted/topfiles/8577.bugfix
@@ -1,1 +1,5 @@
 trial can now run some tests on Windows with Python 3
+
+
+
+


### PR DESCRIPTION
See:
http://twistedmatrix.com/trac/ticket/8577

This is needed, due to conversion to console scripts in https://github.com/twisted/twisted/commit/c5a4c635de259cd1b92a555c930aa426164f9cce

I tested this in Appveyor here:
https://ci.appveyor.com/project/rodrigc/twisted

Getting the coverage target to work will require additional work.
