### PR TITLE
Fix test_stdlib.py on Windows with Python 3.5

### DIFF
--- a/src/twisted/logger/test/test_stdlib.py
+++ b/src/twisted/logger/test/test_stdlib.py
@@ -276,7 +276,7 @@ def handlerAndBytesIO():
     stream = output
     template = py_logging.BASIC_FORMAT
     if _PY3:
-        stream = TextIOWrapper(output, encoding="utf-8")
+        stream = TextIOWrapper(output, encoding="utf-8", newline="\n")
     formatter = py_logging.Formatter(template)
     handler = py_logging.StreamHandler(stream)
     handler.setFormatter(formatter)


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8755

This fix is taken from @hawkowl 's branch: 
https://github.com/twisted/twisted/blame/moar-windows-8025-8/twisted/logger/test/test_stdlib.py
