### PR TITLE
Fix exceptions.AttributeError: 'str' object has no attribute 'path'

### DIFF
--- a/src/twisted/conch/topfiles/9056.bugfix
+++ b/src/twisted/conch/topfiles/9056.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.unix.SFTPServerForUnixConchUser._absPath() use home instead home.path

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -371,7 +371,7 @@ class SFTPServerForUnixConchUser:
 
     def _absPath(self, path):
         home = self.avatar.getHomeDir()
-        return os.path.join(nativeString(home.path), nativeString(path))
+        return os.path.join(nativeString(home), nativeString(path))
 
 
     def gotVersion(self, otherVersion, extData):

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -16,7 +16,6 @@ import time
 import tty
 
 from zope.interface import implementer
-from types import StringTypes
 
 from twisted.conch import ttymodes
 from twisted.conch.avatar import ConchUser
@@ -77,7 +76,7 @@ class UnixConchUser(ConchUser):
 
 
     def getHomeDir(self):
-        return self.pwdData[5]
+        return FilePath(self.pwdData[5])
 
 
     def getShell(self):
@@ -372,11 +371,8 @@ class SFTPServerForUnixConchUser:
 
 
     def _absPath(self, path):
-        home = FilePath(self.avatar.getHomeDir())
-        if isinstance(home, StringTypes):
-            return os.path.join(nativeString(home), nativeString(path))
-        else:
-            return os.path.join(nativeString(home.path), nativeString(path))
+        home = self.avatar.getHomeDir()
+        return os.path.join(nativeString(home.path), nativeString(path))
 
 
 

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -372,7 +372,11 @@ class SFTPServerForUnixConchUser:
 
     def _absPath(self, path):
         home = FilePath(self.avatar.getHomeDir())
-        return os.path.join(nativeString(home.path), nativeString(path))
+        if isinstance(home, str):
+            return os.path.join(nativeString(home), nativeString(path))
+        elif isinstance(home, FilePath):
+            return os.path.join(nativeString(home.path), nativeString(path))
+
 
 
     def gotVersion(self, otherVersion, extData):

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -16,6 +16,7 @@ import time
 import tty
 
 from zope.interface import implementer
+from types import StringTypes
 
 from twisted.conch import ttymodes
 from twisted.conch.avatar import ConchUser
@@ -372,9 +373,9 @@ class SFTPServerForUnixConchUser:
 
     def _absPath(self, path):
         home = FilePath(self.avatar.getHomeDir())
-        if isinstance(home, str):
+        if isinstance(home, StringTypes):
             return os.path.join(nativeString(home), nativeString(path))
-        elif isinstance(home, FilePath):
+        else:
             return os.path.join(nativeString(home.path), nativeString(path))
 
 

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -30,6 +30,7 @@ from twisted.cred import portal
 from twisted.internet.error import ProcessExitedAlready
 from twisted.python import components, log
 from twisted.python.compat import nativeString
+from twisted.python.filepath import FilePath
 
 try:
     import utmp
@@ -370,8 +371,8 @@ class SFTPServerForUnixConchUser:
 
 
     def _absPath(self, path):
-        home = self.avatar.getHomeDir()
-        return os.path.join(nativeString(home), nativeString(path))
+        home = FilePath(self.avatar.getHomeDir())
+        return os.path.join(nativeString(home.path), nativeString(path))
 
 
     def gotVersion(self, otherVersion, extData):


### PR DESCRIPTION
Ticket link: https://twistedmatrix.com/trac/ticket/9056
Python version: 2.7.12
OS: Ubuntu 16.04.2 LTS
twisted: 17.1.0
When use twisted to implement SFTP server, it raises AttributeError exception due to string variable home doesn't have path attribute. 
SFTP server code as below, save as sftp.tac and run /usr/local/bin/twistd -ny sftp.tac.

```
from twisted.application import service, internet
from twisted.conch.ssh import keys
from twisted.conch.ssh.keys import Key
from twisted.conch.ssh.factory import SSHFactory
from twisted.conch.unix import UnixSSHRealm
from twisted.conch.checkers import SSHPublicKeyChecker, InMemorySSHKeyDB
from twisted.cred.credentials import IUsernamePassword
from twisted.cred.portal import Portal
from twisted.protocols import ftp

# Path to RSA SSH keys used by the server.
SERVER_RSA_PRIVATE = '/root/twisted/ssh-keys/ssh_host_rsa_key'
SERVER_RSA_PUBLIC = '/root/twisted/ssh-keys/ssh_host_rsa_key.pub'

# Path to RSA SSH keys accepted by the server.
CLIENT_RSA_PUBLIC = '/root/twisted/ssh-keys/client_rsa.pub'

with open(SERVER_RSA_PRIVATE) as privateBlobFile:
    privateBlob = privateBlobFile.read()
    privateKey = Key.fromString(data=privateBlob)

with open(SERVER_RSA_PUBLIC) as publicBlobFile:
    publicBlob = publicBlobFile.read()
    publicKey = Key.fromString(data=publicBlob)


def makeService():
    factory = SSHFactory()
    factory.privateKeys = {'ssh-rsa': privateKey}
    factory.publicKeys = {'ssh-rsa': publicKey}
    factory.portal = Portal(UnixSSHRealm())
    sshDB = SSHPublicKeyChecker(InMemorySSHKeyDB(
                {b'root': [keys.Key.fromFile(CLIENT_RSA_PUBLIC)]}))
    factory.portal.registerChecker(sshDB)

    return internet.TCPServer(2200, factory)


application = service.Application("sftp server")
sftp_server = makeService()
sftp_server.setServiceParent(application)
```

