### PR TITLE
Properly spell 'twisted.conch.unix' when importing it with requireModule

### DIFF
--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -16,7 +16,7 @@ from zope.interface import implementer
 
 pyasn1 = requireModule('pyasn1')
 cryptography = requireModule('cryptography')
-unix = requireModule('unix')
+unix = requireModule('twisted.conch.unix')
 
 _reason = None
 if cryptography and pyasn1:


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9272

Without this fix, the tests in test_cftp.py are constantly skipping, even on Unix platforms.