### PR TITLE
Ignore PyPy's implementation differences in base object class, fix 9225

### DIFF
--- a/src/twisted/newsfragments/9225.bugfix
+++ b/src/twisted/newsfragments/9225.bugfix
@@ -1,0 +1,1 @@
+Ignore PyPy's implementation differences in base object class.

--- a/src/twisted/python/reflect.py
+++ b/src/twisted/python/reflect.py
@@ -134,7 +134,8 @@ def accumulateMethods(obj, dict, prefix='', curClass=None):
     if not curClass:
         curClass = obj.__class__
     for base in curClass.__bases__:
-        accumulateMethods(obj, dict, prefix, base)
+        if base is not object:
+            accumulateMethods(obj, dict, prefix, base)
 
     for name, method in curClass.__dict__.items():
         optName = name[len(prefix):]

--- a/src/twisted/python/reflect.py
+++ b/src/twisted/python/reflect.py
@@ -134,6 +134,12 @@ def accumulateMethods(obj, dict, prefix='', curClass=None):
     if not curClass:
         curClass = obj.__class__
     for base in curClass.__bases__:
+        # The implementation of the object class is different on PyPy vs.
+        # CPython.  This has the side effect of making accumulateMethods()
+        # pick up object methods from all new-style classes -
+        # such as __getattribute__, etc.
+        # If we ignore 'object' when accumulating methods, we can get
+        # consistent behavior on Pypy and CPython.
         if base is not object:
             accumulateMethods(obj, dict, prefix, base)
 


### PR DESCRIPTION
Fix for [#9225](https://twistedmatrix.com/trac/ticket/9225) by causing `twisted.python.reflect.accumulateMethods()` to ignore the base object class, which normally has no methods but under PyPy looks like it does due to implementation differences.

Should fix 3 tests:  
- test_reflect.AccumulateMethodTests.test_baseClass
- test_reflect.AccumulateMethodTests.test_ownClass
- test_reflect.PrefixedMethodsTests.test_onlyObject
