### PR TITLE
[#9064] Added Support for HTTP multiple same content-length headers

### DIFF
--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -507,7 +507,7 @@ class HTTPClientParser(HTTPParser):
                     b'content-length')
                 if contentLengthHeaders is None:
                     contentLength = None
-                elif len(contentLengthHeaders) == 1:
+                elif len(set(contentLengthHeaders)) == 1:
                     contentLength = int(contentLengthHeaders[0])
                     self.response.length = contentLength
                 else:


### PR DESCRIPTION
Added Support for HTTP multiple same content-length headers.

[RFC7230#section-3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2):
>    If a message is received that has multiple Content-Length header
>    fields with field-values consisting of the same decimal value, or a
>    single Content-Length header field with a field value containing a
>    list of identical decimal values (e.g., "Content-Length: 42, 42"),
>    indicating that duplicate Content-Length header fields have been
>    generated or combined by an upstream message processor, then the
>    recipient MUST either reject the message as invalid or replace the
>    duplicated field-values with a single valid Content-Length field
>    containing that decimal value prior to determining the message body
>    length or forwarding the message.

https://twistedmatrix.com/trac/ticket/9064