### PR TITLE
twisted.python._release.runCommand now uses check_output

### DIFF
--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -46,11 +46,11 @@ def runCommand(args, cwd=None):
     """
     Execute a vector of arguments.
 
-    @type args: L{list} of L{bytes}
+    @type args: L{list} of L{bytes} or L{str}
     @param args: A list of arguments, the first of which will be used
         as the executable to run.
 
-    @type cwd: L{bytes}
+    @type cwd: L{bytes} or L{str}
 
     @param: The current working directory that the command should run
         with.

--- a/twisted/python/_release.py
+++ b/twisted/python/_release.py
@@ -42,26 +42,15 @@ intersphinxURLs = [
 ]
 
 
-def runCommand(args, cwd=None):
+def runCommand(args, **kwargs):
+    """Execute a vector of arguments.
+
+    This is a wrapper around L{subprocess.check_output}, so it takes
+    the same arguments as L{subprocess.Popen} with one difference: all
+    arguments after the vector must be keyword arguments.
     """
-    Execute a vector of arguments.
-
-    @type args: L{list} of L{bytes} or L{str}
-    @param args: A list of arguments, the first of which will be used
-        as the executable to run.
-
-    @type cwd: L{bytes} or L{str}
-
-    @param: The current working directory that the command should run
-        with.
-
-    @rtype: L{bytes}
-    @return: All of the standard output.
-
-    @raise L{subprocess.CalledProcessError}: when the program exited
-        with a non-0 exit code.
-    """
-    return check_output(args, stderr=STDOUT, cwd=cwd)
+    kwargs['stderr'] = STDOUT
+    return check_output(args, **kwargs)
 
 
 

--- a/twisted/python/test/test_release.py
+++ b/twisted/python/test/test_release.py
@@ -29,10 +29,12 @@ from twisted.python import release
 from twisted.python.filepath import FilePath
 from twisted.python.versions import Version
 
+from subprocess import CalledProcessError
+
 from twisted.python._release import (
     _changeVersionInFile, getNextVersion, findTwistedProjects, replaceInFile,
     replaceProjectVersion, Project, generateVersionFileData,
-    changeAllProjectVersions, VERSION_OFFSET, filePathDelta, CommandFailed,
+    changeAllProjectVersions, VERSION_OFFSET, filePathDelta,
     APIBuilder, BuildAPIDocsScript, CheckTopfileScript,
     runCommand, NotWorkingDirectory,
     ChangeVersionsScript, NewsBuilder, SphinxBuilder,
@@ -1543,7 +1545,7 @@ class SphinxBuilderTests(TestCase):
         directory.
         """
         # note no fake sphinx project is created
-        self.assertRaises(CommandFailed,
+        self.assertRaises(CalledProcessError,
                           self.builder.build,
                           self.sphinxDir)
 

--- a/twisted/topfiles/8648.misc
+++ b/twisted/topfiles/8648.misc
@@ -1,0 +1,1 @@
+twisted.python._release now uses subprocess.check_output.


### PR DESCRIPTION
Moved from: https://github.com/twisted/twisted/pull/383

https://twistedmatrix.com/trac/ticket/8648
