### PR TITLE
Adding ECDH and the requested changes.

### DIFF
--- a/twisted/conch/ssh/_kex.py
+++ b/twisted/conch/ssh/_kex.py
@@ -6,7 +6,9 @@
 SSH key exchange handling.
 """
 
-from hashlib import sha1, sha256
+from __future__ import absolute_import, division
+
+from hashlib import sha1, sha256, sha384, sha512
 
 from zope.interface import Attribute, implementer, Interface
 
@@ -46,6 +48,12 @@ class _IFixedGroupKexAlgorithm(_IKexAlgorithm):
         "Python generator functions.)")
 
 
+class _IEllipticCurveExchangeKexAlgorithm(_IKexAlgorithm):
+    """
+    An L{_IEllipticCurveExchangeKexAlgorithm} describes a key exchange algorithm
+    that uses an elliptic curve exchange between the client and server.
+    """
+
 
 class _IGroupExchangeKexAlgorithm(_IKexAlgorithm):
     """
@@ -56,6 +64,33 @@ class _IGroupExchangeKexAlgorithm(_IKexAlgorithm):
     requested size. See RFC 4419.
     """
 
+@implementer(_IEllipticCurveExchangeKexAlgorithm)
+class _ECDH256(object):
+    """
+    Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
+    RFC 5656.
+    """
+    preference = 1
+    hashProcessor = sha256
+
+@implementer(_IEllipticCurveExchangeKexAlgorithm)
+class _ECDH384(object):
+    """
+    Elliptic Curve Key Exchange with SHA-384 as HASH. Defined in
+    RFC 5656.
+    """
+    preference = 2
+    hashProcessor = sha384
+
+@implementer(_IEllipticCurveExchangeKexAlgorithm)
+class _ECDH512(object):
+    """
+    Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
+    RFC 5656.
+    """
+    preference = 3
+    hashProcessor = sha512
+
 
 
 @implementer(_IGroupExchangeKexAlgorithm)
@@ -65,7 +100,7 @@ class _DHGroupExchangeSHA256(object):
     RFC 4419, 4.2.
     """
 
-    preference = 1
+    preference = 4
     hashProcessor = sha256
 
 
@@ -77,7 +112,7 @@ class _DHGroupExchangeSHA1(object):
     RFC 4419, 4.1.
     """
 
-    preference = 2
+    preference = 5
     hashProcessor = sha1
 
 
@@ -89,7 +124,7 @@ class _DHGroup1SHA1(object):
     (1024-bit MODP Group). Defined in RFC 4253, 8.1.
     """
 
-    preference = 3
+    preference = 6
     hashProcessor = sha1
     # Diffie-Hellman primes from Oakley Group 2 (RFC 2409, 6.2).
     prime = long('17976931348623159077083915679378745319786029604875601170644'
@@ -108,7 +143,7 @@ class _DHGroup14SHA1(object):
     (2048-bit MODP Group). Defined in RFC 4253, 8.2.
     """
 
-    preference = 4
+    preference = 7
     hashProcessor = sha1
     # Diffie-Hellman primes from Oakley Group 14 (RFC 3526, 3).
     prime = long('32317006071311007300338913926423828248817941241140239112842'
@@ -125,12 +160,24 @@ class _DHGroup14SHA1(object):
 
 
 
+#Which ECDH hash function to use is dependent on the size.
 _kexAlgorithms = {
-    "diffie-hellman-group-exchange-sha256": _DHGroupExchangeSHA256(),
-    "diffie-hellman-group-exchange-sha1": _DHGroupExchangeSHA1(),
-    "diffie-hellman-group1-sha1": _DHGroup1SHA1(),
-    "diffie-hellman-group14-sha1": _DHGroup14SHA1(),
-    }
+    b"diffie-hellman-group-exchange-sha256": _DHGroupExchangeSHA256(),
+    b"diffie-hellman-group-exchange-sha1": _DHGroupExchangeSHA1(),
+    b"diffie-hellman-group1-sha1": _DHGroup1SHA1(),
+    b"diffie-hellman-group14-sha1": _DHGroup14SHA1(),
+    b"ecdh-sha2-nistp256": _ECDH256(),
+    b"ecdh-sha2-nistp384": _ECDH384(),
+    b"ecdh-sha2-nistp521": _ECDH512(),
+    b"ecdh-sha2-nistk163": _ECDH256(),
+    b"ecdh-sha2-nistp224": _ECDH256(),
+    b"ecdh-sha2-nistk233": _ECDH256(),
+    b"ecdh-sha2-nistb233": _ECDH256(),
+    b"ecdh-sha2-nistk283": _ECDH384(),
+    b"ecdh-sha2-nistk409": _ECDH384(),
+    b"ecdh-sha2-nistb409": _ECDH384(),
+    b"ecdh-sha2-nistt571": _ECDH512()
+    } 
 
 
 
@@ -152,6 +199,19 @@ def getKex(kexAlgorithm):
             "Unsupported key exchange algorithm: %s" % (kexAlgorithm,))
     return _kexAlgorithms[kexAlgorithm]
 
+
+def isEllipticCurve(kexAlgorithm):
+    """
+    Returns C{True} if C{kexAlgorithm} is an elliptic curve.
+
+    @param kexAlgorithm: The key exchange algorithm name.
+    @type kexAlgorithm: C{str}
+
+    @return: C{True} if C{kexAlgorithm} is an elliptic curve,
+        otherwise C{False}.
+    @rtype: C{bool}
+    """
+    return _IEllipticCurveExchangeKexAlgorithm.providedBy(getKex(kexAlgorithm))
 
 
 def isFixedGroup(kexAlgorithm):

--- a/twisted/conch/ssh/factory.py
+++ b/twisted/conch/ssh/factory.py
@@ -24,8 +24,8 @@ class SSHFactory(protocol.Factory):
     protocol = transport.SSHServerTransport
 
     services = {
-        'ssh-userauth':userauth.SSHUserAuthServer,
-        'ssh-connection':connection.SSHConnection
+        b'ssh-userauth':userauth.SSHUserAuthServer,
+        b'ssh-connection':connection.SSHConnection
     }
     def startFactory(self):
         """
@@ -58,7 +58,7 @@ class SSHFactory(protocol.Factory):
                     'because we cannot find moduli file')
             t.supportedKeyExchanges = [
                 kexAlgorithm for kexAlgorithm in t.supportedKeyExchanges
-                if _kex.isFixedGroup(kexAlgorithm)]
+                if _kex.isFixedGroup(kexAlgorithm) or _kex.isEllipticCurve(kexAlgorithm)]
         return t
 
 
@@ -102,8 +102,7 @@ class SSHFactory(protocol.Factory):
         @type bits: L{int}
         @rtype:     L{tuple}
         """
-        primesKeys = self.primes.keys()
-        primesKeys.sort(lambda x, y: cmp(abs(x - bits), abs(y - bits)))
+        primesKeys = sorted(self.primes.keys(), key=lambda i: abs(i - bits))
         realBits = primesKeys[0]
         return random.choice(self.primes[realBits])
 
@@ -113,8 +112,8 @@ class SSHFactory(protocol.Factory):
         Return a class to use as a service for the given transport.
 
         @type transport:    L{transport.SSHServerTransport}
-        @type service:      L{str}
+        @type service:      L{bytes}
         @rtype:             subclass of L{service.SSHService}
         """
-        if service == 'ssh-userauth' or hasattr(transport, 'avatar'):
+        if service == b'ssh-userauth' or hasattr(transport, 'avatar'):
             return self.services[service]

--- a/twisted/conch/ssh/transport.py
+++ b/twisted/conch/ssh/transport.py
@@ -16,15 +16,18 @@ import binascii
 import hmac
 import struct
 import zlib
+import re
 
-from hashlib import md5, sha1, sha256, sha512
+from hashlib import md5, sha1, sha256, sha384, sha512
 
-from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
+from cryptography.hazmat.primitives.asymmetric import ec
 
 from twisted.internet import protocol, defer
 from twisted.python import log, randbytes
+from twisted.python.compat import networkString, iterbytes, _bytesChr as chr
 
 from twisted.conch.ssh import address, keys, _kex
 from twisted.conch.ssh.common import (
@@ -140,6 +143,7 @@ class SSHCiphers:
     }
     macMap = {
         b'hmac-sha2-512': sha512,
+        b'hmac-sha2-384': sha384,
         b'hmac-sha2-256': sha256,
         b'hmac-sha1': sha1,
         b'hmac-md5': md5,
@@ -462,6 +466,7 @@ class SSHTransportBase(protocol.Protocol):
     supportedCiphers = _getSupportedCiphers()
     supportedMACs = [
         b'hmac-sha2-512',
+        b'hmac-sha2-384',
         b'hmac-sha2-256',
         b'hmac-sha1',
         b'hmac-md5',
@@ -642,8 +647,9 @@ class SSHTransportBase(protocol.Protocol):
             del self.first
         packetLen, paddingLen = struct.unpack('!LB', first[:5])
         if packetLen > 1048576: # 1024 ** 2
-            self.sendDisconnect(DISCONNECT_PROTOCOL_ERROR,
-                                b'bad packet length %s' % (packetLen,))
+            self.sendDisconnect(
+                DISCONNECT_PROTOCOL_ERROR,
+                networkString('bad packet length %s' % (packetLen,)))
             return
         if len(self.buf) < packetLen + 4 + ms:
             # Not enough data for a packet
@@ -652,8 +658,9 @@ class SSHTransportBase(protocol.Protocol):
         if (packetLen + 4) % bs != 0:
             self.sendDisconnect(
                 DISCONNECT_PROTOCOL_ERROR,
-                b'bad packet mod (%i%%%i == %i)' % (packetLen + 4, bs,
-                                                   (packetLen + 4) % bs))
+                networkString(
+                    'bad packet mod (%i%%%i == %i)' % (
+                        packetLen + 4, bs,(packetLen + 4) % bs)))
             return
         encData, self.buf = self.buf[:4 + packetLen], self.buf[4 + packetLen:]
         packet = first + self.currentEncryptions.decrypt(encData[bs:])
@@ -720,7 +727,7 @@ class SSHTransportBase(protocol.Protocol):
                     self.buf = b'\n'.join(lines[i + 1:])
         packet = self.getPacket()
         while packet:
-            messageNum = ord(packet[0])
+            messageNum = ord(packet[0:1])
             self.dispatchMessage(messageNum, packet[1:])
             packet = self.getPacket()
 
@@ -789,11 +796,7 @@ class SSHTransportBase(protocol.Protocol):
     def kexAlg(self, value):
         """
         Set the key exchange algorithm name.
-
-        @raises ConchError: if the key exchange algorithm is not found.
         """
-        # Check for supportedness.
-        _kex.getKex(value)
         self._kexAlg = value
 
     # Client-initiated rekeying looks like this:
@@ -1224,10 +1227,75 @@ class SSHServerTransport(SSHTransportBase):
             return
         else:
             kexAlgs, keyAlgs, rest = retval
-        if ord(rest[0]): # Flag first_kex_packet_follows?
+        if ord(rest[0:1]): # Flag first_kex_packet_follows?
             if (kexAlgs[0] != self.supportedKeyExchanges[0] or
                 keyAlgs[0] != self.supportedPublicKeys[0]):
                 self.ignoreNextPacket = True # Guess was wrong
+
+
+    def _ssh_KEX_ECDH_INIT(self, packet):
+        """
+        Called from ssh_KEX_DH_GEX_REQUEST_OLD.
+ 
+        Payload::
+
+            string client Elliptic Curve Diffie-Hellman public key
+
+        First we load the host's public/private keys.
+        Then we generate the ECDH public/private keypair for the given curve.
+        With that we generate the shared secret key.
+        Then we compute the hash to sign and send back to the client
+        Along with the server's public key and the ECDH public key.
+
+        @type packet: L{bytes}
+        @param packet: The message data.
+
+        @return: None.
+        """
+        #Get the raw client public key.
+        pktPub, packet = getNS(packet)
+
+        #Get the host's public and private keys
+        pubHostKey = self.factory.publicKeys[self.keyAlg]
+        privHostKey = self.factory.privateKeys[self.keyAlg]
+
+        #Get the base curve info
+        try:
+            shortKex = re.search(b"(nist[kpbt]\d{3})$", self.kexAlg).group(1)
+        except AttributeError:
+            raise UnsupportedAlgorithm(self.kexAlg)
+
+        #Get the curve instance
+        self.curve = keys.curveTable[shortKex]
+        
+        #Generate the private key
+        self.ecPriv = ec.generate_private_key(self.curve, default_backend())
+
+        #Get the public key
+        self.ecPub = self.ecPriv.public_key()
+        encPub = self.ecPub.public_numbers().encode_point()
+
+        #Take the provided public key and transform it into a format for the cryptography module
+        self.theirECPub = ec.EllipticCurvePublicNumbers.from_encoded_point(self.curve, pktPub).public_key(default_backend())
+    
+        #We need to convert to hex, so we can convert to an int so we can make it a multiple precision int.
+        sharedSecret = MP(int(binascii.hexlify(self.ecPriv.exchange(ec.ECDH(), self.theirECPub)), 16))
+
+        # Finish update and digest
+        h = _kex.getHashProcessor(self.kexAlg)()
+        h.update(NS(self.otherVersionString))
+        h.update(NS(self.ourVersionString))
+        h.update(NS(self.otherKexInitPayload))
+        h.update(NS(self.ourKexInitPayload))
+        h.update(NS(pubHostKey.blob()))
+        h.update(NS(pktPub))
+        h.update(NS(encPub))
+        h.update(sharedSecret)
+        exchangeHash = h.digest()
+
+        # DH_GEX_GROUP has the same number we need
+        self.sendPacket(MSG_KEX_DH_GEX_GROUP, NS(pubHostKey.blob()) + NS(encPub) + NS(privHostKey.sign(exchangeHash)))
+        self._keySetup(sharedSecret, exchangeHash)
 
 
     def _ssh_KEXDH_INIT(self, packet):
@@ -1275,8 +1343,9 @@ class SSHServerTransport(SSHTransportBase):
         """
         This represents different key exchange methods that share the same
         integer value.  If the message is determined to be a KEXDH_INIT,
-        C{_ssh_KEXDH_INIT} is called to handle it.  Otherwise, for
-        KEX_DH_GEX_REQUEST_OLD payload::
+        C{_ssh_KEXDH_INIT} is called to handle it. If it is a KEX_ECDH_INIT,
+        C{_ssh_KEX_ECDH_INIT} is called.
+        Otherwise, for KEX_DH_GEX_REQUEST_OLD payload::
 
                 integer ideal (ideal size for the Diffie-Hellman prime)
 
@@ -1293,10 +1362,12 @@ class SSHServerTransport(SSHTransportBase):
             self.ignoreNextPacket = 0
             return
 
-        # KEXDH_INIT and KEX_DH_GEX_REQUEST_OLD have the same value, so use
+        # KEXDH_INIT, KEX_ECDH_INIT, and KEX_DH_GEX_REQUEST_OLD have the same value, so use
         # another cue to decide what kind of message the peer sent us.
         if _kex.isFixedGroup(self.kexAlg):
             return self._ssh_KEXDH_INIT(packet)
+        elif _kex.isEllipticCurve(self.kexAlg):
+            return self._ssh_KEX_ECDH_INIT(packet)
         else:
             self.dhGexRequest = packet
             ideal = struct.unpack('>L', packet)[0]
@@ -1470,17 +1541,40 @@ class SSHClientTransport(SSHTransportBase):
         """
         Called when we receive a MSG_KEXINIT message.  For a description
         of the packet, see SSHTransportBase.ssh_KEXINIT().  Additionally,
-        this method sends the first key exchange packet.  If the agreed-upon
-        exchange has a fixed prime/generator group, generate a public key
-        and send it in a MSG_KEXDH_INIT message. Otherwise, ask for a 2048
-        bit group with a MSG_KEX_DH_GEX_REQUEST message.
+        this method sends the first key exchange packet.  
+
+        If the agreed-upon exchange is ECDH, generate a key pair for the 
+        corresponding curve and send the public key.
+
+        If the agreed-upon exchange has a fixed prime/generator group,
+        generate a public key and send it in a MSG_KEXDH_INIT message.
+        Otherwise, ask for a 2048 bit group with a MSG_KEX_DH_GEX_REQUEST
+        message.
         """
         if SSHTransportBase.ssh_KEXINIT(self, packet) is None:
             # Connection was disconnected while doing base processing.
             # Maybe no common protocols were agreed.
             return
+        # Are we using ECDH?
+        if _kex.isEllipticCurve(self.kexAlg):
+            #Find the base curve info
+            try:
+                shortKex = re.search(b"(nist[kpbt]\d{3})$", self.kexAlg).group(1)
+            except AttributeError:
+                raise UnsupportedAlgorithm(self.kexAlg)
 
-        if _kex.isFixedGroup(self.kexAlg):
+            #Get the curve
+            self.curve = keys.curveTable[shortKex]
+
+            #Generate the keys
+            self.ecPriv = ec.generate_private_key(self.curve, default_backend())
+            self.ecPub = self.ecPriv.public_key()
+
+            #DH_GEX_REQUEST_OLD is the same number we need.
+            self.sendPacket(
+                    MSG_KEX_DH_GEX_REQUEST_OLD,
+                    NS(self.ecPub.public_numbers().encode_point()))
+        elif _kex.isFixedGroup(self.kexAlg):
             # We agreed on a fixed group key exchange algorithm.
             self.x = _generateX(randbytes.secureRandom, 512)
             self.g, self.p = _kex.getDHGeneratorAndPrime(self.kexAlg)
@@ -1499,6 +1593,52 @@ class SSHClientTransport(SSHTransportBase):
                     self._dhMaximalGroupSize,
                     ))
 
+    def _ssh_KEX_ECDH_REPLY(self, packet):
+        """
+        Called to handle a reply to a ECDH exchange message(KEX_ECDH_INIT).
+
+        Like the handler for I{KEXDH_INIT}, this message type has an
+        overlapping value.  This method is called from C{ssh_KEX_DH_GEX_GROUP}
+        if that method detects a non-group key exchange is in progress.
+
+        Payload::
+
+            string serverHostKey
+            string server Elliptic Curve Diffie-Hellman public key
+            string signature
+
+        We verify the host key and continue if it passes verificiation.
+        Otherwise raise an exception and return.
+
+        @type packet: L{bytes}
+        @param packet: The message data.
+
+        @return: None.
+        """
+        #Get the host public key, the raw ECDH public key bytes and the signature
+        self.theirECHost, pktPub, signature, packet = getNS(packet, 3)
+
+        #Take the provided public key and transform it into a format for the cryptography module
+        self.theirECPub = ec.EllipticCurvePublicNumbers.from_encoded_point(self.curve, pktPub).public_key(default_backend())
+
+        #We need to convert to hex, so we can convert to an int so we can make a multiple precision int.
+        sharedSecret = MP(int(binascii.hexlify(self.ecPriv.exchange(ec.ECDH(), self.theirECPub)), 16))
+
+        h = _kex.getHashProcessor(self.kexAlg)()
+        h.update(NS(self.ourVersionString))
+        h.update(NS(self.otherVersionString))
+        h.update(NS(self.ourKexInitPayload))
+        h.update(NS(self.otherKexInitPayload))
+        h.update(NS(self.theirECHost))
+        h.update(NS(self.ecPub.public_numbers().encode_point()))
+        h.update(NS(pktPub))
+        h.update(sharedSecret)
+        exchangeHash = h.digest()
+
+        if not keys.Key.fromString(self.theirECHost).verify(signature, exchangeHash):
+            raise InvalidSignature("Signature Verification Failed!")
+
+        self._keySetup(sharedSecret, exchangeHash)
 
     def _ssh_KEXDH_REPLY(self, packet):
         """
@@ -1527,7 +1667,7 @@ class SSHClientTransport(SSHTransportBase):
         f, packet = getMP(packet)
         signature, packet = getNS(packet)
         fingerprint = b':'.join([binascii.hexlify(ch) for ch in
-                                 md5(pubKey).digest()])
+                                 iterbytes(md5(pubKey).digest())])
         d = self.verifyHostKey(pubKey, fingerprint)
         d.addCallback(self._continueKEXDH_REPLY, pubKey, f, signature)
         d.addErrback(
@@ -1553,6 +1693,8 @@ class SSHClientTransport(SSHTransportBase):
         """
         if _kex.isFixedGroup(self.kexAlg):
             return self._ssh_KEXDH_REPLY(packet)
+        elif _kex.isEllipticCurve(self.kexAlg):
+            self._ssh_KEX_ECDH_REPLY(packet)
         else:
             self.p, rest = getMP(packet)
             self.g, rest = getMP(rest)
@@ -1611,8 +1753,8 @@ class SSHClientTransport(SSHTransportBase):
         pubKey, packet = getNS(packet)
         f, packet = getMP(packet)
         signature, packet = getNS(packet)
-        fingerprint = ':'.join(map(lambda c: '%02x' % (ord(c),),
-            md5(pubKey).digest()))
+        fingerprint = b':'.join(
+            [binascii.hexlify(c) for c in iterbytes(md5(pubKey).digest())])
         d = self.verifyHostKey(pubKey, fingerprint)
         d.addCallback(self._continueGEX_REPLY, pubKey, f, signature)
         d.addErrback(
@@ -1846,7 +1988,7 @@ DISCONNECT_ILLEGAL_USER_NAME = 15
 
 
 messages = {}
-for name, value in globals().items():
+for name, value in list(globals().items()):
     # Avoid legacy messages which overlap with never ones
     if name.startswith('MSG_') and not name.startswith('MSG_KEXDH_'):
         messages[value] = name


### PR DESCRIPTION
Let's hope 3rd time's the charm.

Additional notes for this request:
It seems that some of the upstream commits created a few more errors in my code that I needed to address.  Most of them involved putting b in front of strings, but I did need to make a possibly significant change on line 1282 and 1625 of transport.py.

I changed
`sharedSecret = MP(int(self.ecPriv.exchange(ec.ECDH(), self.theirECPub).encode('hex')), 16))`
to
`sharedSecret = MP(int(binascii.hexlify(self.ecPriv.exchange(ec.ECDH(), self.theirECPub)), 16))`
to work with python 3.

I still feel like this transformation could be done better, but it's the best I could come up with.

Also as I mentioned before, but will reiterate this code does not pass all trials.  It still fails on the twisted.conch.test.test_endpoints.NewConnectionTests.test_mismatchedHostKey check.

While making changes to the code I found that it appears to have to do with the addition of  `or _kex.isEllipticCurve(kexAlgorithm)]` to factory.py.  Why I'm not exactly sure, and I'm not sure how to fix it, but hasn't caused any errors when I use Twisted as a client or a server.

I can add a ticket for this to be fixed.
