### PR TITLE
Add extractCurrentResult() and observeCurrentResult() to synchronously interact with a Deferred's result.

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -53,6 +53,17 @@ class TimeoutError(Exception):
 
 
 
+class NoCurrentResult(BaseException):
+    """
+    This error is raised when attempting to call L{extractCurrentResult} on a
+    L{Deferred} that has not yet called all of its callbacks.
+
+    This error inherits from L{BaseException} rather than L{Exception} to
+    reduce the likelihood of inadvertingly catching this exception as part of
+    an exception handler for other errors.
+    """
+
+
 def logError(err):
     """
     Log and return failure.
@@ -157,6 +168,87 @@ def maybeDeferred(f, *args, **kw):
         return fail(result)
     else:
         return succeed(result)
+
+
+
+def extractCurrentResult(deferred, raises=True, passthrough=False):
+    """
+    Extract the current result from a L{Deferred} that has already fired all of
+    its callbacks.
+
+    Take a deferred that has already fired all of its callbacks and extract and
+    return the result of the L{Deferred}. This process of extracting the result
+    will, by default, consume the result - error or not - unless the
+    L{passthrough} parameter is set to L{True}. If the L{Deferred} has an
+    error then the process of extracting the result will, by default, re-raise
+    the original exception unless the L{raises} parameter is set to L{False}.
+
+    The primary purpose of this function is to allow code to be written that is
+    internally asynchronous but which can be consumed without an event loop in
+    a synchronous fashion by using L{extractCurrentResult} at the boundaries.
+    This enables libraries to be written that can function both with Twisted
+    and with synchronous code instead of requiring an asynchronous and a
+    synchronous implementation for all functionality.
+
+    @attention: This function CANNOT take a Deferred with pending asynchronous
+        work to be done and make it synchronous. It can ONLY extract results
+        from a L{Deferred} which has already fired its callbacks.
+
+    @type deferred: Deferred
+    @param deferred: The Deferred from which results will be extracted..
+
+    @type raises: bool
+    @param raises: Whether or not to raise the original exception (L{True}) or
+        to return the failure object (L{False}).
+
+    @type passthrough: bool
+    @param passthrough: Whether or not to pass through the original value
+        (L{True}) or to consume any results, error or otherwise (L{False}).
+
+    @raise NoCurrentResult: If C{deferred} has pending work to be done
+        and has no current result to extract.
+
+    @return: The result of the L{Deferred}.
+    """
+    def done(result):
+        done.result = result
+
+        # We return the result here so that if anything else continued to use
+        # this Deferred after it's been unboxed then the act of unboxing
+        # has not broken the flow of values through the callback chain.
+        if passthrough:
+            return result
+
+    # We need a place to store the result, and a way to determine the
+    # difference between no result and any other possible object. So we'll
+    # create a sigil object and stash it locally and default our result to
+    # that.
+    # Note: This *has* to happen before adding the done callback to the
+    #       Deferred or else the callback can fire prior to setting our
+    #       default, thus causing the default to override the value from the
+    #       callback.
+    nothing = done.result = object()
+
+    # Now that the callback is fully setup and prepared, register it with the
+    # deferred. This *should* run immediately since only Deferreds that do not
+    # have any pending work should be passed into this function.
+    deferred.addBoth(done)
+
+    # If we've gotten to this point and we haven't had our collect function
+    # called, then we must be waiting on something in the Deferred chain. If so
+    # we'll error out here because there's nothing we can do to advance the
+    # state of the Deferred. If we've got a result then we'll go ahead and
+    # return it or raise the given exception.
+    if done.result is nothing:
+        raise NoCurrentResult(
+            "Cannot extract the current result of a Deferred that has not "
+            "currently called all of its callbacks."
+        )
+    else:
+        if raises and isinstance(done.result, failure.Failure):
+            done.result.raiseException()
+        else:
+            return done.result
 
 
 
@@ -1823,10 +1915,10 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
 
 
 __all__ = ["Deferred", "DeferredList", "succeed", "fail", "FAILURE", "SUCCESS",
-           "AlreadyCalledError", "TimeoutError", "gatherResults",
-           "maybeDeferred", "ensureDeferred",
-           "waitForDeferred", "deferredGenerator", "inlineCallbacks",
-           "returnValue",
+           "AlreadyCalledError", "TimeoutError", "NoCurrentResult",
+           "gatherResults", "maybeDeferred", "ensureDeferred",
+           "extractCurrentResult", "waitForDeferred", "deferredGenerator",
+           "inlineCallbacks", "returnValue",
            "DeferredLock", "DeferredSemaphore", "DeferredQueue",
            "DeferredFilesystemLock", "AlreadyTryingToLockError",
           ]

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -671,7 +671,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
 
     def test_extractCurrentResultReturnsFailureWithNoRaises(self):
         """
-        L{deferextractCurrentResult} returns the failure instance if
+        L{defer.extractCurrentResult} returns the failure instance if
         raises=False.
         """
         d = defer.Deferred()
@@ -708,28 +708,6 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         d = defer.Deferred()
         d.callback(None)
         self.assertEqual(inner(d), "success")
-
-
-    def test_extractCurrentResultPreservesCallbackChain(self):
-        """
-        L{defer.extractCurrentResult} chains the value that will be passed into
-        the next function of the callback chain if passthrough=True.
-        """
-        result1 = object()
-        result2 = object()
-
-        d = defer.Deferred()
-        d.callback(result1)
-
-        self.assertIs(defer.extractCurrentResult(d, passthrough=True), result1)
-
-        def cb(r):
-            self.assertIs(r, result1)
-            return result2
-
-        d.addCallback(cb)
-
-        self.assertIs(defer.extractCurrentResult(d), result2)
 
 
     def test_extractCurrentResultRaisesErrorIfPending(self):
@@ -786,6 +764,136 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
 
         self.assertIs(defer.extractCurrentResult(d, raises=False), result)
         self.assertIs(defer.extractCurrentResult(d), None)
+
+
+    def test_observeCurrentResult(self):
+        """
+        L{defer.observeCurrentResult} extracts the results from a Deferred that
+        has already had its callback function called.
+        """
+        result = object()
+
+        d = defer.Deferred()
+        d.callback(result)
+
+        self.assertIs(defer.observeCurrentResult(d), result)
+        # Observing the result does not change the result, so calling it twice
+        # will return the same value.
+        self.assertIs(defer.observeCurrentResult(d), result)
+
+
+    def test_observeCurrentResultRaisesFailureException(self):
+        """
+        L{defer.observeCurrentResult} raises the original exception if the
+        result of the deferred is a failure.
+        """
+        d = defer.Deferred()
+        d.errback(ValueError())
+
+        self.assertRaises(ValueError, defer.observeCurrentResult, d)
+        # Observing the result does not change the result, so calling it twice
+        # will raise the same value.
+        self.assertRaises(ValueError, defer.observeCurrentResult, d)
+
+        # Squash the error to avoid logging an unhandled error.
+        d.addErrback(lambda r: None)
+
+
+    def test_observeCurrentResultReturnsFailureWithNoRaises(self):
+        """
+        L{defer.observeCurrentResult} returns the failure instance if
+        raises=False.
+        """
+        d = defer.Deferred()
+        d.errback(ValueError())
+
+        result = defer.observeCurrentResult(d, raises=False)
+
+        self.assertIsInstance(result, failure.Failure)
+        self.assertIsInstance(result.value, ValueError)
+
+        # Squash the error to avoid logging an unhandled error.
+        d.addErrback(lambda r: None)
+
+
+    def test_observeCurrentResultWithoutResultsNotCaughtByException(self):
+        """
+        L{defer.observeCurrentResult} raises a L{defer.NoCurrentResult}
+        exception which is not caught when catching L{Exception}.
+        """
+        def inner(d):
+            try:
+                defer.observeCurrentResult(d)
+            except Exception:
+                return "error"
+            return "success"
+
+        d = defer.Deferred()
+        self.assertRaises(defer.NoCurrentResult, inner, d)
+
+        # In order to get 100% patch coverage we need to exercise the "error"
+        # and "success" paths. This is not actually testing the functionality
+        # of observeCurrentResult but is testing the functionality of the test
+        # function `inner`.
+        d = defer.Deferred()
+        d.errback(Exception())
+        self.assertEqual(inner(d), "error")
+        # Squash the error to avoid logging an unhandled error.
+        d.addErrback(lambda r: None)
+        d = defer.Deferred()
+        d.callback(None)
+        self.assertEqual(inner(d), "success")
+
+
+    def test_observeCurrentResultPreservesCallbackChain(self):
+        """
+        L{defer.observeCurrentResult} chains the value that will be passed into
+        the next function of the callback chain.
+        """
+        result1 = object()
+        result2 = object()
+
+        d = defer.Deferred()
+        d.callback(result1)
+
+        self.assertIs(defer.observeCurrentResult(d), result1)
+
+        def cb(r):
+            self.assertIs(r, result1)
+            return result2
+
+        d.addCallback(cb)
+
+        self.assertIs(defer.observeCurrentResult(d), result2)
+
+
+    def test_observeCurrentResultRaisesErrorIfPending(self):
+        """
+        L{defer.observeCurrentResult} raises an error if there currently any
+        pending work to be done on the L{Deferred}.
+        """
+        d = defer.Deferred()
+
+        self.assertRaises(defer.NoCurrentResult, defer.observeCurrentResult, d)
+
+
+    def test_observeCurrentResultRaisesErrorIfPendingChainedDeferred(self):
+        """
+        L{defer.observeCurrentResult} raises an error if there is currently any
+        pending work to be done on the L{Deferred} if it is via a chained
+        L{Deferred}.
+        """
+        result = object()
+
+        d = defer.Deferred()
+        d.callback(result)
+
+        self.assertIs(defer.observeCurrentResult(d), result)
+
+        d2 = defer.Deferred()
+        d.addCallback(lambda _: d2)
+
+        self.assertRaises(defer.NoCurrentResult, defer.observeCurrentResult, d)
 
 
     def test_maybeDeferredSync(self):

--- a/src/twisted/topfiles/8900.feature
+++ b/src/twisted/topfiles/8900.feature
@@ -1,2 +1,3 @@
-The new function twisted.internet.defer.extractCurrentResult enables extracting
-the current result of an already fired Deferred.
+The new functions twisted.internet.defer.extractCurrentResult and
+twisted.internet.defer.observeCurrentResult enables extracting or observing the
+current result of an already fired Deferred.

--- a/src/twisted/topfiles/8900.feature
+++ b/src/twisted/topfiles/8900.feature
@@ -1,0 +1,2 @@
+The new function twisted.internet.defer.extractCurrentResult enables extracting
+the current result of an already fired Deferred.

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -14,6 +14,7 @@ import inspect
 import os, warnings, sys, tempfile, types
 from dis import findlinestarts as _findlinestarts
 
+from twisted.internet import defer
 from twisted.python import failure, log, monkey
 from twisted.python.reflect import fullyQualifiedName
 from twisted.python.util import runWithWarningsSuppressed
@@ -686,20 +687,24 @@ class _Assertions(pyunit.TestCase, object):
 
         @return: The result of C{deferred}.
         """
-        result = []
-        deferred.addBoth(result.append)
-        if not result:
+        try:
+            result = defer.extractCurrentResult(deferred, raises=False)
+        except defer.NoCurrentResult:
             self.fail(
-                "Success result expected on %r, found no result instead" % (
-                    deferred,))
-        elif isinstance(result[0], failure.Failure):
-            self.fail(
-                "Success result expected on %r, "
-                "found failure result instead:\n%s" % (
-                    deferred, result[0].getTraceback()))
-        else:
-            return result[0]
+                "Success result expected on {!r}, found no result "
+                "instead".format(deferred)
+            )
 
+        if isinstance(result, failure.Failure):
+            self.fail(
+                "Success result expected on {!r}, "
+                "found failure result instead:\n{}".format(
+                    deferred,
+                    result.getTraceback(),
+                )
+            )
+        else:
+            return result
 
     def failureResultOf(self, deferred, *expectedExceptionTypes):
         """
@@ -726,30 +731,39 @@ class _Assertions(pyunit.TestCase, object):
         @return: The failure result of C{deferred}.
         @rtype: L{failure.Failure}
         """
-        result = []
-        deferred.addBoth(result.append)
-        if not result:
+        try:
+            result = defer.extractCurrentResult(deferred, raises=False)
+        except defer.NoCurrentResult:
             self.fail(
-                "Failure result expected on %r, found no result instead" % (
-                    deferred,))
-        elif not isinstance(result[0], failure.Failure):
+                "Failure result expected on {0!r}, found no result "
+                "instead".format(deferred)
+            )
+
+        if not isinstance(result, failure.Failure):
             self.fail(
-                "Failure result expected on %r, "
-                "found success result (%r) instead" % (deferred, result[0]))
+                "Failure result expected on {0!r}, "
+                "found success result ({1!r}) instead".format(
+                    deferred,
+                    result,
+                )
+            )
         elif (expectedExceptionTypes and
-              not result[0].check(*expectedExceptionTypes)):
+              not result.check(*expectedExceptionTypes)):
             expectedString = " or ".join([
                 '.'.join((t.__module__, t.__name__)) for t in
                 expectedExceptionTypes])
 
             self.fail(
-                "Failure of type (%s) expected on %r, "
-                "found type %r instead: %s" % (
-                    expectedString, deferred, result[0].type,
-                    result[0].getTraceback()))
+                "Failure of type ({0}) expected on {1!r}, "
+                "found type {2!r} instead: {3}".format(
+                    expectedString,
+                    deferred,
+                    result.type,
+                    result.getTraceback(),
+                )
+            )
         else:
-            return result[0]
-
+            return result
 
     def assertNoResult(self, deferred):
         """
@@ -770,19 +784,24 @@ class _Assertions(pyunit.TestCase, object):
         @raise SynchronousTestCase.failureException: If the
             L{Deferred<twisted.internet.defer.Deferred>} has a result.
         """
-        result = []
-        def cb(res):
-            result.append(res)
-            return res
-        deferred.addBoth(cb)
-        if result:
+        try:
+            result = defer.extractCurrentResult(
+                deferred,
+                raises=False,
+                passthrough=True,
+            )
+        except defer.NoCurrentResult:
+            pass
+        else:
             # If there is already a failure, the self.fail below will
             # report it, so swallow it in the deferred
             deferred.addErrback(lambda _: None)
             self.fail(
-                "No result expected on %r, found %r instead" % (
-                    deferred, result[0]))
-
+                "No result expected on {0!r}, found {1!r} instead".format(
+                    deferred,
+                    result,
+                )
+            )
 
     def assertRegex(self, text, regex, msg=None):
         """

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -785,11 +785,7 @@ class _Assertions(pyunit.TestCase, object):
             L{Deferred<twisted.internet.defer.Deferred>} has a result.
         """
         try:
-            result = defer.extractCurrentResult(
-                deferred,
-                raises=False,
-                passthrough=True,
-            )
+            result = defer.observeCurrentResult(deferred, raises=False)
         except defer.NoCurrentResult:
             pass
         else:


### PR DESCRIPTION
Ticket: https://twistedmatrix.com/trac/ticket/8900