### PR TITLE
8683 ssh channel name bytestring

### DIFF
--- a/twisted/conch/ssh/channel.py
+++ b/twisted/conch/ssh/channel.py
@@ -14,7 +14,7 @@ from __future__ import division, absolute_import
 from zope.interface import implementer
 
 from twisted.python import log
-from twisted.python.compat import nativeString
+from twisted.python.compat import nativeString, networkString
 from twisted.internet import interfaces
 
 
@@ -77,12 +77,19 @@ class SSHChannel(log.Logger):
 
 
     def __str__(self):
+        return '<SSHChannel %s (lw %i rw %i)>' % (self.name,
+                self.localWindowLeft, self.remoteWindowLeft)
+
+    def __bytes__(self):
+        """
+        Return a byte string representation of the channel
+        """
         name = self.name
         if name:
             name = nativeString(name)
-        return '<SSHChannel %s (lw %i rw %i)>' % (name,
-                self.localWindowLeft, self.remoteWindowLeft)
-
+        return networkString(
+            '<SSHChannel %s (lw %i rw %i)>' % (
+                name, self.localWindowLeft, self.remoteWindowLeft))
 
     def logPrefix(self):
         id = (self.id is not None and str(self.id)) or "unknown"

--- a/twisted/conch/ssh/channel.py
+++ b/twisted/conch/ssh/channel.py
@@ -29,7 +29,7 @@ class SSHChannel(log.Logger):
     packet going each way.
 
     @ivar name: the name of the channel.
-    @type name: L{str}
+    @type name: L{bytes}
     @ivar localWindowSize: the maximum size of the local window in bytes.
     @type localWindowSize: L{int}
     @ivar localWindowLeft: how many bytes are left in the local window.
@@ -77,13 +77,19 @@ class SSHChannel(log.Logger):
 
 
     def __str__(self):
-        return '<SSHChannel %s (lw %i rw %i)>' % (self.name,
+        name = self.name
+        if name:
+            name = nativeString(name)
+        return '<SSHChannel %s (lw %i rw %i)>' % (name,
                 self.localWindowLeft, self.remoteWindowLeft)
 
 
     def logPrefix(self):
         id = (self.id is not None and str(self.id)) or "unknown"
-        return "SSHChannel %s (%s) on %s" % (self.name, id,
+        name = self.name
+        if name:
+            name = nativeString(name)
+        return "SSHChannel %s (%s) on %s" % (name, id,
                 self.conn.logPrefix())
 
 

--- a/twisted/conch/test/test_channel.py
+++ b/twisted/conch/test/test_channel.py
@@ -22,7 +22,7 @@ except ImportError:
     skipTest = 'Conch SSH not supported.'
     SSHService = object
 from twisted.trial import unittest
-from twisted.python.compat import intToBytes
+from twisted.python.compat import intToBytes, _PY3
 
 
 class MockConnection(SSHService):
@@ -151,8 +151,22 @@ class ChannelTests(unittest.TestCase):
         Test that str(SSHChannel) works gives the channel name and local and
         remote windows at a glance..
         """
-        self.assertEqual(str(self.channel), '<SSHChannel channel (lw 131072 '
-                'rw 0)>')
+        if _PY3:
+            self.assertEqual(
+                str(self.channel), "<SSHChannel b'channel' (lw 131072 rw 0)>")
+
+        else:
+            self.assertEqual(
+                str(self.channel), '<SSHChannel channel (lw 131072 rw 0)>')
+
+    def test_bytes(self):
+        """
+        Test that bytes(SSHChannel) works, gives the channel name and
+        local and remote windows at a glance..
+
+        """
+        self.assertEqual(
+            bytes(self.channel), b'<SSHChannel channel (lw 131072 rw 0)>')
 
     def test_logPrefix(self):
         """

--- a/twisted/conch/test/test_channel.py
+++ b/twisted/conch/test/test_channel.py
@@ -168,6 +168,9 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(
             self.channel.__bytes__(),
             b'<SSHChannel channel (lw 131072 rw 0)>')
+        self.assertEqual(
+            channel.SSHChannel(localWindow=1).__bytes__(),
+            b'<SSHChannel None (lw 1 rw 0)>')
 
     def test_logPrefix(self):
         """

--- a/twisted/conch/test/test_channel.py
+++ b/twisted/conch/test/test_channel.py
@@ -106,7 +106,7 @@ class ChannelTests(unittest.TestCase):
         self.conn = MockConnection()
         self.channel = channel.SSHChannel(conn=self.conn,
                 remoteMaxPacket=10)
-        self.channel.name = 'channel'
+        self.channel.name = b'channel'
 
 
     def test_interface(self):

--- a/twisted/conch/test/test_channel.py
+++ b/twisted/conch/test/test_channel.py
@@ -166,7 +166,8 @@ class ChannelTests(unittest.TestCase):
 
         """
         self.assertEqual(
-            bytes(self.channel), b'<SSHChannel channel (lw 131072 rw 0)>')
+            self.channel.__bytes__(),
+            b'<SSHChannel channel (lw 131072 rw 0)>')
 
     def test_logPrefix(self):
         """

--- a/twisted/conch/topfiles/8683.bugfix
+++ b/twisted/conch/topfiles/8683.bugfix
@@ -1,0 +1,1 @@
+The name field in SShChannel is now a bytestring


### PR DESCRIPTION
This is a fix for bug https://twistedmatrix.com/trac/ticket/8683, and changes the name field in SSHChannel to a bytestring. 

I am a bit conflicted about the changes to **str** and logPrefix.  I am not sure they are the best way of solving the failing unittest when changing the name field. It might be better to either change the unittest to expect differences between Python 3 and 2, or modify the result from them to be common between the two variants but different from what it is today. 
