### PR TITLE
Prepare for OpenSSL 1.1.1: Enable TLS 1.3 ciphers

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1897,6 +1897,8 @@ class OpenSSLAcceptableCiphers(object):
 # - disable NULL authentication, MD5 MACs and DSS for security reasons.
 #
 defaultCiphers = OpenSSLAcceptableCiphers.fromOpenSSLCipherString(
+    "TLS13-AES-256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:"
+    "TLS13-AES-128-GCM-SHA256:"
     "ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:DH+CHACHA20:ECDH+AES256:DH+AES256:"
     "ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:"
     "!aNULL:!MD5:!DSS"

--- a/src/twisted/topfiles/9128.feature
+++ b/src/twisted/topfiles/9128.feature
@@ -1,0 +1,1 @@
+twisted.internet._sslverify now enables TLS 1.3 cipher suites.


### PR DESCRIPTION
TLS 1.3 does not use any of the existing cipher suites from TLS 1.2 and
earlier. A new set of cipher suites was introduced that only specify
bulk encryption, AEAD and PRF algorithms.

I expect that OpenSSL 1.1.1 will enable TLS 1.3 by default. If both
server and client have TLS version 1.3 enabled but have not configured
necessary cipher suites, handshake is going to fail.

Signed-off-by: Christian Heimes <christian@python.org>