### PR TITLE
[#8877] allow DNS resolution over IPv6 with twisted.names

### DIFF
--- a/src/twisted/topfiles/8877.bugfix
+++ b/src/twisted/topfiles/8877.bugfix
@@ -1,0 +1,1 @@
+twisted.names.client.Resolver can now resolve names with IPv6 DNS servers.


### PR DESCRIPTION
This commit lets twisted query ipv6 DNS servers by using a ipv6 socket by
default and converting ipv4 nameservers to ipv6.

https://tm.tl/8877