### PR TITLE
Ensure HTTP path is of type bytes to avoid 404 errors in py3

### DIFF
--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -216,6 +216,10 @@ class Resource:
 
         @see: L{IResource.putChild}
         """
+        if not isinstance(path, bytes):
+            emsg = "HTTP paths must be of type bytes (got {0})"
+            raise TypeError(emsg.format(type(path)))
+
         self.children[path] = child
         child.server = self.server
 


### PR DESCRIPTION
Under python 3, running `Resource.putChild` with a `path` argument that is not of type `bytes` results in a 404 when visiting the link.  Note that absurd types are also silently accepted (e.g.:  `some_resource.putChild(42, some_other_resource)`.

This patch does a simple type-check and throws a `TypeError` on failure. 

Trac ticket [here](https://twistedmatrix.com/trac/ticket/9135#ticket).