### PR TITLE
fixed TypeError: sys.stdout.write() and sys.stderr.write() argument m…

### DIFF
--- a/src/twisted/application/runner/_exit.py
+++ b/src/twisted/application/runner/_exit.py
@@ -33,7 +33,7 @@ def exit(status, message=None):
         else:
             out = stderr
         out.write(message)
-        out.write(b"\n")
+        out.write("\n")
 
     sysexit(code)
 


### PR DESCRIPTION
The argument  of sys.stdout.write and sys.stderr.write() accept str, not bytes.
