### PR TITLE
[#9090] Remove deprecated parameters on h2.H2Connection

### DIFF
--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -25,6 +25,7 @@ from collections import deque
 from zope.interface import implementer
 
 import priority
+import h2.config
 import h2.connection
 import h2.errors
 import h2.events
@@ -122,9 +123,10 @@ class H2Connection(Protocol, TimeoutMixin):
     _abortingCall = None
 
     def __init__(self, reactor=None):
-        self.conn = h2.connection.H2Connection(
+        config = h2.config.H2Configuration(
             client_side=False, header_encoding=None
         )
+        self.conn = h2.connection.H2Connection(config=config)
         self.streams = {}
 
         self.priority = priority.PriorityTree()


### PR DESCRIPTION
Using explicit `client_side` and `header_encoding` parameters on
`H2Connection` was deprecated in h2 2.5.0, and is being removed
entirely in h2 3.0.  Switch to the new behaviour, which is using
an `H2Configuration` instance.

https://twistedmatrix.com/trac/ticket/9090#ticket