### PR TITLE
Port twisted.conch.client.default to Python 3

### DIFF
--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -189,7 +189,8 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         if prompt:
             prompt = nativeString(prompt)
         else:
-            prompt = "%s@%s's password: " % (nativeString(self.user), self.transport.transport.getPeer().host)
+            prompt = ("%s@%s's password: " %
+                (nativeString(self.user), self.transport.transport.getPeer().host))
         try:
             # We don't know the encoding the other side is using,
             # signaling that is not part of the SSH protocol. But

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -295,7 +295,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         and return them.
 
         @return: File objects for reading and writing to /dev/tty,
-                 standard input and standard output.
+                 corresponding to standard input and standard output.
         @rtype: A L{tuple} of L{io.TextIOWrapper} on Python 3.
                 A L{tuple} of binary files on Python 2.
         """

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -89,8 +89,10 @@ def verifyHostKey(transport, host, pubKey, fingerprint):
     return kh.verifyHostKey(ui, actualHost, host, actualKey)
 
 
+
 def isInKnownHosts(host, pubKey, options):
-    """checks to see if host is in the known_hosts file for the user.
+    """
+    checks to see if host is in the known_hosts file for the user.
     returns 0 if it isn't, 1 if it is and is the same, 2 if it's changed.
     """
     keyType = common.getNS(pubKey)[0]
@@ -136,6 +138,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         if not options.identitys:
             options.identitys = ['~/.ssh/id_rsa', '~/.ssh/id_dsa']
 
+
     def serviceStarted(self):
         if 'SSH_AUTH_SOCK' in os.environ and not self.options['noagent']:
             log.msg('using agent')
@@ -146,10 +149,12 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         else:
             userauth.SSHUserAuthClient.serviceStarted(self)
 
+
     def serviceStopped(self):
         if self.keyAgent:
             self.keyAgent.transport.loseConnection()
             self.keyAgent = None
+
 
     def _setAgent(self, a):
         self.keyAgent = a
@@ -157,8 +162,10 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         d.addBoth(self._ebSetAgent)
         return d
 
+
     def _ebSetAgent(self, f):
         userauth.SSHUserAuthClient.serviceStarted(self)
+
 
     def _getPassword(self, prompt):
         """
@@ -176,6 +183,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
             except (KeyboardInterrupt, IOError):
                 print()
                 raise ConchError('PEBKAC')
+
 
     def getPassword(self, prompt = None):
         if prompt:

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -291,6 +291,11 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         """
         Open /dev/tty as two streams one in read, one in write mode,
         and return them.
+
+        @return: File objects for reading and writing to /dev/tty,
+                 standard input and standard output.
+        @rtype: A L{tuple} of L{io.TextIOWrapper} on Python 3.
+                A L{tuple} of binary files on Python 2.
         """
         stdin = open("/dev/tty", "rb")
         stdout = open("/dev/tty", "wb")

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -274,11 +274,11 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         responses = []
         with self._replaceStdoutStdin():
             if name:
-                print(name.decode("UTF8"))
+                print(name.decode("utf-8"))
             if instruction:
-                print(instruction.decode("UTF8"))
+                print(instruction.decode("utf-8"))
             for prompt, echo in prompts:
-                prompt = prompt.decode("UTF8")
+                prompt = prompt.decode("utf-8")
                 if echo:
                     responses.append(raw_input(prompt))
                 else:

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -178,7 +178,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         """
         with self._replaceStdoutStdin():
             try:
-                p=getpass.getpass(prompt)
+                p = getpass.getpass(prompt)
                 return p
             except (KeyboardInterrupt, IOError):
                 print()

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -92,8 +92,10 @@ def verifyHostKey(transport, host, pubKey, fingerprint):
 
 def isInKnownHosts(host, pubKey, options):
     """
-    checks to see if host is in the known_hosts file for the user.
-    returns 0 if it isn't, 1 if it is and is the same, 2 if it's changed.
+    Checks to see if host is in the known_hosts file for the user.
+
+    @return: 0 if it isn't, 1 if it is and is the same, 2 if it's changed.
+    @rtype: L{int}
     """
     keyType = common.getNS(pubKey)[0]
     retVal = 0

--- a/twisted/conch/client/default.py
+++ b/twisted/conch/client/default.py
@@ -161,6 +161,14 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         userauth.SSHUserAuthClient.serviceStarted(self)
 
     def _getPassword(self, prompt):
+        """
+        Prompt for a password using L{getpass.getpass}.
+
+        @param prompt: Written on tty to ask for the input.
+        @type prompt: L{str}
+        @return: The input.
+        @rtype: L{str}
+        """
         with self._replaceStdoutStdin():
             try:
                 p=getpass.getpass(prompt)

--- a/twisted/conch/test/keydata.py
+++ b/twisted/conch/test/keydata.py
@@ -8,9 +8,7 @@ Data used by test_keys as well as others.
 
 from __future__ import absolute_import, division
 
-from base64 import decodestring
-
-from twisted.python.compat import long
+from twisted.python.compat import long, _b64decodebytes as decodebytes
 
 RSAData = {
     'n': long('106248668575524741116943830949539894737212779118943280948138'
@@ -202,7 +200,7 @@ czUdxCus0pfEP1bddaXRLQ==
 -----END DSA PRIVATE KEY-----\
 """
 
-publicDSA_lsh = decodestring(b"""\
+publicDSA_lsh = decodebytes(b"""\
 e0tERXdPbkIxWW14cFl5MXJaWGtvTXpwa2MyRW9NVHB3TVRJNU9nQ1NrRHJGUkVWUTBDS1FEUngv
 aVFBTXBhUFM3eFdKaFJWVENMaHhScFdhU0MrN0lkeURKS3N2bkxMQ0RUUDVaeHc5MzVyQU1pNVZG
 MmJiZWp3L1M0R1VXczdEem9LYmJoL2hydVBCdnNoYmhQSmRIMVZWSXI2TFB6Sm1GU2V1cWsvZlli
@@ -216,7 +214,7 @@ WjlTWHhNNTlQK2hlY2MvR1UvR0hha1c1WVdFNGRQMkdnZGdNUVdDN1M2V0ZJWGVQR0dYcU5RRGRX
 eGxYOHVtaGVudlFxYTFQbktyRlJoRHJKdzhaN0dqZEh4ZmxzeENFbVhQb0xOOHBLU2s9fQ==
 """)
 
-privateDSA_lsh = decodestring(b"""\
+privateDSA_lsh = decodebytes(b"""\
 KDExOnByaXZhdGUta2V5KDM6ZHNhKDE6cDEyOToAkpA6xURFUNAikA0cf4kADKWj0u8ViYUVUwi4
 cUaVmkgvuyHcgySrL5yywg0z+WccPd+awDIuVRdm23o8P0uBlFrOw86Cm24f4a7jwb7IW4TyXR9V
 VSK+iz8yZhUnrqpP32G1xkpq2tNZmelVbuAUAGirD6F7YtnSCR5TT5LH1rkpKDE6cTIxOgD0EYmT
@@ -228,7 +226,7 @@ h2pFuWFhOHT9hoHYDEFgu0ulhSF3jxhl6jUA3VsZV/LpoXp70KmtT5yqxUYQ6ycPGexo3R8X5bMQ
 hJlz6CzfKSgxOngyMToA1doGy3M1HcQrrNKXxD9W3XWl0S0pKSk=
 """)
 
-privateDSA_agentv3 = decodestring(b"""\
+privateDSA_agentv3 = decodebytes(b"""\
 AAAAB3NzaC1kc3MAAACBAJKQOsVERVDQIpANHH+JAAylo9LvFYmFFVMIuHFGlZpIL7sh3IMkqy+c
 ssINM/lnHD3fmsAyLlUXZtt6PD9LgZRazsPOgptuH+Gu48G+yFuE8l0fVVUivos/MmYVJ66qT99h
 tcZKatrTWZnpVW7gFABoqw+he2LZ0gkeU0+Sx9a5AAAAFQD0EYmTNaFJ8CS0+vFSF4nYcyEnSQAA

--- a/twisted/conch/test/test_default.py
+++ b/twisted/conch/test/test_default.py
@@ -36,6 +36,12 @@ if platform.isWindows():
 else:
     windowsSkip = skip
 
+ttySkip = None
+if not sys.stdin.isatty():
+    ttySkip = "sys.stdin is not an interactive tty"
+if not sys.stdout.isatty():
+    ttySkip = "sys.stdout is not an interactive tty"
+
 
 class SSHUserAuthClientTests(TestCase):
     """
@@ -211,7 +217,8 @@ class SSHUserAuthClientTests(TestCase):
         d = client.getPassword()
         d.addCallback(self.assertEqual, b'bad password')
         return d
-    test_getPassword.skip = windowsSkip
+
+    test_getPassword.skip = windowsSkip or ttySkip
 
 
     def test_getPasswordPrompt(self):
@@ -232,7 +239,8 @@ class SSHUserAuthClientTests(TestCase):
         d = client.getPassword(prompt)
         d.addCallback(self.assertEqual, b'bad password')
         return d
-    test_getPasswordPrompt.skip = windowsSkip
+
+    test_getPasswordPrompt.skip = windowsSkip or ttySkip
 
 
     def test_getPasswordConchError(self):
@@ -256,7 +264,8 @@ class SSHUserAuthClientTests(TestCase):
                 [stdout, stdin], [sys.stdout, sys.stdin])
             return fail
         self.assertFailure(d, ConchError)
-    test_getPasswordConchError.skip = windowsSkip
+
+    test_getPasswordConchError.skip = windowsSkip or ttySkip
 
 
     def test_getGenericAnswers(self):
@@ -284,4 +293,5 @@ class SSHUserAuthClientTests(TestCase):
         d.addCallback(
             self.assertListEqual, ["getpass", "raw_input"])
         return d
-    test_getGenericAnswers.skip = windowsSkip
+
+    test_getGenericAnswers.skip = windowsSkip or ttySkip

--- a/twisted/conch/test/test_default.py
+++ b/twisted/conch/test/test_default.py
@@ -196,7 +196,6 @@ class SSHUserAuthClientTests(TestCase):
         Verify that the getPassword function in L{SSHUserAuthClient}
         works, when prompt is sent, and fetching the password from the
         user succeeds.
-
         """
         class FakeTransport:
             def __init__(self, host):
@@ -287,7 +286,7 @@ class SSHUserAuthClientTests(TestCase):
             return "raw_input"
 
         self.patch(default, 'raw_input', raw_input)
-        d =client.getGenericAnswers(
+        d = client.getGenericAnswers(
             b"Name", b"Instruction", [
                 (b"pass prompt", False), (b"raw_input prompt", True)])
         d.addCallback(

--- a/twisted/conch/test/test_default.py
+++ b/twisted/conch/test/test_default.py
@@ -4,21 +4,37 @@
 """
 Tests for L{twisted.conch.client.default}.
 """
+
+from __future__ import absolute_import, division
+
+import sys
+
 from twisted.python.reflect import requireModule
 
 if requireModule('cryptography') and requireModule('pyasn1'):
     from twisted.conch.client.agent import SSHAgentClient
     from twisted.conch.client.default import SSHUserAuthClient
     from twisted.conch.client.options import ConchOptions
+    from twisted.conch.client import default
     from twisted.conch.ssh.keys import Key
+    skip = None
 else:
     skip = "cryptography and PyASN1 required for twisted.conch.client.default."
 
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
+from twisted.conch.error import ConchError
 from twisted.conch.test import keydata
 from twisted.test.proto_helpers import StringTransport
+from twisted.python.compat import nativeString
+from twisted.python.runtime import platform
 
+if platform.isWindows():
+    windowsSkip = (
+        "genericAnswers and getPassword does not work on Windows."
+        " Should be fixed as part of fixing bug 6409 and 6410")
+else:
+    windowsSkip = skip
 
 
 class SSHUserAuthClientTests(TestCase):
@@ -43,18 +59,18 @@ class SSHUserAuthClientTests(TestCase):
         When connected to an agent, L{SSHUserAuthClient} can use it to
         request signatures of particular data with a particular L{Key}.
         """
-        client = SSHUserAuthClient("user", ConchOptions(), None)
+        client = SSHUserAuthClient(b"user", ConchOptions(), None)
         agent = SSHAgentClient()
         transport = StringTransport()
         agent.makeConnection(transport)
         client.keyAgent = agent
-        cleartext = "Sign here"
+        cleartext = b"Sign here"
         client.signData(self.rsaPublic, cleartext)
         self.assertEqual(
             transport.value(),
-            "\x00\x00\x00\x8b\r\x00\x00\x00u" + self.rsaPublic.blob() +
-            "\x00\x00\x00\t" + cleartext +
-            "\x00\x00\x00\x00")
+            b"\x00\x00\x00\x8b\r\x00\x00\x00u" + self.rsaPublic.blob() +
+            b"\x00\x00\x00\t" + cleartext +
+            b"\x00\x00\x00\x00")
 
 
     def test_agentGetPublicKey(self):
@@ -80,7 +96,7 @@ class SSHUserAuthClientTests(TestCase):
         """
         options = ConchOptions()
         options.identitys = [self.rsaFile.path]
-        client = SSHUserAuthClient("user",  options, None)
+        client = SSHUserAuthClient(b"user",  options, None)
         key = client.getPublicKey()
         self.assertTrue(key.isPublic())
         self.assertEqual(key, self.rsaPublic)
@@ -94,7 +110,7 @@ class SSHUserAuthClientTests(TestCase):
         options = ConchOptions()
         options.identitys = [self.rsaFile.path]
         agent = SSHAgentClient()
-        client = SSHUserAuthClient("user",  options, None)
+        client = SSHUserAuthClient(b"user",  options, None)
         client.keyAgent = agent
         key = client.getPublicKey()
         self.assertTrue(key.isPublic())
@@ -112,8 +128,8 @@ class SSHUserAuthClientTests(TestCase):
         dsaFile = self.tmpdir.child('id_dsa')
         dsaFile.setContent(keydata.privateDSA_openssh)
         options.identitys = [self.rsaFile.path, dsaFile.path]
-        self.tmpdir.child('id_rsa.pub').setContent('not a key!')
-        client = SSHUserAuthClient("user",  options, None)
+        self.tmpdir.child('id_rsa.pub').setContent(b'not a key!')
+        client = SSHUserAuthClient(b"user",  options, None)
         key = client.getPublicKey()
         self.assertTrue(key.isPublic())
         self.assertEqual(key, Key.fromString(keydata.publicDSA_openssh))
@@ -129,7 +145,7 @@ class SSHUserAuthClientTests(TestCase):
         rsaPrivate = Key.fromString(keydata.privateRSA_openssh)
         options = ConchOptions()
         options.identitys = [self.rsaFile.path]
-        client = SSHUserAuthClient("user",  options, None)
+        client = SSHUserAuthClient(b"user",  options, None)
         # Populate the list of used files
         client.getPublicKey()
 
@@ -147,19 +163,19 @@ class SSHUserAuthClientTests(TestCase):
         encrypted.
         """
         rsaPrivate = Key.fromString(keydata.privateRSA_openssh)
-        passphrase = 'this is the passphrase'
+        passphrase = b'this is the passphrase'
         self.rsaFile.setContent(rsaPrivate.toString('openssh', passphrase))
         options = ConchOptions()
         options.identitys = [self.rsaFile.path]
-        client = SSHUserAuthClient("user",  options, None)
+        client = SSHUserAuthClient(b"user",  options, None)
         # Populate the list of used files
         client.getPublicKey()
 
         def _getPassword(prompt):
-            self.assertEqual(prompt,
-                              "Enter passphrase for key '%s': " % (
-                              self.rsaFile.path,))
-            return passphrase
+            self.assertEqual(
+                prompt,
+                "Enter passphrase for key '%s': " % (self.rsaFile.path,))
+            return nativeString(passphrase)
 
         def _cbGetPrivateKey(key):
             self.assertFalse(key.isPublic())
@@ -167,3 +183,105 @@ class SSHUserAuthClientTests(TestCase):
 
         self.patch(client, '_getPassword', _getPassword)
         return client.getPrivateKey().addCallback(_cbGetPrivateKey)
+
+
+    def test_getPassword(self):
+        """
+        Verify that the getPassword function in L{SSHUserAuthClient}
+        works, when prompt is sent, and fetching the password from the
+        user succeeds.
+
+        """
+        class FakeTransport:
+            def __init__(self, host):
+                self.transport = self
+                self.host = host
+            def getPeer(self):
+                return self
+
+        options = ConchOptions()
+        client = SSHUserAuthClient(b"user",  options, None)
+        client.transport = FakeTransport("127.0.0.1")
+
+        def getpass(prompt):
+            self.assertEqual(prompt, "user@127.0.0.1's password: ")
+            return 'bad password'
+
+        self.patch(default.getpass, 'getpass', getpass)
+        d = client.getPassword()
+        d.addCallback(self.assertEqual, b'bad password')
+        return d
+    test_getPassword.skip = windowsSkip
+
+
+    def test_getPasswordPrompt(self):
+        """
+        Verify that the getPassword function in L{SSHUserAuthClient}
+        works, when prompt is sent, and fetching the password from the
+        user succeeds.
+        """
+        options = ConchOptions()
+        client = SSHUserAuthClient(b"user",  options, None)
+        prompt = b"Give up your password"
+
+        def getpass(p):
+            self.assertEqual(p, nativeString(prompt))
+            return 'bad password'
+
+        self.patch(default.getpass, 'getpass', getpass)
+        d = client.getPassword(prompt)
+        d.addCallback(self.assertEqual, b'bad password')
+        return d
+    test_getPasswordPrompt.skip = windowsSkip
+
+
+    def test_getPasswordConchError(self):
+        """
+        Verify that the getPassword function in L{SSHUserAuthClient}
+        fails it's deferred if the underlying _getPassword function
+        raises a ConchError
+        """
+        options = ConchOptions()
+        client = SSHUserAuthClient(b"user",  options, None)
+
+        def getpass(prompt):
+            raise KeyboardInterrupt("User pressed CTRL-C")
+
+        self.patch(default.getpass, 'getpass', getpass)
+        stdout, stdin = sys.stdout, sys.stdin
+        d = client.getPassword(b'?')
+        @d.addErrback
+        def check_sys(fail):
+            self.assertEqual(
+                [stdout, stdin], [sys.stdout, sys.stdin])
+            return fail
+        self.assertFailure(d, ConchError)
+    test_getPasswordConchError.skip = windowsSkip
+
+
+    def test_getGenericAnswers(self):
+        """
+        Verify that the getGenericAnswers function in L{SSHUserAuthClient}
+        works.
+        """
+        options = ConchOptions()
+        client = SSHUserAuthClient(b"user",  options, None)
+
+        def getpass(prompt):
+            self.assertEqual(prompt, "pass prompt")
+            return "getpass"
+
+        self.patch(default.getpass, 'getpass', getpass)
+
+        def raw_input(prompt):
+            self.assertEqual(prompt, "raw_input prompt")
+            return "raw_input"
+
+        self.patch(default, 'raw_input', raw_input)
+        d =client.getGenericAnswers(
+            b"Name", b"Instruction", [
+                (b"pass prompt", False), (b"raw_input prompt", True)])
+        d.addCallback(
+            self.assertListEqual, ["getpass", "raw_input"])
+        return d
+    test_getGenericAnswers.skip = windowsSkip

--- a/twisted/conch/test/test_default.py
+++ b/twisted/conch/test/test_default.py
@@ -43,6 +43,7 @@ if not sys.stdout.isatty():
     ttySkip = "sys.stdout is not an interactive tty"
 
 
+
 class SSHUserAuthClientTests(TestCase):
     """
     Tests for L{SSHUserAuthClient}.
@@ -193,9 +194,8 @@ class SSHUserAuthClientTests(TestCase):
 
     def test_getPassword(self):
         """
-        Verify that the getPassword function in L{SSHUserAuthClient}
-        works, when prompt is sent, and fetching the password from the
-        user succeeds.
+        Get the password using
+        L{twisted.conch.client.default.SSHUserAuthClient.getPassword}
         """
         class FakeTransport:
             def __init__(self, host):
@@ -222,9 +222,9 @@ class SSHUserAuthClientTests(TestCase):
 
     def test_getPasswordPrompt(self):
         """
-        Verify that the getPassword function in L{SSHUserAuthClient}
-        works, when prompt is sent, and fetching the password from the
-        user succeeds.
+        Get the password using
+        L{twisted.conch.client.default.SSHUserAuthClient.getPassword}
+        using a different prompt.
         """
         options = ConchOptions()
         client = SSHUserAuthClient(b"user",  options, None)
@@ -244,9 +244,9 @@ class SSHUserAuthClientTests(TestCase):
 
     def test_getPasswordConchError(self):
         """
-        Verify that the getPassword function in L{SSHUserAuthClient}
-        fails it's deferred if the underlying _getPassword function
-        raises a ConchError
+        Get the password using
+        L{twisted.conch.client.default.SSHUserAuthClient.getPassword}
+        and trigger a {twisted.conch.error import ConchError}.
         """
         options = ConchOptions()
         client = SSHUserAuthClient(b"user",  options, None)
@@ -269,8 +269,7 @@ class SSHUserAuthClientTests(TestCase):
 
     def test_getGenericAnswers(self):
         """
-        Verify that the getGenericAnswers function in L{SSHUserAuthClient}
-        works.
+        L{twisted.conch.client.default.SSHUserAuthClient.getGenericAnswers}
         """
         options = ConchOptions()
         client = SSHUserAuthClient(b"user",  options, None)

--- a/twisted/conch/topfiles/8700.feature
+++ b/twisted/conch/topfiles/8700.feature
@@ -1,0 +1,1 @@
+twisted.conch.client.default is now ported to Python 3.

--- a/twisted/python/compat.py
+++ b/twisted/python/compat.py
@@ -758,8 +758,10 @@ def _coercedUnicode(s):
 
 if _PY3:
     unichr = chr
+    raw_input = input
 else:
     unichr = unichr
+    raw_input = raw_input
 
 
 
@@ -799,4 +801,5 @@ __all__ = [
     "_coercedUnicode",
     "intern",
     "unichr",
+    "raw_input",
 ]

--- a/twisted/python/dist3.py
+++ b/twisted/python/dist3.py
@@ -56,6 +56,7 @@ modules = [
     "twisted.conch.avatar",
     "twisted.conch.checkers",
     "twisted.conch.client.__init__",
+    "twisted.conch.client.default",
     "twisted.conch.client.knownhosts",
     "twisted.conch.error",
     "twisted.conch.interfaces",
@@ -386,6 +387,7 @@ testModules = [
     "twisted.conch.test.test_channel",
     "twisted.conch.test.test_checkers",
     "twisted.conch.test.test_connection",
+    "twisted.conch.test.test_default",
     "twisted.conch.test.test_filetransfer",
     "twisted.conch.test.test_forwarding",
     "twisted.conch.test.test_insults",
@@ -664,8 +666,14 @@ testDataFiles = [
 
 almostModules = [
     # twisted.conch.test_knownhosts tests parts of the default module
-    "twisted.conch.client.default",
     "twisted.conch.client.agent",
+    # twisted.conch.client.default has tests that depend on
+    "twisted.conch.client.options",
+    # twisted.conch.test.test_text and twisted.conch.test.test_window
+    # need these conch modules.  They need more work to get full
+    # Python 3 test coverage
+    "twisted.conch.insults.helper",
+    "twisted.conch.insults.insults",
     # Required for Trial
     "twisted.python.logfile",
     # Missing test coverage, see #6156:

--- a/twisted/test/test_compat.py
+++ b/twisted/test/test_compat.py
@@ -869,7 +869,7 @@ class RawInputTests(unittest.TestCase):
     """
     def test_raw_input(self):
         """
-        Verify that raw_input exists and that it works.
+        L{twisted.python.compat.raw_input}
         """
         class FakeStdin:
             def readline(self):

--- a/twisted/test/test_compat.py
+++ b/twisted/test/test_compat.py
@@ -16,7 +16,7 @@ from twisted.python.compat import (
     reduce, execfile, _PY3, _PYPY, comparable, cmp, nativeString,
     networkString, unicode as unicodeCompat, lazyByteSlice, reraise,
     NativeStringIO, iterbytes, intToBytes, ioType, bytesEnviron, iteritems,
-    _coercedUnicode, unichr,
+    _coercedUnicode, unichr, raw_input
 )
 from twisted.python.filepath import FilePath
 
@@ -861,3 +861,27 @@ class UnichrTests(unittest.TestCase):
         unichar exists and returns a unicode string with the given code point.
         """
         self.assertEqual(unichr(0x2603), u"\N{SNOWMAN}")
+
+
+class RawInputTests(unittest.TestCase):
+    """
+    Tests for L{raw_input}
+    """
+    def test_raw_input(self):
+        """
+        Verify that raw_input exists and that it works.
+        """
+        class FakeStdin:
+            def readline(self):
+                return "User input\n"
+
+        class FakeStdout:
+            data = ""
+            def write(self, data):
+                self.data += data
+
+        self.patch(sys, "stdin", FakeStdin())
+        stdout = FakeStdout()
+        self.patch(sys, "stdout", stdout)
+        self.assertEqual(raw_input("Prompt"), "User input")
+        self.assertEqual(stdout.data, "Prompt")


### PR DESCRIPTION
This work was originally done in this pull request: https://github.com/twisted/twisted/pull/438

With one additional patch to skip tests that require an interactive tty
if we are not on an interactive tty.

Tickets addressed:
http://twistedmatrix.com/trac/ticket/8700
http://twistedmatrix.com/trac/ticket/8715
