### PR TITLE
Use twistedchecker 0.7.1 and run under Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ matrix:
       env: TOXENV=pyflakes3
     # Twistedchecker is running as a separate job so that we can ignore if it
     # fails.
-    - python: 2.7
+    - python: 3.5
       env: TOXENV=txchecker-travis-required
-    - python: 2.7
+    - python: 3.5
       env: TOXENV=txchecker-travis-all
   allow_failures:
     - env: TOXENV=txchecker-travis-all

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ deps =
     pyflakes{,3}: pyflakes
     manifest-checker: check-manifest
 
-    {twistedchecker,txchecker-travis}: twistedchecker>=0.6.0
+    {twistedchecker,txchecker-travis}: twistedchecker>=0.7.1
     txchecker-travis: diff_cover
 
 ; All environment variables are passed.
@@ -125,7 +125,7 @@ commands =
     manifest-checker: check-manifest --ignore "docs/_build*,docs/historic/*,admin*,bin/admin*,twisted/topfiles/*.Old"
 
 [testenv:twistedchecker]
-basepython=python2.7
+basepython=python3.5
 [testenv:pyflakes]
 basepython=python2.7
 [testenv:pyflakes3]
@@ -137,6 +137,8 @@ basepython=python2.7
 [testenv:manifest-checker]
 basepython=python2.7
 [testenv:txchecker-travis-required]
+basepython=python3.5
 usedevelop=True
 [testenv:txchecker-travis-all]
+basepython=python3.5
 usedevelop=True


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9074

Using twistedchecker and pylint under Python 3 is becoming increasingly important,
now that Python 3 only constructs are starting to go into Twisted, such as *await*.