### PR TITLE
Fix test_windowsErrorExcept fails on Windows with Python 3.5

### DIFF
--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -331,16 +331,24 @@ class AbstractFilePath(object):
         try:
             subnames = self.listdir()
         except WindowsError as winErrObj:
-            # WindowsError is an OSError subclass, so if not for this clause
-            # the OSError clause below would be handling these.  Windows error
-            # codes aren't the same as POSIX error codes, so we need to handle
-            # them differently.
+            # Under Python 3.3 and higher on Windows, WindowsError is an
+            # alias for OSError.  OSError has a winerror attribute and an
+            # errno attribute.
 
-            # Under Python 2.5 on Windows, WindowsError has a winerror
-            # attribute and an errno attribute.  The winerror attribute is
-            # bound to the Windows error code while the errno attribute is
-            # bound to a translation of that code to a perhaps equivalent POSIX
-            # error number.
+            # Under Python 2, WindowsError is an OSError subclass.
+
+            # Under Python 2.5 and higher on Windows, WindowsError has a
+            # winerror attribute and an errno attribute.
+
+            # The winerror attribute is bound to the Windows error code while
+            # the errno attribute is bound to a translation of that code to a
+            # perhaps equivalent POSIX error number.
+
+            # If not for this clause OSError would be handling all of these
+            # errors on Windows.  The errno attribute contains a POSIX error
+            # code while the winerror attribute contains a Windows error code.
+            # Windows error codes aren't the same as POSIX error codes,
+            # so we need to handle them differently.
 
             # Under Python 2.4 on Windows, WindowsError only has an errno
             # attribute.  It is bound to the Windows error code.

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -343,6 +343,9 @@ class AbstractFilePath(object):
             # The winerror attribute is bound to the Windows error code while
             # the errno attribute is bound to a translation of that code to a
             # perhaps equivalent POSIX error number.
+            #
+            # For further details, refer to:
+            # https://docs.python.org/3/library/exceptions.html#OSError
 
             # If not for this clause OSError would be handling all of these
             # errors on Windows.  The errno attribute contains a POSIX error

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -257,9 +257,23 @@ class FakeWindowsPath(filepath.FilePath):
         """
         @raise WindowsError: always.
         """
-        raise WindowsError(
-            ERROR_DIRECTORY,
-            "A directory's validness was called into question")
+        if _PY3:
+            # For Python 3.3 and higher, WindowsError is an alias for OSError.
+            # The first argument to the OSError constructor is errno, and the fourth
+            # argument is winerror.
+            #
+            # On Windows, if winerror is set in the constructor,
+            # the errno value in the constructor is ignored, and OSError internally
+            # maps the winerror value to an errno value.
+            raise WindowsError(
+                None,
+                "A directory's validness was called into question",
+                self.path,
+                ERROR_DIRECTORY)
+        else:
+            raise WindowsError(
+                ERROR_DIRECTORY,
+                "A directory's validness was called into question")
 
 
 
@@ -276,6 +290,9 @@ class ListingCompatibilityTests(BytesTestCase):
         fwp = FakeWindowsPath(self.mktemp())
         self.assertRaises(filepath.UnlistableError, fwp.children)
         self.assertRaises(WindowsError, fwp.children)
+
+    if not platform.isWindows():
+        test_windowsErrorExcept.skip = "Only relevant on on Windows."
 
 
     def test_alwaysCatchOSError(self):

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -261,6 +261,8 @@ class FakeWindowsPath(filepath.FilePath):
             # For Python 3.3 and higher, WindowsError is an alias for OSError.
             # The first argument to the OSError constructor is errno, and the fourth
             # argument is winerror.
+            # For further details, refer to:
+            # https://docs.python.org/3/library/exceptions.html#OSError
             #
             # On Windows, if winerror is set in the constructor,
             # the errno value in the constructor is ignored, and OSError internally


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/8776

On Python 3.3 and higher, WIndowsError is an alias to OSError.  The winerror attribute needs to
be specified as the fourth argument to the OSError constructor:
https://docs.python.org/3/library/exceptions.html#OSError
