### PR TITLE
Don't explode when the client resets a stream while it uploads data.

### DIFF
--- a/twisted/web/_http2.py
+++ b/twisted/web/_http2.py
@@ -692,8 +692,13 @@ class H2Connection(Protocol, TimeoutMixin):
             )
         except h2.exceptions.StreamClosedError:
             # The stream got reset and we haven't worked it out yet. The stream
-            # window doesn't matter now. We still want to increment the
-            # connection window though.
+            # window doesn't matter now as all the data that can possibly be
+            # received on the stream already has been. We still want to
+            # increment the connection window though: the data received on this
+            # stream counted against the connection flow control window, and if
+            # we don't expand the window this becomes a DoS vector that leads
+            # to us eventually preventing the client from sending any more data
+            # to us.
             # NOTE: This branch may become unneeded in the future if
             # https://github.com/python-hyper/hyper-h2/issues/228 happens.
             pass

--- a/twisted/web/test/test_http2.py
+++ b/twisted/web/test/test_http2.py
@@ -2116,13 +2116,11 @@ class H2FlowControlTests(unittest.TestCase, HTTP2TestHelpers):
         frames = framesFromBytes(transport.value())
 
         # Check that the only WINDOW_UPDATE frames came for the connection.
-        windowUpdateFrames = (
-            f for f in frames
+        windowUpdateFrameIDs = [
+            f.stream_id for f in frames
             if isinstance(f, hyperframe.frame.WindowUpdateFrame)
-        )
-        self.assertTrue(
-            all(frame.stream_id == 0 for frame in windowUpdateFrames)
-        )
+        ]
+        self.assertEqual([0, 0, 0], windowUpdateFrameIDs)
 
         # While we're here: we shouldn't have received HEADERS or DATA for this
         # either.

--- a/twisted/web/topfiles/8682.bugfix
+++ b/twisted/web/topfiles/8682.bugfix
@@ -1,0 +1,1 @@
+Twisted Web's HTTP/2 server can now tolerate streams being reset by the client midway through a data upload without throwing exceptions.


### PR DESCRIPTION
See https://twistedmatrix.com/trac/ticket/8682
