### PR TITLE
Use serial.serialutil.to_bytes() in twisted.internet._win32serialport

### DIFF
--- a/src/twisted/internet/_win32serialport.py
+++ b/src/twisted/internet/_win32serialport.py
@@ -13,6 +13,7 @@ from __future__ import division, absolute_import
 from serial import PARITY_NONE
 from serial import STOPBITS_ONE
 from serial import EIGHTBITS
+from serial.serialutil import to_bytes
 import win32file, win32event
 
 # twisted imports
@@ -72,7 +73,7 @@ class SerialPort(BaseSerialPort, abstract.FileDescriptor):
         #get that character we set up
         n = win32file.GetOverlappedResult(self._serial.hComPort, self._overlappedRead, 0)
         if n:
-            first = str(self.read_buf[:n])
+            first = to_bytes(self.read_buf[:n])
             #now we should get everything that is already in the buffer
             flags, comstat = win32file.ClearCommError(self._serial.hComPort)
             if comstat.cbInQue:
@@ -82,7 +83,7 @@ class SerialPort(BaseSerialPort, abstract.FileDescriptor):
                                              self._overlappedRead)
                 n = win32file.GetOverlappedResult(self._serial.hComPort, self._overlappedRead, 1)
                 #handle all the received data:
-                self.protocol.dataReceived(first + str(buf[:n]))
+                self.protocol.dataReceived(first + to_bytes(buf[:n]))
             else:
                 #handle all the received data:
                 self.protocol.dataReceived(first)

--- a/src/twisted/newsfragments/9186.bugfix
+++ b/src/twisted/newsfragments/9186.bugfix
@@ -1,0 +1,1 @@
+twisted.internet._win32serialport now uses serial.serialutil.to_bytes() to provide bytes in Python 3.


### PR DESCRIPTION
In Python 3 I do not expect serial bytes to be a `str`, let alone an
`object.__repr__()` string.  Example data received looked like this.

Python 2: `<type 'str'>, "'\\x01'"`

Python 3: `<class 'str'> '<memory at 0x048285E0>'`

https://twistedmatrix.com/trac/ticket/9186

I messed up #820 and this replaces it.