### PR TITLE
8771 ssh userauth keyboard interactive

### DIFF
--- a/src/twisted/conch/ssh/userauth.py
+++ b/src/twisted/conch/ssh/userauth.py
@@ -526,7 +526,7 @@ class SSHUserAuthClient(service.SSHService):
         prompts = []
         for i in range(numPrompts):
             prompt, data = getNS(data)
-            echo = bool(ord(data[0]))
+            echo = bool(ord(data[0:1]))
             data = data[1:]
             prompts.append((prompt, echo))
         d = self.getGenericAnswers(name, instruction, prompts)

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -702,6 +702,20 @@ class SSHUserAuthClientTests(unittest.TestCase):
         self.assertFalse(self.authClient.tryAuth(b'password'))
 
 
+    def test_keyboardInteractive(self):
+        """
+        Make sure that the client can authenticate with the keyboard
+        interactive method.
+        """
+        self.authClient.ssh_USERAUTH_PK_OK_keyboard_interactive(
+            NS(b'') + NS(b'') + NS(b'') + b'\x00\x00\x00\x01' +
+            NS(b'Password: ') + b'\x00')
+        self.assertEqual(
+            self.authClient.transport.packets[-1],
+            (userauth.MSG_USERAUTH_REQUEST,
+             NS(b'foo') + NS(b'nancy') + NS(b'none')))
+
+
     def test_USERAUTH_PK_OK_unknown_method(self):
         """
         If C{SSHUserAuthClient} gets a MSG_USERAUTH_PK_OK packet when it's not

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -82,7 +82,7 @@ class ClientUserAuth(userauth.SSHUserAuthClient):
         """
         Return 'foo' as the answer to two questions.
         """
-        return defer.succeed((b'foo', b'foo'))
+        return defer.succeed(('foo', 'foo'))
 
 
 
@@ -712,8 +712,8 @@ class SSHUserAuthClientTests(unittest.TestCase):
             NS(b'Password: ') + b'\x00')
         self.assertEqual(
             self.authClient.transport.packets[-1],
-            (userauth.MSG_USERAUTH_REQUEST,
-             NS(b'foo') + NS(b'nancy') + NS(b'none')))
+            (userauth.MSG_USERAUTH_INFO_RESPONSE,
+             b'\x00\x00\x00\x02' + NS(b'foo') + NS(b'foo')))
 
 
     def test_USERAUTH_PK_OK_unknown_method(self):

--- a/src/twisted/conch/topfiles/8771.bugfix
+++ b/src/twisted/conch/topfiles/8771.bugfix
@@ -1,0 +1,1 @@
+SSHUserAuthServer does not crash on keyboard interactive authentication when running on Python 3


### PR DESCRIPTION
This will fix a problem with keyboard interactive userauth on Python3 and is a fix for https://twistedmatrix.com/trac/ticket/8771
