### PR TITLE
Use bytes instead of string in twisted.internet._sslverify

### DIFF
--- a/twisted/internet/_sslverify.py
+++ b/twisted/internet/_sslverify.py
@@ -452,7 +452,7 @@ class CertBase:
         @type interface: L{zope.interface.interfaces.IInterface}
 
         @return: an L{IOpenSSLTrustRoot} provider or L{NotImplemented}
-        @rtype: C{interface} or L{NotImplemented}
+        @rtype: L{IOpenSSLTrustRoot} or L{NotImplemented}
         """
         if interface is IOpenSSLTrustRoot:
             return OpenSSLCertificateAuthorities([self.original])
@@ -532,11 +532,12 @@ class Certificate(CertBase):
         """
         Get the certificate for the remote end of the given transport.
 
-        @type: L{ISystemHandle}
+        @param transport: an L{ISystemHandle} provider
+
         @rtype: C{Class}
 
         @raise: L{CertificateError}, if the given transport does not have a peer
-        certificate.
+            certificate.
         """
         return _handleattrhelper(Class, transport, 'peer')
     peerFromTransport = classmethod(peerFromTransport)
@@ -551,7 +552,7 @@ class Certificate(CertBase):
         @rtype: C{Class}
 
         @raise: L{CertificateError}, if the given transport does not have a host
-        certificate.
+            certificate.
         """
         return _handleattrhelper(Class, transport, 'host')
     hostFromTransport = classmethod(hostFromTransport)
@@ -585,7 +586,9 @@ class Certificate(CertBase):
         algorithm.
 
         @param method: One of C{'md5'} or C{'sha'}.
-        @rtype: L{str}
+
+        @return: The digest of the object, formatted as b":"-delimited hex pairs
+        @rtype: L{bytes}
         """
         return self.original.digest(method)
 

--- a/twisted/internet/_sslverify.py
+++ b/twisted/internet/_sslverify.py
@@ -327,7 +327,7 @@ class DistinguishedName(dict):
 
     A L{DistinguishedName} should be constructed using keyword arguments whose
     keys can be any of the field names above (as a native string), and the
-    values are either Unicode text which is encodable to ASCII, or C{bytes}
+    values are either Unicode text which is encodable to ASCII, or L{bytes}
     limited to the ASCII subset. Any fields passed to the constructor will be
     set as attributes, accessible using both their extended name and their
     shortened acronym. The attribute values will be the ASCII-encoded
@@ -394,7 +394,7 @@ class DistinguishedName(dict):
         """
         Return a multi-line, human-readable representation of this DN.
 
-        @rtype: C{str}
+        @rtype: L{str}
         """
         l = []
         lablen = 0
@@ -513,7 +513,7 @@ class Certificate(CertBase):
         """
         Dump this certificate to a PEM-format data string.
 
-        @rtype: C{str}
+        @rtype: L{str}
         """
         return self.dump(crypto.FILETYPE_PEM)
 
@@ -574,7 +574,7 @@ class Certificate(CertBase):
         """
         Retrieve the serial number of this certificate.
 
-        @rtype: C{int}
+        @rtype: L{int}
         """
         return self.original.get_serial_number()
 
@@ -585,7 +585,7 @@ class Certificate(CertBase):
         algorithm.
 
         @param method: One of C{'md5'} or C{'sha'}.
-        @rtype: C{str}
+        @rtype: L{str}
         """
         return self.original.digest(method)
 
@@ -1289,7 +1289,7 @@ def optionsForClientTLS(hostname, trustRoot=None, clientCertificate=None,
         remote peer does not offer NPN or ALPN, the connection will be
         established, but no protocol wil be negotiated. Protocols earlier in
         the list are preferred over those later in the list.
-    @type acceptableProtocols: C{list} of C{bytes}
+    @type acceptableProtocols: L{list} of L{bytes}
 
     @param extraCertificateOptions: keyword-only argument; this is a dictionary
         of additional keyword arguments to be presented to
@@ -1413,7 +1413,7 @@ class OpenSSLCertificateOptions(object):
             ignored otherwise.  Since verify is L{False} by default, this is
             L{None} by default.
 
-        @type caCerts: C{list} of L{OpenSSL.crypto.X509}
+        @type caCerts: L{list} of L{OpenSSL.crypto.X509}
 
         @param verifyDepth: Depth in certificate chain down to which to verify.
             If unspecified, use the underlying default (9).
@@ -1482,7 +1482,7 @@ class OpenSSLCertificateOptions(object):
             If the remote peer does not offer NPN or ALPN, the connection will
             be established, but no protocol wil be negotiated. Protocols
             earlier in the list are preferred over those later in the list.
-        @type acceptableProtocols: C{list} of C{bytes}
+        @type acceptableProtocols: L{list} of L{bytes}
 
         @raise ValueError: when C{privateKey} or C{certificate} are set without
             setting the respective other.
@@ -1910,7 +1910,7 @@ def _setAcceptableProtocols(context, acceptableProtocols):
         remote peer does not offer NPN or ALPN, the connection will be
         established, but no protocol wil be negotiated. Protocols earlier in
         the list are preferred over those later in the list.
-    @type acceptableProtocols: C{list} of C{bytes}
+    @type acceptableProtocols: L{list} of L{bytes}
     """
     def protoSelectCallback(conn, protocols):
         """
@@ -1922,7 +1922,7 @@ def _setAcceptableProtocols(context, acceptableProtocols):
         @type conn: L{OpenSSL.SSL.Connection}
 
         @param conn: Protocols advertised by the other side.
-        @type conn: C{list} of C{bytes}
+        @type conn: L{list} of L{bytes}
         """
         overlap = set(protocols) & set(acceptableProtocols)
 

--- a/twisted/internet/_sslverify.py
+++ b/twisted/internet/_sslverify.py
@@ -1645,11 +1645,11 @@ class OpenSSLCertificateOptions(object):
             name = "%s-%d" % (reflect.qual(self.__class__), _sessionCounter())
             sessionName = md5(networkString(name)).hexdigest()
 
-            ctx.set_session_id(sessionName)
+            ctx.set_session_id(sessionName.encode('ascii'))
 
         if self.dhParameters:
             ctx.load_tmp_dh(self.dhParameters._dhFile.path)
-        ctx.set_cipher_list(nativeString(self._cipherString))
+        ctx.set_cipher_list(self._cipherString.encode('ascii'))
 
         if self._ecCurve is not None:
             try:
@@ -1788,7 +1788,7 @@ def _expandCipherString(cipherString, method, options):
     ctx = SSL.Context(method)
     ctx.set_options(options)
     try:
-        ctx.set_cipher_list(nativeString(cipherString))
+        ctx.set_cipher_list(cipherString.encode('ascii'))
     except SSL.Error as e:
         if e.args[0][0][2] == 'no cipher match':
             return []

--- a/twisted/test/test_sslverify.py
+++ b/twisted/test/test_sslverify.py
@@ -747,7 +747,7 @@ class OpenSSLOptionsTests(unittest.TestCase):
         )
         opts._contextFactory = FakeContext
         ctx = opts.getContext()
-        self.assertEqual(opts._cipherString, ctx._cipherList)
+        self.assertEqual(opts._cipherString.encode('ascii'), ctx._cipherList)
 
 
     def test_givesMeaningfulErrorMessageIfNoCipherMatches(self):
@@ -781,7 +781,7 @@ class OpenSSLOptionsTests(unittest.TestCase):
         )
         opts._contextFactory = FakeContext
         ctx = opts.getContext()
-        self.assertEqual(u'sentinel', ctx._cipherList)
+        self.assertEqual(b'sentinel', ctx._cipherList)
 
 
     def test_basicSecurityOptionsAreSet(self):

--- a/twisted/test/test_sslverify.py
+++ b/twisted/test/test_sslverify.py
@@ -392,7 +392,7 @@ class FakeContext(object):
 
     @ivar _method: See C{method} parameter of L{__init__}.
 
-    @ivar _options: C{int} of C{OR}ed values from calls of L{set_options}.
+    @ivar _options: L{int} of C{OR}ed values from calls of L{set_options}.
 
     @ivar _certificate: Set by L{use_certificate}.
 
@@ -404,7 +404,7 @@ class FakeContext(object):
 
     @ivar _sessionID: Set by L{set_session_id}.
 
-    @ivar _extraCertChain: Accumulated C{list} of all extra certificates added
+    @ivar _extraCertChain: Accumulated L{list} of all extra certificates added
         by L{add_extra_chain_cert}.
 
     @ivar _cipherList: Set by L{set_cipher_list}.
@@ -1811,7 +1811,7 @@ def negotiateProtocol(serverProtocols,
     @param clientProtocols: The protocols the client is willing to negotiate.
     @param clientOptions: The type of C{OpenSSLCertificateOptions} class to
         use for the client. Defaults to C{OpenSSLCertificateOptions}.
-    @return: A C{typle} of: the negotiated protocol and the reason the
+    @return: A L{tuple} of the negotiated protocol and the reason the
         connection was lost.
     """
     caCertificate, serverCertificate = certificatesForAuthorityAndServer()


### PR DESCRIPTION
Moved from: https://github.com/twisted/twisted/pull/415

https://twistedmatrix.com/trac/ticket/8672
