### PR TITLE
Fix test_compat on Windows with Python 3

### DIFF
--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -19,6 +19,7 @@ from twisted.python.compat import (
     _coercedUnicode, unichr, raw_input, _bytesRepr
 )
 from twisted.python.filepath import FilePath
+from twisted.python.runtime import platform
 
 
 
@@ -769,6 +770,9 @@ class BytesEnvironTests(unittest.TestCase):
             types.add(type(val))
 
         self.assertEqual(list(types), [bytes])
+
+    if platform.isWindows():
+        test_alwaysBytes.skip = "Environment vars are always str on Windows."
 
 
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8757

This fix is taken from @hawkowl 's branch: https://github.com/twisted/twisted/blame/moar-windows-8025-8/twisted/test/test_compat.py
