### PR TITLE
Fix typo on Line 122 : `backend` instead of `backed` #8889

### DIFF
--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -119,7 +119,7 @@ def generateDSAkey(options):
     print('Generating public/private dsa key pair.')
     keyPrimitive = dsa.generate_private_key(
         key_size=int(options['bits']),
-        backed=default_backend(),
+        backend=default_backend(),
         )
     key = keys.Key(keyPrimitive)
     _saveKey(key, options)


### PR DESCRIPTION
There is a typo that makes generating DSA keys impossible.
Issue reported here: https://github.com/tnich/honssh/issues/85#issuecomment-257733949

Trac link: https://twistedmatrix.com/trac/ticket/8889