### PR TITLE
[9101] tcp: adding support for SO_REUSEPORT

### DIFF
--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -451,7 +451,7 @@ class _TCPServerEndpoint(object):
     A TCP server endpoint interface
     """
 
-    def __init__(self, reactor, port, backlog, interface):
+    def __init__(self, reactor, port, backlog, interface, listenMultiple):
         """
         @param reactor: An L{IReactorTCP} provider.
 
@@ -463,11 +463,15 @@ class _TCPServerEndpoint(object):
 
         @param interface: The hostname to bind to
         @type interface: str
+
+        @param listenMultiple: allow multiple processes to listen to the same port
+        @type listenMultiple: bool
         """
         self._reactor = reactor
         self._port = port
         self._backlog = backlog
         self._interface = interface
+        self._listenMultiple = listenMultiple
 
 
     def listen(self, protocolFactory):
@@ -479,7 +483,8 @@ class _TCPServerEndpoint(object):
                              self._port,
                              protocolFactory,
                              backlog=self._backlog,
-                             interface=self._interface)
+                             interface=self._interface,
+                             listenMultiple=self._listenMultiple)
 
 
 
@@ -487,7 +492,7 @@ class TCP4ServerEndpoint(_TCPServerEndpoint):
     """
     Implements TCP server endpoint with an IPv4 configuration
     """
-    def __init__(self, reactor, port, backlog=50, interface=''):
+    def __init__(self, reactor, port, backlog=50, interface='', listenMultiple=False):
         """
         @param reactor: An L{IReactorTCP} provider.
 
@@ -499,8 +504,12 @@ class TCP4ServerEndpoint(_TCPServerEndpoint):
 
         @param interface: The hostname to bind to, defaults to '' (all)
         @type interface: str
+
+        @param listenMultiple: allow multiple processes to listen to the same port
+        @type listenMultiple: bool
         """
-        _TCPServerEndpoint.__init__(self, reactor, port, backlog, interface)
+        _TCPServerEndpoint.__init__(self, reactor, port, backlog, interface,
+                listenMultiple)
 
 
 
@@ -508,7 +517,8 @@ class TCP6ServerEndpoint(_TCPServerEndpoint):
     """
     Implements TCP server endpoint with an IPv6 configuration
     """
-    def __init__(self, reactor, port, backlog=50, interface='::'):
+    def __init__(self, reactor, port, backlog=50, interface='::',
+            listenMultiple=False):
         """
         @param reactor: An L{IReactorTCP} provider.
 
@@ -520,8 +530,12 @@ class TCP6ServerEndpoint(_TCPServerEndpoint):
 
         @param interface: The hostname to bind to, defaults to C{::} (all)
         @type interface: str
+
+        @param listenMultiple: allow multiple processes to listen to the same port
+        @type listenMultiple: bool
         """
-        _TCPServerEndpoint.__init__(self, reactor, port, backlog, interface)
+        _TCPServerEndpoint.__init__(self, reactor, port, backlog, interface,
+                listenMultiple)
 
 
 

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -910,7 +910,7 @@ class SSL4ServerEndpoint(object):
     """
 
     def __init__(self, reactor, port, sslContextFactory,
-                 backlog=50, interface=''):
+                 backlog=50, interface='', listenMultiple=False):
         """
         @param reactor: An L{IReactorSSL} provider.
 
@@ -931,6 +931,7 @@ class SSL4ServerEndpoint(object):
         self._sslContextFactory = sslContextFactory
         self._backlog = backlog
         self._interface = interface
+        self._listenMultiple = listenMultiple
 
 
     def listen(self, protocolFactory):
@@ -942,7 +943,8 @@ class SSL4ServerEndpoint(object):
                              protocolFactory,
                              contextFactory=self._sslContextFactory,
                              backlog=self._backlog,
-                             interface=self._interface)
+                             interface=self._interface,
+                             listenMultiple=self._listenMultiple)
 
 
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -728,7 +728,7 @@ class IResolver(IResolverSimple):
 
 class IReactorTCP(Interface):
 
-    def listenTCP(port, factory, backlog=50, interface=''):
+    def listenTCP(port, factory, backlog=50, interface='', listenMultiple=False):
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
 
@@ -741,6 +741,8 @@ class IReactorTCP(Interface):
         @param interface: The local IPv4 or IPv6 address to which to bind;
             defaults to '', ie all IPv4 addresses.  To bind to all IPv4 and IPv6
             addresses, you must call this method twice.
+
+        @param listenMultiple: listen to the same port using different processes
 
         @return: an object that provides L{IListeningPort}.
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -800,7 +800,8 @@ class IReactorSSL(Interface):
         @return: An object which provides L{IConnector}.
         """
 
-    def listenSSL(port, factory, contextFactory, backlog=50, interface=''):
+    def listenSSL(port, factory, contextFactory, backlog=50, interface='',
+            listenMultiple=False):
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
         The connection is a SSL one, using contexts created by the context
@@ -815,6 +816,8 @@ class IReactorSSL(Interface):
         @param backlog: size of the listen queue
 
         @param interface: the hostname to bind to, defaults to '' (all)
+
+        @param listenMultiple: listen to the same port with different processes
         """
 
 

--- a/src/twisted/internet/iocpreactor/reactor.py
+++ b/src/twisted/internet/iocpreactor/reactor.py
@@ -169,14 +169,15 @@ class IOCPReactor(base._SignalReactorMixin, base.ReactorBase,
 
 
     if TLSMemoryBIOFactory is not None:
-        def listenSSL(self, port, factory, contextFactory, backlog=50, interface=''):
+        def listenSSL(self, port, factory, contextFactory, backlog=50, interface='',
+                multiListen=False):
             """
             @see: twisted.internet.interfaces.IReactorSSL.listenSSL
             """
             port = self.listenTCP(
                 port,
                 TLSMemoryBIOFactory(contextFactory, False, factory),
-                backlog, interface)
+                backlog, interface, multiListen)
             port._type = 'TLS'
             return port
 
@@ -190,7 +191,8 @@ class IOCPReactor(base._SignalReactorMixin, base.ReactorBase,
                 TLSMemoryBIOFactory(contextFactory, True, factory),
                 timeout, bindAddress)
     else:
-        def listenSSL(self, port, factory, contextFactory, backlog=50, interface=''):
+        def listenSSL(self, port, factory, contextFactory, backlog=50, interface='',
+                multiListen=False):
             """
             Non-implementation of L{IReactorSSL.listenSSL}.  Some dependency
             is not satisfied.  This implementation always raises

--- a/src/twisted/internet/iocpreactor/reactor.py
+++ b/src/twisted/internet/iocpreactor/reactor.py
@@ -149,11 +149,12 @@ class IOCPReactor(base._SignalReactorMixin, base.ReactorBase,
         return skt
 
 
-    def listenTCP(self, port, factory, backlog=50, interface=''):
+    def listenTCP(self, port, factory, backlog=50, interface='',
+            multiListen=False):
         """
         @see: twisted.internet.interfaces.IReactorTCP.listenTCP
         """
-        p = tcp.Port(port, factory, backlog, interface, self)
+        p = tcp.Port(port, factory, backlog, interface, self, multiListen)
         p.startListening()
         return p
 

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -500,15 +500,18 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin,
 
 
 
-    def listenSSL(self, port, factory, contextFactory, backlog=50, interface=''):
+    def listenSSL(self, port, factory, contextFactory, backlog=50, interface='',
+            listenMultiple=False):
         if tls is not None:
             tlsFactory = tls.TLSMemoryBIOFactory(contextFactory, False, factory)
-            port = self.listenTCP(port, tlsFactory, backlog, interface)
+            port = self.listenTCP(port, tlsFactory, backlog, interface,
+                    listenMultiple)
             port._type = 'TLS'
             return port
         elif ssl is not None:
             p = ssl.Port(
-                port, factory, contextFactory, backlog, interface, self)
+                port, factory, contextFactory, backlog, interface, self,
+                listenMultiple)
             p.startListening()
             return p
         else:

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -473,8 +473,9 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin,
 
     # IReactorTCP
 
-    def listenTCP(self, port, factory, backlog=50, interface=''):
-        p = tcp.Port(port, factory, backlog, interface, self)
+    def listenTCP(self, port, factory, backlog=50, interface='',
+            listenMultiple=False):
+        p = tcp.Port(port, factory, backlog, interface, self, listenMultiple)
         p.startListening()
         return p
 

--- a/src/twisted/internet/ssl.py
+++ b/src/twisted/internet/ssl.py
@@ -198,8 +198,10 @@ class Port(tcp.Port):
 
     _type = 'TLS'
 
-    def __init__(self, port, factory, ctxFactory, backlog=50, interface='', reactor=None):
-        tcp.Port.__init__(self, port, factory, backlog, interface, reactor)
+    def __init__(self, port, factory, ctxFactory, backlog=50, interface='', reactor=None,
+            listenMultiple=False):
+        tcp.Port.__init__(self, port, factory, backlog, interface, reactor,
+                listenMultiple)
         self.ctxFactory = ctxFactory
 
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -899,6 +899,7 @@ class Port(base.BasePort, _SocketCloser):
     sessionno = 0
     interface = ''
     backlog = 50
+    listenMultiple = False
 
     _type = 'TCP'
 
@@ -913,7 +914,8 @@ class Port(base.BasePort, _SocketCloser):
     addressFamily = socket.AF_INET
     _addressType = address.IPv4Address
 
-    def __init__(self, port, factory, backlog=50, interface='', reactor=None):
+    def __init__(self, port, factory, backlog=50, interface='', reactor=None,
+            listenMultiple=False):
         """Initialize with a numeric port to listen on.
         """
         base.BasePort.__init__(self, reactor=reactor)
@@ -924,6 +926,7 @@ class Port(base.BasePort, _SocketCloser):
             self.addressFamily = socket.AF_INET6
             self._addressType = address.IPv6Address
         self.interface = interface
+        self.listenMultiple = listenMultiple
 
 
     @classmethod
@@ -961,6 +964,8 @@ class Port(base.BasePort, _SocketCloser):
         s = base.BasePort.createInternetSocket(self)
         if platformType == "posix" and sys.platform != "cygwin":
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if self.listenMultiple and hasattr(socket, "SO_REUSEPORT"):
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         return s
 
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -1376,7 +1376,8 @@ class TCP4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                                              **listenArgs),
                 (address.port, factory,
                  listenArgs.get('backlog', 50),
-                 listenArgs.get('interface', '')),
+                 listenArgs.get('interface', ''),
+                 listenArgs.get('listenMultiple', False)),
                 address)
 
 
@@ -1485,7 +1486,8 @@ class TCP6EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                                              **listenArgs),
                 (address.port, factory,
                  listenArgs.get('backlog', 50),
-                 interface),
+                 interface,
+                 listenArgs.get('listenMultiple', False)),
                 address)
 
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2315,7 +2315,8 @@ class SSL4EndpointsTests(EndpointTestCaseMixin,
                                              **listenArgs),
                 (address.port, factory, self.serverSSLContext,
                  listenArgs.get('backlog', 50),
-                 listenArgs.get('interface', '')),
+                 listenArgs.get('interface', ''),
+                 listenArgs.get('listenMultiple', False)),
                 address)
 
 

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -466,7 +466,7 @@ def _factoriesShouldConnect(clientInfo, serverInfo):
     (clientHost, clientPort, clientFactory, clientTimeout,
      clientBindAddress) = clientInfo
     (serverPort, serverFactory, serverBacklog,
-     serverInterface) = serverInfo
+     serverInterface, listenMultiple) = serverInfo
     if serverPort == clientPort:
         return clientFactory, serverFactory
     else:

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -657,13 +657,13 @@ class MemoryReactor(object):
 
 
     def listenSSL(self, port, factory, contextFactory,
-                  backlog=50, interface=''):
+                  backlog=50, interface='', listenMultiple=False):
         """
         Fake L{IReactorSSL.listenSSL}, that logs the call and
         returns an L{IListeningPort}.
         """
         self.sslServers.append((port, factory, contextFactory,
-                                backlog, interface))
+                                backlog, interface, listenMultiple))
         return _FakePort(IPv4Address('TCP', '0.0.0.0', port))
 
 
@@ -816,7 +816,7 @@ class RaisingMemoryReactor(object):
 
 
     def listenSSL(self, port, factory, contextFactory,
-                  backlog=50, interface=''):
+                  backlog=50, interface='', listenMultiple=False):
         """
         Fake L{IReactorSSL.listenSSL}, that raises L{_listenException}.
         """

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -626,12 +626,14 @@ class MemoryReactor(object):
         return _FakePort(addr)
 
 
-    def listenTCP(self, port, factory, backlog=50, interface=''):
+    def listenTCP(self, port, factory, backlog=50, interface='',
+            listenMultiple=False):
         """
         Fake L{IReactorTCP.listenTCP}, that logs the call and
         returns an L{IListeningPort}.
         """
-        self.tcpServers.append((port, factory, backlog, interface))
+        self.tcpServers.append((port, factory, backlog, interface,
+            listenMultiple))
         if isIPv6Address(interface):
             address = IPv6Address('TCP', interface, port)
         else:
@@ -798,7 +800,8 @@ class RaisingMemoryReactor(object):
         raise self._listenException
 
 
-    def listenTCP(self, port, factory, backlog=50, interface=''):
+    def listenTCP(self, port, factory, backlog=50, interface='',
+            listenMultiple=False):
         """
         Fake L{IReactorTCP.listenTCP}, that raises L{_listenException}.
         """

--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -721,7 +721,6 @@ class ClientContextFactoryTests(unittest.TestCase):
         self.assertFalse(self.context._options & SSL.OP_NO_TLSv1)
 
 
-
 if interfaces.IReactorSSL(reactor, None) is None:
     for tCase in [StolenTCPTests, TLSTests, SpammyTLSTests,
                   BufferingTests, ConnectionLostTests,

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -184,6 +184,21 @@ class ListeningTests(unittest.TestCase):
         self.addCleanup(p1.stopListening)
         self.assertTrue(interfaces.IListeningPort.providedBy(p1))
 
+    def test_multiListen(self):
+        """
+        Test that multiple sockets can listen on the same port
+        """
+        if not hasattr(socket, "SO_REUSEPORT"):
+            raise unittest.SkipTest('SO_REUSEPORT not supported')
+        f = MyServerFactory()
+        p1 = reactor.listenTCP(0, f, interface="127.0.0.1", listenMultiple=True)
+        self.addCleanup(p1.stopListening)
+        p2 = reactor.listenTCP(p1._realPortNumber, f, interface="127.0.0.1",
+                listenMultiple=True)
+        self.addCleanup(p2.stopListening)
+        self.assertTrue(interfaces.IListeningPort.providedBy(p1))
+        self.assertTrue(interfaces.IListeningPort.providedBy(p2))
+        self.assertEqual(p1._realPortNumber, p2._realPortNumber)
 
     def testStopListening(self):
         """

--- a/src/twisted/topfiles/9101.feature
+++ b/src/twisted/topfiles/9101.feature
@@ -1,0 +1,1 @@
+twisted.internet.tcp.Port now supports multiListen option to allow multiple process to listen to the same port


### PR DESCRIPTION
this makes it possible to listen to the same tcp port using different
processes under linux >= v3.9