### PR TITLE
[WIP] Tweak transfer decoder setup to allow easy extensiblity.

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -2889,3 +2889,32 @@ class IStreamClientEndpointStringParserWithReactor(Interface):
         @return: a client endpoint
         @rtype: a provider of L{IStreamClientEndpoint}
         """
+
+
+class ITransferDecoder(Interface):
+
+    contentLength = Attribute("")
+
+    def setContentLength(self, contentLength):
+        pass
+
+    def dataReceived(self, data):
+        """
+        Interpret the next chunk of bytes received.  Either deliver them to the
+        data callback or invoke the finish callback if enough bytes have been
+        received.
+
+        @return: L{None}
+        """
+
+    def noMoreData(self):
+        """
+        All data which will be delivered to this decoder has been.  Check to
+        make sure as much data as was expected has been received.
+
+        @raise PotentialDataLoss: If the content length is unknown.
+        @raise _DataLoss: If the content length is known and fewer than that
+            many bytes have been delivered.
+
+        @return: L{None}
+        """

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -935,7 +935,8 @@ class IdentityTransferEncodingTests(TestCase):
         self.finish = []
         self.contentLength = 10
         self.decoder = _IdentityTransferDecoder(
-            self.contentLength, self.data.append, self.finish.append)
+            self.data.append, self.finish.append)
+        self.decoder.setContentLength(self.contentLength)
 
 
     def test_exactAmountReceived(self):
@@ -989,7 +990,8 @@ class IdentityTransferEncodingTests(TestCase):
                 decoder.dataReceived(b'foo')
             except:
                 failures.append(Failure())
-        decoder = _IdentityTransferDecoder(5, self.data.append, finish)
+        decoder = _IdentityTransferDecoder(self.data.append, finish)
+        decoder.setContentLength(5)
         decoder.dataReceived(b'x' * 4)
         self.assertEqual(failures, [])
         decoder.dataReceived(b'y')
@@ -1007,7 +1009,7 @@ class IdentityTransferEncodingTests(TestCase):
         """
         data = []
         finish = []
-        decoder = _IdentityTransferDecoder(None, data.append, finish.append)
+        decoder = _IdentityTransferDecoder(data.append, finish.append)
         decoder.dataReceived(b'x')
         self.assertEqual(data, [b'x'])
         decoder.dataReceived(b'y')
@@ -1043,7 +1045,7 @@ class IdentityTransferEncodingTests(TestCase):
         """
         body = []
         finished = []
-        decoder = _IdentityTransferDecoder(None, body.append, finished.append)
+        decoder = _IdentityTransferDecoder(body.append, finished.append)
         self.assertRaises(PotentialDataLoss, decoder.noMoreData)
         self.assertEqual(body, [])
         self.assertEqual(finished, [b''])


### PR DESCRIPTION
This allows to customize transfer decoders.

One use case is to handle HTTP connection data loss gracefully without
dropping the response.