### PR TITLE
collectWarning: supports arbitrary warning arguments

### DIFF
--- a/src/twisted/topfiles/9005.bugfix
+++ b/src/twisted/topfiles/9005.bugfix
@@ -1,0 +1,1 @@
+Fix crash when using SynchronousTestCase with Warning object which does not store a string as its first argument (like libmysqlclient).

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -166,7 +166,7 @@ def _collectWarnings(observeWarning, f, *args, **kwargs):
     def showWarning(message, category, filename, lineno, file=None, line=None):
         assert isinstance(message, Warning)
         observeWarning(_Warning(
-                message.args[0], category, filename, lineno))
+                str(message), category, filename, lineno))
 
     # Disable the per-module cache for every module otherwise if the warning
     # which the caller is expecting us to collect was already emitted it won't

--- a/src/twisted/trial/test/test_warning.py
+++ b/src/twisted/trial/test/test_warning.py
@@ -376,11 +376,13 @@ class CollectWarningsTests(SynchronousTestCase):
         """
         firstMessage = "dummy calls observer warning"
         secondMessage = firstMessage[::-1]
+        thirdMessage = Warning(1, 2, 3)
         events = []
         def f():
             events.append('call')
             warnings.warn(firstMessage)
             warnings.warn(secondMessage)
+            warnings.warn(thirdMessage)
             events.append('returning')
 
         _collectWarnings(events.append, f)
@@ -388,8 +390,9 @@ class CollectWarningsTests(SynchronousTestCase):
         self.assertEqual(events[0], 'call')
         self.assertEqual(events[1].message, firstMessage)
         self.assertEqual(events[2].message, secondMessage)
-        self.assertEqual(events[3], 'returning')
-        self.assertEqual(len(events), 4)
+        self.assertEqual(events[3].message, str(thirdMessage))
+        self.assertEqual(events[4], 'returning')
+        self.assertEqual(len(events), 5)
 
 
     def test_suppresses(self):


### PR DESCRIPTION
mysqlclient library warnings that comes from the server have integer as their
first argument

See:
https://github.com/twisted/twisted/pull/688


