### PR TITLE
Add assertion helpers to test log events

### DIFF
--- a/src/twisted/internet/test/test_protocol.py
+++ b/src/twisted/internet/test/test_protocol.py
@@ -420,14 +420,13 @@ class FactoryTests(TestCase):
         the L{repr} of the L{Factory} instance that is being stopped.
         """
         with capturingLogEventsFromGlobalLogPublisher() as events:
-            class MyFactory(Factory):
-                numPorts = 1
-            f = MyFactory()
+            f = Factory()
+            f.numPorts = 1
 
             f.doStop()
 
             assertGlobalLogEvent(
-                self, events[0], LogLevel.info, fullyQualifiedName(MyFactory),
+                self, events[0], LogLevel.info, fullyQualifiedName(Factory),
                 log_source=f, log_format='Stopping factory {factory!r}',
                 factory=f
             )

--- a/src/twisted/logger/test/_assertionhelpers.py
+++ b/src/twisted/logger/test/_assertionhelpers.py
@@ -1,0 +1,244 @@
+# -*- test-case-name: twisted.logger.test.test_assertionhelpers -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+General assertion helpers for testing log events.
+"""
+
+from contextlib import contextmanager
+
+from twisted.logger import globalLogPublisher
+from twisted.logger._legacy import _ensureCompatWithLegacyObservers
+
+
+
+@contextmanager
+def capturingLogEventsFrom(logger):
+    """
+    Context manager to accumulate log events emitted by a L{Logger}
+    instance by passing list.append as an observer.
+
+    @param logger: L{Logger} object that the event was emitted to.
+    @type logger: L{Logger}
+    """
+    events = []
+    logger.observer = events.append
+    if logger.source is not None:
+        logger.source._log = logger
+
+    yield events
+
+
+
+@contextmanager
+def capturingLogEventsFromGlobalLogPublisher():
+    """
+    Context manager to accumulate log events emitted by a L{Logger}
+    instance that is not directly accessible for testing, such as
+    when L{twisted.logger._loggerFor} is used to create a L{Logger}
+    on the fly. This is to avoid creating L{Logger} instance attributes in
+    the Twisted codebase itself to avoid namespace conflicts for when end
+    users subclass. In this case we don't assert log_logger in the event
+    dict and ignore it and accumulate the events in a list by passing
+    list.append as an observer to L{twisted.logger.globalLogPublisher}.
+    In the event that the L{Logger} is an instance attribute,
+    L{capturingLogEventsFrom} should be used in conjunction with
+    L{assertGlobalLogEvent} and L{assertGlobalLogEvents} for optimum test
+    coverage. Note that this is preferrably only for use in Twisted itself
+    to facilitate default logging.
+    """
+    events = []
+    globalLogPublisher.addObserver(events.append)
+
+    yield events
+
+    globalLogPublisher.removeObserver(events.append)
+
+
+
+def assertGlobalLogEvent(testCase, event, log_level, log_namespace,
+                         log_source=None, log_format=None, **kwargs):
+    """
+    Assertion helper for testing a single log event that has been
+    emitted using L{twisted.logger._loggerFor}, in which case
+    the L{Logger} that the event was emitted to may not be available
+    for testing, hence no argument for log_logger. This helper should
+    preferably be used in conjunction with the context manager
+    L{capturingLogEventsFromGlobalLogPublisher} for optimum test
+    coverage for events that can only be tested by passing an observer
+    to a L{globalLogPublisher}.
+
+    @param testCase: The L{TestCase} object that wants to test some
+        log events using L{assertLogEvent}.
+    @type testCase: L{TestCase}
+
+    @param event: The emitted event, which is a L{dict}.
+    @type event: L{dict}
+
+    @param log_level: A L{LogLevel}.
+    @type log_level: L{LogLevel}
+
+    @param log_namespace: The namespace associated with the L{Logger}.
+    @type log_namespace: L{str} (native string)
+
+    @param log_source: The source object that emitted the event. This
+        will be L{None} if the L{Logger} is not accessed as an
+        attribute of an instance or class.
+    @type log_source: L{object} or L{None}
+
+    @param log_format: The format string provided for use by observers
+        that wish to render the event as text. The format string uses
+        new-style PEP 3101 formatting and is rendered using the log
+        event (which is a L{dict}). This may be L{None}, if no format
+        string was provided. The format string is optional, except when
+        a failure is being logged using L{Logger.failure}, in which
+        case a format string describing the failure must be provided.
+    @type log_format: L{str} or L{None}
+
+    @param kwargs: Additional key/value pairs that we expect to see
+        in the event being tested. This L{dict} may contain key/value
+        pairs needed to effectively render the format string.
+    @type kwargs: L{dict}
+    """
+    expectedEvent = {
+        'log_level': log_level, 'log_source': log_source,
+        'log_format': log_format, 'log_namespace': log_namespace
+    }
+    expectedEvent.update(kwargs)
+    expectedEvent.update(log_time=event['log_time'])
+    if 'log_failure' in event:
+        expectedEvent.update(log_failure=event['log_failure'])
+
+    # Since we can't test log_logger, treat it like log_time
+    expectedEvent.update(log_logger=event['log_logger'])
+
+    # Compatibility with the old logging system, for more on this,
+    # see twisted.logger._legacy.LegacyLogObserverWrapper and
+    # twisted.logger._legacy.ensureCompatWithLegacyObservers
+    expectedEvent = _ensureCompatWithLegacyObservers(expectedEvent)
+    if event['log_format'] is not None:
+        expectedEvent.update(log_legacy=event['log_legacy'])
+
+    testCase.maxDiff = None
+
+    testCase.assertEqual(event, expectedEvent)
+
+
+
+def assertLogEvent(testCase, event, log_logger, log_level, log_namespace,
+                   log_source=None, log_format=None, **kwargs):
+    """
+    Assertion helper for testing a single log event.
+
+    @param testCase: The L{TestCase} object that wants to test some
+        log events using L{assertLogEvent}.
+    @type testCase: L{TestCase}
+
+    @param event: The emitted event, which is a L{dict}.
+    @type event: L{dict}
+
+    @param log_logger: L{Logger} object that the event was emitted to.
+    @type log_logger: L{Logger}
+
+    @param log_level: A L{LogLevel}.
+    @type log_level: L{LogLevel}
+
+    @param log_namespace: The namespace associated with the L{Logger}.
+    @type log_namespace: L{str} (native string)
+
+    @param log_source: The source object that emitted the event. This
+        will be L{None} if the L{Logger} is not accessed as an
+        attribute of an instance or class.
+    @type log_source: L{object} or L{None}
+
+    @param log_format: The format string provided for use by observers
+        that wish to render the event as text. The format string uses
+        new-style PEP 3101 formatting and is rendered using the log
+        event (which is a L{dict}). This may be L{None}, if no format
+        string was provided. The format string is optional, except when
+        a failure is being logged using L{Logger.failure}, in which
+        case a format string describing the failure must be provided.
+    @type log_format: L{str} or L{None}
+
+    @param kwargs: Additional key/value pairs that we expect to see
+        in the event being tested. This L{dict} may contain key/value
+        pairs needed to effectively render the format string.
+    @type kwargs: L{dict}
+   """
+    expectedEvent = {
+        'log_logger': log_logger, 'log_level': log_level,
+        'log_source': log_source, 'log_format': log_format,
+        'log_namespace': log_namespace
+    }
+    expectedEvent.update(kwargs)
+    expectedEvent.update(log_time=event['log_time'])
+    if 'log_failure' in event:
+        expectedEvent.update(log_failure=event['log_failure'])
+
+    testCase.maxDiff = None
+
+    testCase.assertEqual(event, expectedEvent)
+
+
+
+def assertGlobalLogEvents(testCase, actualEvents, expectedEvents):
+    """
+    Assertion helper for testing multiple log events that have been
+    emitted using L{twisted.logger._loggerFor}, in which case
+    the L{Logger} that the event was emitted to may not be available
+    for testing, therefore we do not test for it. This helper should
+    preferably be used in conjunction with the context manager
+    L{capturingLogEventsFromGlobalLogPublisher} for optimum test
+    coverage for events that can only be tested by passing an observer
+    to a L{globalLogPublisher}.
+
+    @param testCase: The L{TestCase} object that wants to test some
+        log events using L{assertLogEvents}.
+    @type testCase: L{TestCase}
+
+    @param actualEvents: A L{list} of L{dict} where each L{dict} is a
+        logged event emitted to a L{Logger} that appends events
+        to a L{list}.
+    @type actualEvents: L{list} of L{dict}
+
+    @param expectedEvents: A L{list} of L{dict} where each L{dict}
+        consists of key/value pairs that the testing code expects
+        to see in the C{actualEvents} being tested. The contents of
+        a an example L{dict} in this L{list} would contain everything
+        that you would pass to a valid call to L{assertGlobalLogEvent}.
+    @type expectedEvents: L{list} of L{dict}
+    """
+    testCase.assertEqual(len(actualEvents), len(expectedEvents))
+
+    for actualEvent, expectedEvent in zip(actualEvents, expectedEvents):
+        assertGlobalLogEvent(testCase, actualEvent, **expectedEvent)
+
+
+
+def assertLogEvents(testCase, actualEvents, expectedEvents):
+    """
+    Assertion helper for testing multiple log events.
+
+    @param testCase: The L{TestCase} object that wants to test some
+        log events using L{assertLogEvents}.
+    @type testCase: L{TestCase}
+
+    @param actualEvents: A L{list} of L{dict} where each L{dict} is a
+        logged event emitted to a L{Logger} that appends events
+        to a L{list}.
+    @type actualEvents: L{list} of L{dict}
+
+    @param expectedEvents: A L{list} of L{dict} where each L{dict}
+        consists of key/value pairs that the testing code expects
+        to see in the C{actualEvents} being tested.
+    @type expectedEvents: L{list} of L{dict}
+    """
+    testCase.assertEqual(len(actualEvents), len(expectedEvents))
+
+    for actualEvent, expectedEvent in zip(actualEvents, expectedEvents):
+        assertLogEvent(testCase, actualEvent, **expectedEvent)
+
+
+
+__all__ = ['assertLogEvent', 'assertLogEvents']

--- a/src/twisted/logger/test/test_assertionhelpers.py
+++ b/src/twisted/logger/test/test_assertionhelpers.py
@@ -1,0 +1,466 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.logger.test._assertionhelpers}.
+"""
+
+from twisted.trial.unittest import TestCase
+from twisted.logger.test._assertionhelpers import (
+    assertLogEvent, assertLogEvents, assertGlobalLogEvent,
+    capturingLogEventsFromGlobalLogPublisher,
+    capturingLogEventsFrom, assertGlobalLogEvents)
+from twisted.logger import (
+    Logger, LogLevel, _loggerFor, globalLogPublisher)
+from twisted.python.reflect import fullyQualifiedName
+
+
+
+class ThingThatLogs(object):
+    """
+    Simple object that logs events.
+    """
+    _log = Logger()
+
+    def logInfo(self):
+        """
+        Log event at log level L{LogLevel.info}.
+        """
+        self._log.info('INFO: {quote} {obj!r}', obj=self,
+                       quote='Twisted is amazing!')
+
+
+    def logFailure(self):
+        """
+        Log a captured L{Failure}.
+        """
+        try:
+            1/0
+        except:
+            self._log.failure('Math is hard!')
+
+
+    def logEventWithNoFormatString(self):
+        """
+        Log an event at log level L{LogLevel.info} without
+        a format string.
+        """
+        self._log.info(obj=self)
+
+
+    def logMultipleEvents(self):
+        """
+        Log multiple events by calling all the log* methods
+        defined so far.
+        """
+        self.logInfo()
+        self.logFailure()
+        self.logEventWithNoFormatString()
+
+
+    def logInfoUsingLoggerFor(self):
+        """
+        Log an event using L{twisted.logger._loggerFor}.
+        """
+        _loggerFor(self).info('Info: {quote}, {obj!r}', obj=self,
+                              quote='Twisted rules!')
+
+
+    def logEventWithNoFormatStringUsingLoggerFor(self):
+        """
+        Log an event at log level L{LogLevel.info} without
+        a format string using L{twisted.logger._loggerFor}.
+        """
+        _loggerFor(self).info(obj=self)
+
+
+    def logMultipleEventsUsingLoggerFor(self):
+        """
+        Log multiple events using L{twisted.logger._loggerFor}.
+        """
+        self.logInfoUsingLoggerFor()
+        self.logEventWithNoFormatStringUsingLoggerFor()
+
+
+
+class GlobalLogPublisherContextManagerTests(TestCase):
+    """
+    Tests for L{capturingLogEventsFromGlobalLogPublisher}.
+    """
+    def setUp(self):
+        """
+        Sets up an intance of an object that emits log events.
+        """
+        self.thingThatLogs = ThingThatLogs()
+
+
+    def test_appendIsNotInGlobalObservers(self):
+        """
+        Test that list.append is removed as an observer from the
+        L{globalLogPublisher} after the test finishes.
+        """
+        appendObserver = None
+
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.assertIn(events.append, globalLogPublisher._observers)
+            appendObserver = events.append
+
+        self.assertNotIn(appendObserver, globalLogPublisher._observers)
+
+
+
+class AssertGlobalLogEventTests(TestCase):
+    """
+    Tests for L{twisted.logger.test._assertionhelpers.assertGlobalLogEvent}.
+    """
+    def setUp(self):
+        """
+        Sets up an instance of an object that emits log events.
+        """
+        self.thingThatLogs = ThingThatLogs()
+
+
+    def test_assertInfoLogEvent(self):
+        """
+        Test a true condition of L{assertGlobalLogEvent} when some
+        log event is emitted.
+        """
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logInfoUsingLoggerFor()
+
+            assertGlobalLogEvent(
+                self, events[0], LogLevel.info,
+                fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                log_format='Info: {quote}, {obj!r}', obj=self.thingThatLogs,
+                quote='Twisted rules!'
+            )
+
+
+    def test_assertLogEventWithNoFormatString(self):
+        """
+        Test a true condition of L{assertGlobalLogEvent} when an
+        emitted event has no format string, C{log_format}.
+        """
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logEventWithNoFormatStringUsingLoggerFor()
+
+            assertGlobalLogEvent(
+                self, events[0], LogLevel.info,
+                fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                obj=self.thingThatLogs
+            )
+
+
+    def test_assertLogEventWithNoSource(self):
+        """
+        Test a true condition of L{assertGlobalLogEvent} when an emitted
+        event has no source object (C{log_source} is L{None}, i.e. the
+        L{Logger} that the event was emitted to cannot be accessed
+        as an attribute of an instance or class).
+        """
+        log = Logger()
+
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            log.info(home='Twisted Matrix Labs')
+
+            assertGlobalLogEvent(
+                self, events[0], LogLevel.info,
+                __name__, home='Twisted Matrix Labs'
+            )
+
+
+    def test_assertGlobalLogEventError(self):
+        """
+        Test an error with L{assertGlobalLogEvent}.
+        """
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logInfoUsingLoggerFor()
+
+            self.assertRaises(
+                self.failureException, assertGlobalLogEvent, self,
+                events[0], LogLevel.warn,
+                fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                universalTruth='TWISTED PREVAILS!'
+            )
+
+
+
+class AssertGlobalLogEventsTests(TestCase):
+    """
+    Tests for L{twisted.logger.test._assertionhelpers.assertGlobalLogEvents}.
+    """
+    def setUp(self):
+        """
+        Sets up an instance of an object that emits log events.
+        """
+        self.thingThatLogs = ThingThatLogs()
+
+
+    def test_assertMultipleLogEvents(self):
+        """
+        Test a true condition of L{assertLogEvents} when multiple
+        events are logged.
+        """
+        log = Logger()
+
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logMultipleEventsUsingLoggerFor()
+            log.info(home='Twisted Matrix Labs')
+
+            assertGlobalLogEvents(self, events, [
+                {
+                    'log_level': LogLevel.info,
+                    'log_namespace': fullyQualifiedName(ThingThatLogs),
+                    'log_source': self.thingThatLogs,
+                    'log_format': 'Info: {quote}, {obj!r}',
+                    'obj': self.thingThatLogs,
+                    'quote': 'Twisted rules!'
+                },
+                {
+                    'log_level': LogLevel.info,
+                    'log_namespace': fullyQualifiedName(ThingThatLogs),
+                    'log_source': self.thingThatLogs,
+                    'obj': self.thingThatLogs
+                },
+                {
+                    'log_level': LogLevel.info,
+                    'log_namespace': __name__,
+                    'home': 'Twisted Matrix Labs'
+                }
+            ])
+
+
+    def test_lenOfActualEventsIsNotEqualToLenOfExpectedEvents(self):
+        """
+        Test an error of L{assertGlobalLogEvents} when the length of
+        C{actualEvents} is not equal to the length of L{expectedEvents}.
+        """
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logMultipleEventsUsingLoggerFor()
+
+            self.assertRaises(
+                self.failureException, assertGlobalLogEvents, self, events,
+                [
+                    {
+                        'log_level': LogLevel.info,
+                        'log_namespace': fullyQualifiedName(ThingThatLogs),
+                        'log_source': self.thingThatLogs,
+                        'log_format': 'Info: {quote}, {obj!r}',
+                        'obj': self.thingThatLogs,
+                        'quote': 'Twisted rules!'
+                    }
+                ]
+            )
+
+
+    def test_expectedEventsAreNotActualEvents(self):
+        """
+        Test an error of L{assertGlobalLogEvents} when the expected
+        events are not the actual events that have been logged.
+        """
+        with capturingLogEventsFromGlobalLogPublisher() as events:
+            self.thingThatLogs.logInfoUsingLoggerFor()
+
+            self.assertRaises(
+                self.failureException, assertGlobalLogEvents, self, events,
+                [
+                    {
+                        'log_level': LogLevel.warn,
+                        'log_namespace': 'some.random.Object',
+                        'log_source': self.thingThatLogs,
+                        'log_format': 'Twisted rocks!',
+                        'truth': 'Twisted rules!'
+                    }
+                ]
+            )
+
+
+
+class AssertLogEventTests(TestCase):
+    """
+    Tests for L{twisted.logger.test._assertionhelpers.assertLogEvents}.
+    """
+    def setUp(self):
+        """
+        Sets up an instance of an object that emits log events.
+        """
+        self.thingThatLogs = ThingThatLogs()
+
+
+    def test_assertInfoLogEvent(self):
+        """
+        Test a true condition of L{assertLogEvent} when some log event
+        is emitted.
+        """
+        with capturingLogEventsFrom(self.thingThatLogs._log) as events:
+            self.thingThatLogs.logInfo()
+
+            assertLogEvent(
+                self, events[0], self.thingThatLogs._log, LogLevel.info,
+                fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                log_format='INFO: {quote} {obj!r}', obj=self.thingThatLogs,
+                quote='Twisted is amazing!'
+            )
+
+
+    def test_assertFailureLogEvent(self):
+        """
+        Test a true condition of L{assertLogEvent} when a failure is
+        logged using L{Logger.failure}.
+        """
+        with capturingLogEventsFrom(self.thingThatLogs._log) as events:
+            self.thingThatLogs.logFailure()
+
+            assertLogEvent(
+                self, events[0], self.thingThatLogs._log,
+                LogLevel.critical, fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                log_format='Math is hard!'
+            )
+
+
+    def test_assertLogEventWithNoFormatString(self):
+        """
+        Test a true condition of L{assertLogEvent} when an emitted
+        event has no format string, C{log_format}.
+        """
+        with capturingLogEventsFrom(self.thingThatLogs._log) as events:
+            self.thingThatLogs.logEventWithNoFormatString()
+
+            assertLogEvent(
+                self, events[0], self.thingThatLogs._log, LogLevel.info,
+                fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                obj=self.thingThatLogs
+            )
+
+
+    def test_assertLogEventWithNoSource(self):
+        """
+        Test a true condition of L{assertLogEvent} when an emitted
+        event has no source object (C{log_source} is L{None}, i.e. the
+        L{Logger} that the event was emitted to cannot be accessed
+        as an attribute of an instance or class).
+        """
+        log = Logger()
+
+        with capturingLogEventsFrom(log) as events:
+            log.info(home='Twisted Matrix Labs')
+
+            assertLogEvent(self, events[0], log, LogLevel.info, __name__,
+                           home='Twisted Matrix Labs')
+
+
+    def test_assertLogEventError(self):
+        """
+        Test an error with L{assertLogEvent}.
+        """
+        log = Logger()
+
+        with capturingLogEventsFrom(log) as events:
+            log.info('Twisted rocks!')
+
+            self.assertRaises(
+                self.failureException, assertLogEvent, self, events[0],
+                log, LogLevel.warn, fullyQualifiedName(ThingThatLogs),
+                log_source=self.thingThatLogs,
+                universalTruth='TWISTED PREVAILS!'
+            )
+
+
+
+class AssertLogEventsTests(TestCase):
+    """
+    Tests for L{twisted.logger.test._assertionhelpers.assertLogEvents}.
+    """
+    def setUp(self):
+        """
+        Sets up an instance of an object that emits log events.
+        """
+        self.thingThatLogs = ThingThatLogs()
+
+
+    def test_assertMultipleLogEvents(self):
+        """
+        Test a true condition of L{assertLogEvents} when multiple
+        events are logged.
+        """
+        with capturingLogEventsFrom(self.thingThatLogs._log) as events:
+            self.thingThatLogs.logMultipleEvents()
+
+            assertLogEvents(self, events, [
+                {
+                    'log_logger': self.thingThatLogs._log,
+                    'log_level': LogLevel.info,
+                    'log_namespace': fullyQualifiedName(ThingThatLogs),
+                    'log_source': self.thingThatLogs,
+                    'obj': self.thingThatLogs,
+                    'log_format': 'INFO: {quote} {obj!r}',
+                    'quote': 'Twisted is amazing!'
+                },
+                {
+                    'log_logger': self.thingThatLogs._log,
+                    'log_level': LogLevel.critical,
+                    'log_namespace': fullyQualifiedName(ThingThatLogs),
+                    'log_source': self.thingThatLogs,
+                    'log_format': 'Math is hard!'
+                },
+                {
+                    'log_logger': self.thingThatLogs._log,
+                    'log_level': LogLevel.info,
+                    'log_namespace': fullyQualifiedName(ThingThatLogs),
+                    'log_source': self.thingThatLogs,
+                    'obj': self.thingThatLogs
+                },
+
+            ])
+
+
+    def test_lenOfActualEventsIsNotEqualToLenOfExpectedEvents(self):
+        """
+        Test an error of L{assertLogEvents} when the length of
+        C{actualEvents} is not equal to the length of L{expectedEvents}.
+        """
+        with capturingLogEventsFrom(self.thingThatLogs._log) as events:
+            self.thingThatLogs.logMultipleEvents()
+
+            self.assertRaises(
+                self.failureException, assertLogEvents, self, events,
+                [
+                    {
+                        'log_logger': self.thingThatLogs._log,
+                        'log_level': LogLevel.info,
+                        'log_namespace': fullyQualifiedName(ThingThatLogs),
+                        'log_source': self.thingThatLogs,
+                        'obj': self.thingThatLogs
+                    }
+                ]
+            )
+
+
+    def test_expectedEventsAreNotActualEvents(self):
+        """
+        Test an error of L{assertLogEvents} when the expected events
+        are not the actual events that have been logged.
+        """
+        log = Logger()
+
+        with capturingLogEventsFrom(log) as events:
+
+            log.info('Twisted rocks!')
+
+            self.assertRaises(
+                self.failureException, assertLogEvents, self, events,
+                [
+                    {
+                        'log_logger': log, 'log_level': LogLevel.warn,
+                        'log_namespace': fullyQualifiedName(ThingThatLogs),
+                        'log_source': self.thingThatLogs,
+                        'universalTruth': 'TWISTED PREVAILS!'
+                    }
+                ]
+            )


### PR DESCRIPTION
Hello everyone!

Sorry for taking so long to work on this (life happened!). This is a rewritten patch for [7934](https://twistedmatrix.com/trac/ticket/7934), as per @glyph's feedback in [this comment](https://twistedmatrix.com/trac/ticket/7934#comment:6). A few things I would like to say:
- I have deliberately chosen not to write any .rst documentation for these helpers, mainly because after [7983](https://twistedmatrix.com/trac/ticket/7983) (more on this below), a lot of new functionality had to be implemented and some of the existing functionality re-implemented. I don't know whether the ideas I had are worth documenting beforehand at this point and I would like some feedback and be a bit surer about the future of this patch before moving any further.
-  The changes in [7987](https://twistedmatrix.com/trac/ticket/7897) have been refactored to use these helpers as per feedback. Doing this gives us an idea of whether these helpers make testing log events more elegant or not. If not (a scenario I am well-prepared for), then there's no use to this code.
- After [7983](https://twistedmatrix.com/trac/ticket/7983), using `_loggerFor` meant that since the `Logger` that emits a certain event is created on the fly (i.e. it is not accessible as an attribute of any object) every time something needs to be logged, the `Logger` object in question is not accessible for testing. Therefore, these events needed to be tested by passing `list.append` as an observer to `GlobalLogPublisher`, see [here](https://github.com/twisted/twisted/blob/trunk/src/twisted/internet/test/test_protocol.py#L416). So I had to implement a different set of context managers and assertion helpers to test these "global" log events by passing an observer to `GlobalLogPublisher`. One of the most salient differences from the other general helpers (`assertLogEvent`, `assertLogEvents`, etc.) is that `log_logger` is not tested in the "global" helpers (since its not accessible anywhere but the event being tested against itself). On a different note, it turned out that (I'm not exactly sure why!) when `_loggerFor` is used, the emitted events are modified (by `GlobalLogPublisher` maybe?) to ensure compatibility with the old logging system, so I refactored some of [this existing code](https://github.com/twisted/twisted/blob/trunk/src/twisted/logger/_legacy.py#L46) to make sure that the relevant helpers (`assertGlobalLogEvent` and `assertGlobalLogEvents`) modified the arguments passed to them to ensure compatibility with the old-style events before making the final assertion.

Apart from all of the above, I discovered that using `_loggerFor` has a caveat (I don't know if this is just my code, @hawkowl, I would really appreciate your feedback on this). `_loggerFor` fails when logging failures. Some rough git grepping shows that `_loggerFor` has not been used to log failures anywhere within Twisted so far, so this could be something that warrants further discussion.  For instance,

``` python
class SomeObject(object):
    log = Logger()
    def someMethod(self):
        try:
            1/0
        except:
            self.log.failure("Math is hard!")
```

The above code snippet works as expected, the exception is caught and the failure is logged and can be tested using `assertLogEvent` or `assertLogEvent`, as you can see [here](https://github.com/twisted/twisted/compare/trunk...eeshangarg:7934-eeshangarg-logging-assertion-helpers?expand=1#diff-abd0faf23a054e752747fc89471425f9R310).

However, in the event that `_loggerFor` is used:

``` python
class SomeObject(object):
    def someMethod(self):
        try:
            1/0
        except:
            _loggerFor(self).failure("Math is hard!")
```

In this case, the exception isn't caught at all but is still raised (or _"reraised"_ maybe?). No event is emitted or logged, therefore, no event can be tested. The test fails at `1/0`. As you'll notice, I have left this unaddressed in my PR, mainly because I couldn't figure out a away around it and partly because I had already implemented so many things that I hadn't anticipated when I submitted the last patch to this ticket approximately 13 months ago. I didn't want to make any more changes without further review. Not to mention that, if this is a bug, it warrants a distinct ticket. :-)

Once we are finished with this ticket, I would love to help out with porting Twisted to the new logging system and writing tests for all events that are logged within the Twisted code base. Also, I would be up for working on writing documentation for these helpers and any new features I implement along the way. :-)

The rest, I leave it to you, and your fine sense of judgement! Looking forward to hearing everyone's feedback! Have a great day!

Thanks & regards,
Eeshan Garg
