### PR TITLE
Clarify that AbstractFilePath.getContent() returns bytes

### DIFF
--- a/twisted/python/filepath.py
+++ b/twisted/python/filepath.py
@@ -288,7 +288,10 @@ class AbstractFilePath(object):
 
     def getContent(self):
         """
-        Retrieve the file-like object for this file path.
+        Retrieve the contents of the file at this path.
+
+        @return: the contents of the file
+        @rtype: L{bytes}
         """
         with self.open() as fp:
             return fp.read()

--- a/twisted/topfiles/8637.doc
+++ b/twisted/topfiles/8637.doc
@@ -1,0 +1,1 @@
+twisted.python.filepath.AbstractFilePath.getContent() returns bytes.  The docstring was updated to clarify this.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8637
