### PR TITLE
Allow use of SHA256 hashes in  SSH fingerprints

### DIFF
--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -64,7 +64,7 @@ def run():
         else:
             sys.exit('Key type was %s, must be one of: rsa, dsa' % options['type'])
     elif options['fingerprint']:
-        enumrepresentation(options)
+        options = enumrepresentation(options)
         printFingerprint(options)
     elif options['changepass']:
         changePassPhrase(options)

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -113,8 +113,8 @@ def generateDSAkey(options):
 
 
 def printFingerprint(options):
-    if not options.has_key('fingerPrintformat'):
-        options['fingerPrintformat'] = 'md5-hex'
+    if not options.has_key('format'):
+        options['format'] = 'md5-hex'
     if not options['filename']:
         filename = os.path.expanduser('~/.ssh/id_rsa')
         options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
@@ -124,7 +124,7 @@ def printFingerprint(options):
         key = keys.Key.fromFile(options['filename'])
         print('%s %s %s' % (
             key.size(),
-            key.fingerprint(options['fingerPrintformat']),
+            key.fingerprint(options['format']),
             os.path.basename(options['filename'])))
     except keys.BadKeyError:
         sys.exit('bad key')
@@ -205,8 +205,8 @@ def _saveKey(key, options):
     @type options: L{dict}
     """
     keyTypeName = key.type().lower()
-    if not options.has_key('fingerPrintformat'):
-        options['fingerPrintformat'] = 'md5-hex'
+    if not options.has_key('format'):
+        options['format'] = 'md5-hex'
     if not options['filename']:
         defaultPath = os.path.expanduser(u'~/.ssh/id_%s' % (keyTypeName,))
         newPath = raw_input(
@@ -243,7 +243,7 @@ def _saveKey(key, options):
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))
     print('The key fingerprint is:')
-    print(key.fingerprint(options['fingerPrintformat']))
+    print(key.fingerprint(options['format']))
 
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -33,10 +33,10 @@ class GeneralOptions(usage.Options):
                      ['type', 't', None, 'Specify type of key to create.'],
                      ['comment', 'C', None, 'Provide new comment.'],
                      ['newpass', 'N', None, 'Provide new passphrase.'],
-                     ['pass', 'P', None, 'Provide old passphrase.']]
+                     ['pass', 'P', None, 'Provide old passphrase.'],
+                     ['fingerprint', 'l', 'md5-hex', 'Show fingerprint of key file.']]
 
-    optFlags = [['fingerprint', 'l', 'Show fingerprint of key file.'],
-                ['changepass', 'p', 'Change passphrase of private key file.'],
+    optFlags = [['changepass', 'p', 'Change passphrase of private key file.'],
                 ['quiet', 'q', 'Quiet.'],
                 ['no-passphrase', None, "Create the key with no passphrase."],
                 ['showpub', 'y', 'Read private key file and print public key.']]

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -34,9 +34,10 @@ class GeneralOptions(usage.Options):
                      ['comment', 'C', None, 'Provide new comment.'],
                      ['newpass', 'N', None, 'Provide new passphrase.'],
                      ['pass', 'P', None, 'Provide old passphrase.'],
-                     ['fingerprint', 'l', 'sha256-base64', 'Fingerprint format of key file.']]
+                     ['format', 'o', 'sha256-base64', 'Fingerprint format of key file.']]
 
-    optFlags = [['changepass', 'p', 'Change passphrase of private key file.'],
+    optFlags = [['fingerprint', 'l', 'Show fingerprint of key file.'],
+                ['changepass', 'p', 'Change passphrase of private key file.'],
                 ['quiet', 'q', 'Quiet.'],
                 ['no-passphrase', None, "Create the key with no passphrase."],
                 ['showpub', 'y', 'Read private key file and print public key.']]
@@ -76,15 +77,15 @@ def run():
 
 
 def enumrepresentation(options):
-    if options['fingerprint'] == 'md5-hex':
-        options['fingerprint'] = keys.FingerprintFormats.MD5_HEX
+    if options['format'] == 'md5-hex':
+        options['format'] = keys.FingerprintFormats.MD5_HEX
         return options
-    elif options['fingerprint'] == 'sha256-base64':
-        options['fingerprint'] = keys.FingerprintFormats.SHA256_BASE64
+    elif options['format'] == 'sha256-base64':
+        options['format'] = keys.FingerprintFormats.SHA256_BASE64
         return options
     else:
         raise keys.BadFingerPrintFormat(
-            'Unsupported fingerprint format: %s' % (options['fingerprint'],))
+            'Unsupported fingerprint format: %s' % (options['format'],))
 
 
 
@@ -135,7 +136,7 @@ def printFingerprint(options):
         key = keys.Key.fromFile(options['filename'])
         print('%s %s %s' % (
             key.size(),
-            key.fingerprint(options['fingerprint']),
+            key.fingerprint(options['format']),
             os.path.basename(options['filename'])))
     except keys.BadKeyError:
         sys.exit('bad key')
@@ -251,8 +252,8 @@ def _saveKey(key, options):
 
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))
-    print('The key fingerprint in %s is:' % (options['fingerprint'],))
-    print(key.fingerprint(options['fingerprint']))
+    print('The key fingerprint in %s is:' % (options['format'],))
+    print(key.fingerprint(options['format']))
 
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -113,6 +113,8 @@ def generateDSAkey(options):
 
 
 def printFingerprint(options):
+    if not options.has_key('fingerPrintformat'):
+        options['fingerPrintformat'] = 'md5-hex'
     if not options['filename']:
         filename = os.path.expanduser('~/.ssh/id_rsa')
         options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
@@ -122,9 +124,9 @@ def printFingerprint(options):
         key = keys.Key.fromFile(options['filename'])
         print('%s %s %s' % (
             key.size(),
-            key.fingerprint(),
+            key.fingerprint(options['fingerPrintformat']),
             os.path.basename(options['filename'])))
-    except:
+    except keys.BadKeyError:
         sys.exit('bad key')
 
 
@@ -203,6 +205,8 @@ def _saveKey(key, options):
     @type options: L{dict}
     """
     keyTypeName = key.type().lower()
+    if not options.has_key('fingerPrintformat'):
+        options['fingerPrintformat'] = 'md5-hex'
     if not options['filename']:
         defaultPath = os.path.expanduser(u'~/.ssh/id_%s' % (keyTypeName,))
         newPath = raw_input(
@@ -239,7 +243,7 @@ def _saveKey(key, options):
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))
     print('The key fingerprint is:')
-    print(key.fingerprint())
+    print(key.fingerprint(options['fingerPrintformat']))
 
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -113,7 +113,6 @@ def generateDSAkey(options):
 
 
 def printFingerprint(options):
-    options.setdefault('format', 'md5-hex')
     if not options['filename']:
         filename = os.path.expanduser('~/.ssh/id_rsa')
         options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
@@ -204,7 +203,6 @@ def _saveKey(key, options):
     @type options: L{dict}
     """
     keyTypeName = key.type().lower()
-    options.setdefault('format', 'md5-hex')
     if not options['filename']:
         defaultPath = os.path.expanduser(u'~/.ssh/id_%s' % (keyTypeName,))
         newPath = raw_input(

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -113,8 +113,7 @@ def generateDSAkey(options):
 
 
 def printFingerprint(options):
-    if not options.has_key('format'):
-        options['format'] = 'md5-hex'
+    options.setdefault('format', 'md5-hex')
     if not options['filename']:
         filename = os.path.expanduser('~/.ssh/id_rsa')
         options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
@@ -205,8 +204,7 @@ def _saveKey(key, options):
     @type options: L{dict}
     """
     keyTypeName = key.type().lower()
-    if not options.has_key('format'):
-        options['format'] = 'md5-hex'
+    options.setdefault('format', 'md5-hex')
     if not options['filename']:
         defaultPath = os.path.expanduser(u'~/.ssh/id_%s' % (keyTypeName,))
         newPath = raw_input(
@@ -242,7 +240,7 @@ def _saveKey(key, options):
 
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))
-    print('The key fingerprint is:')
+    print('The key fingerprint in %s is:' % (options['format'],))
     print(key.fingerprint(options['format']))
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -34,7 +34,7 @@ class GeneralOptions(usage.Options):
                      ['comment', 'C', None, 'Provide new comment.'],
                      ['newpass', 'N', None, 'Provide new passphrase.'],
                      ['pass', 'P', None, 'Provide old passphrase.'],
-                     ['fingerprint', 'l', 'md5-hex', 'Show fingerprint of key file.']]
+                     ['format', 'l', 'md5-hex', 'Fingerprint format of key file.']]
 
     optFlags = [['changepass', 'p', 'Change passphrase of private key file.'],
                 ['quiet', 'q', 'Quiet.'],
@@ -63,7 +63,7 @@ def run():
             generateDSAkey(options)
         else:
             sys.exit('Key type was %s, must be one of: rsa, dsa' % options['type'])
-    elif options['fingerprint']:
+    elif options['format']:
         printFingerprint(options)
     elif options['changepass']:
         changePassPhrase(options)

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -64,6 +64,7 @@ def run():
         else:
             sys.exit('Key type was %s, must be one of: rsa, dsa' % options['type'])
     elif options['fingerprint']:
+        enumrepresentation(options)
         printFingerprint(options)
     elif options['changepass']:
         changePassPhrase(options)
@@ -72,6 +73,18 @@ def run():
     else:
         options.opt_help()
         sys.exit(1)
+
+
+def enumrepresentation(options):
+    if options['fingerprint'] == 'md5-hex':
+        options['fingerprint'] = keys.FingerprintFormats.MD5_HEX
+        return options
+    elif options['fingerprint'] == 'sha256-base64':
+        options['fingerprint'] = keys.FingerprintFormats.SHA256_BASE64
+        return options
+    else:
+        raise keys.BadFingerPrintFormat(
+            'Unsupported fingerprint format: %s' % (options['fingerprint'],))
 
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -34,7 +34,7 @@ class GeneralOptions(usage.Options):
                      ['comment', 'C', None, 'Provide new comment.'],
                      ['newpass', 'N', None, 'Provide new passphrase.'],
                      ['pass', 'P', None, 'Provide old passphrase.'],
-                     ['format', 'l', 'md5-hex', 'Fingerprint format of key file.']]
+                     ['fingerprint', 'l', 'sha256-base64', 'Fingerprint format of key file.']]
 
     optFlags = [['changepass', 'p', 'Change passphrase of private key file.'],
                 ['quiet', 'q', 'Quiet.'],
@@ -63,7 +63,7 @@ def run():
             generateDSAkey(options)
         else:
             sys.exit('Key type was %s, must be one of: rsa, dsa' % options['type'])
-    elif options['format']:
+    elif options['fingerprint']:
         printFingerprint(options)
     elif options['changepass']:
         changePassPhrase(options)
@@ -122,7 +122,7 @@ def printFingerprint(options):
         key = keys.Key.fromFile(options['filename'])
         print('%s %s %s' % (
             key.size(),
-            key.fingerprint(options['format']),
+            key.fingerprint(options['fingerprint']),
             os.path.basename(options['filename'])))
     except keys.BadKeyError:
         sys.exit('bad key')
@@ -238,8 +238,8 @@ def _saveKey(key, options):
 
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))
-    print('The key fingerprint in %s is:' % (options['format'],))
-    print(key.fingerprint(options['format']))
+    print('The key fingerprint in %s is:' % (options['fingerprint'],))
+    print(key.fingerprint(options['fingerprint']))
 
 
 

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -65,7 +65,6 @@ def run():
         else:
             sys.exit('Key type was %s, must be one of: rsa, dsa' % options['type'])
     elif options['fingerprint']:
-        options = enumrepresentation(options)
         printFingerprint(options)
     elif options['changepass']:
         changePassPhrase(options)
@@ -132,6 +131,7 @@ def printFingerprint(options):
         options['filename'] = raw_input('Enter file in which the key is (%s): ' % filename)
     if os.path.exists(options['filename']+'.pub'):
         options['filename'] += '.pub'
+    options = enumrepresentation(options)
     try:
         key = keys.Key.fromFile(options['filename'])
         print('%s %s %s' % (
@@ -249,6 +249,7 @@ def _saveKey(key, options):
 
     filepath.FilePath(options['filename'] + '.pub').setContent(
         key.public().toString('openssh', comment))
+    options = enumrepresentation(options)
 
     print('Your identification has been saved in %s' % (options['filename'],))
     print('Your public key has been saved in %s.pub' % (options['filename'],))

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -783,7 +783,7 @@ class Key(object):
         return Key(self._keyObject.public_key())
 
 
-    def fingerprint(self, hash_function=sha256):
+    def fingerprint(self, fingerPrintformat='md5-hex'):
         """
         Get the user presentation of the fingerprint of this L{Key}.  As
         described by U{RFC 4716 section
@@ -808,10 +808,13 @@ class Key(object):
 
         @rtype: L{str}
         """
-        fingerprint_digest=hash_function(self.blob()).digest()
-        if hash_function==sha256:
+        hashFunction_dispatcher = {'md5' : md5, 'sha256' : sha256}
+        hashFunction_string = fingerPrintformat.split("-")[0]
+        fingerprint_digest = hashFunction_dispatcher[hashFunction_string](
+            self.blob()).digest()
+        if hashFunction_string == 'sha256':
             return nativeString(base64.b64encode(fingerprint_digest))
-        else:
+        elif hashFunction_string == 'md5':
             return nativeString(
                 b':'.join([binascii.hexlify(x)
                            for x in iterbytes(fingerprint_digest)]))

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -63,7 +63,7 @@ class EncryptedKeyError(Exception):
 
 class UnsupportedHashFunction(Exception):
     """
-    Raises when a hash function other than md5, sha256 is presented to 
+    Raises when a hash function other than md5, sha256 is presented to
     fingerprint
     """
 
@@ -793,21 +793,19 @@ class Key(object):
 
     def fingerprint(self, fingerPrintformat='md5-hex'):
         """
-        Get the user presentation of the fingerprint of this L{Key}.  As
-        described by U{RFC 4716 section
-        4<http://tools.ietf.org/html/rfc4716#section-4>}::
+        The fingerprint of a public key consists of the output of the
+        message-digest algorithm for the given hash function(sha256 or MD5).
+        The input to the algorithm is the public key data as specified by [RFC4253].
 
-            The fingerprint of a public key consists of the output of the
-            message-digest algorithm for the given hash function(sha256 or MD5).
-            The input to the algorithm is the public key data as specified by [RFC4253].
-            The output of sha256 (default)[RFC4634] algorithm is presented to the
-            user in the form of base64 encoded sha256 hashes.
-            The output of the MD5[RFC1321] algorithm is presented to the user as
-            a sequence of 16 octets printed as hexadecimal with lowercase letters
-            and separated by colons.
+        The output of sha256[RFC4634] algorithm is presented to the
+        user in the form of base64 encoded sha256 hashes.
 
-        @param hash_function: algorithm used for fingerprint generation.
-            Default is sha256, also supports MD5
+        The output of the MD5[RFC1321](default) algorithm is presented to the user as
+        a sequence of 16 octets printed as hexadecimal with lowercase letters
+        and separated by colons.
+
+        @param fingerPrintformat: Format for fingerprint generation. Consists
+            hash function and representation format. Default is C{md5-hex}
 
         @since: 8.2
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -61,10 +61,10 @@ class EncryptedKeyError(Exception):
 
 
 
-class UnsupportedHashFunction(Exception):
+class BadFingerprintFormat(Exception):
     """
-    Raises when a hash function other than md5, sha256 is presented to
-    fingerprint
+    Raises when a fingerprint format other than C{md5-hex} or C{sha256-base64}
+    is presented to fingerprint.
     """
 
 
@@ -814,21 +814,21 @@ class Key(object):
 
         @rtype: L{str}
         """
-        hashFunction_dispatcher = {'md5' : md5, 'sha256' : sha256}
-        hashFunction_string = fingerPrintformat.split("-")[0]
+        hashFunction = {'md5-hex' : md5, 'sha256-base64' : sha256}
 
         try:
-            fingerprint_digest = hashFunction_dispatcher[hashFunction_string](
+            fingerprint = hashFunction[fingerPrintformat](
                 self.blob()).digest()
         except KeyError:
-            raise UnsupportedHashFunction(
-                "unsupported hash function: %s" % hashFunction_string)
-        if hashFunction_string == 'sha256':
-            return nativeString(base64.b64encode(fingerprint_digest))
-        elif hashFunction_string == 'md5':
+            raise BadFingerprintFormat(
+                "unsupported fingerprint format: %s" % fingerPrintformat)
+
+        if fingerPrintformat == 'sha256-base64':
+            return nativeString(base64.b64encode(fingerprint))
+        elif fingerPrintformat == 'md5-hex':
             return nativeString(
                 b':'.join([binascii.hexlify(x)
-                           for x in iterbytes(fingerprint_digest)]))
+                           for x in iterbytes(fingerprint)]))
 
 
     def type(self):

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -789,12 +789,17 @@ class Key(object):
         described by U{RFC 4716 section
         4<http://tools.ietf.org/html/rfc4716#section-4>}::
 
-            The fingerprint of a public key consists of the output of the MD5
-            message-digest algorithm [RFC1321].  The input to the algorithm is
-            the public key data as specified by [RFC4253].  (...)  The output
-            of the (MD5) algorithm is presented to the user as a sequence of 16
-            octets printed as hexadecimal with lowercase letters and separated
-            by colons.
+            The fingerprint of a public key consists of the output of the
+            message-digest algorithm for the given hash function(sha256 or MD5).
+            The input to the algorithm is the public key data as specified by [RFC4253].
+            The output of sha256 (default)[RFC4634] algorithm is presented to the
+            user in the form of base64 encoded sha256 hashes.
+            The output of the MD5[RFC1321] algorithm is presented to the user as
+            a sequence of 16 octets printed as hexadecimal with lowercase letters
+            and separated by colons.
+
+        @param hash_function: algorithm used for fingerprint generation.
+            Default is sha256, also supports MD5
 
         @since: 8.2
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -63,8 +63,7 @@ class EncryptedKeyError(Exception):
 
 class BadFingerPrintFormat(Exception):
     """
-    Raises when a fingerprint format other than C{md5-hex} or C{sha256-base64}
-    is presented to fingerprint.
+    Raises when unsupported fingerprint formats are presented to fingerprint.
     """
 
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -73,6 +73,14 @@ class BadFingerPrintFormat(Exception):
 class FingerprintFormats(Names):
     """
     Constants representing the supported formats of key fingerprints.
+
+    @cvar MD5_HEX: Named constant representing fingerprint format generated
+        using md5[RFC1321] algorithm in hexadecimal encoding.
+    @type MD5_HEX: L{twisted.python.constants.NamedConstant}
+
+    @cvar SHA256_BASE64: Named constant representing fingerprint format
+        generated using sha256[RFC4634] algorithm in base64 encoding
+    @type SHA256_BASE64: L{twisted.python.constants.NamedConstant}
     """
     MD5_HEX = NamedConstant()
     SHA256_BASE64 = NamedConstant()
@@ -805,7 +813,9 @@ class Key(object):
         """
         The fingerprint of a public key consists of the output of the
         message-digest algorithm in the specified format.
-        Supported formats inclide C{md5-hex} and C{sha256-base64}
+        Supported formats include L{FingerprintFormats.MD5-HEX} and
+        L{FingerprintFormats.SHA256-BASE64}
+
         The input to the algorithm is the public key data as specified by [RFC4253].
 
         The output of sha256[RFC4634] algorithm is presented to the
@@ -818,7 +828,8 @@ class Key(object):
         Example: C{c1:b1:30:29:d7:b8:de:6c:97:77:10:d7:46:41:63:87}
 
         @param format: Format for fingerprint generation. Consists
-            hash function and representation format. Default is C{md5-hex}
+            hash function and representation format.
+            Default is L{FingerprintFormats.MD5-HEX}
 
         @since: 8.2
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -819,19 +819,16 @@ class Key(object):
         """
         hashFunction = {'md5-hex' : md5, 'sha256-base64' : sha256}
 
-        try:
-            fingerprint = hashFunction[format](
-                self.blob()).digest()
-        except KeyError:
-            raise BadFingerPrintFormat(
-                "unsupported fingerprint format: %s" % format)
-
         if format == 'sha256-base64':
-            return nativeString(base64.b64encode(fingerprint))
-        else:
+            return nativeString(base64.b64encode(
+                hashFunction[format](self.blob()).digest()))
+        elif format == 'md5-hex':
             return nativeString(
                 b':'.join([binascii.hexlify(x)
-                           for x in iterbytes(fingerprint)]))
+                for x in iterbytes(hashFunction[format](self.blob()).digest())]))
+        else:
+            raise BadFingerPrintFormat(
+                "unsupported fingerprint format: %s" % format)
 
 
     def type(self):

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -13,6 +13,7 @@ import itertools
 import warnings
 
 from hashlib import md5, sha256
+import base64
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
@@ -782,7 +783,7 @@ class Key(object):
         return Key(self._keyObject.public_key())
 
 
-    def fingerprint(self):
+    def fingerprint(self, hash_function=sha256):
         """
         Get the user presentation of the fingerprint of this L{Key}.  As
         described by U{RFC 4716 section
@@ -802,9 +803,13 @@ class Key(object):
 
         @rtype: L{str}
         """
-        return nativeString(
-            b':'.join([binascii.hexlify(x)
-                       for x in iterbytes(md5(self.blob()).digest())]))
+        fingerprint_digest=hash_function(self.blob()).digest()
+        if hash_function==sha256:
+            return nativeString(base64.b64encode(fingerprint_digest))
+        else:
+            return nativeString(
+                b':'.join([binascii.hexlify(x)
+                           for x in iterbytes(fingerprint_digest)]))
 
 
     def type(self):

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -39,8 +39,10 @@ from twisted.python import randbytes
 from twisted.python.compat import (
     iterbytes, long, izip, nativeString, _PY3,
     _b64decodebytes as decodebytes, _b64encodebytes as encodebytes)
+from twisted.python.constants import NamedConstant, Names
 from twisted.python.deprecate import deprecated, getDeprecationWarningString
 from twisted.python.versions import Version
+
 
 
 
@@ -65,6 +67,15 @@ class BadFingerPrintFormat(Exception):
     """
     Raises when unsupported fingerprint formats are presented to fingerprint.
     """
+
+
+
+class FingerprintFormats(Names):
+    """
+    Constants representing the supported formats of key fingerprints.
+    """
+    MD5_HEX = NamedConstant()
+    SHA256_BASE64 = NamedConstant()
 
 
 
@@ -790,7 +801,7 @@ class Key(object):
         return Key(self._keyObject.public_key())
 
 
-    def fingerprint(self, format='md5-hex'):
+    def fingerprint(self, format=FingerprintFormats.MD5_HEX):
         """
         The fingerprint of a public key consists of the output of the
         message-digest algorithm in the specified format.
@@ -816,15 +827,13 @@ class Key(object):
 
         @rtype: L{str}
         """
-        hashFunction = {'md5-hex' : md5, 'sha256-base64' : sha256}
-
-        if format == 'sha256-base64':
+        if format is FingerprintFormats.SHA256_BASE64:
             return nativeString(base64.b64encode(
-                hashFunction[format](self.blob()).digest()))
-        elif format == 'md5-hex':
+                sha256(self.blob()).digest()))
+        elif format is FingerprintFormats.MD5_HEX:
             return nativeString(
                 b':'.join([binascii.hexlify(x)
-                for x in iterbytes(hashFunction[format](self.blob()).digest())]))
+                for x in iterbytes(md5(self.blob()).digest())]))
         else:
             raise BadFingerPrintFormat(
                 'Unsupported fingerprint format: %s' % (format,))

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -61,6 +61,14 @@ class EncryptedKeyError(Exception):
 
 
 
+class UnsupportedHashFunction(Exception):
+    """
+    Raises when a hash function other than md5, sha256 is presented to 
+    fingerprint
+    """
+
+
+
 class Key(object):
     """
     An object representing a key.  A key can be either a public or
@@ -810,8 +818,13 @@ class Key(object):
         """
         hashFunction_dispatcher = {'md5' : md5, 'sha256' : sha256}
         hashFunction_string = fingerPrintformat.split("-")[0]
-        fingerprint_digest = hashFunction_dispatcher[hashFunction_string](
-            self.blob()).digest()
+
+        try:
+            fingerprint_digest = hashFunction_dispatcher[hashFunction_string](
+                self.blob()).digest()
+        except KeyError:
+            raise UnsupportedHashFunction(
+                "unsupported hash function: %s" % hashFunction_string)
         if hashFunction_string == 'sha256':
             return nativeString(base64.b64encode(fingerprint_digest))
         elif hashFunction_string == 'md5':

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -828,7 +828,7 @@ class Key(object):
                 for x in iterbytes(hashFunction[format](self.blob()).digest())]))
         else:
             raise BadFingerPrintFormat(
-                "unsupported fingerprint format: %s" % format)
+                'Unsupported fingerprint format: %s' % (format,))
 
 
     def type(self):

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -12,7 +12,7 @@ import binascii
 import itertools
 import warnings
 
-from hashlib import md5
+from hashlib import md5, sha256
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -61,7 +61,7 @@ class EncryptedKeyError(Exception):
 
 
 
-class BadFingerprintFormat(Exception):
+class BadFingerPrintFormat(Exception):
     """
     Raises when a fingerprint format other than C{md5-hex} or C{sha256-base64}
     is presented to fingerprint.
@@ -791,20 +791,23 @@ class Key(object):
         return Key(self._keyObject.public_key())
 
 
-    def fingerprint(self, fingerPrintformat='md5-hex'):
+    def fingerprint(self, format='md5-hex'):
         """
         The fingerprint of a public key consists of the output of the
-        message-digest algorithm for the given hash function(sha256 or MD5).
+        message-digest algorithm in the specified format.
+        Supported formats inclide C{md5-hex} and C{sha256-base64}
         The input to the algorithm is the public key data as specified by [RFC4253].
 
         The output of sha256[RFC4634] algorithm is presented to the
         user in the form of base64 encoded sha256 hashes.
+        Example: C{US5jTUa0kgX5ZxdqaGF0yGRu8EgKXHNmoT8jHKo1StM=}
 
         The output of the MD5[RFC1321](default) algorithm is presented to the user as
         a sequence of 16 octets printed as hexadecimal with lowercase letters
         and separated by colons.
+        Example: C{c1:b1:30:29:d7:b8:de:6c:97:77:10:d7:46:41:63:87}
 
-        @param fingerPrintformat: Format for fingerprint generation. Consists
+        @param format: Format for fingerprint generation. Consists
             hash function and representation format. Default is C{md5-hex}
 
         @since: 8.2
@@ -817,15 +820,15 @@ class Key(object):
         hashFunction = {'md5-hex' : md5, 'sha256-base64' : sha256}
 
         try:
-            fingerprint = hashFunction[fingerPrintformat](
+            fingerprint = hashFunction[format](
                 self.blob()).digest()
         except KeyError:
-            raise BadFingerprintFormat(
-                "unsupported fingerprint format: %s" % fingerPrintformat)
+            raise BadFingerPrintFormat(
+                "unsupported fingerprint format: %s" % format)
 
-        if fingerPrintformat == 'sha256-base64':
+        if format == 'sha256-base64':
             return nativeString(base64.b64encode(fingerprint))
-        elif fingerPrintformat == 'md5-hex':
+        else:
             return nativeString(
                 b':'.join([binascii.hexlify(x)
                            for x in iterbytes(fingerprint)]))

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -92,9 +92,10 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        self.assertRaisesRegexp(BadFingerPrintFormat,
-            'Unsupported fingerprint format: sha-base64', printFingerprint,
+        exception = self.assertRaises(BadFingerPrintFormat, printFingerprint,
             {'filename': filename, 'fingerprint':'sha-base64'})
+        self.assertEqual('Unsupported fingerprint format: sha-base64',
+            exception.message)
 
 
     def test_saveKey(self):
@@ -161,10 +162,10 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        self.assertRaisesRegexp(BadFingerPrintFormat,
-            'Unsupported fingerprint format: sha-base64', _saveKey,
+        exception = self.assertRaises(BadFingerPrintFormat, _saveKey,
             key, {'filename': filename, 'pass': 'passphrase',
             'fingerprint': 'sha-base64'})
+        self.assertEqual('Unsupported fingerprint format: sha-base64', exception.message)
 
 
     def test_saveKeyEmptyPassphrase(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -72,7 +72,7 @@ class KeyGenTests(TestCase):
 
     def test_enumrepresentationsha256(self):
         """
-        Test for format C{sha256-base64}
+        Test for format L{FingerprintFormats.SHA256-BASE64}.
         """
         options = enumrepresentation({'format': 'sha256-base64'})
         self.assertIs(options['format'],
@@ -108,8 +108,8 @@ class KeyGenTests(TestCase):
 
     def test_printFingerprintsha256(self):
         """
-        L{printFigerprint} will print key fingerprint in C{sha256-base64}
-        format if explicitly specified.
+        L{printFigerprint} will print key fingerprint in
+        L{FingerprintFormats.SHA256-BASE64} format if explicitly specified.
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
@@ -163,8 +163,8 @@ class KeyGenTests(TestCase):
 
     def test_saveKeysha256(self):
         """
-        L{_saveKey} will generate key fingerprint in C{sha256-base64} format
-        if explicitly specified.
+        L{_saveKey} will generate key fingerprint in
+        L{FingerprintFormats.SHA256-BASE64} format if explicitly specified.
         """
         base = FilePath(self.mktemp())
         base.makedirs()

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -95,8 +95,8 @@ class KeyGenTests(TestCase):
         FilePath(filename).setContent(publicRSA_openssh)
         with self.assertRaises(BadFingerPrintFormat) as em:
             printFingerprint({'filename': filename, 'fingerprint':'sha-base64'})
-            self.assertEqual('Unsupported fingerprint format: sha-base64',
-                em.message)
+        self.assertEqual('Unsupported fingerprint format: sha-base64',
+            em.exception.message)
 
 
     def test_saveKey(self):
@@ -166,9 +166,9 @@ class KeyGenTests(TestCase):
         key = Key.fromString(privateRSA_openssh)
         with self.assertRaises(BadFingerPrintFormat) as em:
             _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-                'fingerprint': 'sha-base64'}),
-            self.assertEqual('Unsupported fingerprint format: sha-base64',
-                em.message)
+                'fingerprint': 'sha-base64'})
+        self.assertEqual('Unsupported fingerprint format: sha-base64',
+            em.exception.message)
 
 
     def test_saveKeyEmptyPassphrase(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -13,9 +13,11 @@ from StringIO import StringIO
 from twisted.python.reflect import requireModule
 
 if requireModule('cryptography') and requireModule('pyasn1'):
-    from twisted.conch.ssh.keys import Key, BadKeyError, BadFingerPrintFormat
+    from twisted.conch.ssh.keys import (Key, BadKeyError,
+        BadFingerPrintFormat, FingerprintFormats)
     from twisted.conch.scripts.ckeygen import (
-        changePassPhrase, displayPublicKey, printFingerprint, _saveKey)
+        changePassPhrase, displayPublicKey, printFingerprint,
+        _saveKey, enumrepresentation)
 else:
     skip = "cryptography and pyasn1 required for twisted.conch.scripts.ckeygen"
 
@@ -58,6 +60,37 @@ class KeyGenTests(TestCase):
         self.patch(sys, 'stdout', self.stdout)
 
 
+    def test_enumrepresentation(self):
+        """
+        L{enumrepresentation} takes a dictionary as input and returns a
+        dictionary with its attributes changed to enum representation.
+        """
+        options = enumrepresentation({'fingerprint': 'md5-hex'})
+        self.assertIs(options['fingerprint'],
+            FingerprintFormats.MD5_HEX)
+
+
+    def test_enumrepresentationsha256(self):
+        """
+        Test for format C{sha256-base64}
+        """
+        options = enumrepresentation({'fingerprint': 'sha256-base64'})
+        self.assertIs(options['fingerprint'],
+            FingerprintFormats.SHA256_BASE64)
+
+
+
+    def test_enumrepresentationBadFormat(self):
+        """
+        Test for unsupported fingerprint format
+        """
+        with self.assertRaises(BadFingerPrintFormat) as em:
+            enumrepresentation({'fingerprint': 'sha-base64'})
+        self.assertEqual('Unsupported fingerprint format: sha-base64',
+            em.exception.args[0])
+
+
+
     def test_printFingerprint(self):
         """
         L{printFingerprint} writes a line to standard out giving the number of
@@ -66,7 +99,8 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        printFingerprint({'filename': filename, 'fingerprint': 'md5-hex'})
+        printFingerprint({'filename': filename,
+            'fingerprint': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
@@ -80,7 +114,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename,
-            'fingerprint': 'sha256-base64'})
+            'fingerprint': FingerprintFormats.SHA256_BASE64})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
@@ -109,12 +143,12 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'fingerprint': 'md5-hex'})
+            'fingerprint': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
             "Your public key has been saved in %s.pub\n"
-            "The key fingerprint in md5-hex is:\n"
+            "The key fingerprint in <FingerprintFormats=MD5_HEX> is:\n"
             "3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af\n" % (
                 filename,
                 filename))
@@ -137,12 +171,12 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'fingerprint': 'sha256-base64'})
+            'fingerprint': FingerprintFormats.SHA256_BASE64})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
             "Your public key has been saved in %s.pub\n"
-            "The key fingerprint in sha256-base64 is:\n"
+            "The key fingerprint in <FingerprintFormats=SHA256_BASE64> is:\n"
             "ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts=\n" % (
                 filename,
                 filename))
@@ -181,7 +215,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'no-passphrase': True,
-            'fingerprint':'md5-hex'})
+            'fingerprint': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -200,7 +234,7 @@ class KeyGenTests(TestCase):
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': None, 'no-passphrase': True,
-            'fingerprint': 'md5-hex'})
+            'fingerprint': FingerprintFormats.MD5_HEX})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -93,10 +93,10 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        exception = self.assertRaises(BadFingerPrintFormat, printFingerprint,
-            {'filename': filename, 'fingerprint':'sha-base64'})
-        self.assertEqual('Unsupported fingerprint format: sha-base64',
-            exception.message)
+        with self.assertRaises(BadFingerPrintFormat) as em:
+            printFingerprint({'filename': filename, 'fingerprint':'sha-base64'})
+            self.assertEqual('Unsupported fingerprint format: sha-base64',
+                em.message)
 
 
     def test_saveKey(self):
@@ -164,11 +164,11 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        exception = self.assertRaises(BadFingerPrintFormat, _saveKey,
-            key, {'filename': filename, 'pass': 'passphrase',
-            'fingerprint': 'sha-base64'})
-        self.assertEqual('Unsupported fingerprint format: sha-base64',
-            exception.message)
+        with self.assertRaises(BadFingerPrintFormat) as em:
+            _saveKey(key, {'filename': filename, 'pass': 'passphrase',
+                'fingerprint': 'sha-base64'}),
+            self.assertEqual('Unsupported fingerprint format: sha-base64',
+                em.message)
 
 
     def test_saveKeyEmptyPassphrase(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -65,8 +65,8 @@ class KeyGenTests(TestCase):
         L{enumrepresentation} takes a dictionary as input and returns a
         dictionary with its attributes changed to enum representation.
         """
-        options = enumrepresentation({'fingerprint': 'md5-hex'})
-        self.assertIs(options['fingerprint'],
+        options = enumrepresentation({'format': 'md5-hex'})
+        self.assertIs(options['format'],
             FingerprintFormats.MD5_HEX)
 
 
@@ -74,8 +74,8 @@ class KeyGenTests(TestCase):
         """
         Test for format C{sha256-base64}
         """
-        options = enumrepresentation({'fingerprint': 'sha256-base64'})
-        self.assertIs(options['fingerprint'],
+        options = enumrepresentation({'format': 'sha256-base64'})
+        self.assertIs(options['format'],
             FingerprintFormats.SHA256_BASE64)
 
 
@@ -85,7 +85,7 @@ class KeyGenTests(TestCase):
         Test for unsupported fingerprint format
         """
         with self.assertRaises(BadFingerPrintFormat) as em:
-            enumrepresentation({'fingerprint': 'sha-base64'})
+            enumrepresentation({'format': 'sha-base64'})
         self.assertEqual('Unsupported fingerprint format: sha-base64',
             em.exception.args[0])
 
@@ -100,7 +100,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename,
-            'fingerprint': FingerprintFormats.MD5_HEX})
+            'format': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
@@ -114,7 +114,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename,
-            'fingerprint': FingerprintFormats.SHA256_BASE64})
+            'format': FingerprintFormats.SHA256_BASE64})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
@@ -128,7 +128,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         with self.assertRaises(BadFingerPrintFormat) as em:
-            printFingerprint({'filename': filename, 'fingerprint':'sha-base64'})
+            printFingerprint({'filename': filename, 'format':'sha-base64'})
         self.assertEqual('Unsupported fingerprint format: sha-base64',
             em.exception.args[0])
 
@@ -143,7 +143,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'fingerprint': FingerprintFormats.MD5_HEX})
+            'format': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -171,7 +171,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'fingerprint': FingerprintFormats.SHA256_BASE64})
+            'format': FingerprintFormats.SHA256_BASE64})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -200,7 +200,7 @@ class KeyGenTests(TestCase):
         key = Key.fromString(privateRSA_openssh)
         with self.assertRaises(BadFingerPrintFormat) as em:
             _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-                'fingerprint': 'sha-base64'})
+                'format': 'sha-base64'})
         self.assertEqual('Unsupported fingerprint format: sha-base64',
             em.exception.args[0])
 
@@ -215,7 +215,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'no-passphrase': True,
-            'fingerprint': FingerprintFormats.MD5_HEX})
+            'format': FingerprintFormats.MD5_HEX})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -234,7 +234,7 @@ class KeyGenTests(TestCase):
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': None, 'no-passphrase': True,
-            'fingerprint': FingerprintFormats.MD5_HEX})
+            'format': FingerprintFormats.MD5_HEX})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -96,7 +96,7 @@ class KeyGenTests(TestCase):
         with self.assertRaises(BadFingerPrintFormat) as em:
             printFingerprint({'filename': filename, 'fingerprint':'sha-base64'})
         self.assertEqual('Unsupported fingerprint format: sha-base64',
-            em.exception.message)
+            em.exception.args[0])
 
 
     def test_saveKey(self):
@@ -168,7 +168,7 @@ class KeyGenTests(TestCase):
             _saveKey(key, {'filename': filename, 'pass': 'passphrase',
                 'fingerprint': 'sha-base64'})
         self.assertEqual('Unsupported fingerprint format: sha-base64',
-            em.exception.message)
+            em.exception.args[0])
 
 
     def test_saveKeyEmptyPassphrase(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -66,7 +66,7 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        printFingerprint({'filename': filename, 'format': 'md5-hex'})
+        printFingerprint({'filename': filename, 'fingerprint': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
@@ -79,7 +79,7 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        printFingerprint({'filename': filename, 'format': 'sha256-base64'})
+        printFingerprint({'filename': filename, 'fingerprint': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
@@ -94,7 +94,7 @@ class KeyGenTests(TestCase):
         FilePath(filename).setContent(publicRSA_openssh)
         self.assertRaisesRegexp(BadFingerPrintFormat,
             'Unsupported fingerprint format: sha-base64', printFingerprint,
-            {'filename': filename, 'format':'sha-base64'})
+            {'filename': filename, 'fingerprint':'sha-base64'})
 
 
     def test_saveKey(self):
@@ -106,7 +106,7 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'pass': 'passphrase', 'format': 'md5-hex'})
+        _saveKey(key, {'filename': filename, 'pass': 'passphrase', 'fingerprint': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -134,7 +134,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'format': 'sha256-base64'})
+            'fingerprint': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -164,7 +164,7 @@ class KeyGenTests(TestCase):
         self.assertRaisesRegexp(BadFingerPrintFormat,
             'Unsupported fingerprint format: sha-base64', _saveKey,
             key, {'filename': filename, 'pass': 'passphrase',
-            'format': 'sha-base64'})
+            'fingerprint': 'sha-base64'})
 
 
     def test_saveKeyEmptyPassphrase(self):
@@ -176,7 +176,7 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'no-passphrase': True, 'format':'md5-hex'})
+        _saveKey(key, {'filename': filename, 'no-passphrase': True, 'fingerprint':'md5-hex'})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -194,7 +194,7 @@ class KeyGenTests(TestCase):
 
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': None, 'no-passphrase': True, 'format': 'md5-hex'})
+        _saveKey(key, {'filename': None, 'no-passphrase': True, 'fingerprint': 'md5-hex'})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -92,10 +92,9 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        self.assertRaises(BadFingerPrintFormat, printFingerprint,
+        self.assertRaisesRegexp(BadFingerPrintFormat,
+            'Unsupported fingerprint format: sha-base64', printFingerprint,
             {'filename': filename, 'format':'sha-base64'})
-        self.assertRaises(BadFingerPrintFormat, printFingerprint,
-            {'filename': filename, 'format':'md5-base64'})
 
 
     def test_saveKey(self):
@@ -162,7 +161,8 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        self.assertRaises(BadFingerPrintFormat, _saveKey,
+        self.assertRaisesRegexp(BadFingerPrintFormat,
+            'Unsupported fingerprint format: sha-base64', _saveKey,
             key, {'filename': filename, 'pass': 'passphrase',
             'format': 'sha-base64'})
 

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -66,7 +66,7 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        printFingerprint({'filename': filename})
+        printFingerprint({'filename': filename, 'format': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
@@ -107,7 +107,7 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'pass': 'passphrase'})
+        _saveKey(key, {'filename': filename, 'pass': 'passphrase', 'format': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -176,7 +176,7 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'no-passphrase': True})
+        _saveKey(key, {'filename': filename, 'no-passphrase': True, 'format':'md5-hex'})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -194,7 +194,7 @@ class KeyGenTests(TestCase):
 
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': None, 'no-passphrase': True})
+        _saveKey(key, {'filename': None, 'no-passphrase': True, 'format': 'md5-hex'})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -13,7 +13,7 @@ from StringIO import StringIO
 from twisted.python.reflect import requireModule
 
 if requireModule('cryptography') and requireModule('pyasn1'):
-    from twisted.conch.ssh.keys import Key, BadKeyError, BadFingerprintFormat
+    from twisted.conch.ssh.keys import Key, BadKeyError, BadFingerPrintFormat
     from twisted.conch.scripts.ckeygen import (
         changePassPhrase, displayPublicKey, printFingerprint, _saveKey)
 else:
@@ -67,13 +67,13 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename})
-        printFingerprint({'filename': filename, 'fingerPrintformat': 'sha256-base64'})
+        printFingerprint({'filename': filename, 'format': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n'+
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
-        self.assertRaises(BadFingerprintFormat, printFingerprint,
-            {'filename': filename, 'fingerPrintformat':'sha-base64'})
+        self.assertRaises(BadFingerPrintFormat, printFingerprint,
+            {'filename': filename, 'format':'sha-base64'})
 
 
     def test_saveKey(self):
@@ -113,7 +113,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'fingerPrintformat': 'sha256-base64'})
+            'format': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -140,9 +140,9 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        self.assertRaises(BadFingerprintFormat, _saveKey,
+        self.assertRaises(BadFingerPrintFormat, _saveKey,
             key, {'filename': filename, 'pass': 'passphrase',
-            'fingerPrintformat': 'sha-base64'})
+            'format': 'sha-base64'})
 
 
     def test_saveKeyEmptyPassphrase(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -79,7 +79,8 @@ class KeyGenTests(TestCase):
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
-        printFingerprint({'filename': filename, 'fingerprint': 'sha256-base64'})
+        printFingerprint({'filename': filename,
+            'fingerprint': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
@@ -107,7 +108,8 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'pass': 'passphrase', 'fingerprint': 'md5-hex'})
+        _saveKey(key, {'filename': filename, 'pass': 'passphrase',
+            'fingerprint': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -165,7 +167,8 @@ class KeyGenTests(TestCase):
         exception = self.assertRaises(BadFingerPrintFormat, _saveKey,
             key, {'filename': filename, 'pass': 'passphrase',
             'fingerprint': 'sha-base64'})
-        self.assertEqual('Unsupported fingerprint format: sha-base64', exception.message)
+        self.assertEqual('Unsupported fingerprint format: sha-base64',
+            exception.message)
 
 
     def test_saveKeyEmptyPassphrase(self):
@@ -177,7 +180,8 @@ class KeyGenTests(TestCase):
         base.makedirs()
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': filename, 'no-passphrase': True, 'fingerprint':'md5-hex'})
+        _saveKey(key, {'filename': filename, 'no-passphrase': True,
+            'fingerprint':'md5-hex'})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -195,7 +199,8 @@ class KeyGenTests(TestCase):
 
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
-        _saveKey(key, {'filename': None, 'no-passphrase': True, 'fingerprint': 'md5-hex'})
+        _saveKey(key, {'filename': None, 'no-passphrase': True,
+            'fingerprint': 'md5-hex'})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -112,7 +112,7 @@ class KeyGenTests(TestCase):
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
             "Your public key has been saved in %s.pub\n"
-            "The key fingerprint is:\n"
+            "The key fingerprint in md5-hex is:\n"
             "3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af\n" % (
                 filename,
                 filename))
@@ -140,7 +140,7 @@ class KeyGenTests(TestCase):
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
             "Your public key has been saved in %s.pub\n"
-            "The key fingerprint is:\n"
+            "The key fingerprint in sha256-base64 is:\n"
             "ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts=\n" % (
                 filename,
                 filename))

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -67,13 +67,35 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename})
+        self.assertEqual(
+            self.stdout.getvalue(),
+            '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
+
+
+    def test_printFingerprintsha256(self):
+        """
+        L{printFigerprint} will print key fingerprint in C{sha256-base64}
+        format if explicitly specified.
+        """
+        filename = self.mktemp()
+        FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename, 'format': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
-            '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n'+
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
+
+
+    def test_printFingerprintBadFingerPrintFormat(self):
+        """
+        L{printFigerprint} raises C{keys.BadFingerprintFormat} for formats
+        other than C{md5-hex} and C{sha256-base64}.
+        """
+        filename = self.mktemp()
+        FilePath(filename).setContent(publicRSA_openssh)
         self.assertRaises(BadFingerPrintFormat, printFingerprint,
             {'filename': filename, 'format':'sha-base64'})
+        self.assertRaises(BadFingerPrintFormat, printFingerprint,
+            {'filename': filename, 'format':'md5-base64'})
 
 
     def test_saveKey(self):

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -87,8 +87,8 @@ class KeyGenTests(TestCase):
 
     def test_printFingerprintBadFingerPrintFormat(self):
         """
-        L{printFigerprint} raises C{keys.BadFingerprintFormat} for formats
-        other than C{md5-hex} and C{sha256-base64}.
+        L{printFigerprint} raises C{keys.BadFingerprintFormat} when unsupported
+        formats are requested.
         """
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
@@ -154,8 +154,8 @@ class KeyGenTests(TestCase):
 
     def test_saveKeyBadFingerPrintformat(self):
         """
-        L{_saveKey} raises C{keys.BadFingerprintFormat} for formats other
-        than C{md5-hex} and C{sha256-base64}.
+        L{_saveKey} raises C{keys.BadFingerprintFormat} when unsupported
+        formats are requested.
         """
         base = FilePath(self.mktemp())
         base.makedirs()

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -100,7 +100,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename,
-            'format': FingerprintFormats.MD5_HEX})
+            'format': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af temp\n')
@@ -114,7 +114,7 @@ class KeyGenTests(TestCase):
         filename = self.mktemp()
         FilePath(filename).setContent(publicRSA_openssh)
         printFingerprint({'filename': filename,
-            'format': FingerprintFormats.SHA256_BASE64})
+            'format': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             '768 ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts= temp\n')
@@ -143,7 +143,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'format': FingerprintFormats.MD5_HEX})
+            'format': 'md5-hex'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -171,7 +171,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'pass': 'passphrase',
-            'format': FingerprintFormats.SHA256_BASE64})
+            'format': 'sha256-base64'})
         self.assertEqual(
             self.stdout.getvalue(),
             "Your identification has been saved in %s\n"
@@ -215,7 +215,7 @@ class KeyGenTests(TestCase):
         filename = base.child('id_rsa').path
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': filename, 'no-passphrase': True,
-            'format': FingerprintFormats.MD5_HEX})
+            'format': 'md5-hex'})
         self.assertEqual(
             key.fromString(
                 base.child('id_rsa').getContent(), None, b''),
@@ -234,7 +234,7 @@ class KeyGenTests(TestCase):
         self.patch(__builtin__, 'raw_input', lambda _: keyPath)
         key = Key.fromString(privateRSA_openssh)
         _saveKey(key, {'filename': None, 'no-passphrase': True,
-            'format': FingerprintFormats.MD5_HEX})
+            'format': 'md5-hex'})
 
         persistedKeyContent = base.child('custom_key').getContent()
         persistedKey = key.fromString(persistedKeyContent, None, b'')

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -564,13 +564,25 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         self.assertTrue(rsa1 != None)
 
 
-    def test_fingerprint(self):
+    def test_fingerprintdefault(self):
         """
-        Test that the fingerprint method works correctly.
+        Test that the fingerprint method returns fingerprint in
+        C{md5-hex} format by default.
         """
         self.assertEqual(keys.Key(self.rsaObj).fingerprint(),
             '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
         self.assertEqual(keys.Key(self.dsaObj).fingerprint(),
+            '63:15:b3:0e:e6:4f:50:de:91:48:3d:01:6b:b3:13:c1')
+
+
+    def test_fingerprint_md5_hex(self):
+        """
+        fingerprint method generates key fingerprint in C{md5-hex}
+        format if explicitly specified.
+        """
+        self.assertEqual(keys.Key(self.rsaObj).fingerprint('md5-hex'),
+            '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
+        self.assertEqual(keys.Key(self.dsaObj).fingerprint('md5-hex'),
             '63:15:b3:0e:e6:4f:50:de:91:48:3d:01:6b:b3:13:c1')
 
 
@@ -587,8 +599,8 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
 
     def test_fingerprintBadFormat(self):
         """
-        A C{BadFingerPrintFormat} error is raised when format other than
-        C{md5-hex} or C{sha256-base64} is supplied.
+        A C{BadFingerPrintFormat} error is raised when unsupported
+        formats are requested.
         """
         self.assertRaisesRegexp(keys.BadFingerPrintFormat,
             'Unsupported fingerprint format: sha256-base',

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -564,6 +564,38 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         self.assertTrue(rsa1 != None)
 
 
+    def test_fingerprint(self):
+        """
+        Test that the fingerprint method works correctly.
+        """
+        self.assertEqual(keys.Key(self.rsaObj).fingerprint(),
+            '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
+        self.assertEqual(keys.Key(self.dsaObj).fingerprint(),
+            '63:15:b3:0e:e6:4f:50:de:91:48:3d:01:6b:b3:13:c1')
+
+
+    def test_fingerprintsha256(self):
+        """
+        fingerprint method generates key fingerprint in C{sha256-base64}
+        format if explicitly specified.
+        """
+        self.assertEqual(keys.Key(self.rsaObj).fingerprint('sha256-base64'),
+            'ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts=')
+        self.assertEqual(keys.Key(self.dsaObj).fingerprint('sha256-base64'),
+            'Wz5o2YbKyxOEcJn1au/UaALSVruUzfz0vaLI1xiIGyY=')
+
+
+    def test_fingerprintBadFormat(self):
+        """
+        A C{BadFingerPrintFormat} error is raised when format other than
+        C{md5-hex} or C{sha256-base64} is supplied.
+        """
+        self.assertRaises(keys.BadFingerPrintFormat,
+            keys.Key(self.rsaObj).fingerprint,'sha256-base')
+        self.assertRaises(keys.BadFingerPrintFormat,
+            keys.Key(self.dsaObj).fingerprint, 'md5-base')
+
+
     def test_type(self):
         """
         Test that the type method returns the correct type for an object.

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -567,7 +567,7 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
     def test_fingerprintdefault(self):
         """
         Test that the fingerprint method returns fingerprint in
-        C{md5-hex} format by default.
+        L{FingerprintFormats.MD5-HEX} format by default.
         """
         self.assertEqual(keys.Key(self.rsaObj).fingerprint(),
             '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
@@ -577,8 +577,8 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
 
     def test_fingerprint_md5_hex(self):
         """
-        fingerprint method generates key fingerprint in C{md5-hex}
-        format if explicitly specified.
+        fingerprint method generates key fingerprint in
+        L{FingerprintFormats.MD5-HEX} format if explicitly specified.
         """
         self.assertEqual(
             keys.Key(self.rsaObj).fingerprint(
@@ -592,8 +592,8 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
 
     def test_fingerprintsha256(self):
         """
-        fingerprint method generates key fingerprint in C{sha256-base64}
-        format if explicitly specified.
+        fingerprint method generates key fingerprint in
+        L{FingerprintFormats.SHA256-BASE64} format if explicitly specified.
         """
         self.assertEqual(
             keys.Key(self.rsaObj).fingerprint(

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -608,8 +608,8 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         """
         with self.assertRaises(keys.BadFingerPrintFormat) as em:
             keys.Key(self.rsaObj).fingerprint('sha256-base')
-            self.assertEqual('Unsupported fingerprint format: sha256-base',
-                em.message)
+        self.assertEqual('Unsupported fingerprint format: sha256-base',
+            em.exception.message)
 
 
     def test_type(self):

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -602,9 +602,10 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         A C{BadFingerPrintFormat} error is raised when unsupported
         formats are requested.
         """
-        self.assertRaisesRegexp(keys.BadFingerPrintFormat,
-            'Unsupported fingerprint format: sha256-base',
+        exception = self.assertRaises(keys.BadFingerPrintFormat,
             keys.Key(self.rsaObj).fingerprint,'sha256-base')
+        self.assertEqual('Unsupported fingerprint format: sha256-base',
+            exception.message)
 
 
     def test_type(self):

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -590,10 +590,9 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         A C{BadFingerPrintFormat} error is raised when format other than
         C{md5-hex} or C{sha256-base64} is supplied.
         """
-        self.assertRaises(keys.BadFingerPrintFormat,
+        self.assertRaisesRegexp(keys.BadFingerPrintFormat,
+            'Unsupported fingerprint format: sha256-base',
             keys.Key(self.rsaObj).fingerprint,'sha256-base')
-        self.assertRaises(keys.BadFingerPrintFormat,
-            keys.Key(self.dsaObj).fingerprint, 'md5-base')
 
 
     def test_type(self):

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -580,9 +580,11 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         fingerprint method generates key fingerprint in C{md5-hex}
         format if explicitly specified.
         """
-        self.assertEqual(keys.Key(self.rsaObj).fingerprint('md5-hex'),
+        self.assertEqual(
+            keys.Key(self.rsaObj).fingerprint('md5-hex'),
             '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
-        self.assertEqual(keys.Key(self.dsaObj).fingerprint('md5-hex'),
+        self.assertEqual(
+            keys.Key(self.dsaObj).fingerprint('md5-hex'),
             '63:15:b3:0e:e6:4f:50:de:91:48:3d:01:6b:b3:13:c1')
 
 
@@ -591,9 +593,11 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         fingerprint method generates key fingerprint in C{sha256-base64}
         format if explicitly specified.
         """
-        self.assertEqual(keys.Key(self.rsaObj).fingerprint('sha256-base64'),
+        self.assertEqual(
+            keys.Key(self.rsaObj).fingerprint('sha256-base64'),
             'ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts=')
-        self.assertEqual(keys.Key(self.dsaObj).fingerprint('sha256-base64'),
+        self.assertEqual(
+            keys.Key(self.dsaObj).fingerprint('sha256-base64'),
             'Wz5o2YbKyxOEcJn1au/UaALSVruUzfz0vaLI1xiIGyY=')
 
 

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -581,10 +581,12 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         format if explicitly specified.
         """
         self.assertEqual(
-            keys.Key(self.rsaObj).fingerprint('md5-hex'),
+            keys.Key(self.rsaObj).fingerprint(
+                keys.FingerprintFormats.MD5_HEX),
             '3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
         self.assertEqual(
-            keys.Key(self.dsaObj).fingerprint('md5-hex'),
+            keys.Key(self.dsaObj).fingerprint(
+                keys.FingerprintFormats.MD5_HEX),
             '63:15:b3:0e:e6:4f:50:de:91:48:3d:01:6b:b3:13:c1')
 
 
@@ -594,10 +596,12 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         format if explicitly specified.
         """
         self.assertEqual(
-            keys.Key(self.rsaObj).fingerprint('sha256-base64'),
+            keys.Key(self.rsaObj).fingerprint(
+                keys.FingerprintFormats.SHA256_BASE64),
             'ryaugIFT0B8ItuszldMEU7q14rG/wj9HkRosMeBWkts=')
         self.assertEqual(
-            keys.Key(self.dsaObj).fingerprint('sha256-base64'),
+            keys.Key(self.dsaObj).fingerprint(
+                keys.FingerprintFormats.SHA256_BASE64),
             'Wz5o2YbKyxOEcJn1au/UaALSVruUzfz0vaLI1xiIGyY=')
 
 

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -609,7 +609,7 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         with self.assertRaises(keys.BadFingerPrintFormat) as em:
             keys.Key(self.rsaObj).fingerprint('sha256-base')
         self.assertEqual('Unsupported fingerprint format: sha256-base',
-            em.exception.message)
+            em.exception.args[0])
 
 
     def test_type(self):

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -606,10 +606,10 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         A C{BadFingerPrintFormat} error is raised when unsupported
         formats are requested.
         """
-        exception = self.assertRaises(keys.BadFingerPrintFormat,
-            keys.Key(self.rsaObj).fingerprint,'sha256-base')
-        self.assertEqual('Unsupported fingerprint format: sha256-base',
-            exception.message)
+        with self.assertRaises(keys.BadFingerPrintFormat) as em:
+            keys.Key(self.rsaObj).fingerprint('sha256-base')
+            self.assertEqual('Unsupported fingerprint format: sha256-base',
+                em.message)
 
 
     def test_type(self):

--- a/src/twisted/conch/topfiles/8701.feature
+++ b/src/twisted/conch/topfiles/8701.feature
@@ -1,0 +1,1 @@
+SSH key fingerprints can be generated using base64 encoded SHA256 hashes.

--- a/twisted/topfiles/8701.feature
+++ b/twisted/topfiles/8701.feature
@@ -1,0 +1,1 @@
+SSH key fingerprints are now base64 encoded SHA256 hashes by default.

--- a/twisted/topfiles/8701.feature
+++ b/twisted/topfiles/8701.feature
@@ -1,1 +1,1 @@
-SSH key fingerprints are now base64 encoded SHA256 hashes by default.
+SSH key fingerprints can be generated using base64 encoded SHA256 hashes.

--- a/twisted/topfiles/8701.feature
+++ b/twisted/topfiles/8701.feature
@@ -1,1 +1,0 @@
-SSH key fingerprints can be generated using base64 encoded SHA256 hashes.


### PR DESCRIPTION
http://twistedmatrix.com/trac/ticket/8701

(moved from https://github.com/twisted/twisted/pull/468 )
