### PR TITLE
Make sure to unregister the producer when timing out a HTTP connection.

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2006,7 +2006,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
 
     def timeoutConnection(self):
         log.msg("Timing out client: %s" % str(self.transport.getPeer()))
-        policies.TimeoutMixin.timeoutConnection(self)
+        self.loseConnection()
 
 
     def connectionLost(self, reason):

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -3272,3 +3272,27 @@ class ChannelProductionTests(unittest.TestCase):
             self.assertEqual(responseBody, expectedResponseBody)
 
         return responseComplete.addCallback(validate)
+
+
+    def test_HTTPChannelUnregistersSelfWhenTimingOut(self):
+        """
+        L{HTTPChannel} unregisters itself when it times out a connection.
+        """
+        clock = Clock()
+        transport = StringTransport()
+        channel = http.HTTPChannel()
+
+        # Patch the channel's callLater method.
+        channel.timeOut = 100
+        channel.callLater = clock.callLater
+        channel.makeConnection(transport)
+
+        # Tick the clock forward almost to the timeout.
+        clock.advance(99)
+        self.assertIs(transport.producer, channel)
+        self.assertIs(transport.streaming, True)
+
+        # Fire the timeout.
+        clock.advance(1)
+        self.assertIs(transport.producer, None)
+        self.assertIs(transport.streaming, None)

--- a/src/twisted/web/topfiles/8992.bugfix
+++ b/src/twisted/web/topfiles/8992.bugfix
@@ -1,1 +1,1 @@
-twisted.web's HTTP server no longer leaks file descriptors when timing out inactive clients using TLS connections.
+twisted.web.http.HTTPChannel is less likely to leak file descriptors when timing out clients using HTTPS connections. In some cases it is still possible to leak a file descriptor when timing out HTTP clients: further patches will address this issue.

--- a/src/twisted/web/topfiles/8992.bugfix
+++ b/src/twisted/web/topfiles/8992.bugfix
@@ -1,0 +1,1 @@
+twisted.web's HTTP server no longer leaks file descriptors when timing out inactive clients using TLS connections.


### PR DESCRIPTION
Resolves [Twisted issue 8992](https://twistedmatrix.com/trac/ticket/8992).