### PR TITLE
Correctly fire notifyFinish with HTTP/2 errors.

### DIFF
--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -32,6 +32,7 @@ import h2.events
 import h2.exceptions
 
 from twisted.internet.defer import Deferred
+from twisted.internet.error import ConnectionLost
 from twisted.internet.interfaces import (
     IProtocol, ITransport, IConsumer, IPushProducer, ISSLTransport
 )
@@ -39,6 +40,7 @@ from twisted.internet._producer_helpers import _PullToPush
 from twisted.internet.protocol import Protocol
 from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
+from twisted.python.failure import Failure
 
 
 # This API is currently considered private.
@@ -172,7 +174,7 @@ class H2Connection(Protocol, TimeoutMixin):
             dataToSend = self.conn.data_to_send()
             self.transport.write(dataToSend)
             self.transport.loseConnection()
-            self.connectionLost("Protocol error from peer.")
+            self.connectionLost(Failure())
             return
 
         for event in events:
@@ -190,7 +192,7 @@ class H2Connection(Protocol, TimeoutMixin):
                 self._handlePriorityUpdate(event)
             elif isinstance(event, h2.events.ConnectionTerminated):
                 self.transport.loseConnection()
-                self.connectionLost("Shutdown by remote peer")
+                self.connectionLost(ConnectionLost("Remote peer sent GOAWAY"))
 
         dataToSend = self.conn.data_to_send()
         if dataToSend:
@@ -330,7 +332,7 @@ class H2Connection(Protocol, TimeoutMixin):
         This tells the L{H2Connection} that its consumer has died, so it must
         stop producing data for good.
         """
-        self.connectionLost("stopProducing")
+        self.connectionLost(ConnectionLost("Producing stopped"))
 
 
     def pauseProducing(self):
@@ -500,7 +502,9 @@ class H2Connection(Protocol, TimeoutMixin):
         @type event: L{h2.events.StreamReset}
         """
         stream = self.streams[event.stream_id]
-        stream.connectionLost("Stream reset")
+        stream.connectionLost(
+            ConnectionLost("Stream reset with code %s" % event.error_code)
+        )
         self._requestDone(event.stream_id)
 
 
@@ -788,7 +792,7 @@ class H2Connection(Protocol, TimeoutMixin):
         self.transport.write(self.conn.data_to_send())
 
         stream = self.streams[streamID]
-        stream.connectionLost("Stream reset")
+        stream.connectionLost(ConnectionLost("Invalid request"))
         self._requestDone(streamID)
 
 

--- a/src/twisted/web/newsfragments/9208.bugfix
+++ b/src/twisted/web/newsfragments/9208.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http.Request and all subclasses now correctly fire Deferreds returned from notifyFinish with errbacks when errors are encountered in HTTP/2 streams.

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -9,7 +9,10 @@ from __future__ import absolute_import, division
 
 import itertools
 
+from zope.interface import providedBy, directlyProvides
+
 from twisted.internet import defer, reactor, task, error
+from twisted.python import failure
 from twisted.python.compat import iterbytes
 from twisted.test.proto_helpers import StringTransport
 from twisted.test.test_internet import DummyProducer
@@ -17,9 +20,10 @@ from twisted.trial import unittest
 from twisted.web import http
 from twisted.web.test.test_http import (
     DummyHTTPHandler, DummyHTTPHandlerProxy,
-    DelayedHTTPHandlerProxy,
+    DelayedHTTPHandler, DelayedHTTPHandlerProxy,
     DummyPullProducerHandlerProxy,
     _makeRequestProxyFactory,
+    _IDeprecatedHTTPChannelToRequestInterfaceProxy
 )
 from twisted.internet.address import IPv4Address
 
@@ -32,6 +36,7 @@ try:
     # is compiled in. We do not use them in the main code: only in the tests.
     import h2
     import h2.errors
+    import h2.exceptions
     import hyperframe
     import priority
     from hpack.hpack import Encoder, Decoder
@@ -384,6 +389,38 @@ class DummyProducerHandler(http.Request):
 
 
 DummyProducerHandlerProxy = _makeRequestProxyFactory(DummyProducerHandler)
+
+
+
+class NotifyingRequestFactory(object):
+    """
+    A L{http.Request} factory that calls L{http.Request.notifyFinish} on all
+    L{http.Request} objects before it returns them, and squirrels the resulting
+    L{defer.Deferred} away on the class for later use. This is done as early
+    as possible to ensure that we always see the result.
+    """
+    def __init__(self, wrappedFactory):
+        self.results = []
+        self._wrappedFactory = wrappedFactory
+
+        # Add interfaces provided by the factory we are wrapping. We expect
+        # this only to be INonQueuedRequestFactory, but we don't want to
+        # hard-code that rule.
+        for interface in providedBy(self._wrappedFactory):
+            directlyProvides(self, interface)
+
+
+    def __call__(self, *args, **kwargs):
+        req = self._wrappedFactory(*args, **kwargs)
+        self.results.append(req.notifyFinish())
+        return _IDeprecatedHTTPChannelToRequestInterfaceProxy(req)
+
+
+
+NotifyingRequestFactoryProxy = _makeRequestProxyFactory(
+    NotifyingRequestFactory
+)
+
 
 
 class HTTP2TestHelpers(object):
@@ -1380,6 +1417,238 @@ class HTTP2ServerTests(unittest.TestCase, HTTP2TestHelpers):
         # response.
         cleanupCallback = connection._streamCleanupCallbacks[1]
         return defer.gatherResults([d, cleanupCallback])
+
+
+    def test_notifyOnCompleteRequest(self):
+        """
+        A request sent to a HTTP/2 connection fires the
+        L{http.Request.notifyFinish} callback with a L{None} value.
+        """
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DummyHTTPHandler)
+        _, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 1)
+
+        def validate(result):
+            self.assertIsNone(result)
+
+        d = deferreds[0]
+        d.addCallback(validate)
+
+        # We need to wait for the stream cleanup callback to drain the
+        # response.
+        cleanupCallback = connection._streamCleanupCallbacks[1]
+        return defer.gatherResults([d, cleanupCallback])
+
+
+    def test_notifyOnResetStream(self):
+        """
+        A HTTP/2 reset stream fires the L{http.Request.notifyFinish} deferred
+        with L{ConnectionLost}.
+        """
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DelayedHTTPHandler)
+        frameFactory, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 1)
+
+        # We need this to errback with a Failure indicating the RSTSTREAM
+        # frame.
+        def callback(ign):
+            self.fail("Didn't errback, called back instead")
+
+        def errback(reason):
+            self.assertIsInstance(reason, failure.Failure)
+            self.assertIs(reason.type, error.ConnectionLost)
+            return None  # Trap the error
+
+        d = deferreds[0]
+        d.addCallbacks(callback, errback)
+
+        # Now send the RSTSTREAM frame.
+        invalidData = frameFactory.buildRstStreamFrame(streamID=1).serialize()
+        connection.dataReceived(invalidData)
+
+        return d
+
+
+    def test_failWithProtocolError(self):
+        """
+        A HTTP/2 protocol error triggers the L{http.Request.notifyFinish}
+        deferred for all outstanding requests with a Failure that contains the
+        underlying exception.
+        """
+        # We need to set up two requests concurrently so that we can validate
+        # that these all fail. connectAndReceive will set up one: we will need
+        # to manually send the rest.
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DelayedHTTPHandler)
+        frameFactory, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        secondRequest = buildRequestBytes(
+            self.getRequestHeaders, [], frameFactory=frameFactory, streamID=3
+        )
+        connection.dataReceived(secondRequest)
+
+        # Now we want to grab the deferreds from the notifying factory.
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 2)
+
+        # We need these to errback with a Failure representing the
+        # ProtocolError.
+        def callback(ign):
+            self.fail("Didn't errback, called back instead")
+
+        def errback(reason):
+            self.assertIsInstance(reason, failure.Failure)
+            self.assertIsInstance(reason.value, h2.exceptions.ProtocolError)
+            return None  # Trap the error
+
+        for d in deferreds:
+            d.addCallbacks(callback, errback)
+
+        # Now trigger the protocol error. The easiest protocol error to trigger
+        # is to send a data frame for a non-existent stream.
+        invalidData = frameFactory.buildDataFrame(
+            data=b'yo', streamID=0xF0
+        ).serialize()
+        connection.dataReceived(invalidData)
+
+        return defer.gatherResults(deferreds)
+
+
+    def test_failOnGoaway(self):
+        """
+        A HTTP/2 GoAway triggers the L{http.Request.notifyFinish}
+        deferred for all outstanding requests with a Failure that contains a
+        RemoteGoAway error.
+        """
+        # We need to set up two requests concurrently so that we can validate
+        # that these all fail. connectAndReceive will set up one: we will need
+        # to manually send the rest.
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DelayedHTTPHandler)
+        frameFactory, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        secondRequest = buildRequestBytes(
+            self.getRequestHeaders, [], frameFactory=frameFactory, streamID=3
+        )
+        connection.dataReceived(secondRequest)
+
+        # Now we want to grab the deferreds from the notifying factory.
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 2)
+
+        # We need these to errback with a Failure indicating the GOAWAY frame.
+        def callback(ign):
+            self.fail("Didn't errback, called back instead")
+
+        def errback(reason):
+            self.assertIsInstance(reason, failure.Failure)
+            self.assertIs(reason.type, error.ConnectionLost)
+            return None  # Trap the error
+
+        for d in deferreds:
+            d.addCallbacks(callback, errback)
+
+        # Now send the GoAway frame.
+        invalidData = frameFactory.buildGoAwayFrame(lastStreamID=3).serialize()
+        connection.dataReceived(invalidData)
+
+        return defer.gatherResults(deferreds)
+
+
+    def test_failOnStopProducing(self):
+        """
+        The transport telling the HTTP/2 connection to stop producing will
+        fire all L{http.Request.notifyFinish} errbacks with L{error.}
+        """
+        # We need to set up two requests concurrently so that we can validate
+        # that these all fail. connectAndReceive will set up one: we will need
+        # to manually send the rest.
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DelayedHTTPHandler)
+        frameFactory, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        secondRequest = buildRequestBytes(
+            self.getRequestHeaders, [], frameFactory=frameFactory, streamID=3
+        )
+        connection.dataReceived(secondRequest)
+
+        # Now we want to grab the deferreds from the notifying factory.
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 2)
+
+        # We need these to errback with a Failure indicating the consumer
+        # aborted our data production.
+        def callback(ign):
+            self.fail("Didn't errback, called back instead")
+
+        def errback(reason):
+            self.assertIsInstance(reason, failure.Failure)
+            self.assertIs(reason.type, error.ConnectionLost)
+            return None  # Trap the error
+
+        for d in deferreds:
+            d.addCallbacks(callback, errback)
+
+        # Now call stopProducing.
+        connection.stopProducing()
+
+        return defer.gatherResults(deferreds)
+
+
+    def test_notifyOnFast400(self):
+        """
+        A HTTP/2 stream that has had _respondToBadRequestAndDisconnect called
+        on it from a request handler calls the L{http.Request.notifyFinish}
+        errback with L{ConnectionLost}.
+        """
+        connection = H2Connection()
+        connection.requestFactory = NotifyingRequestFactory(DelayedHTTPHandler)
+        frameFactory, transport = self.connectAndReceive(
+            connection, self.getRequestHeaders, []
+        )
+
+        deferreds = connection.requestFactory.results
+        self.assertEqual(len(deferreds), 1)
+
+        # We need this to errback with a Failure indicating the loss of the
+        # connection.
+        def callback(ign):
+            self.fail("Didn't errback, called back instead")
+
+        def errback(reason):
+            self.assertIsInstance(reason, failure.Failure)
+            self.assertIs(reason.type, error.ConnectionLost)
+            return None  # Trap the error
+
+        d = deferreds[0]
+        d.addCallbacks(callback, errback)
+
+        # Abort the stream. The only "natural" way to trigger this in the
+        # current codebase is to send a multipart/form-data request that the
+        # cgi module doesn't like.
+        # That's absurdly hard, so instead we'll just call it ourselves. For
+        # this reason we use the DummyProducerHandler, which doesn't write the
+        # headers straight away.
+        stream = connection.streams[1]
+        stream._respondToBadRequestAndDisconnect()
+
+        return d
 
 
 


### PR DESCRIPTION
See: https://twistedmatrix.com/trac/ticket/9208