### PR TITLE
Ignore unexpected 1XX status codes.

### DIFF
--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -461,6 +461,9 @@ class HTTPClientParser(HTTPParser):
             # going to do. We reset the parser here, but we leave
             # _everReceivedData in its True state because we have, in fact,
             # received data.
+            log.msg(
+                "Ignoring unexpected {} response".format(self.response.code)
+            )
             self.connectionMade()
             del self.response
             return

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -455,6 +455,16 @@ class HTTPClientParser(HTTPParser):
         Figure out how long the response body is going to be by examining
         headers and stuff.
         """
+        if 100 <= self.response.code < 200:
+            # RFC 7231 Section 6.2 says that if we receive a 1XX status code
+            # and aren't expecting it, we MAY ignore it. That's what we're
+            # going to do. We reset the parser here, but we leave
+            # _everReceivedData in its True state because we have, in fact,
+            # received data.
+            self.connectionMade()
+            del self.response
+            return
+
         if (self.response.code in self.NO_BODY_CODES
             or self.request.method == b'HEAD'):
             self.response.length = 0

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -840,6 +840,109 @@ class HTTPClientParserTests(TestCase):
             self.assertIsInstance, ResponseFailed)
 
 
+    def test_1XXResponseIsSwallowed(self):
+        """
+        If a response in the 1XX range is received it just gets swallowed and
+        the parser resets itself.
+        """
+        sample103Response = (
+            b'HTTP/1.1 103 Early Hints\r\n'
+            b'Server: socketserver/1.0.0\r\n'
+            b'Link: </other/styles.css>; rel=preload; as=style\r\n'
+            b'Link: </other/action.js>; rel=preload; as=script\r\n'
+            b'\r\n'
+        )
+
+        protocol = HTTPClientParser(
+            Request(b'GET', b'/', _boringHeaders, None),
+            lambda ign: None
+        )
+        protocol.makeConnection(StringTransport())
+        protocol.dataReceived(sample103Response)
+
+        # The response should have been erased
+        self.assertTrue(protocol.response is None)
+        self.assertEqual(protocol.state, STATUS)
+        self.assertEqual(len(protocol.headers), 0)
+        self.assertEqual(len(protocol.connHeaders), 0)
+        self.assertTrue(protocol._everReceivedData)
+
+
+    def test_1XXFollowedByFinalResponseOnlyEmitsFinal(self):
+        """
+        When a 1XX response is swallowed, the final response that follows it is
+        the only one that gets sent to the application.
+        """
+        sample103Response = (
+            b'HTTP/1.1 103 Early Hints\r\n'
+            b'Server: socketserver/1.0.0\r\n'
+            b'Link: </other/styles.css>; rel=preload; as=style\r\n'
+            b'Link: </other/action.js>; rel=preload; as=script\r\n'
+            b'\r\n'
+        )
+        following200Response = (
+            b'HTTP/1.1 200 OK\r\n'
+            b'Content-Length: 123\r\n'
+            b'\r\n'
+        )
+
+        protocol = HTTPClientParser(
+            Request(b'GET', b'/', _boringHeaders, None),
+            lambda ign: None
+        )
+        protocol.makeConnection(StringTransport())
+        protocol.dataReceived(sample103Response + following200Response)
+
+        self.assertEqual(protocol.response.code, 200)
+        self.assertEqual(
+            protocol.response.headers,
+            Headers({}))
+        self.assertEqual(
+            protocol.connHeaders,
+            Headers({b'content-length': [b'123']}))
+        self.assertEqual(protocol.response.length, 123)
+
+
+    def test_multiple1XXResponsesAreIgnored(self):
+        """
+        It is acceptable for multiple 1XX responses to come through, all of
+        which get ignored.
+        """
+        sample103Response = (
+            b'HTTP/1.1 103 Early Hints\r\n'
+            b'Server: socketserver/1.0.0\r\n'
+            b'Link: </other/styles.css>; rel=preload; as=style\r\n'
+            b'Link: </other/action.js>; rel=preload; as=script\r\n'
+            b'\r\n'
+        )
+        following200Response = (
+            b'HTTP/1.1 200 OK\r\n'
+            b'Content-Length: 123\r\n'
+            b'\r\n'
+        )
+
+        protocol = HTTPClientParser(
+            Request(b'GET', b'/', _boringHeaders, None),
+            lambda ign: None
+        )
+        protocol.makeConnection(StringTransport())
+        protocol.dataReceived(
+            sample103Response +
+            sample103Response +
+            sample103Response +
+            following200Response
+        )
+
+        self.assertEqual(protocol.response.code, 200)
+        self.assertEqual(
+            protocol.response.headers,
+            Headers({}))
+        self.assertEqual(
+            protocol.connHeaders,
+            Headers({b'content-length': [b'123']}))
+        self.assertEqual(protocol.response.length, 123)
+
+
 
 class SlowRequest:
     """

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -861,10 +861,10 @@ class HTTPClientParserTests(TestCase):
         protocol.dataReceived(sample103Response)
 
         # The response should have been erased
-        self.assertTrue(protocol.response is None)
+        self.assertTrue(getattr(protocol, 'response', None) is None)
         self.assertEqual(protocol.state, STATUS)
-        self.assertEqual(len(protocol.headers), 0)
-        self.assertEqual(len(protocol.connHeaders), 0)
+        self.assertEqual(len(list(protocol.headers.getAllRawHeaders())), 0)
+        self.assertEqual(len(list(protocol.connHeaders.getAllRawHeaders())), 0)
         self.assertTrue(protocol._everReceivedData)
 
 

--- a/src/twisted/web/topfiles/8885.bugfix
+++ b/src/twisted/web/topfiles/8885.bugfix
@@ -1,0 +1,1 @@
+twisted.web.Agent now tolerates receiving unexpected status codes in the 100 range by discarding them, which is what RFC 7231 recommends doing.


### PR DESCRIPTION
See https://twistedmatrix.com/trac/ticket/8885

Some notes on this review:

1. I suspect we should log out a message when we drop a 1XX status code like this, but I'm reluctant to contribute to the continued use of the old logging system in twisted.web. Thoughts?
2. I wondered whether we should continue to surface 101 responses as per their old logic. We might accidentally regress something if users are expecting to be delivered those responses. Any thoughts there?