### PR TITLE
Fix twisted.internet.test.test_pollingfile on Python 3

### DIFF
--- a/twisted/internet/_pollingfile.py
+++ b/twisted/internet/_pollingfile.py
@@ -7,6 +7,7 @@ Implements a simple polling interface for file descriptors that don't work with
 select() - this is pretty much only useful on Windows.
 """
 
+from __future__ import absolute_import, division
 
 from zope.interface import implementer
 from twisted.internet.interfaces import IConsumer, IPushProducer

--- a/twisted/internet/_pollingfile.py
+++ b/twisted/internet/_pollingfile.py
@@ -10,6 +10,7 @@ select() - this is pretty much only useful on Windows.
 
 from zope.interface import implementer
 from twisted.internet.interfaces import IConsumer, IPushProducer
+from twisted.python.compat import unicode
 
 
 MIN_TIMEOUT = 0.000000001

--- a/twisted/internet/_pollingfile.py
+++ b/twisted/internet/_pollingfile.py
@@ -273,7 +273,7 @@ class _PollableWritePipe(_PollableResource):
                 self.writeConnectionLost()
                 return 0
             try:
-                win32file.WriteFile(self.writePipe, '', None)
+                win32file.WriteFile(self.writePipe, b'', None)
             except pywintypes.error:
                 self.writeConnectionLost()
                 return numBytesWritten

--- a/twisted/internet/_pollingfile.py
+++ b/twisted/internet/_pollingfile.py
@@ -130,7 +130,7 @@ class _PollableReadPipe(_PollableResource):
                 finished = 1
                 break
 
-        dataBuf = ''.join(fullDataRead)
+        dataBuf = b''.join(fullDataRead)
         if dataBuf:
             self.receivedCallback(dataBuf)
         if finished:

--- a/twisted/python/dist3.py
+++ b/twisted/python/dist3.py
@@ -438,6 +438,7 @@ testModules = [
     "twisted.internet.test.test_kqueuereactor",
     "twisted.internet.test.test_main",
     "twisted.internet.test.test_newtls",
+    "twisted.internet.test.test_pollingfile",
     "twisted.internet.test.test_posixbase",
     "twisted.internet.test.test_posixprocess",
     "twisted.internet.test.test_process",

--- a/twisted/topfiles/8733.feature
+++ b/twisted/topfiles/8733.feature
@@ -1,0 +1,1 @@
+twisted.internet._pollingfile has been ported to Python 3


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8733

This fix is cherrypicked from @hawkowl 's branch: https://github.com/twisted/twisted/blame/moar-windows-8025-8/twisted/internet/_pollingfile.py
