### PR TITLE
8697 einarfd py3 conch client knownhosts

### DIFF
--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -96,16 +96,16 @@ def isInKnownHosts(host, pubKey, options):
         os.mkdir(os.path.expanduser('~/.ssh'))
     kh_file = options['known-hosts'] or _KNOWN_HOSTS
     try:
-        known_hosts = open(os.path.expanduser(kh_file))
+        known_hosts = open(os.path.expanduser(kh_file), 'rb')
     except IOError:
         return 0
     with known_hosts:
-        for line in known_hosts.xreadlines():
+        for line in known_hosts.readlines():
             split = line.split()
             if len(split) < 3:
                 continue
             hosts, hostKeyType, encodedKey = split[:3]
-            if host not in hosts.split(','): # incorrect host
+            if host not in hosts.split(b','): # incorrect host
                 continue
             if hostKeyType != keyType: # incorrect type of key
                 continue

--- a/twisted/conch/client/knownhosts.py
+++ b/twisted/conch/client/knownhosts.py
@@ -8,8 +8,10 @@ An implementation of the OpenSSH known_hosts database.
 @since: 8.2
 """
 
+from __future__ import absolute_import, division
+
 import hmac
-from binascii import Error as DecodeError, b2a_base64
+from binascii import Error as DecodeError, b2a_base64, a2b_base64
 from contextlib import closing
 from hashlib import sha1
 
@@ -22,6 +24,7 @@ from twisted.python.util import FancyEqMixin
 from twisted.conch.interfaces import IKnownHostEntry
 from twisted.conch.error import HostKeyChanged, UserRejectedKey, InvalidEntry
 from twisted.conch.ssh.keys import Key, BadKeyError
+from twisted.python.compat import nativeString
 
 
 def _b64encode(s):
@@ -58,11 +61,11 @@ def _extractCommon(string):
     splitkey = keyAndComment.split(None, 1)
     if len(splitkey) == 2:
         keyString, comment = splitkey
-        comment = comment.rstrip("\n")
+        comment = comment.rstrip(b"\n")
     else:
         keyString = splitkey[0]
         comment = None
-    key = Key.fromString(keyString.decode('base64'))
+    key = Key.fromString(a2b_base64(keyString))
     return hostnames, keyType, key, comment
 
 
@@ -73,13 +76,13 @@ class _BaseEntry(object):
     represent keys and key types the same way.
 
     @ivar keyType: The type of the key; either ssh-dss or ssh-rsa.
-    @type keyType: L{str}
+    @type keyType: L{bytes}
 
     @ivar publicKey: The server public key indicated by this line.
     @type publicKey: L{twisted.conch.ssh.keys.Key}
 
     @ivar comment: Trailing garbage after the key line.
-    @type comment: L{str}
+    @type comment: L{bytes}
     """
 
     def __init__(self, keyType, publicKey, comment):
@@ -110,7 +113,7 @@ class PlainEntry(_BaseEntry):
     file.
 
     @ivar _hostnames: the list of all host-names associated with this entry.
-    @type _hostnames: L{list} of L{str}
+    @type _hostnames: L{list} of L{bytes}
     """
 
     def __init__(self, hostnames, keyType, publicKey, comment):
@@ -126,7 +129,7 @@ class PlainEntry(_BaseEntry):
         @param string: a space-separated string formatted like "hostname
         key-type base64-key-data comment".
 
-        @type string: L{str}
+        @type string: L{bytes}
 
         @raise DecodeError: if the key is not valid encoded as valid base64.
 
@@ -142,7 +145,7 @@ class PlainEntry(_BaseEntry):
         @rtype: L{PlainEntry}
         """
         hostnames, keyType, key, comment = _extractCommon(string)
-        self = cls(hostnames.split(","), keyType, key, comment)
+        self = cls(hostnames.split(b","), keyType, key, comment)
         return self
 
     fromString = classmethod(fromString)
@@ -154,7 +157,7 @@ class PlainEntry(_BaseEntry):
 
         @param hostname: A hostname or IP address literal to check against this
             entry.
-        @type hostname: L{str}
+        @type hostname: L{bytes}
 
         @return: C{True} if this entry is for the given hostname or IP address,
             C{False} otherwise.
@@ -172,12 +175,12 @@ class PlainEntry(_BaseEntry):
             information.
         @rtype: L{bytes}
         """
-        fields = [','.join(self._hostnames),
+        fields = [b','.join(self._hostnames),
                   self.keyType,
                   _b64encode(self.publicKey.blob())]
         if self.comment is not None:
             fields.append(self.comment)
-        return ' '.join(fields)
+        return b' '.join(fields)
 
 
 
@@ -218,7 +221,7 @@ class UnparsedEntry(object):
             used to initialize this entry but without a trailing newline.
         @rtype: L{bytes}
         """
-        return self._string.rstrip("\n")
+        return self._string.rstrip(b"\n")
 
 
 
@@ -255,7 +258,7 @@ class HashedEntry(_BaseEntry, FancyEqMixin):
     known_hosts file as opposed to a plaintext one.
     """
 
-    MAGIC = '|1|'
+    MAGIC = b'|1|'
 
     compareAttributes = (
         "_hostSalt", "_hostHash", "keyType", "publicKey", "comment")
@@ -289,11 +292,11 @@ class HashedEntry(_BaseEntry, FancyEqMixin):
             information from C{string}.
         """
         stuff, keyType, key, comment = _extractCommon(string)
-        saltAndHash = stuff[len(cls.MAGIC):].split("|")
+        saltAndHash = stuff[len(cls.MAGIC):].split(b"|")
         if len(saltAndHash) != 2:
             raise InvalidEntry()
         hostSalt, hostHash = saltAndHash
-        self = cls(hostSalt.decode("base64"), hostHash.decode("base64"),
+        self = cls(a2b_base64(hostSalt), a2b_base64(hostHash),
                    keyType, key, comment)
         return self
 
@@ -325,13 +328,13 @@ class HashedEntry(_BaseEntry, FancyEqMixin):
             hashed.
         @rtype: L{bytes}
         """
-        fields = [self.MAGIC + '|'.join([_b64encode(self._hostSalt),
-                                         _b64encode(self._hostHash)]),
+        fields = [self.MAGIC + b'|'.join([_b64encode(self._hostSalt),
+                                          _b64encode(self._hostHash)]),
                   self.keyType,
                   _b64encode(self.publicKey.blob())]
         if self.comment is not None:
             fields.append(self.comment)
-        return ' '.join(fields)
+        return b' '.join(fields)
 
 
 
@@ -467,7 +470,7 @@ class KnownHostsFile(object):
                 if not self.hasHostKey(ip, key):
                     ui.warn("Warning: Permanently added the %s host key for "
                             "IP address '%s' to the list of known hosts." %
-                            (key.type(), ip))
+                            (key.type(), nativeString(ip)))
                     self.addHostKey(ip, key)
                     self.save()
                 return result
@@ -485,7 +488,8 @@ class KnownHostsFile(object):
                     "can't be established.\n"
                     "RSA key fingerprint is %s.\n"
                     "Are you sure you want to continue connecting (yes/no)? " %
-                    (hostname, ip, key.fingerprint()))
+                    (nativeString(hostname), nativeString(ip),
+                     key.fingerprint()))
                 return proceed.addCallback(promptResponse)
         return hhk.addCallback(gotHasKey)
 
@@ -508,7 +512,7 @@ class KnownHostsFile(object):
         @rtype: L{HashedEntry}
         """
         salt = secureRandom(20)
-        keyType = "ssh-" + key.type().lower()
+        keyType = key.sshType()
         entry = HashedEntry(salt, _hmacedString(salt, hostname),
                             keyType, key, None)
         self._added.append(entry)
@@ -524,15 +528,15 @@ class KnownHostsFile(object):
             p.makedirs()
 
         if self._clobber:
-            mode = "w"
+            mode = "wb"
         else:
-            mode = "a"
+            mode = "ab"
 
         with self._savePath.open(mode) as hostsFileObj:
             if self._added:
                 hostsFileObj.write(
-                    "\n".join([entry.toString() for entry in self._added]) +
-                    "\n")
+                    b"\n".join([entry.toString() for entry in self._added]) +
+                    b"\n")
                 self._added = []
         self._clobber = False
 

--- a/twisted/conch/ssh/keys.py
+++ b/twisted/conch/ssh/keys.py
@@ -9,6 +9,7 @@ Handling of RSA and DSA keys.
 from __future__ import absolute_import, division
 
 import base64
+import binascii
 import itertools
 import warnings
 
@@ -800,7 +801,9 @@ class Key(object):
 
         @rtype: L{str}
         """
-        return ':'.join([x.encode('hex') for x in md5(self.blob()).digest()])
+        return nativeString(
+            b':'.join([binascii.hexlify(x)
+                       for x in iterbytes(md5(self.blob()).digest())]))
 
 
     def type(self):

--- a/twisted/conch/test/test_knownhosts.py
+++ b/twisted/conch/test/test_knownhosts.py
@@ -5,6 +5,8 @@
 Tests for L{twisted.conch.client.knownhosts}.
 """
 
+from __future__ import absolute_import, division
+
 import os
 from binascii import Error as BinasciiError, b2a_base64, a2b_base64
 
@@ -21,6 +23,7 @@ else:
 from zope.interface.verify import verifyObject
 
 from twisted.python.filepath import FilePath
+from twisted.python.compat import networkString
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import Deferred
 from twisted.conch.interfaces import IKnownHostEntry
@@ -29,42 +32,42 @@ from twisted.test.testutils import ComparisonTestsMixin
 
 
 sampleEncodedKey = (
-    'AAAAB3NzaC1yc2EAAAABIwAAAQEAsV0VMRbGmzhqxxayLRHmvnFvtyNqgbNKV46dU1bVFB+3y'
-    'tNvue4Riqv/SVkPRNwMb7eWH29SviXaBxUhYyzKkDoNUq3rTNnH1Vnif6d6X4JCrUb5d3W+Dm'
-    'YClyJrZ5HgD/hUpdSkTRqdbQ2TrvSAxRacj+vHHT4F4dm1bJSewm3B2D8HVOoi/CbVh3dsIiC'
-    'dp8VltdZx4qYVfYe2LwVINCbAa3d3tj9ma7RVfw3OH2Mfb+toLd1N5tBQFb7oqTt2nC6I/6Bd'
-    '4JwPUld+IEitw/suElq/AIJVQXXujeyiZlea90HE65U2mF1ytr17HTAIT2ySokJWyuBANGACk'
-    '6iIaw==')
+    b'AAAAB3NzaC1yc2EAAAABIwAAAQEAsV0VMRbGmzhqxxayLRHmvnFvtyNqgbNKV46dU1bVFB+3y'
+    b'tNvue4Riqv/SVkPRNwMb7eWH29SviXaBxUhYyzKkDoNUq3rTNnH1Vnif6d6X4JCrUb5d3W+Dm'
+    b'YClyJrZ5HgD/hUpdSkTRqdbQ2TrvSAxRacj+vHHT4F4dm1bJSewm3B2D8HVOoi/CbVh3dsIiC'
+    b'dp8VltdZx4qYVfYe2LwVINCbAa3d3tj9ma7RVfw3OH2Mfb+toLd1N5tBQFb7oqTt2nC6I/6Bd'
+    b'4JwPUld+IEitw/suElq/AIJVQXXujeyiZlea90HE65U2mF1ytr17HTAIT2ySokJWyuBANGACk'
+    b'6iIaw==')
 
 otherSampleEncodedKey = (
-    'AAAAB3NzaC1yc2EAAAABIwAAAIEAwaeCZd3UCuPXhX39+/p9qO028jTF76DMVd9mPvYVDVXuf'
-    'WckKZauF7+0b7qm+ChT7kan6BzRVo4++gCVNfAlMzLysSt3ylmOR48tFpAfygg9UCX3DjHz0E'
-    'lOOUKh3iifc9aUShD0OPaK3pR5JJ8jfiBfzSYWt/hDi/iZ4igsSs8=')
+    b'AAAAB3NzaC1yc2EAAAABIwAAAIEAwaeCZd3UCuPXhX39+/p9qO028jTF76DMVd9mPvYVDVXuf'
+    b'WckKZauF7+0b7qm+ChT7kan6BzRVo4++gCVNfAlMzLysSt3ylmOR48tFpAfygg9UCX3DjHz0E'
+    b'lOOUKh3iifc9aUShD0OPaK3pR5JJ8jfiBfzSYWt/hDi/iZ4igsSs8=')
 
 thirdSampleEncodedKey = (
-    'AAAAB3NzaC1yc2EAAAABIwAAAQEAl/TQakPkePlnwCBRPitIVUTg6Z8VzN1en+DGkyo/evkmLw'
-    '7o4NWR5qbysk9A9jXW332nxnEuAnbcCam9SHe1su1liVfyIK0+3bdn0YRB0sXIbNEtMs2LtCho'
-    '/aV3cXPS+Cf1yut3wvIpaRnAzXxuKPCTXQ7/y0IXa8TwkRBH58OJa3RqfQ/NsSp5SAfdsrHyH2'
-    'aitiVKm2jfbTKzSEqOQG/zq4J9GXTkq61gZugory/Tvl5/yPgSnOR6C9jVOMHf27ZPoRtyj9SY'
-    '343Hd2QHiIE0KPZJEgCynKeWoKz8v6eTSK8n4rBnaqWdp8MnGZK1WGy05MguXbyCDuTC8AmJXQ'
-    '==')
+    b'AAAAB3NzaC1yc2EAAAABIwAAAQEAl/TQakPkePlnwCBRPitIVUTg6Z8VzN1en+DGkyo/evkmLw'
+    b'7o4NWR5qbysk9A9jXW332nxnEuAnbcCam9SHe1su1liVfyIK0+3bdn0YRB0sXIbNEtMs2LtCho'
+    b'/aV3cXPS+Cf1yut3wvIpaRnAzXxuKPCTXQ7/y0IXa8TwkRBH58OJa3RqfQ/NsSp5SAfdsrHyH2'
+    b'aitiVKm2jfbTKzSEqOQG/zq4J9GXTkq61gZugory/Tvl5/yPgSnOR6C9jVOMHf27ZPoRtyj9SY'
+    b'343Hd2QHiIE0KPZJEgCynKeWoKz8v6eTSK8n4rBnaqWdp8MnGZK1WGy05MguXbyCDuTC8AmJXQ'
+    b'==')
 
 sampleKey = a2b_base64(sampleEncodedKey)
 otherSampleKey = a2b_base64(otherSampleEncodedKey)
 thirdSampleKey = a2b_base64(thirdSampleEncodedKey)
 
 samplePlaintextLine = (
-    "www.twistedmatrix.com ssh-rsa " + sampleEncodedKey + "\n")
+    b"www.twistedmatrix.com ssh-rsa " + sampleEncodedKey + b"\n")
 
 otherSamplePlaintextLine = (
-    "divmod.com ssh-rsa " + otherSampleEncodedKey + "\n")
+    b"divmod.com ssh-rsa " + otherSampleEncodedKey + b"\n")
 
 sampleHostIPLine = (
-    "www.twistedmatrix.com,198.49.126.131 ssh-rsa " + sampleEncodedKey + "\n")
+    b"www.twistedmatrix.com,198.49.126.131 ssh-rsa " + sampleEncodedKey + b"\n")
 
 sampleHashedLine = (
-    "|1|gJbSEPBG9ZSBoZpHNtZBD1bHKBA=|bQv+0Xa0dByrwkA1EB0E7Xop/Fo= ssh-rsa " +
-    sampleEncodedKey + "\n")
+    b"|1|gJbSEPBG9ZSBoZpHNtZBD1bHKBA=|bQv+0Xa0dByrwkA1EB0E7Xop/Fo= ssh-rsa " +
+    sampleEncodedKey + b"\n")
 
 
 class EntryTestsMixin:
@@ -95,7 +98,7 @@ class EntryTestsMixin:
         """
         entry = self.entry
         self.assertEqual(entry.publicKey, Key.fromString(sampleKey))
-        self.assertEqual(entry.keyType, "ssh-rsa")
+        self.assertEqual(entry.keyType, b"ssh-rsa")
 
 
     def test_matchesKey(self):
@@ -118,8 +121,8 @@ class EntryTestsMixin:
         L{IKnownHostEntry.matchesHost} checks to see if an entry matches a
         given hostname.
         """
-        self.assertTrue(self.entry.matchesHost("www.twistedmatrix.com"))
-        self.assertFalse(self.entry.matchesHost("www.divmod.com"))
+        self.assertTrue(self.entry.matchesHost(b"www.twistedmatrix.com"))
+        self.assertFalse(self.entry.matchesHost(b"www.divmod.com"))
 
 
 
@@ -142,7 +145,7 @@ class PlainEntryTests(EntryTestsMixin, TestCase):
         A "hostname,ip" formatted line will match both the host and the IP.
         """
         self.entry = PlainEntry.fromString(self.hostIPLine)
-        self.assertTrue(self.entry.matchesHost("198.49.126.131"))
+        self.assertTrue(self.entry.matchesHost(b"198.49.126.131"))
         self.test_matchesHost()
 
 
@@ -151,10 +154,10 @@ class PlainEntryTests(EntryTestsMixin, TestCase):
         L{PlainEntry.toString} generates the serialized OpenSSL format string
         for the entry, sans newline.
         """
-        self.assertEqual(self.entry.toString(), self.plaintextLine.rstrip("\n"))
+        self.assertEqual(self.entry.toString(), self.plaintextLine.rstrip(b"\n"))
         multiHostEntry = PlainEntry.fromString(self.hostIPLine)
         self.assertEqual(multiHostEntry.toString(),
-                         self.hostIPLine.rstrip("\n"))
+                         self.hostIPLine.rstrip(b"\n"))
 
 
 
@@ -163,8 +166,8 @@ class PlainTextWithCommentTests(PlainEntryTests):
     Test cases for L{PlainEntry} when parsed from a line with a comment.
     """
 
-    plaintextLine = samplePlaintextLine[:-1] + " plain text comment.\n"
-    hostIPLine = sampleHostIPLine[:-1] + " text following host/IP line\n"
+    plaintextLine = samplePlaintextLine[:-1] + b" plain text comment.\n"
+    hostIPLine = sampleHostIPLine[:-1] + b" text following host/IP line\n"
 
 
 
@@ -192,7 +195,7 @@ class HashedEntryTests(EntryTestsMixin, ComparisonTestsMixin, TestCase):
         L{HashedEntry.toString} generates the serialized OpenSSL format string
         for the entry, sans the newline.
         """
-        self.assertEqual(self.entry.toString(), self.hashedLine.rstrip("\n"))
+        self.assertEqual(self.entry.toString(), self.hashedLine.rstrip(b"\n"))
 
 
     def test_equality(self):
@@ -201,49 +204,50 @@ class HashedEntryTests(EntryTestsMixin, ComparisonTestsMixin, TestCase):
         the same host and key in exactly the same way: the host salt, host hash,
         public key type, public key, and comment fields must all be equal.
         """
-        hostSalt = "gJbSEPBG9ZSBoZpHNtZBD1bHKBA"
-        hostHash = "bQv+0Xa0dByrwkA1EB0E7Xop/Fo"
+        hostSalt = b"gJbSEPBG9ZSBoZpHNtZBD1bHKBA"
+        hostHash = b"bQv+0Xa0dByrwkA1EB0E7Xop/Fo"
         publicKey = Key.fromString(sampleKey)
-        comment = "hello, world"
+        keyType = networkString(publicKey.type())
+        comment = b"hello, world"
 
         entry = HashedEntry(
-            hostSalt, hostHash, publicKey.type(), publicKey, comment)
+            hostSalt, hostHash, keyType, publicKey, comment)
         duplicate = HashedEntry(
-            hostSalt, hostHash, publicKey.type(), publicKey, comment)
+            hostSalt, hostHash, keyType, publicKey, comment)
 
         # Vary the host salt
         self.assertNormalEqualityImplementation(
             entry, duplicate,
             HashedEntry(
-                hostSalt[::-1], hostHash, publicKey.type(), publicKey,
+                hostSalt[::-1], hostHash, keyType, publicKey,
                 comment))
 
         # Vary the host hash
         self.assertNormalEqualityImplementation(
             entry, duplicate,
             HashedEntry(
-                hostSalt, hostHash[::-1], publicKey.type(), publicKey,
+                hostSalt, hostHash[::-1], keyType, publicKey,
                 comment))
 
         # Vary the key type
         self.assertNormalEqualityImplementation(
             entry, duplicate,
             HashedEntry(
-                hostSalt, hostHash, publicKey.type()[::-1], publicKey,
+                hostSalt, hostHash, keyType[::-1], publicKey,
                 comment))
 
         # Vary the key
         self.assertNormalEqualityImplementation(
             entry, duplicate,
             HashedEntry(
-                hostSalt, hostHash, publicKey.type(),
+                hostSalt, hostHash, keyType,
                 Key.fromString(otherSampleKey), comment))
 
         # Vary the comment
         self.assertNormalEqualityImplementation(
             entry, duplicate,
             HashedEntry(
-                hostSalt, hostHash, publicKey.type(), publicKey,
+                hostSalt, hostHash, keyType, publicKey,
                 comment[::-1]))
 
 
@@ -253,7 +257,7 @@ class HashedEntryWithCommentTests(HashedEntryTests):
     Test cases for L{PlainEntry} when parsed from a line with a comment.
     """
 
-    hashedLine = sampleHashedLine[:-1] + " plain text comment.\n"
+    hashedLine = sampleHashedLine[:-1] + b" plain text comment.\n"
 
 
 
@@ -265,7 +269,7 @@ class UnparsedEntryTests(TestCase, EntryTestsMixin):
         """
         Set up the 'entry' to be an unparsed entry for some random text.
         """
-        self.entry = UnparsedEntry("    This is a bogus entry.  \n")
+        self.entry = UnparsedEntry(b"    This is a bogus entry.  \n")
 
 
     def test_fromString(self):
@@ -273,7 +277,7 @@ class UnparsedEntryTests(TestCase, EntryTestsMixin):
         Creating an L{UnparsedEntry} should simply record the string it was
         passed.
         """
-        self.assertEqual("    This is a bogus entry.  \n",
+        self.assertEqual(b"    This is a bogus entry.  \n",
                          self.entry._string)
 
 
@@ -281,7 +285,7 @@ class UnparsedEntryTests(TestCase, EntryTestsMixin):
         """
         An unparsed entry can't match any hosts.
         """
-        self.assertFalse(self.entry.matchesHost("www.twistedmatrix.com"))
+        self.assertFalse(self.entry.matchesHost(b"www.twistedmatrix.com"))
 
 
     def test_matchesKey(self):
@@ -296,7 +300,7 @@ class UnparsedEntryTests(TestCase, EntryTestsMixin):
         L{UnparsedEntry.toString} returns its input string, sans trailing
         newline.
         """
-        self.assertEqual("    This is a bogus entry.  ", self.entry.toString())
+        self.assertEqual(b"    This is a bogus entry.  ", self.entry.toString())
 
 
 
@@ -315,14 +319,14 @@ class ParseErrorTests(TestCase):
         If there are fewer than three elements, C{fromString} should raise
         L{InvalidEntry}.
         """
-        self.assertRaises(InvalidEntry, cls.fromString, "invalid")
+        self.assertRaises(InvalidEntry, cls.fromString, b"invalid")
 
 
     def notBase64Test(self, cls):
         """
         If the key is not base64, C{fromString} should raise L{BinasciiError}.
         """
-        self.assertRaises(BinasciiError, cls.fromString, "x x x")
+        self.assertRaises(BinasciiError, cls.fromString, b"x x x")
 
 
     def badKeyTest(self, cls, prefix):
@@ -330,9 +334,9 @@ class ParseErrorTests(TestCase):
         If the key portion of the entry is valid base64, but is not actually an
         SSH key, C{fromString} should raise L{BadKeyError}.
         """
-        self.assertRaises(BadKeyError, cls.fromString, ' '.join(
-                [prefix, "ssh-rsa", b2a_base64(
-                        "Hey, this isn't an SSH key!").strip()]))
+        self.assertRaises(BadKeyError, cls.fromString, b' '.join(
+                [prefix, b"ssh-rsa", b2a_base64(
+                    b"Hey, this isn't an SSH key!").strip()]))
 
 
     def test_invalidPlainEntry(self):
@@ -351,8 +355,8 @@ class ParseErrorTests(TestCase):
         """
         self.invalidEntryTest(HashedEntry)
         a, b, c = sampleHashedLine.split()
-        self.assertRaises(InvalidEntry, HashedEntry.fromString, ' '.join(
-                [a + "||", b, c]))
+        self.assertRaises(InvalidEntry, HashedEntry.fromString, b' '.join(
+                [a + b"||", b, c]))
 
 
     def test_plainNotBase64(self):
@@ -373,16 +377,17 @@ class ParseErrorTests(TestCase):
         # Salt not valid base64.
         self.assertRaises(
             BinasciiError, HashedEntry.fromString,
-            ' '.join(["|1|x|" + b2a_base64("stuff").strip(), b, c]))
+            b' '.join([b"|1|x|" + b2a_base64(b"stuff").strip(), b, c]))
         # Host hash not valid base64.
         self.assertRaises(
             BinasciiError, HashedEntry.fromString,
-            ' '.join([HashedEntry.MAGIC + b2a_base64("stuff").strip() + "|x",
+            b' '.join(
+                [HashedEntry.MAGIC + b2a_base64(b"stuff").strip() + b"|x",
             b, c]))
         # Neither salt nor hash valid base64.
         self.assertRaises(
             BinasciiError, HashedEntry.fromString,
-            ' '.join(["|1|x|x", b, c]))
+            b' '.join([b"|1|x|x", b, c]))
 
 
     def test_hashedBadKey(self):
@@ -399,7 +404,7 @@ class ParseErrorTests(TestCase):
         If the key portion of the entry is valid base64, but is not actually an
         SSH key, C{PlainEntry.fromString} should raise L{BadKeyError}.
         """
-        self.badKeyTest(PlainEntry, "hostname")
+        self.badKeyTest(PlainEntry, b"hostname")
 
 
 
@@ -419,9 +424,9 @@ class KnownHostsDatabaseTests(TestCase):
 
     def loadSampleHostsFile(self, content=(
             sampleHashedLine + otherSamplePlaintextLine +
-            "\n# That was a blank line.\n"
-            "This is just unparseable.\n"
-            "|1|This also unparseable.\n")):
+            b"\n# That was a blank line.\n"
+            b"This is just unparseable.\n"
+            b"|1|This also unparseable.\n")):
         """
         Return a sample hosts file, with keys for www.twistedmatrix.com and
         divmod.com present.
@@ -459,12 +464,12 @@ class KnownHostsDatabaseTests(TestCase):
         path = self.pathWithContent(sampleHashedLine)
         hostsFile = KnownHostsFile(path)
         entry = hostsFile.addHostKey(
-            "www.example.com", Key.fromString(otherSampleKey))
+            b"www.example.com", Key.fromString(otherSampleKey))
         hostsFile.save()
         # Check KnownHostsFile to see what it thinks the state is
         self.assertEqual([entry], list(hostsFile.iterentries()))
         # And also directly check the underlying file itself
-        self.assertEqual(entry.toString() + "\n", path.getContent())
+        self.assertEqual(entry.toString() + b"\n", path.getContent())
 
 
     def test_saveResetsClobberState(self):
@@ -475,10 +480,10 @@ class KnownHostsDatabaseTests(TestCase):
         """
         hostsFile = KnownHostsFile(self.pathWithContent(sampleHashedLine))
         preSave = hostsFile.addHostKey(
-            "www.example.com", Key.fromString(otherSampleKey))
+            b"www.example.com", Key.fromString(otherSampleKey))
         hostsFile.save()
         postSave = hostsFile.addHostKey(
-            "another.example.com", Key.fromString(thirdSampleKey))
+            b"another.example.com", Key.fromString(thirdSampleKey))
         hostsFile.save()
 
         self.assertEqual([preSave, postSave], list(hostsFile.iterentries()))
@@ -500,7 +505,7 @@ class KnownHostsDatabaseTests(TestCase):
         L{KnownHostsFile.iterentries} still returns added but unsaved entries.
         """
         hostsFile = KnownHostsFile(FilePath(self.mktemp()))
-        hostsFile.addHostKey("www.example.com", Key.fromString(sampleKey))
+        hostsFile.addHostKey(b"www.example.com", Key.fromString(sampleKey))
         self.assertEqual(1, len(list(hostsFile.iterentries())))
 
 
@@ -513,7 +518,7 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile((sampleHashedLine))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], HashedEntry)
-        self.assertTrue(entries[0].matchesHost("www.twistedmatrix.com"))
+        self.assertTrue(entries[0].matchesHost(b"www.twistedmatrix.com"))
         self.assertEqual(1, len(entries))
 
 
@@ -526,7 +531,7 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile((otherSamplePlaintextLine))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], PlainEntry)
-        self.assertTrue(entries[0].matchesHost("divmod.com"))
+        self.assertTrue(entries[0].matchesHost(b"divmod.com"))
         self.assertEqual(1, len(entries))
 
 
@@ -536,10 +541,10 @@ class KnownHostsDatabaseTests(TestCase):
         result in a L{KnownHostsFile} object containing a L{UnparsedEntry}
         object.
         """
-        hostsFile = self.loadSampleHostsFile(("\n"))
+        hostsFile = self.loadSampleHostsFile((b"\n"))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], UnparsedEntry)
-        self.assertEqual(entries[0].toString(), "")
+        self.assertEqual(entries[0].toString(), b"")
         self.assertEqual(1, len(entries))
 
 
@@ -549,10 +554,10 @@ class KnownHostsDatabaseTests(TestCase):
         result in a L{KnownHostsFile} object containing a L{UnparsedEntry}
         object.
         """
-        hostsFile = self.loadSampleHostsFile(("# That was a blank line.\n"))
+        hostsFile = self.loadSampleHostsFile((b"# That was a blank line.\n"))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], UnparsedEntry)
-        self.assertEqual(entries[0].toString(), "# That was a blank line.")
+        self.assertEqual(entries[0].toString(), b"# That was a blank line.")
 
 
     def test_verifyUnparsableLine(self):
@@ -560,10 +565,10 @@ class KnownHostsDatabaseTests(TestCase):
         Loading a L{KnownHostsFile} from a path that contains an unparseable
         line will be represented as an L{UnparsedEntry} instance.
         """
-        hostsFile = self.loadSampleHostsFile(("This is just unparseable.\n"))
+        hostsFile = self.loadSampleHostsFile((b"This is just unparseable.\n"))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], UnparsedEntry)
-        self.assertEqual(entries[0].toString(), "This is just unparseable.")
+        self.assertEqual(entries[0].toString(), b"This is just unparseable.")
         self.assertEqual(1, len(entries))
 
 
@@ -573,10 +578,10 @@ class KnownHostsDatabaseTests(TestCase):
         that starts with an encryption marker will be represented as an
         L{UnparsedEntry} instance.
         """
-        hostsFile = self.loadSampleHostsFile(("|1|This is unparseable.\n"))
+        hostsFile = self.loadSampleHostsFile((b"|1|This is unparseable.\n"))
         entries = list(hostsFile.iterentries())
         self.assertIsInstance(entries[0], UnparsedEntry)
-        self.assertEqual(entries[0].toString(), "|1|This is unparseable.")
+        self.assertEqual(entries[0].toString(), b"|1|This is unparseable.")
         self.assertEqual(1, len(entries))
 
 
@@ -601,7 +606,7 @@ class KnownHostsDatabaseTests(TestCase):
         to that path, creating its parent directory(ies) in the process.
         """
         thePath = FilePath(self.mktemp())
-        knownHostsPath = thePath.child("foo").child("known_hosts")
+        knownHostsPath = thePath.child("foo").child(b"known_hosts")
         knownHostsFile = KnownHostsFile.fromPath(knownHostsPath)
         knownHostsFile.save()
         knownHostsPath.restat(False)
@@ -616,18 +621,18 @@ class KnownHostsDatabaseTests(TestCase):
         path = self.pathWithContent(sampleHashedLine +
                                     otherSamplePlaintextLine)
         knownHostsFile = KnownHostsFile.fromPath(path)
-        newEntry = knownHostsFile.addHostKey("some.example.com",
+        newEntry = knownHostsFile.addHostKey(b"some.example.com",
             Key.fromString(thirdSampleKey))
         expectedContent = (
             sampleHashedLine +
             otherSamplePlaintextLine + HashedEntry.MAGIC +
-            b2a_base64(newEntry._hostSalt).strip() + "|" +
-            b2a_base64(newEntry._hostHash).strip() + " ssh-rsa " +
-            thirdSampleEncodedKey + "\n")
+            b2a_base64(newEntry._hostSalt).strip() + b"|" +
+            b2a_base64(newEntry._hostHash).strip() + b" ssh-rsa " +
+            thirdSampleEncodedKey + b"\n")
 
         # Sanity check, let's make sure the base64 API being used for the test
         # isn't inserting spurious newlines.
-        self.assertEqual(3, expectedContent.count("\n"))
+        self.assertEqual(3, expectedContent.count(b"\n"))
         knownHostsFile.save()
         self.assertEqual(expectedContent, path.getContent())
 
@@ -641,7 +646,7 @@ class KnownHostsDatabaseTests(TestCase):
         path = FilePath(self.mktemp())
         knownHosts = KnownHostsFile(path)
         entry = knownHosts.addHostKey(
-            "some.example.com", Key.fromString(sampleKey))
+            b"some.example.com", Key.fromString(sampleKey))
         knownHosts.save()
         knownHosts.save()
 
@@ -666,17 +671,17 @@ class KnownHostsDatabaseTests(TestCase):
 
         # Add a third host/key pair using the KnownHostsFile instance
         key = Key.fromString(thirdSampleKey)
-        knownHosts.addHostKey("brandnew.example.com", key)
+        knownHosts.addHostKey(b"brandnew.example.com", key)
         knownHosts.save()
 
         # Check that all three host/key pairs are present.
         knownHosts = KnownHostsFile.fromPath(path)
         self.assertEqual([True, True, True], [
                 knownHosts.hasHostKey(
-                    "www.twistedmatrix.com", Key.fromString(sampleKey)),
+                    b"www.twistedmatrix.com", Key.fromString(sampleKey)),
                 knownHosts.hasHostKey(
-                    "divmod.com", Key.fromString(otherSampleKey)),
-                knownHosts.hasHostKey("brandnew.example.com", key)])
+                    b"divmod.com", Key.fromString(otherSampleKey)),
+                knownHosts.hasHostKey(b"brandnew.example.com", key)])
 
 
     def test_hasPresentKey(self):
@@ -686,7 +691,7 @@ class KnownHostsDatabaseTests(TestCase):
         """
         hostsFile = self.loadSampleHostsFile()
         self.assertTrue(hostsFile.hasHostKey(
-                "www.twistedmatrix.com", Key.fromString(sampleKey)))
+                b"www.twistedmatrix.com", Key.fromString(sampleKey)))
 
 
     def test_hasNonPresentKey(self):
@@ -696,7 +701,7 @@ class KnownHostsDatabaseTests(TestCase):
         """
         hostsFile = self.loadSampleHostsFile()
         self.assertFalse(hostsFile.hasHostKey(
-                "non-existent.example.com", Key.fromString(sampleKey)))
+                b"non-existent.example.com", Key.fromString(sampleKey)))
 
 
     def test_hasLaterAddedKey(self):
@@ -706,12 +711,12 @@ class KnownHostsDatabaseTests(TestCase):
         after the L{KnownHostsFile} instance is initialized.
         """
         key = Key.fromString(sampleKey)
-        entry = PlainEntry(["brandnew.example.com"], key.sshType(), key, "")
+        entry = PlainEntry([b"brandnew.example.com"], key.sshType(), key, b"")
         hostsFile = self.loadSampleHostsFile()
         with hostsFile.savePath.open("a") as hostsFileObj:
-            hostsFileObj.write(entry.toString() + "\n")
+            hostsFileObj.write(entry.toString() + b"\n")
         self.assertEqual(
-            True, hostsFile.hasHostKey("brandnew.example.com", key))
+            True, hostsFile.hasHostKey(b"brandnew.example.com", key))
 
 
     def test_savedEntryHasKeyMismatch(self):
@@ -725,7 +730,7 @@ class KnownHostsDatabaseTests(TestCase):
         entries = list(hostsFile.iterentries())
         exception = self.assertRaises(
             HostKeyChanged, hostsFile.hasHostKey,
-            "www.twistedmatrix.com", Key.fromString(otherSampleKey))
+            b"www.twistedmatrix.com", Key.fromString(otherSampleKey))
         self.assertEqual(exception.offendingEntry, entries[0])
         self.assertEqual(exception.lineno, 1)
         self.assertEqual(exception.path, hostsFile.savePath)
@@ -741,10 +746,10 @@ class KnownHostsDatabaseTests(TestCase):
         """
         hostsFile = self.loadSampleHostsFile()
         hostsFile.addHostKey(
-            "www.example.com", Key.fromString(otherSampleKey))
+            b"www.example.com", Key.fromString(otherSampleKey))
         exception = self.assertRaises(
             HostKeyChanged, hostsFile.hasHostKey,
-            "www.twistedmatrix.com", Key.fromString(otherSampleKey))
+            b"www.twistedmatrix.com", Key.fromString(otherSampleKey))
         self.assertEqual(exception.lineno, 1)
         self.assertEqual(exception.path, hostsFile.savePath)
 
@@ -759,10 +764,10 @@ class KnownHostsDatabaseTests(TestCase):
         """
         hostsFile = KnownHostsFile(FilePath(self.mktemp()))
         entry = hostsFile.addHostKey(
-            "www.example.com", Key.fromString(otherSampleKey))
+            b"www.example.com", Key.fromString(otherSampleKey))
         exception = self.assertRaises(
             HostKeyChanged, hostsFile.hasHostKey,
-            "www.example.com", Key.fromString(thirdSampleKey))
+            b"www.example.com", Key.fromString(thirdSampleKey))
         self.assertEqual(exception.offendingEntry, entry)
         self.assertIsNone(exception.lineno)
         self.assertIsNone(exception.path)
@@ -776,19 +781,19 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile()
         aKey = Key.fromString(thirdSampleKey)
         self.assertEqual(False,
-                         hostsFile.hasHostKey("somewhere.example.com", aKey))
-        newEntry = hostsFile.addHostKey("somewhere.example.com", aKey)
+                         hostsFile.hasHostKey(b"somewhere.example.com", aKey))
+        newEntry = hostsFile.addHostKey(b"somewhere.example.com", aKey)
 
         # The code in OpenSSH requires host salts to be 20 characters long.
         # This is the required length of a SHA-1 HMAC hash, so it's just a
         # sanity check.
         self.assertEqual(20, len(newEntry._hostSalt))
         self.assertEqual(True,
-                         newEntry.matchesHost("somewhere.example.com"))
-        self.assertEqual(newEntry.keyType, "ssh-rsa")
+                         newEntry.matchesHost(b"somewhere.example.com"))
+        self.assertEqual(newEntry.keyType, b"ssh-rsa")
         self.assertEqual(aKey, newEntry.publicKey)
         self.assertEqual(True,
-                         hostsFile.hasHostKey("somewhere.example.com", aKey))
+                         hostsFile.hasHostKey(b"somewhere.example.com", aKey))
 
 
     def test_randomSalts(self):
@@ -799,8 +804,8 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile()
         aKey = Key.fromString(thirdSampleKey)
         self.assertNotEqual(
-            hostsFile.addHostKey("somewhere.example.com", aKey)._hostSalt,
-            hostsFile.addHostKey("somewhere-else.example.com", aKey)._hostSalt)
+            hostsFile.addHostKey(b"somewhere.example.com", aKey)._hostSalt,
+            hostsFile.addHostKey(b"somewhere-else.example.com", aKey)._hostSalt)
 
 
     def test_verifyValidKey(self):
@@ -809,9 +814,9 @@ class KnownHostsDatabaseTests(TestCase):
         True.
         """
         hostsFile = self.loadSampleHostsFile()
-        hostsFile.addHostKey("1.2.3.4", Key.fromString(sampleKey))
+        hostsFile.addHostKey(b"1.2.3.4", Key.fromString(sampleKey))
         ui = FakeUI()
-        d = hostsFile.verifyHostKey(ui, "www.twistedmatrix.com", "1.2.3.4",
+        d = hostsFile.verifyHostKey(ui, b"www.twistedmatrix.com", b"1.2.3.4",
                                     Key.fromString(sampleKey))
         l = []
         d.addCallback(l.append)
@@ -826,9 +831,9 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile()
         wrongKey = Key.fromString(thirdSampleKey)
         ui = FakeUI()
-        hostsFile.addHostKey("1.2.3.4", Key.fromString(sampleKey))
+        hostsFile.addHostKey(b"1.2.3.4", Key.fromString(sampleKey))
         d = hostsFile.verifyHostKey(
-            ui, "www.twistedmatrix.com", "1.2.3.4", wrongKey)
+            ui, b"www.twistedmatrix.com", b"1.2.3.4", wrongKey)
         return self.assertFailure(d, HostKeyChanged)
 
 
@@ -848,7 +853,7 @@ class KnownHostsDatabaseTests(TestCase):
         ui = FakeUI()
         l = []
         d = hostsFile.verifyHostKey(
-            ui, "sample-host.example.com", "4.3.2.1", absentKey)
+            ui, b"sample-host.example.com", b"4.3.2.1", absentKey)
         d.addBoth(l.append)
         self.assertEqual([], l)
         self.assertEqual(
@@ -873,10 +878,10 @@ class KnownHostsDatabaseTests(TestCase):
         reloaded = KnownHostsFile.fromPath(knownHostsFile.savePath)
         self.assertEqual(
             True,
-            reloaded.hasHostKey("4.3.2.1", Key.fromString(thirdSampleKey)))
+            reloaded.hasHostKey(b"4.3.2.1", Key.fromString(thirdSampleKey)))
         self.assertEqual(
             True,
-            reloaded.hasHostKey("sample-host.example.com",
+            reloaded.hasHostKey(b"sample-host.example.com",
                                 Key.fromString(thirdSampleKey)))
 
 
@@ -902,7 +907,7 @@ class KnownHostsDatabaseTests(TestCase):
         wrongKey = Key.fromString(thirdSampleKey)
         ui = FakeUI()
         d = hostsFile.verifyHostKey(
-            ui, "www.twistedmatrix.com", "4.3.2.1", wrongKey)
+            ui, b"www.twistedmatrix.com", b"4.3.2.1", wrongKey)
         return self.assertFailure(d, HostKeyChanged)
 
 
@@ -916,10 +921,10 @@ class KnownHostsDatabaseTests(TestCase):
         hostsFile = self.loadSampleHostsFile()
         expectedKey = Key.fromString(sampleKey)
         hostsFile.verifyHostKey(
-            ui, "www.twistedmatrix.com", "5.4.3.2", expectedKey)
+            ui, b"www.twistedmatrix.com", b"5.4.3.2", expectedKey)
         self.assertEqual(
             True, KnownHostsFile.fromPath(hostsFile.savePath).hasHostKey(
-                "5.4.3.2", expectedKey))
+                b"5.4.3.2", expectedKey))
         self.assertEqual(
             ["Warning: Permanently added the RSA host key for IP address "
              "'5.4.3.2' to the list of known hosts."],
@@ -1147,14 +1152,14 @@ class DefaultAPITests(TestCase):
         self.hostsOption = self.mktemp()
         self.hashedEntries = {}
         knownHostsFile = KnownHostsFile(FilePath(self.hostsOption))
-        for host in ("exists.example.com", "4.3.2.1"):
+        for host in (b"exists.example.com", b"4.3.2.1"):
             entry = knownHostsFile.addHostKey(host, Key.fromString(sampleKey))
             self.hashedEntries[host] = entry
         knownHostsFile.save()
         self.fakeTransport = FakeObject()
         self.fakeTransport.factory = FakeObject()
         self.options = self.fakeTransport.factory.options = {
-            'host': "exists.example.com",
+            'host': b"exists.example.com",
             'known-hosts': self.hostsOption
             }
 
@@ -1166,8 +1171,8 @@ class DefaultAPITests(TestCase):
         known_hosts file it is supposed to check.
         """
         l = []
-        default.verifyHostKey(self.fakeTransport, "4.3.2.1", sampleKey,
-                              "I don't care.").addCallback(l.append)
+        default.verifyHostKey(self.fakeTransport, b"4.3.2.1", sampleKey,
+                              b"I don't care.").addCallback(l.append)
         self.assertEqual([1], l)
 
 
@@ -1205,8 +1210,8 @@ class DefaultAPITests(TestCase):
         FilePath(oldHostsOption).moveTo(hostsNonOption)
         self.replaceHome(tmpdir)
         self.options['known-hosts'] = None
-        default.verifyHostKey(self.fakeTransport, "4.3.2.1", sampleKey,
-                              "I don't care.").addCallback(l.append)
+        default.verifyHostKey(self.fakeTransport, b"4.3.2.1", sampleKey,
+                              b"I don't care.").addCallback(l.append)
         self.assertEqual([1], l)
 
 
@@ -1218,15 +1223,15 @@ class DefaultAPITests(TestCase):
         IP address.
         """
         l = []
-        default.verifyHostKey(self.fakeTransport, "8.7.6.5", sampleKey,
-                              "Fingerprint not required.").addCallback(l.append)
+        default.verifyHostKey(self.fakeTransport, b"8.7.6.5", sampleKey,
+                              b"Fingerprint not required.").addCallback(l.append)
         self.assertEqual(
             ["Warning: Permanently added the RSA host key for IP address "
             "'8.7.6.5' to the list of known hosts."],
             self.fakeFile.outchunks)
         self.assertEqual([1], l)
         knownHostsFile = KnownHostsFile.fromPath(FilePath(self.hostsOption))
-        self.assertTrue(knownHostsFile.hasHostKey("8.7.6.5",
+        self.assertTrue(knownHostsFile.hasHostKey(b"8.7.6.5",
                                              Key.fromString(sampleKey)))
 
 
@@ -1235,10 +1240,11 @@ class DefaultAPITests(TestCase):
         L{default.verifyHostKey} should return a L{Default} which fires with
         C{0} when passed an unknown host that the user refuses to acknowledge.
         """
-        self.fakeTransport.factory.options['host'] = 'fake.example.com'
+        self.fakeTransport.factory.options['host'] = b'fake.example.com'
         self.fakeFile.inlines.append("no")
         d = default.verifyHostKey(
-            self.fakeTransport, "9.8.7.6", otherSampleKey, "No fingerprint!")
+            self.fakeTransport, b"9.8.7.6", otherSampleKey,
+            b"No fingerprint!")
         self.assertEqual(
             ["The authenticity of host 'fake.example.com (9.8.7.6)' "
              "can't be established.\n"
@@ -1255,7 +1261,7 @@ class DefaultAPITests(TestCase):
         L{HostKeyChanged} if the host key is incorrect.
         """
         d = default.verifyHostKey(
-            self.fakeTransport, "4.3.2.1", otherSampleKey,
+            self.fakeTransport, b"4.3.2.1", otherSampleKey,
             "Again, not required.")
         return self.assertFailure(d, HostKeyChanged)
 
@@ -1265,7 +1271,7 @@ class DefaultAPITests(TestCase):
         L{default.isInKnownHosts} should return C{1} when a host with a key
         is in the known hosts file.
         """
-        host = self.hashedEntries["4.3.2.1"].toString().split()[0]
+        host = self.hashedEntries[b"4.3.2.1"].toString().split()[0]
         r = default.isInKnownHosts(
             host, Key.fromString(sampleKey).blob(),
             {"known-hosts": FilePath(self.hostsOption).path})
@@ -1288,7 +1294,7 @@ class DefaultAPITests(TestCase):
         L{default.isInKnownHosts} should return C{2} when a host with a key
         other than the given one is in the known hosts file.
         """
-        host = self.hashedEntries["4.3.2.1"].toString().split()[0]
+        host = self.hashedEntries[b"4.3.2.1"].toString().split()[0]
         r = default.isInKnownHosts(
             host, Key.fromString(otherSampleKey).blob(),
             {"known-hosts": FilePath(self.hostsOption).path})

--- a/twisted/conch/topfiles/8697.feature
+++ b/twisted/conch/topfiles/8697.feature
@@ -1,0 +1,1 @@
+twisted.conch.client.knownhosts is now ported to Python 3.

--- a/twisted/python/dist3.py
+++ b/twisted/python/dist3.py
@@ -55,6 +55,8 @@ modules = [
     "twisted.conch.__init__",
     "twisted.conch.avatar",
     "twisted.conch.checkers",
+    "twisted.conch.client.__init__",
+    "twisted.conch.client.knownhosts",
     "twisted.conch.error",
     "twisted.conch.interfaces",
     "twisted.conch.insults.__init__",
@@ -369,6 +371,7 @@ testModules = [
     "twisted.conch.test.test_filetransfer",
     "twisted.conch.test.test_forwarding",
     "twisted.conch.test.test_keys",
+    "twisted.conch.test.test_knownhosts",
     "twisted.conch.test.test_openssh_compat",
     "twisted.conch.test.test_session",
     "twisted.conch.test.test_ssh",
@@ -633,6 +636,9 @@ testDataFiles = [
 
 
 almostModules = [
+    # twisted.conch.test_knownhosts tests parts of the default module
+    "twisted.conch.client.default",
+    "twisted.conch.client.agent",
     # twisted.conch.test.test_text and twisted.conch.test.test_window
     # need these conch modules.  They need more work to get full
     # Python 3 test coverage


### PR DESCRIPTION
This ports conch.client.knownhosts to Python 3 and is a fix for https://twistedmatrix.com/trac/ticket/8697 .
