### PR TITLE
docs.zope.org is dead, so use zopeinterface.readthedocs.io instead.

### DIFF
--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -34,7 +34,7 @@ intersphinxURLs = [
     u"https://twisted.github.io/incremental/docs/objects.inv",
     u"https://python-hyper.org/h2/en/stable/objects.inv",
     u"https://python-hyper.org/priority/en/stable/objects.inv",
-    u"https://docs.zope.org/zope.interface/objects.inv",
+    u"http://zopeinterface.readthedocs.io/en/latest/objects.inv",
 ]
 
 

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -34,7 +34,7 @@ intersphinxURLs = [
     u"https://twisted.github.io/incremental/docs/objects.inv",
     u"https://python-hyper.org/h2/en/stable/objects.inv",
     u"https://python-hyper.org/priority/en/stable/objects.inv",
-    u"http://zopeinterface.readthedocs.io/en/latest/objects.inv",
+    u"https://zopeinterface.readthedocs.io/en/latest/objects.inv",
 ]
 
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9276