### PR TITLE
Re-adding in the RFC 5656 recommended curves and DH-Group1.  

### DIFF
--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -132,7 +132,7 @@ class _DHGroup14SHA1(object):
     (2048-bit MODP Group). Defined in RFC 4253, 8.2.
     """
 
-    preference = 7
+    preference = 6
     hashProcessor = sha1
     # Diffie-Hellman primes from Oakley Group 14 (RFC 3526, 3).
     prime = long('32317006071311007300338913926423828248817941241140239112842'
@@ -149,14 +149,42 @@ class _DHGroup14SHA1(object):
 
 
 
+@implementer(_IFixedGroupKexAlgorithm)
+class _DHGroup1SHA1(object):
+    """
+    Diffie-Hellman key exchange with SHA-1 as HASH, and Oakley Group 2
+    (1024-bit MODP Group). Defined in RFC 4253, 8.1.
+    """
+
+    preference = 7
+    hashProcessor = sha1
+    # Diffie-Hellman primes from Oakley Group 2 (RFC 2409, 6.2).
+    prime = long('17976931348623159077083915679378745319786029604875601170644'
+        '44236841971802161585193689478337958649255415021805654859805036464405'
+        '48199239100050792877003355816639229553136239076508735759914822574862'
+        '57500742530207744771258955095793777842444242661733472762929938766870'
+        '9205606050270810842907692932019128194467627007')
+    generator = 2
+
+
+
 # Which ECDH hash function to use is dependent on the size.
 _kexAlgorithms = {
     b"diffie-hellman-group-exchange-sha256": _DHGroupExchangeSHA256(),
     b"diffie-hellman-group-exchange-sha1": _DHGroupExchangeSHA1(),
+    b"diffie-hellman-group1-sha1": _DHGroup1SHA1(),
     b"diffie-hellman-group14-sha1": _DHGroup14SHA1(),
     b"ecdh-sha2-nistp256": _ECDH256(),
     b"ecdh-sha2-nistp384": _ECDH384(),
     b"ecdh-sha2-nistp521": _ECDH512(),
+    b"ecdh-sha2-nistk163": _ECDH256(),
+    b"ecdh-sha2-nistp224": _ECDH256(),
+    b"ecdh-sha2-nistk233": _ECDH256(),
+    b"ecdh-sha2-nistb233": _ECDH256(),
+    b"ecdh-sha2-nistk283": _ECDH384(),
+    b"ecdh-sha2-nistk409": _ECDH384(),
+    b"ecdh-sha2-nistb409": _ECDH384(),
+    b"ecdh-sha2-nistt571": _ECDH512()
     }
 
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -54,12 +54,30 @@ _curveTable = {
     b'ecdsa-sha2-nistp256': ec.SECP256R1(),
     b'ecdsa-sha2-nistp384': ec.SECP384R1(),
     b'ecdsa-sha2-nistp521': ec.SECP521R1(),
+    b'ecdsa-sha2-nistk163': ec.SECT163K1(),
+    b'ecdsa-sha2-nistp192': ec.SECP192R1(),
+    b'ecdsa-sha2-nistp224': ec.SECP224R1(),
+    b'ecdsa-sha2-nistk233': ec.SECT233K1(),
+    b'ecdsa-sha2-nistb233': ec.SECT233R1(),
+    b'ecdsa-sha2-nistk283': ec.SECT283K1(),
+    b'ecdsa-sha2-nistk409': ec.SECT409K1(),
+    b'ecdsa-sha2-nistb409': ec.SECT409R1(),
+    b'ecdsa-sha2-nistt571': ec.SECT571K1()
 }
 
 _secToNist = {
-    b'secp256r1' : b'nistp256',
-    b'secp384r1' : b'nistp384',
-    b'secp521r1' : b'nistp521',
+    b'secp256r1': b'nistp256',
+    b'secp384r1': b'nistp384',
+    b'secp521r1': b'nistp521',
+    b'sect163k1': b'nistk163',
+    b'secp192r1': b'nistp192',
+    b'secp224r1': b'nistp224',
+    b'sect233k1': b'nistk233',
+    b'sect233r1': b'nistb233',
+    b'sect283k1': b'nistk283',
+    b'sect409k1': b'nistk409',
+    b'sect409r1': b'nistb409',
+    b'sect571k1': b'nistt571'
 }
 
 

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -631,6 +631,15 @@ class OpenSSHKeyExchangeTests(ConchServerSetupMixin, OpenSSHClientMixin,
             'ecdh-sha2-nistp521')
 
 
+    def test_DH_GROUP1(self):
+        """
+        The diffie-hellman-group1-sha1 key exchange algorithm is compatible
+        with OpenSSH.
+        """
+        return self.assertExecuteWithKexAlgorithm(
+            'diffie-hellman-group1-sha1')
+
+
     def test_DH_GROUP14(self):
         """
         The diffie-hellman-group14-sha1 key exchange algorithm is compatible

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -1294,8 +1294,8 @@ class ServerSSHTransportTests(ServerSSHTransportBaseCase, TransportTestCase):
         self.proto.dataReceived(
             b'SSH-2.0-Twisted\r\n\x00\x00\x01\xf4\x04\x14'
             b'\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99'
-            b'\x99\x00\x00\x00bdiffie-hellman-group1-sha1,diffie-hellman-g'
-            b'roup-exchange-sha1,diffie-hellman-group-exchange-sha256\x00'
+            b'\x99\x00\x00\x00bdiffie-hellman-group-exchange-sha1,diffie-he'
+            b'llman-group-exchange-sha256,diffie-hellman-group1-sha1\x00'
             b'\x00\x00\x0fssh-dss,ssh-rsa\x00\x00\x00\x85aes128-ctr,aes128-'
             b'cbc,aes192-ctr,aes192-cbc,aes256-ctr,aes256-cbc,cast128-ctr,c'
             b'ast128-cbc,blowfish-ctr,blowfish-cbc,3des-ctr,3des-cbc\x00'
@@ -1468,6 +1468,14 @@ class ServerSSHTransportTests(ServerSSHTransportBaseCase, TransportTestCase):
         self.proto.ssh_KEXINIT(kexmsg)
         self.assertRaises(AttributeError)
         self.assertRaises(UnsupportedAlgorithm)
+
+
+    def test_KEXDH_INIT_GROUP1(self):
+        """
+        KEXDH_INIT messages are processed when the
+        diffie-hellman-group1-sha1 key exchange algorithm is requested.
+        """
+        self.assertKexDHInitResponse(b'diffie-hellman-group1-sha1')
 
 
     def test_KEXDH_INIT_GROUP14(self):
@@ -1819,6 +1827,14 @@ class ClientSSHTransportTests(ClientSSHTransportBaseCase, TransportTestCase):
         KEXDH_INIT responses.
         """
         self.assertKexInitResponseForDH(b'diffie-hellman-group14-sha1')
+
+
+    def test_KEXINIT_group1(self):
+       """
+       KEXINIT messages requesting diffie-hellman-group1-sha1 result in
+       KEXDH_INIT responses.
+       """
+       self.assertKexInitResponseForDH(b'diffie-hellman-group1-sha1')
 
 
     def test_KEXINIT_badKexAlg(self):

--- a/src/twisted/topfiles/9109.bugfix
+++ b/src/twisted/topfiles/9109.bugfix
@@ -1,0 +1,1 @@
+Re-adding the elliptic curves and DH-Group1 that we removed.


### PR DESCRIPTION
This is effectively rolling back #748 and #749.

I think removing these curves is a bad idea.  The curves worked, and in the case of nistt571, provided stronger encryption that is available now.  Plus the removed curves are the ones recommended by [RFC 5656](https://tools.ietf.org/html/rfc5656#page-17).  Re-enabling support these curves both increases security and usability.

I also think it's worth re-enabling DHGroup1.  I know this exchange has been deprecated by OpenSSH, and for good reason, but I don't think that's a good enough reason to remove it from Twisted.

DHGroup1 is still widely supported by many clients, including OpenSSH, and thus supporting it makes Twisted more compatible with those clients.  And there isn't a security risk in supporting DHGroup1.  It is now at the bottom of the list of supported key exchanges and so it will only ever be used if no other exchange is supported.  When this happens we either have the choice of allowing the user do what they need to do, or make them find another client because we don't like the exchange.