### PR TITLE
There is no Travis macOS.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,28 +2,6 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-    curl -O https://bootstrap.pypa.io/get-pip.py
-    python get-pip.py --user
-    python -m pip install --user virtualenv
-    python -m virtualenv ~/.venv
-    source ~/.venv/bin/activate
-
-    if [[ "${TOXENV}" == "py35-alldeps-withcov-macos,codecov-publish" ]]; then
-
-        brew update;
-        brew upgrade openssl;
-        brew install pyenv;
-        PYENV_ROOT="$HOME/.pyenv";
-        PATH="$PYENV_ROOT/bin:$PATH";
-        eval "$(pyenv init -)";
-        pyenv install -s 3.5.2;
-        pyenv global system 3.5.2;
-        pyenv rehash;
-
-    fi
-fi
-
 # We need to test on machines that do not have IPv6, because this is a
 # supported configuration and we've broken our tests for this in the past.
 # See https://twistedmatrix.com/trac/ticket/9144


### PR DESCRIPTION
This script is not run on the macOS builders, so we simply don't need any of this.

GOODBYE OLD FRIEND.

See https://twistedmatrix.com/trac/ticket/9145