### PR TITLE
Bugfix: logger crash when formatting exception with non ascii character

### DIFF
--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -284,6 +284,4 @@ def formatWithCall(formatString, mapping):
     @return: The string with formatted values interpolated.
     @rtype: L{unicode}
     """
-    return unicode(
-        aFormatter.vformat(formatString, (), CallMapping(mapping))
-    )
+    return aFormatter.vformat(formatString, (), CallMapping(mapping)).decode('utf8')


### PR DESCRIPTION
Hi,

I use Twisted HTTP server with new logging system.
I have an edge case that crash that logger.

When I process an HTTP request (e.g. in a `Resource.getChild` method), If for some reason an exception is raised, that exception will be log by the Twisted logging system. 
But if that exception contains byte strings with non ASCII data, like `raise Exception(b"é")`, this cryptic error occurs :

```
2017-04-07T12:57:46+0200 [twisted.logger._observer#critical] Temporarily disabling observer <twisted.logger._file.FileLogObserver object at 0x7f805c1cc350> due to exception: [Failure instance: Traceback: <type 'exceptions.UnicodeDecodeError'>: 'ascii' codec can't decode byte 0xc3 in position 304: ordinal not in range(128)
        /usr/local/lib/python2.7/dist-packages/twisted/python/log.py:134:err
        /usr/local/lib/python2.7/dist-packages/twisted/python/threadable.py:53:sync
        /usr/local/lib/python2.7/dist-packages/twisted/python/log.py:286:msg
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_legacy.py:154:publishToNewObserver
        --- <exception caught here> ---
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_observer.py:131:__call__
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_file.py:50:__call__
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_file.py:83:formatEvent
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py:190:formatEventAsClassicLogText
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py:57:formatEvent
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py:90:formatUnformattableEvent
        /usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py:90:<genexpr>
        ]
        Traceback (most recent call last):
          File "/usr/local/lib/python2.7/dist-packages/twisted/python/log.py", line 134, in err
            msg(failure=_stuff, why=_why, isError=1, **kw)
          File "/usr/local/lib/python2.7/dist-packages/twisted/python/threadable.py", line 53, in sync
            return function(self, *args, **kwargs)
          File "/usr/local/lib/python2.7/dist-packages/twisted/python/log.py", line 286, in msg
            _publishNew(self._publishPublisher, actualEventDict, textFromEventDict)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_legacy.py", line 154, in publishToNewObserver
            observer(eventDict)
        --- <exception caught here> ---
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_observer.py", line 131, in __call__
            observer(event)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_file.py", line 50, in __call__
            text = self.formatEvent(event)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_file.py", line 83, in formatEvent
            event, formatTime=lambda e: formatTime(e, timeFormat)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py", line 190, in formatEventAsClassicLogText
            eventText = formatEvent(event)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py", line 57, in formatEvent
            return formatUnformattableEvent(event, e)
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py", line 90, in formatUnformattableEvent
            for key, value in event.items()
          File "/usr/local/lib/python2.7/dist-packages/twisted/logger/_format.py", line 90, in <genexpr>
            for key, value in event.items()
        exceptions.UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 304: ordinal not in range(128)
```

I finally found that was https://github.com/SamyCookie/twisted/blob/dcd8bfa6634dc5ace9013e4efdf2a8fcd4753f49/src/twisted/logger/_format.py#L287 that is in fact failing with the `unicode` conversion.
Then, after that fail,  the logger system try to log with call of the `formatUnformattableEvent` method, which fails too...
With the proposed patch, everything seems to work fine, even if I don't know really why.

Python version : 2.7 with _future__.unicode_literals
Twisted version : 17.01

PS : sorry for my bad english