### PR TITLE
Fix 8919 -- Procmon Python 3.5 bytes/string issues

### DIFF
--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -19,7 +19,7 @@ transport = DummyTransport()
 class LineLogger(basic.LineReceiver):
 
     tag = None
-    delimiter = '\n'
+    delimiter = b'\n'
 
     def lineReceived(self, line):
         log.msg('[%s] %s' % (self.tag, line))
@@ -39,14 +39,14 @@ class LoggingProtocol(protocol.ProcessProtocol):
 
     def outReceived(self, data):
         self.output.dataReceived(data)
-        self.empty = data[-1] == '\n'
+        self.empty = data[-1] == b'\n'
 
     errReceived = outReceived
 
 
     def processEnded(self, reason):
         if not self.empty:
-            self.output.dataReceived('\n')
+            self.output.dataReceived(b'\n')
         self.service.connectionLost(self.name)
 
 

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -22,7 +22,11 @@ class LineLogger(basic.LineReceiver):
     delimiter = b'\n'
 
     def lineReceived(self, line):
-        log.msg('[%s] %s' % (self.tag, line))
+        try:
+            line = line.decode('utf-8')
+        except UnicodeDecodeError:
+            line = repr(line)
+        log.msg(u'[%s] %s' % (self.tag, line))
 
 
 class LoggingProtocol(protocol.ProcessProtocol):

--- a/src/twisted/runner/test/test_procmon.py
+++ b/src/twisted/runner/test/test_procmon.py
@@ -11,6 +11,7 @@ from twisted.internet.error import (ProcessDone, ProcessTerminated,
                                     ProcessExitedAlready)
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
+from twisted.python import log
 from twisted.test.proto_helpers import MemoryReactor
 
 
@@ -305,6 +306,52 @@ class ProcmonTests(unittest.TestCase):
         self.pm.addProcess("foo", ["foo"])
         self.assertIsNone(self.pm.stopProcess("foo"))
 
+
+    def test_outputReceivedCompleteLine(self):
+        """
+        Getting a complete output line generates a log message.
+        """
+        events = []
+        self.addCleanup(log.removeObserver, events.append)
+        log.addObserver(events.append)
+        self.pm.addProcess("foo", ["foo"])
+        # Schedule the process to start
+        self.pm.startService()
+        # advance the reactor to start the process
+        self.reactor.advance(0)
+        self.assertIn("foo", self.pm.protocols)
+        # Long time passes
+        self.reactor.advance(self.pm.threshold)
+        # Process greets
+        self.pm.protocols["foo"].outReceived(b'hello world!\n')
+        self.assertEquals(len(events), 1)
+        message = events[0]['message']
+        self.assertEquals(message, tuple([u'[foo] hello world!']))
+
+    def test_outputReceivedCompleteLineInvalidUTF8(self):
+        """
+        Getting a complete output line generates a log message.
+        """
+        events = []
+        self.addCleanup(log.removeObserver, events.append)
+        log.addObserver(events.append)
+        self.pm.addProcess("foo", ["foo"])
+        # Schedule the process to start
+        self.pm.startService()
+        # advance the reactor to start the process
+        self.reactor.advance(0)
+        self.assertIn("foo", self.pm.protocols)
+        # Long time passes
+        self.reactor.advance(self.pm.threshold)
+        # Process greets
+        self.pm.protocols["foo"].outReceived(b'\xffhello world!\n')
+        self.assertEquals(len(events), 1)
+        messages = events[0]['message']
+        self.assertEquals(len(messages), 1)
+        message = messages[0]
+        tag, output = message.split(' ', 1)
+        self.assertEquals(tag, '[foo]')
+        self.assertEquals(output, repr(b'\xffhello world!'))
 
     def test_connectionLostLongLivedProcess(self):
         """

--- a/src/twisted/runner/test/test_procmon.py
+++ b/src/twisted/runner/test/test_procmon.py
@@ -317,7 +317,7 @@ class ProcmonTests(unittest.TestCase):
         self.pm.addProcess("foo", ["foo"])
         # Schedule the process to start
         self.pm.startService()
-        # advance the reactor to start the process
+        # Advance the reactor to start the process
         self.reactor.advance(0)
         self.assertIn("foo", self.pm.protocols)
         # Long time passes
@@ -327,6 +327,7 @@ class ProcmonTests(unittest.TestCase):
         self.assertEquals(len(events), 1)
         message = events[0]['message']
         self.assertEquals(message, tuple([u'[foo] hello world!']))
+
 
     def test_outputReceivedCompleteLineInvalidUTF8(self):
         """
@@ -338,7 +339,7 @@ class ProcmonTests(unittest.TestCase):
         self.pm.addProcess("foo", ["foo"])
         # Schedule the process to start
         self.pm.startService()
-        # advance the reactor to start the process
+        # Advance the reactor to start the process
         self.reactor.advance(0)
         self.assertIn("foo", self.pm.protocols)
         # Long time passes
@@ -353,6 +354,7 @@ class ProcmonTests(unittest.TestCase):
         self.assertEquals(tag, '[foo]')
         self.assertEquals(output, repr(b'\xffhello world!'))
 
+
     def test_outputReceivedPartialLine(self):
         """
         Getting partial line results in no events until process end
@@ -363,7 +365,7 @@ class ProcmonTests(unittest.TestCase):
         self.pm.addProcess("foo", ["foo"])
         # Schedule the process to start
         self.pm.startService()
-        # advance the reactor to start the process
+        # Advance the reactor to start the process
         self.reactor.advance(0)
         self.assertIn("foo", self.pm.protocols)
         # Long time passes

--- a/src/twisted/runner/topfiles/8919.bugfix
+++ b/src/twisted/runner/topfiles/8919.bugfix
@@ -1,0 +1,1 @@
+On Python 3, procmon now handles process output without exceptions


### PR DESCRIPTION
Author: moshez

Reviewer: wsanchez

Fixes: #8919 

On Python 3, procmon now handles process output without exceptions
