### PR TITLE
AXFR AttributeError

### DIFF
--- a/src/twisted/names/newsfragments/9174.bugfix
+++ b/src/twisted/names/newsfragments/9174.bugfix
@@ -1,0 +1,1 @@
+Failed TCP connections for AFXR queries no longer raise an AttributeError.

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -433,6 +433,15 @@ class ServerDNSTests(unittest.TestCase):
             results
         )
 
+    def test_zoneTransferConnectionFails(self):
+        """
+        A failed AXFR TCP connection errbacks the L{Deferred} returned
+        from L{Resolver.lookupZone}.
+        """
+        resolver = Resolver(servers=[("nameserver.invalid", 53)])
+        return self.assertFailure(resolver.lookupZone("impossible.invalid"),
+                                  error.DNSLookupError)
+
 
     def test_similarZonesDontInterfere(self):
         """Tests that unrelated zones don't mess with each other."""


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9174

Failed TCP connections for AXFR queries no longer raise an AttributeError.

AXFRController now has a pending list that contains a one-element
tuple Deferred returned by Resolver.lookupZone, and DNSClientFactory
only requires the first element of that tuple be a Deferred.

Note that lookupZone cannot use Resolver.queryTCP because it requires
AXFRController, and Resolver.queryTCP assumes that it can reuse an
existing connection whose controller is that Resolver instance.

See Changelog in a237ef3123b86c1a915d078f12adad63b9bfcb24.