### PR TITLE
Do not call sys.exc_clear() on Python 3 in twisted/scripts/trial.py

### DIFF
--- a/twisted/scripts/trial.py
+++ b/twisted/scripts/trial.py
@@ -526,13 +526,12 @@ def _wrappedPdb():
         namedModule('readline')
     except ImportError:
         print("readline module not available")
-        sys.exc_clear()
     for path in ('.pdbrc', 'pdbrc'):
         if os.path.exists(path):
             try:
                 rcFile = open(path, 'r')
             except IOError:
-                sys.exc_clear()
+                pass
             else:
                 with rcFile:
                     dbg.rcLines.extend(rcFile.readlines())


### PR DESCRIPTION
See:
http://twistedmatrix.com/trac/ticket/8468
