### PR TITLE
limit the globalLogBeginner buffer to dramatically less than 65k

### DIFF
--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -23,6 +23,8 @@ from ._io import LoggingFile
 from ._file import FileLogObserver
 
 
+_INITIAL_BUFFER_MAX = 256
+
 
 MORE_THAN_ONCE_WARNING = (
     "Warning: primary log target selected twice at <{fileNow}:{lineNow}> - "
@@ -74,7 +76,7 @@ class LogBeginner(object):
     """
 
     def __init__(self, publisher, errorStream, stdio, warningsModule):
-        self._initialBuffer = LimitedHistoryLogObserver()
+        self._initialBuffer = LimitedHistoryLogObserver(_INITIAL_BUFFER_MAX)
         self._publisher = publisher
         self._log = Logger(observer=publisher)
         self._stdio = stdio

--- a/src/twisted/topfiles/9020.bugfix
+++ b/src/twisted/topfiles/9020.bugfix
@@ -1,0 +1,3 @@
+reduce the globalLogBeginner replay buffer to dramatically less than
+65k to reduce memory usage in the case that beginLoggingTo was not
+called.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9020