### PR TITLE
Prepare for OpenSSL 1.1.1: Enable TLS 1.3 ciphers

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1897,6 +1897,8 @@ class OpenSSLAcceptableCiphers(object):
 # - disable NULL authentication, MD5 MACs and DSS for security reasons.
 #
 defaultCiphers = OpenSSLAcceptableCiphers.fromOpenSSLCipherString(
+    "TLS13-AES-256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:"
+    "TLS13-AES-128-GCM-SHA256:"
     "ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:DH+CHACHA20:ECDH+AES256:DH+AES256:"
     "ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:"
     "!aNULL:!MD5:!DSS"

--- a/src/twisted/topfiles/9128.feature
+++ b/src/twisted/topfiles/9128.feature
@@ -1,0 +1,1 @@
+twisted.internet._sslverify now enables TLS 1.3 cipher suites.

--- a/src/twisted/topfiles/9128.feature
+++ b/src/twisted/topfiles/9128.feature
@@ -1,1 +1,1 @@
-twisted.internet._sslverify now enables TLS 1.3 cipher suites.
+twisted.protocols.tls.TLSMemoryBIOProtocol and anything that uses it indirectly including the TLS client and server endpoints now enables TLS 1.3 cipher suites.


### PR DESCRIPTION
See [this issue](https://twistedmatrix.com/trac/ticket/9128). Supersedes #774.