### PR TITLE
8653 einarfd ssh transport service name

### DIFF
--- a/twisted/conch/ssh/transport.py
+++ b/twisted/conch/ssh/transport.py
@@ -25,8 +25,7 @@ from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
 
 from twisted.internet import protocol, defer
 from twisted.python import log, randbytes
-from twisted.python.compat import networkString, nativeString, iterbytes
-from twisted.python.compat import _bytesChr as chr
+from twisted.python.compat import networkString, iterbytes, _bytesChr as chr
 
 from twisted.conch.ssh import address, keys, _kex
 from twisted.conch.ssh.common import (
@@ -1704,7 +1703,7 @@ class SSHClientTransport(SSHTransportBase):
         if packet == b'':
             log.msg('got SERVICE_ACCEPT without payload')
         else:
-            name = nativeString(getNS(packet)[0])
+            name = getNS(packet)[0]
             if name != self.instance.name:
                 self.sendDisconnect(
                     DISCONNECT_PROTOCOL_ERROR,
@@ -1719,7 +1718,7 @@ class SSHClientTransport(SSHTransportBase):
         @type instance: subclass of L{twisted.conch.ssh.service.SSHService}
         @param instance: The service to run.
         """
-        self.sendPacket(MSG_SERVICE_REQUEST, NS(networkString(instance.name)))
+        self.sendPacket(MSG_SERVICE_REQUEST, NS(instance.name))
         self.instance = instance
 
     # Client methods

--- a/twisted/conch/test/test_transport.py
+++ b/twisted/conch/test/test_transport.py
@@ -218,7 +218,7 @@ class MockService(service.SSHService):
     @ivar started: True if this service has been started.
     @ivar stopped: True if this service has been stopped.
     """
-    name = "MockService"
+    name = b"MockService"
     started = False
     stopped = False
     protocolMessages = {0xff: "MSG_TEST", 71: "MSG_fiction"}
@@ -1478,7 +1478,7 @@ class ServerSSHTransportTests(ServerSSHTransportBaseCase, TransportTestCase):
         self.proto.ssh_SERVICE_REQUEST(common.NS(b'ssh-userauth'))
         self.assertEqual(self.packets, [(transport.MSG_SERVICE_ACCEPT,
                                          common.NS(b'ssh-userauth'))])
-        self.assertEqual(self.proto.service.name, 'MockService')
+        self.assertEqual(self.proto.service.name, b'MockService')
 
 
     def test_disconnectNEWKEYSData(self):

--- a/twisted/conch/topfiles/8653.bugfix
+++ b/twisted/conch/topfiles/8653.bugfix
@@ -1,0 +1,1 @@
+On Python 3, the SSHService is now a bytestring


### PR DESCRIPTION
This is a fix for https://twistedmatrix.com/trac/ticket/8653

Basically it simplifies the code that has to care about service names and do on wire communication. 
Both the code that has been ported and some of the other SSH code that I haven't finished readying for merge requests yet. 
