### PR TITLE
inlinecallbacks: pass deferred on to next callback

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1355,6 +1355,7 @@ def _inlineCallbacks(result, g, deferred):
                     waiting[1] = r
                 else:
                     _inlineCallbacks(r, g, deferred)
+                return r
 
             result.addBoth(gotResult)
             if waiting[0]:


### PR DESCRIPTION
fix problem where the callback added by inlineCallbacks would not return
its argument, so callbacks next in the chain would not work anymore