### PR TITLE
Make twisted.logger.Logger.failure directly usable as an errback.

### DIFF
--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -5,6 +5,8 @@
 Test cases for L{twisted.logger._logger}.
 """
 
+from twisted.internet.defer import maybeDeferred
+from twisted.python.failure import Failure
 from twisted.trial import unittest
 
 from .._levels import InvalidLogLevelError
@@ -200,6 +202,25 @@ class LoggerTests(unittest.TestCase):
             raise RuntimeError("baloney!")
         except RuntimeError:
             log.failure("Whoops")
+
+        errors = self.flushLoggedErrors(RuntimeError)
+        self.assertEqual(len(errors), 1)
+
+        self.assertEqual(log.emitted["level"], LogLevel.critical)
+        self.assertEqual(log.emitted["format"], "Whoops")
+
+
+    def test_failureTransposedArguments(self):
+        """
+        Test that log.failure() emits the right data when given format and
+        failure arguments in reverse order. This is pertinent when logging in
+        an errback.
+        """
+        def crash():
+            raise RuntimeError("baloney!")
+
+        log = TestLogger()
+        maybeDeferred(crash).addErrback(log.failure, "Whoops")
 
         errors = self.flushLoggedErrors(RuntimeError)
         self.assertEqual(len(errors), 1)

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -6,7 +6,6 @@ Test cases for L{twisted.logger._logger}.
 """
 
 from twisted.internet.defer import maybeDeferred
-from twisted.python.failure import Failure
 from twisted.trial import unittest
 
 from .._levels import InvalidLogLevelError


### PR DESCRIPTION
In many situations I find myself writing `d.addErrback(log.err, "Failed to ...")`. A similar pattern is possible with `t.logger.Logger.failure` but a lambda is needed/suggested and this lacks the same clarity. This updates `Logger.failure` to allow transposed arguments and so make the same errback pattern possible. It's intended to be a non-breaking change. I'm not amazingly happy with this solution but it works and is the least ugly and surprising thing I've so far come up with.
