### PR TITLE
Make usage synopsis accurate and consistent when running twisted or twisted.trial with `python -m`

### DIFF
--- a/src/twisted/newsfragments/9133.bugfix
+++ b/src/twisted/newsfragments/9133.bugfix
@@ -1,0 +1,1 @@
+Detect when we’re being run using “-m twisted” or “-m twisted.trial” and use it to build an accurate usage message.

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -451,11 +451,13 @@ class Options(dict):
         Returns a string containing a description of these options and how to
         pass them to the executed file.
         """
+        executableName = reflect.filenameToModuleName(sys.argv[0])
 
-        default = "%s%s" % (path.basename(sys.argv[0]),
-                            (self.longOpt and " [options]") or '')
+        if executableName.endswith('.__main__'):
+            executableName = '{} -m {}'.format(os.path.basename(sys.executable), executableName.replace('.__main__', ''))
+
         if self.parent is None:
-            default = "Usage: %s%s" % (path.basename(sys.argv[0]),
+            default = "Usage: %s%s" % (executableName,
                                        (self.longOpt and " [options]") or '')
         else:
             default = '%s' % ((self.longOpt and "[options]") or '')
@@ -466,7 +468,6 @@ class Options(dict):
         if self.parent is not None:
             synopsis = ' '.join((self.parent.getSynopsis(),
                                  self.parent.subCommand, synopsis))
-
         return synopsis
 
     def getUsage(self, width=None):
@@ -866,6 +867,9 @@ def docMakeChunks(optList, width=80):
     """
 
     # XXX: sanity check to make sure we have a sane combination of keys.
+
+    # Sort the options so they always appear in the same order
+    optList.sort(key=lambda o: o.get('short', None) or o.get('long', None))
 
     maxOptLen = 0
     for opt in optList:

--- a/src/twisted/scripts/trial.py
+++ b/src/twisted/scripts/trial.py
@@ -164,9 +164,6 @@ class _BasicOptions(object):
     """
     Basic options shared between trial and its local workers.
     """
-    synopsis = """%s [options] [[file|package|module|TestCase|testmethod]...]
-    """ % (os.path.basename(sys.argv[0]),)
-
     longdesc = ("trial loads and executes a suite of unit tests, obtained "
                 "from modules, packages and files listed on the command line.")
 
@@ -215,6 +212,15 @@ class _BasicOptions(object):
         self['tests'] = []
         usage.Options.__init__(self)
 
+    def getSynopsis(self):
+        executableName = reflect.filenameToModuleName(sys.argv[0])
+
+        if executableName.endswith('.__main__'):
+            executableName = '{} -m {}'.format(os.path.basename(sys.executable),
+                                               executableName.replace('.__main__', ''))
+
+        return """%s [options] [[file|package|module|TestCase|testmethod]...]
+        """ % (executableName,)
 
     def coverdir(self):
         """

--- a/src/twisted/test/test_main.py
+++ b/src/twisted/test/test_main.py
@@ -10,6 +10,7 @@ from __future__ import division, absolute_import
 import sys
 
 from twisted.application.twist._options import TwistOptions
+from twisted.scripts import trial
 from twisted.internet import defer, reactor
 from twisted.python.compat import NativeStringIO as StringIO
 from twisted.test.test_process import Accumulator
@@ -26,11 +27,36 @@ class MainTests(TestCase):
         reactor.spawnProcess(p, cmd, [cmd, '-m', 'twisted', '--help'], env=None)
         p.transport.closeStdin()
 
+        # Fix up our sys args to match the command we issued
+        from twisted import __main__
+        self.patch(sys, 'argv', [__main__.__file__, '--help'])
+
         def processEnded(ign):
             f = p.outF
             output = f.getvalue().replace(b'\r\n', b'\n')
 
             options = TwistOptions()
+            message = '{}\n'.format(options).encode('utf-8')
+            self.assertEqual(output, message)
+        return d.addCallback(processEnded)
+
+    def test_trial(self):
+        """Invoking python -m twisted.trial should execute trial."""
+        cmd = sys.executable
+        p = Accumulator()
+        d = p.endedDeferred = defer.Deferred()
+        reactor.spawnProcess(p, cmd, [cmd, '-m', 'twisted.trial', '--help'], env=None)
+        p.transport.closeStdin()
+
+        # Fix up our sys args to match the command we issued
+        from twisted.trial import __main__
+        self.patch(sys, 'argv', [__main__.__file__, '--help'])
+
+        def processEnded(ign):
+            f = p.outF
+            output = f.getvalue().replace(b'\r\n', b'\n')
+            
+            options = trial.Options()
             message = '{}\n'.format(options).encode('utf-8')
             self.assertEqual(output, message)
         return d.addCallback(processEnded)


### PR DESCRIPTION
Sort the help argument output so the order is consistent under Python 3.x.  Detect when we’re being run using “-m twisted” or “-m twisted.trial” and use it to build an accurate usage message.  Update tests to patch sys.argv appropriately to match the output of the spawned process.