### PR TITLE
[#8723] fix a typo in defer.rst

### DIFF
--- a/docs/core/howto/defer.rst
+++ b/docs/core/howto/defer.rst
@@ -18,7 +18,7 @@ Deferreds
 ---------
 
 Twisted uses the :api:`twisted.internet.defer.Deferred <Deferred>` object to manage the callback sequence.
-The client application attaches a series of functions to the deferred to be called in order when the results of the asynchronous request are available (this series of functions is known as a series of **callbacks**, or a **callback chain**), together with a series of functions to be called if there is an error in the asynchronous request (known as a series of **errbacks** or an**errback chain**).
+The client application attaches a series of functions to the deferred to be called in order when the results of the asynchronous request are available (this series of functions is known as a series of **callbacks**, or a **callback chain**), together with a series of functions to be called if there is an error in the asynchronous request (known as a series of **errbacks** or an **errback chain**).
 The asynchronous library code calls the first callback when the result is available, or the first errback when an error occurs, and the ``Deferred`` object then hands the results of each callback or errback function to the next function in the chain.
 
 

--- a/twisted/topfiles/8723.doc
+++ b/twisted/topfiles/8723.doc
@@ -1,0 +1,1 @@
+A missing space in defer.rst resulted in badly rendered output. The space was added.


### PR DESCRIPTION
​https://twistedmatrix.com/documents/current/core/howto/defer.html has `"known as a series of errbacks or an**errback chain**"`, the missing space between `"an"` and `"**"` leads to bad rendering of the rst

see https://twistedmatrix.com/trac/ticket/8723
