### PR TITLE
[#8912] Safer, better approach decoding UNIX socket recvmsg ancillary data

### DIFF
--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -506,7 +506,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         self.assertEqual(len(proto.fds), 2)
 
         # Verify that received FDs are different from the sent ones.
-        self.assertFalse(set(proto.fdsToSend).intersection(set(proto.fds)))
+        self.assertFalse(set(encoder.fdsToSend).intersection(set(proto.fds)))
     if sendmsgSkip is not None:
         test_multiFileDescriptorReceivedPerRecvmsgTwoCMSGs.skip = sendmsgSkip
 

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -458,14 +458,10 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         """
         from twisted.python.sendmsg import SCM_RIGHTS
 
-        class Encoder:
-            def __init__(self):
-                self.fdsToSend = None
-            def __call__(self, fdsToSend):
-                self.fdsToSend = fdsToSend
-                return [(SOL_SOCKET, SCM_RIGHTS, pack('ii', *fdsToSend))]
+        def encoder(fdsToSend):
+            encoder.fdsToSend = fdsToSend
+            return [(SOL_SOCKET, SCM_RIGHTS, pack('ii', *fdsToSend))]
 
-        encoder = Encoder()
         proto = self._SendmsgMixinFileDescriptorReceivedDriver(encoder)
 
         # Verify that the encoder was used.
@@ -488,17 +484,13 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         """
         from twisted.python.sendmsg import SCM_RIGHTS
 
-        class Encoder:
-            def __init__(self):
-                self.fdsToSend = None
-            def __call__(self, fdsToSend):
-                self.fdsToSend = fdsToSend
-                return [
-                    (SOL_SOCKET, SCM_RIGHTS, pack('i', fd))
-                    for fd in fdsToSend
-                ]
+        def encoder(fdsToSend):
+            encoder.fdsToSend = fdsToSend
+            return [
+                (SOL_SOCKET, SCM_RIGHTS, pack('i', fd))
+                for fd in fdsToSend
+            ]
 
-        encoder = Encoder()
         proto = self._SendmsgMixinFileDescriptorReceivedDriver(encoder)
 
         # Verify that the encoder was used.

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -406,7 +406,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         # IReactorSocket.adoptStreamConnection once AF_UNIX support is
         # implemented; see https://twistedmatrix.com/trac/ticket/5573.
 
-        from socket import socketpair
+        import socket
         from twisted.internet.unix import _SendmsgMixin
         from twisted.python.sendmsg import sendmsg
         from twisted.trial.unittest import SkipTest
@@ -427,7 +427,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             def _dataReceived(self, data):
                 pass
 
-        sendSocket, recvSocket = socketpair(AF_UNIX, SOCK_STREAM)
+        sendSocket, recvSocket = socket.socketpair(AF_UNIX, SOCK_STREAM)
         self.addCleanup(sendSocket.close)
         self.addCleanup(recvSocket.close)
 
@@ -439,7 +439,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         ancillary = ancillaryEncoder(fdsToSend)
         try:
             sendmsg(sendSocket, dataToSend, ancillary)
-        except OSError as e:
+        except (socket.error, OSError) as e:
             # Some platforms fail if ancillary contains more than
             # one entry (Mac OS 10.9.5, for example). No point in
             # continuing if sendmsg fails, skip the test.

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -172,7 +172,8 @@ class _SendmsgMixin(object):
                 return main.CONNECTION_LOST
 
         for cmsgLevel, cmsgType, cmsgData in ancillary:
-            if cmsgLevel != socket.SOL_SOCKET or cmsgType != sendmsg.SCM_RIGHTS:
+            if (cmsgLevel != socket.SOL_SOCKET or
+                cmsgType != sendmsg.SCM_RIGHTS):
                 log.msg(
                     format=(
                         "%(protocolName)s (on %(hostAddress)r) "

--- a/src/twisted/python/_sendmsg.c
+++ b/src/twisted/python/_sendmsg.c
@@ -291,7 +291,7 @@ static PyObject *sendmsg_sendmsg(PyObject *self, PyObject *args, PyObject *keywd
 
         /* Unpack the tuples into the control message. */
         struct cmsghdr *control_message = CMSG_FIRSTHDR(&message_header);
-        while ( (item = PyIter_Next(iterator)) ) {
+        while ( (item = PyIter_Next(iterator)) && control_message!=NULL ) {
             int type, level;
             Py_ssize_t data_len;
             size_t data_size;

--- a/src/twisted/python/_sendmsg.c
+++ b/src/twisted/python/_sendmsg.c
@@ -278,6 +278,14 @@ static PyObject *sendmsg_sendmsg(PyObject *self, PyObject *args, PyObject *keywd
                 PyErr_NoMemory();
                 goto finished;
             }
+            /* From Python 3.5.2 socketmodule.c:3891:
+               Need to zero out the buffer as a workaround for glibc's
+               CMSG_NXTHDR() implementation.  After getting the pointer to
+               the next header, it checks its (uninitialized) cmsg_len
+               member to see if the "message" fits in the buffer, and
+               returns NULL if it doesn't.  Zero-filling the buffer
+               ensures that this doesn't happen. */
+            memset(message_header.msg_control, 0, all_data_len);
         } else {
             message_header.msg_control = NULL;
         }

--- a/src/twisted/topfiles/8912.bugfix
+++ b/src/twisted/topfiles/8912.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.unix.Server.doRead and twisted.internet.unix.Client.doRead now discard recvmsg's ancilliary data of unsupported level or type.


### PR DESCRIPTION
Addresses http://twistedmatrix.com/trac/ticket/8912.

Notes:
* Inspired by Tom Prince's sketch, code logs a message if unsupported ancillary data is received.
* PR improves processing of ancillary data in two ways:
  * Now validates level and type before decoding file descriptors from the data (which would otherwise be wrong and prone to all sorts of "interesting" failures by producing invalid/unpredictable descriptors). :)
  * Processes all received ancillary data messages (previous code would only process the first).

Looking for feedback on:
* Ancillary data processing code is getting long vs. the "recvmsg + return data". Should it be factored out to another method, called from doRead? If so, name suggestions?
* Is there any recommended way of testing that a given log message was logged? (so that a test for ignored incoming ancillary data case can check that)

Thanks in advance for input and guidance.