### PR TITLE
Fix test_zippath on Windows Python 3

### DIFF
--- a/twisted/python/zippath.py
+++ b/twisted/python/zippath.py
@@ -19,6 +19,7 @@ from zipfile import ZipFile
 from twisted.python.compat import comparable, cmp
 from twisted.python.filepath import IFilePath, FilePath, AbstractFilePath
 from twisted.python.filepath import _coerceToFilesystemEncoding
+from twisted.python.filepath import UnlistableError
 
 from zope.interface import implementer
 
@@ -128,9 +129,11 @@ class ZipPath(AbstractFilePath):
             if self.isdir():
                 return list(self.archive.childmap[self.pathInArchive].keys())
             else:
-                raise OSError(errno.ENOTDIR, "Leaf zip entry listed")
+                raise UnlistableError(
+                    OSError(errno.ENOTDIR, "Leaf zip entry listed"))
         else:
-            raise OSError(errno.ENOENT, "Non-existent zip entry listed")
+            raise UnlistableError(
+                OSError(errno.ENOENT, "Non-existent zip entry listed"))
 
 
     def splitext(self):

--- a/twisted/topfiles/8747.feature
+++ b/twisted/topfiles/8747.feature
@@ -1,0 +1,1 @@
+twisted.python.zippath now works on Windows with Python 3.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8747

This fix is cherrypicked from @hawkowl 's branch: https://github.com/twisted/twisted/blame/moar-windows-8025-7/twisted/python/zippath.py
