### PR TITLE
Remove use of deprecated "import imp" in runtime.py

### DIFF
--- a/twisted/python/runtime.py
+++ b/twisted/python/runtime.py
@@ -7,15 +7,7 @@ from __future__ import division, absolute_import
 import os
 import sys
 import time
-import imp
 import warnings
-
-from twisted.python import compat
-
-if compat._PY3:
-    _threadModule = "_thread"
-else:
-    _threadModule = "thread"
 
 
 
@@ -207,7 +199,8 @@ class Platform:
         @rtype: C{bool}
         """
         try:
-            return imp.find_module(_threadModule)[0] is None
+            import threading
+            return threading is not None # shh pyflakes
         except ImportError:
             return False
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8702

The Python documentation recommends use of **import threading** to see if
threads are supported on this platform, and to use **dummy_threading** if **threading** fails to import: 

https://docs.python.org/3/library/dummy_threading.html
https://docs.python.org/2/library/dummy_threading.html

Also, the threading module tries to import thread on Python 2:
https://github.com/python/cpython/blob/2.7/Lib/threading.py#L6

and _thread on Python 3:
https://github.com/python/cpython/blob/3.3/Lib/threading.py#L4

so we can remove those references here as well.
