### PR TITLE
Print traceback of original exception for python 2.x

### DIFF
--- a/twisted/__init__.py
+++ b/twisted/__init__.py
@@ -39,6 +39,9 @@ def _checkRequirements():
         raise ImportError(required + ": no module named zope.interface.")
     except:
         # It is installed but not compatible with this version of Python.
+        if version < (3, 0):
+            import traceback
+            traceback.print_exc()
         raise ImportError(required + ".")
     try:
         # Try using the API that we need, which only works right with

--- a/twisted/topfiles/8620.misc
+++ b/twisted/topfiles/8620.misc
@@ -1,0 +1,1 @@
+Will print traceback of origin exception in __init__.py


### PR DESCRIPTION
[#8620](http://twistedmatrix.com/trac/ticket/8620)
