### PR TITLE
More verbose error output

### DIFF
--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1486,7 +1486,7 @@ class _StandardEndpointFactory(object):
                                                                       uri.port)
             return wrapClientTLS(connectionCreator, endpoint)
         else:
-            raise SchemeNotSupported("Unsupported scheme: %r" % (uri.scheme,))
+            raise SchemeNotSupported("Unsupported scheme, forgot http:// or ftp:// in the url: %r ?" % (uri.toBytes()))
 
 
 


### PR DESCRIPTION
treq.get('somedomain.de')

goes from:
failure: [Failure instance: Traceback: <class 'twisted.web.error.SchemeNotSupported'>: Unsupported scheme: b''

to:
failure: [Failure instance: Traceback: <class 'twisted.web.error.SchemeNotSupported'>: Unsupported scheme, forgot http:// or ftp:// in the url: b'somedomain.de' ?


reason:
the whole traceback does not point directly to the line in the users code where the error comes from, this could help make the error more abvious