### PR TITLE
Fix test_tcp on Windows Python 3

### DIFF
--- a/twisted/internet/test/test_socket.py
+++ b/twisted/internet/test/test_socket.py
@@ -96,6 +96,7 @@ class AdoptStreamPortErrorsTestsBuilder(ReactorBuilder):
         reactor = self.buildReactor()
 
         port = socket.socket()
+        port.bind(("127.0.0.1", 0))
         port.listen(1)
         self.addCleanup(port.close)
 
@@ -119,6 +120,7 @@ class AdoptStreamPortErrorsTestsBuilder(ReactorBuilder):
         portSocket = socket.socket()
         self.addCleanup(portSocket.close)
 
+        portSocket.bind(("127.0.0.1", 0))
         portSocket.listen(1)
         portSocket.setblocking(False)
 
@@ -236,6 +238,7 @@ class AdoptDatagramPortErrorsTestsBuilder(ReactorBuilder):
         portSocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.addCleanup(portSocket.close)
 
+        portSocket.bind(("127.0.0.1", 0))
         portSocket.setblocking(False)
 
         # The file descriptor is duplicated by adoptDatagramPort

--- a/twisted/internet/test/test_socket.py
+++ b/twisted/internet/test/test_socket.py
@@ -20,6 +20,8 @@ from twisted.internet.error import UnsupportedAddressFamily
 from twisted.internet.protocol import DatagramProtocol, ServerFactory
 from twisted.internet.test.reactormixins import (
     ReactorBuilder, needsRunningReactor)
+from twisted.python.compat import _PY3
+from twisted.python.runtime import platform
 
 
 
@@ -79,7 +81,10 @@ class AdoptStreamPortErrorsTestsBuilder(ReactorBuilder):
         exc = self.assertRaises(
             socket.error,
             reactor.adoptStreamPort, fileno, socket.AF_INET, ServerFactory())
-        self.assertEqual(exc.args[0], errno.EBADF)
+        if platform.isWindows() and _PY3:
+            self.assertEqual(exc.args[0], errno.WSAENOTSOCK)
+        else:
+            self.assertEqual(exc.args[0], errno.EBADF)
 
 
     def test_invalidAddressFamily(self):
@@ -193,7 +198,10 @@ class AdoptDatagramPortErrorsTestsBuilder(ReactorBuilder):
             socket.error,
             reactor.adoptDatagramPort, fileno, socket.AF_INET,
             DatagramProtocol())
-        self.assertEqual(exc.args[0], errno.EBADF)
+        if platform.isWindows() and _PY3:
+            self.assertEqual(exc.args[0], errno.WSAENOTSOCK)
+        else:
+            self.assertEqual(exc.args[0], errno.EBADF)
 
 
     def test_invalidAddressFamily(self):

--- a/twisted/internet/test/test_socket.py
+++ b/twisted/internet/test/test_socket.py
@@ -133,7 +133,10 @@ class AdoptStreamPortErrorsTestsBuilder(ReactorBuilder):
             # portSocket.  If it was shutdown, the exception would be
             # EINVAL instead.
             exc = self.assertRaises(socket.error, portSocket.accept)
-            self.assertEqual(exc.args[0], errno.EAGAIN)
+            if platform.isWindows() and _PY3:
+                self.assertEqual(exc.args[0], errno.WSAEWOULDBLOCK)
+            else:
+                self.assertEqual(exc.args[0], errno.EAGAIN)
         d.addCallback(stopped)
         d.addErrback(err, "Failed to accept on original port.")
 
@@ -249,7 +252,10 @@ class AdoptDatagramPortErrorsTestsBuilder(ReactorBuilder):
             # Should still be possible to recv on portSocket.  If
             # it was shutdown, the exception would be EINVAL instead.
             exc = self.assertRaises(socket.error, portSocket.recvfrom, 1)
-            self.assertEqual(exc.args[0], errno.EAGAIN)
+            if platform.isWindows() and _PY3:
+                self.assertEqual(exc.args[0], errno.WSAEWOULDBLOCK)
+            else:
+                self.assertEqual(exc.args[0], errno.EAGAIN)
         d.addCallback(stopped)
         d.addErrback(err, "Failed to read on original port.")
 

--- a/twisted/test/test_tcp.py
+++ b/twisted/test/test_tcp.py
@@ -20,6 +20,8 @@ from twisted.internet import error
 from twisted.internet.address import IPv4Address
 from twisted.internet.interfaces import IHalfCloseableProtocol, IPullProducer
 from twisted.protocols import policies
+from twisted.python.compat import _PY3
+from twisted.python.runtime import platform
 from twisted.test.proto_helpers import AccumulatingProtocol
 
 
@@ -1138,10 +1140,11 @@ class ProperlyCloseFilesMixin:
         Return the errno expected to result from writing to a closed
         platform socket handle.
         """
-        # These platforms have been seen to give EBADF:
-        #
-        #  Linux 2.4.26, Linux 2.6.15, OS X 10.4, FreeBSD 5.4
-        #  Windows 2000 SP 4, Windows XP SP 2
+        # Windows and Python 3: returns WSAENOTSOCK
+        # Windows and Python 2: returns EBADF
+        # Linux, FreeBSD, Mac OS X: returns EBADF
+        if platform.isWindows() and _PY3:
+            return errno.WSAENOTSOCK
         return errno.EBADF
 
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8749

No joke, I ran the same test from the same checkout using Python 2.7
and Python 3.5 under Windows 10, and I got different errno values.

@hawkowl , please review this.  This is similar to the fix that you did here:
https://github.com/twisted/twisted/blame/moar-windows-8025-8/twisted/test/test_tcp.py

but I coded it differently, so you can review it.
