### PR TITLE
Revert "[#8937] Remove deprecated parts of FilePath"

### DIFF
--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -31,7 +31,9 @@ from zope.interface import Interface, Attribute, implementer
 # modified for inclusion in the standard library.  --glyph
 
 from twisted.python.compat import comparable, cmp, unicode
+from twisted.python.deprecate import deprecated
 from twisted.python.runtime import platform
+from incremental import Version
 
 from twisted.python.win32 import ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND
 from twisted.python.win32 import ERROR_INVALID_NAME, ERROR_DIRECTORY, O_BINARY
@@ -480,6 +482,28 @@ class AbstractFilePath(object):
         return hash((self.__class__, self.path))
 
 
+    # pending deprecation in 8.0
+    def getmtime(self):
+        """
+        Deprecated.  Use getModificationTime instead.
+        """
+        return int(self.getModificationTime())
+
+
+    def getatime(self):
+        """
+        Deprecated.  Use getAccessTime instead.
+        """
+        return int(self.getAccessTime())
+
+
+    def getctime(self):
+        """
+        Deprecated.  Use getStatusChangeTime instead.
+        """
+        return int(self.getStatusChangeTime())
+
+
 
 class RWX(FancyEqMixin, object):
     """
@@ -573,6 +597,15 @@ class Permissions(FancyEqMixin, object):
         """
         return "".join(
             [x.shorthand() for x in (self.user, self.group, self.other)])
+
+
+class _SpecialNoValue(object):
+    """
+    An object that represents 'no value', to be used in deprecating statinfo.
+
+    Please remove once statinfo is removed.
+    """
+    pass
 
 
 
@@ -676,6 +709,22 @@ class FilePath(AbstractFilePath):
 
     @type path: L{bytes} or L{unicode}
     @ivar path: The path from which 'downward' traversal is permitted.
+
+    @ivar statinfo: (WARNING: statinfo is deprecated as of Twisted 15.0.0 and
+        will become a private attribute)
+        The currently cached status information about the file on
+        the filesystem that this L{FilePath} points to.  This attribute is
+        L{None} if the file is in an indeterminate state (either this
+        L{FilePath} has not yet had cause to call C{stat()} yet or
+        L{FilePath.changed} indicated that new information is required), 0 if
+        C{stat()} was called and returned an error (i.e. the path did not exist
+        when C{stat()} was called), or a C{stat_result} object that describes
+        the last known status of the underlying file (or directory, as the case
+        may be).  Trust me when I tell you that you do not want to use this
+        attribute.  Instead, use the methods on L{FilePath} which give you
+        information about it, like C{getsize()}, C{isdir()},
+        C{getModificationTime()}, and so on.
+    @type statinfo: L{int} or L{None} or L{os.stat_result}
     """
     _statinfo = None
     path = None
@@ -1685,6 +1734,35 @@ class FilePath(AbstractFilePath):
         else:
             self.changed()
             destination.changed()
+
+
+    def statinfo(self, value=_SpecialNoValue):
+        """
+        FilePath.statinfo is deprecated.
+
+        @param value: value to set statinfo to, if setting a value
+        @return: C{_statinfo} if getting, L{None} if setting
+        """
+        # This is a pretty awful hack to use the deprecated decorator to
+        # deprecate a class attribute.  Ideally, there would just be a
+        # statinfo property and a statinfo property setter, but the
+        # 'deprecated' decorator does not produce the correct FQDN on class
+        # methods.  So the property stuff needs to be set outside the class
+        # definition - but the getter and setter both need the same function
+        # in order for the 'deprecated' decorator to produce the right
+        # deprecation string.
+        if value is _SpecialNoValue:
+            return self._statinfo
+        else:
+            self._statinfo = value
+
+
+# This is all a terrible hack to get statinfo deprecated
+_tmp = deprecated(
+    Version('Twisted', 15, 0, 0),
+    "other FilePath methods such as getsize(), "
+    "isdir(), getModificationTime(), etc.")(FilePath.statinfo)
+FilePath.statinfo = property(_tmp, _tmp)
 
 
 FilePath.clonePath = FilePath

--- a/src/twisted/topfiles/8937.removal
+++ b/src/twisted/topfiles/8937.removal
@@ -1,1 +1,0 @@
-The deprecated property twisted.python.filepath.FilePath.statinfo (since 15.0) and the deprecated methods FilePath.getmtime, FilePath.getatime, and Filepath.getctime (since 8.0) have been removed.

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,6 @@ setenv =
    COVERAGE_FILE = {toxinidir}/.coverage
    # Help tests know where the base directory is.
    TOX_INI_DIR = {toxinidir}
-   PYTHON_OPTIONS = -Wdefault::DeprecationWarning
 
 commands =
     ;
@@ -94,7 +93,7 @@ commands =
     apidocs: pip install --no-deps epydoc pydoctor
 
     ; Run tests without wrapping them using coverage.
-    {nocov,nomodules,tests}: python {env:PYTHON_OPTIONS} -m twisted.trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {posargs:twisted}
+    {nocov,nomodules,tests}: python -m twisted.trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose}  {posargs:twisted}
 
     ; Run the tests wrapped using coverage.
     {withcov,coverage}: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth


### PR DESCRIPTION
Reverts twisted/twisted#621

As @exarkun [put it](https://twistedmatrix.com/trac/ticket/8937#comment:6):

> Regressions for at least two other projects. Beyond just being a technical violation of the compatibility policy. Probably should revert?

Yeah, we should.