### PR TITLE
[#9216] Fix README badge links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 Twisted 17.5.0
 ==============
 
-|pypi|
-|coverage|
-|travis|
-|appveyor|
+|pypi|_
+|coverage|_
+|travis|_
+|appveyor|_
 
 .. code::
 
@@ -108,7 +108,7 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 .. _pypi: https://pypi.python.org/pypi/twisted
 
 .. |travis| image:: https://travis-ci.org/twisted/twisted.svg?branch=trunk
-.. _travis https://travis-ci.org/twisted/twisted
+.. _travis: https://travis-ci.org/twisted/twisted
 
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/x4oyqtl9cqc2i2l8
-.. _appveyor https://ci.appveyor.com/project/adiroiban/twisted
+.. _appveyor: https://ci.appveyor.com/project/adiroiban/twisted

--- a/src/twisted/newsfragments/9216.doc
+++ b/src/twisted/newsfragments/9216.doc
@@ -1,0 +1,1 @@
+Badges at top of README now correctly render as links to respective result pages on GitHub.


### PR DESCRIPTION
Pull request for [Trac ticket 9216](https://twistedmatrix.com/trac/ticket/9216) making the badges link to their respective result pages rather than open the graphic in a new page as currently rendered on GitHub,