### PR TITLE
Fix use of errno in twisted.internet.test.test_tcp on Python 3

### DIFF
--- a/twisted/internet/test/test_tcp.py
+++ b/twisted/internet/test/test_tcp.py
@@ -1102,8 +1102,7 @@ class TCPPortTestsMixin(object):
         try:
             connect(client, (port.getHost().host, port.getHost().port))
         except socket.error as e:
-            errnum, message = e.args
-            self.assertIn(errnum, (errno.EINPROGRESS, errno.EWOULDBLOCK))
+            self.assertIn(e.errno, (errno.EINPROGRESS, errno.EWOULDBLOCK))
 
         self.runReactor(reactor)
 
@@ -1185,8 +1184,7 @@ class TCPPortTestsMixin(object):
         try:
             connect(client, (port.getHost().host, port.getHost().port))
         except socket.error as e:
-            errnum, message = e.args
-            self.assertIn(errnum, (errno.EINPROGRESS, errno.EWOULDBLOCK))
+            self.assertIn(e.errno, (errno.EINPROGRESS, errno.EWOULDBLOCK))
         self.runReactor(reactor)
         return factory.address
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8734

This fix is cherrypicked from @hawkowl 's branch: https://github.com/twisted/twisted/blame/moar-windows-8025-8/twisted/internet/test/test_tcp.py
