### PR TITLE
[#9219] Disable test_plugin.DeveloperSetupTests.test_freshPyReplacesStalePyc under PyPy2

### DIFF
--- a/src/twisted/test/test_plugin.py
+++ b/src/twisted/test/test_plugin.py
@@ -15,7 +15,7 @@ import functools
 from zope.interface import Interface
 
 from twisted.trial import unittest
-from twisted.python.compat import _PY3
+from twisted.python.compat import _PY3, _PYPY
 from twisted.python.log import textFromEventDict, addObserver, removeObserver
 from twisted.python.filepath import FilePath
 
@@ -569,6 +569,10 @@ class DeveloperSetupTests(unittest.TestCase):
         mypath.setContent(pluginFileContents('two'))
         self.failIfIn('one', self.getAllPlugins())
         self.assertIn('two', self.getAllPlugins())
+
+    if _PYPY and not _PY3:
+        test_freshPyReplacesStalePyc.skip = (
+            "PyPy2 will not normally import lone .pyc files.")
 
 
     def test_newPluginsOnReadOnlyPath(self):


### PR DESCRIPTION
The test_plugin.DeveloperSetupTests.test_freshPyReplacesStalePyc test relies on removing the initial stale.py plugin module to ensure .pyc file is being used during sanity check, this causes the import during twisted.plugin.getCache() to ERROR out under PyPy2.

This PR Disables the test under PyPy2 until a better way can be found to deal with this situation.


