### PR TITLE
Fix --auth=unix when used to run a conch server on Python 3

### DIFF
--- a/src/twisted/conch/newsfragments/9130.bugfix
+++ b/src/twisted/conch/newsfragments/9130.bugfix
@@ -1,0 +1,1 @@
+twisted.plugins.cred_unix now properly converts a username and password from bytes to str on Python 3.  In addition, passwords which are encrypted with SHA512 and SH256 are properly verified.  This fixes running a conch server with: "twistd -n conch -d /etc/ssh/ --auth=unix".

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -29,7 +29,7 @@ from twisted.conch.interfaces import ISession, ISFTPServer, ISFTPFile
 from twisted.cred import portal
 from twisted.internet.error import ProcessExitedAlready
 from twisted.python import components, log
-from twisted.python.compat import nativeString
+from twisted.python.compat import _bytesChr as chr, nativeString
 
 try:
     import utmp

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -270,21 +270,11 @@ class CryptTests(unittest.TestCase):
         """
         password = "sample password ^%$"
 
-        # Use MD5 method to encrypt password
-        # The correct string was manually generated with crypt.crypt()
-        cryptMd5Correct = '$1NZEcnLLqFwo'
-        cryptMd5Incorrect = '$1NZEcnwo'
-        # Use traditional crypt method to encrypt password
-        # The correct string was manually generated with crypt.crypt()
-        cryptCryptCorrect = 'SSYv0E4TgOn8U'
-        cryptCryptIncorrect = 'SSYv04ETOgn8U'
-        self.assertTrue(cred_unix.verifyCryptedPassword(cryptMd5Correct,
+        cryptedCorrect = crypt.crypt(password, None)
+        cryptedIncorrect = "$1x1234"
+        self.assertTrue(cred_unix.verifyCryptedPassword(cryptedCorrect,
                                                         password))
-        self.assertFalse(cred_unix.verifyCryptedPassword(cryptMd5Incorrect,
-                                                        password))
-        self.assertTrue(cred_unix.verifyCryptedPassword(cryptCryptCorrect,
-                                                        password))
-        self.assertFalse(cred_unix.verifyCryptedPassword(cryptCryptIncorrect,
+        self.assertFalse(cred_unix.verifyCryptedPassword(cryptedIncorrect,
                                                         password))
 
 

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -661,10 +661,3 @@ class LimitingInterfacesTests(unittest.TestCase):
         self.assertRaises(SystemExit, options.parseOptions,
                           ['--help-auth-type', 'anonymous'])
         self.assertIn(strcred.notSupportedWarning, newStdout.getvalue())
-
-
-__all__ = [
-    "CheckerOptionsTests", "FileDBCheckerTests", "LimitingInterfacesTests",
-    "SSHCheckerTests", "UnixCheckerTests", "AnonymousCheckerTests",
-    "MemoryCheckerTests", "StrcredFunctionsTests", "PublicAPITests"
-]

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -14,7 +14,7 @@ from twisted.trial import unittest
 from twisted.cred import credentials, checkers, error, strcred
 from twisted.plugins import cred_file, cred_anonymous, cred_unix
 from twisted.python import usage
-from twisted.python.compat import _PY3, NativeStringIO
+from twisted.python.compat import NativeStringIO
 from twisted.python.filepath import FilePath
 from twisted.python.fakepwd import UserDatabase
 from twisted.python.reflect import requireModule

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -13,15 +13,11 @@ from twisted import plugin
 from twisted.trial import unittest
 from twisted.cred import credentials, checkers, error, strcred
 from twisted.plugins import cred_file, cred_anonymous
-from twisted.python import usage, compat
+from twisted.python import usage
+from twisted.python.compat import NativeStringIO
 from twisted.python.filepath import FilePath
 from twisted.python.fakepwd import UserDatabase
 from twisted.python.reflect import requireModule
-
-if compat._PY3:
-    from io import StringIO
-else:
-    from io import BytesIO as StringIO
 
 try:
     import crypt
@@ -338,7 +334,7 @@ class FileDBCheckerTests(unittest.TestCase):
         should produce a warning.
         """
         oldOutput = cred_file.theFileCheckerFactory.errorOutput
-        newOutput = StringIO()
+        newOutput = NativeStringIO()
         cred_file.theFileCheckerFactory.errorOutput = newOutput
         strcred.makeChecker('file:' + self._fakeFilename())
         cred_file.theFileCheckerFactory.errorOutput = oldOutput
@@ -462,7 +458,7 @@ class CheckerOptionsTests(unittest.TestCase):
         Test that the --help-auth argument correctly displays all
         available authentication plugins, then exits.
         """
-        newStdout = StringIO()
+        newStdout = NativeStringIO()
         options = DummyOptions()
         options.authOutput = newStdout
         self.assertRaises(SystemExit, options.parseOptions, ['--help-auth'])
@@ -475,7 +471,7 @@ class CheckerOptionsTests(unittest.TestCase):
         Test that the --help-auth-for argument will correctly display
         the help file for a particular authentication plugin.
         """
-        newStdout = StringIO()
+        newStdout = NativeStringIO()
         options = DummyOptions()
         options.authOutput = newStdout
         self.assertRaises(
@@ -660,7 +656,7 @@ class LimitingInterfacesTests(unittest.TestCase):
                 break
         self.assertNotIdentical(invalidFactory, None)
         # Capture output and make sure the warning is there
-        newStdout = StringIO()
+        newStdout = NativeStringIO()
         options.authOutput = newStdout
         self.assertRaises(SystemExit, options.parseOptions,
                           ['--help-auth-type', 'anonymous'])

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -270,12 +270,19 @@ class CryptTests(unittest.TestCase):
         """
         password = "sample password ^%$"
 
-        cryptedCorrect = crypt.crypt(password, None)
-        cryptedIncorrect = "$1x1234"
-        self.assertTrue(cred_unix.verifyCryptedPassword(cryptedCorrect,
-                                                        password))
-        self.assertFalse(cred_unix.verifyCryptedPassword(cryptedIncorrect,
-                                                        password))
+        for salt in (None, ""):
+            try:
+                cryptedCorrect = crypt.crypt(password, salt)
+            except TypeError:
+                # Older Python versions would throw a TypeError if
+                # a value of None was is used for the salt.
+                # Newer Python versions allow it.
+                continue
+            cryptedIncorrect = "$1x1234"
+            self.assertTrue(cred_unix.verifyCryptedPassword(cryptedCorrect,
+                                                            password))
+            self.assertFalse(cred_unix.verifyCryptedPassword(cryptedIncorrect,
+                                                             password))
 
 
         # Python 3.3+ has crypt.METHOD_*, but not all

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -287,11 +287,19 @@ class CryptTests(unittest.TestCase):
                 continue
             password = "interesting password xyz"
             crypted = crypt.crypt(password, cryptMethod)
+            incorrectCrypted = crypted + "blahfooincorrect"
             result = cred_unix.verifyCryptedPassword(crypted, password)
             self.assertTrue(result)
             # Try to pass in bytes
             result = cred_unix.verifyCryptedPassword(crypted.encode("utf-8"),
                                                      password.encode("utf-8"))
+            self.assertTrue(result)
+            result = cred_unix.verifyCryptedPassword(incorrectCrypted, password)
+            self.assertFalse(result)
+            # Try to pass in bytes
+            result = cred_unix.verifyCryptedPassword(incorrectCrypted.encode("utf-8"),
+                                                     password.encode("utf-8"))
+            self.assertFalse(result)
 
 
 

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -286,8 +286,11 @@ class UnixCheckerTests(unittest.TestCase):
             if module is None:
                 availability += [name]
         for method in (test_unixCheckerSucceeds,
+                       test_unixCheckerSucceedsBytes,
                        test_unixCheckerFailsUsername,
-                       test_unixCheckerFailsPassword):
+                       test_unixCheckerFailsUsernameBytes,
+                       test_unixCheckerFailsPassword,
+                       test_unixCheckerFailsPasswordBytes):
             method.skip = ("Required module(s) are unavailable: " +
                            ", ".join(availability))
 

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -270,7 +270,7 @@ class CryptTests(unittest.TestCase):
         """
         password = "sample password ^%$"
 
-        for salt in (None, ""):
+        for salt in (None, "$1"):
             try:
                 cryptedCorrect = crypt.crypt(password, salt)
             except TypeError:

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Tests for L{twisted.cred.strcred}.
+L{twisted.cred.strcred}.
 """
 
 from __future__ import absolute_import, division
@@ -52,7 +52,7 @@ class PublicAPITests(unittest.TestCase):
 
     def test_emptyDescription(self):
         """
-        Test that the description string cannot be empty.
+        The description string cannot be empty.
         """
         iat = getInvalidAuthType()
         self.assertRaises(strcred.InvalidAuthType, strcred.makeChecker, iat)
@@ -62,7 +62,7 @@ class PublicAPITests(unittest.TestCase):
 
     def test_invalidAuthType(self):
         """
-        Test that an unrecognized auth type raises an exception.
+        An unrecognized auth type raises an exception.
         """
         iat = getInvalidAuthType()
         self.assertRaises(strcred.InvalidAuthType, strcred.makeChecker, iat)
@@ -75,7 +75,7 @@ class StrcredFunctionsTests(unittest.TestCase):
 
     def test_findCheckerFactories(self):
         """
-        Test that findCheckerFactories returns all available plugins.
+        L{strcred.findCheckerFactories} returns all available plugins.
         """
         availablePlugins = list(strcred.findCheckerFactories())
         for plg in plugin.getPlugins(strcred.ICheckerFactory):
@@ -84,7 +84,7 @@ class StrcredFunctionsTests(unittest.TestCase):
 
     def test_findCheckerFactory(self):
         """
-        Test that findCheckerFactory returns the first plugin
+        L{strcred.findCheckerFactory} returns the first plugin
         available for a given authentication type.
         """
         self.assertIdentical(strcred.findCheckerFactory('file'),
@@ -114,8 +114,8 @@ class MemoryCheckerTests(unittest.TestCase):
 
     def test_badFormatArgString(self):
         """
-        Test that an argument string which does not contain user:pass
-        pairs (i.e., an odd number of ':' characters) raises an exception.
+        An argument string which does not contain user:pass pairs
+        (i.e., an odd number of ':' characters) raises an exception.
         """
         self.assertRaises(strcred.InvalidAuthArgumentString,
                           strcred.makeChecker, 'memory:a:b:c')
@@ -123,7 +123,7 @@ class MemoryCheckerTests(unittest.TestCase):
 
     def test_memoryCheckerSucceeds(self):
         """
-        Test that the checker works with valid credentials.
+        The checker works with valid credentials.
         """
         def _gotAvatar(username):
             self.assertEqual(username, self.admin.username)
@@ -134,7 +134,7 @@ class MemoryCheckerTests(unittest.TestCase):
 
     def test_memoryCheckerFailsUsername(self):
         """
-        Test that the checker fails with an invalid username.
+        The checker fails with an invalid username.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badUser),
                                   error.UnauthorizedLogin)
@@ -142,7 +142,7 @@ class MemoryCheckerTests(unittest.TestCase):
 
     def test_memoryCheckerFailsPassword(self):
         """
-        Test that the checker fails with an invalid password.
+        The checker fails with an invalid password.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badPass),
                                   error.UnauthorizedLogin)
@@ -163,7 +163,7 @@ class AnonymousCheckerTests(unittest.TestCase):
 
     def testAnonymousAccessSucceeds(self):
         """
-        Test that we can log in anonymously using this checker.
+        We can log in anonymously using this checker.
         """
         checker = strcred.makeChecker('anonymous')
         request = checker.requestAvatarId(credentials.Anonymous())
@@ -223,7 +223,7 @@ class UnixCheckerTests(unittest.TestCase):
 
     def test_unixCheckerSucceeds(self):
         """
-        Test that the checker works with valid credentials.
+        The checker works with valid credentials.
         """
         def _gotAvatar(username):
             self.assertEqual(username, self.admin.username)
@@ -234,7 +234,7 @@ class UnixCheckerTests(unittest.TestCase):
 
     def test_unixCheckerFailsUsername(self):
         """
-        Test that the checker fails with an invalid username.
+        The checker fails with an invalid username.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badUser),
                                   error.UnauthorizedLogin)
@@ -242,7 +242,7 @@ class UnixCheckerTests(unittest.TestCase):
 
     def test_unixCheckerFailsPassword(self):
         """
-        Test that the checker fails with an invalid password.
+        The checker fails with an invalid password.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badPass),
                                   error.UnauthorizedLogin)
@@ -263,7 +263,7 @@ class UnixCheckerTests(unittest.TestCase):
 
 class FileDBCheckerTests(unittest.TestCase):
     """
-    Test for the --auth=file:... file checker.
+    C{--auth=file:...} file checker.
     """
 
     def setUp(self):
@@ -295,7 +295,7 @@ class FileDBCheckerTests(unittest.TestCase):
 
     def test_fileCheckerSucceeds(self):
         """
-        Test that the checker works with valid credentials.
+        The checker works with valid credentials.
         """
         def _gotAvatar(username):
             self.assertEqual(username, self.admin.username)
@@ -306,7 +306,7 @@ class FileDBCheckerTests(unittest.TestCase):
 
     def test_fileCheckerFailsUsername(self):
         """
-        Test that the checker fails with an invalid username.
+        The checker fails with an invalid username.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badUser),
                                   error.UnauthorizedLogin)
@@ -314,7 +314,7 @@ class FileDBCheckerTests(unittest.TestCase):
 
     def test_fileCheckerFailsPassword(self):
         """
-        Test that the checker fails with an invalid password.
+        The checker fails with an invalid password.
         """
         return self.assertFailure(self.checker.requestAvatarId(self.badPass),
                                   error.UnauthorizedLogin)
@@ -322,7 +322,7 @@ class FileDBCheckerTests(unittest.TestCase):
 
     def test_failsWithEmptyFilename(self):
         """
-        Test that an empty filename raises an error.
+        An empty filename raises an error.
         """
         self.assertRaises(ValueError, strcred.makeChecker, 'file')
         self.assertRaises(ValueError, strcred.makeChecker, 'file:')
@@ -344,7 +344,7 @@ class FileDBCheckerTests(unittest.TestCase):
 
 class SSHCheckerTests(unittest.TestCase):
     """
-    Tests for the --auth=sshkey:... checker.  The majority of the tests for the
+    Tests for the C{--auth=sshkey:...} checker.  The majority of the tests for the
     ssh public key database checker are in
     L{twisted.conch.test.test_checkers.SSHPublicKeyCheckerTestCase}.
     """
@@ -381,7 +381,7 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_createsList(self):
         """
-        Test that the --auth command line creates a list in the
+        The C{--auth} command line creates a list in the
         Options instance and appends values to it.
         """
         options = DummyOptions()
@@ -394,7 +394,7 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_invalidAuthError(self):
         """
-        Test that the --auth command line raises an exception when it
+        The C{--auth} command line raises an exception when it
         gets a parameter it doesn't understand.
         """
         options = DummyOptions()
@@ -411,9 +411,8 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_createsDictionary(self):
         """
-        Test that the --auth command line creates a dictionary
-        mapping supported interfaces to the list of credentials
-        checkers that support it.
+        The C{--auth} command line creates a dictionary mapping supported
+        interfaces to the list of credentials checkers that support it.
         """
         options = DummyOptions()
         options.parseOptions(['--auth', 'memory', '--auth', 'anonymous'])
@@ -432,8 +431,8 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_credInterfacesProvidesLists(self):
         """
-        Test that when two --auth arguments are passed along which
-        support the same interface, a list with both is created.
+        When two C{--auth} arguments are passed along which support the same
+        interface, a list with both is created.
         """
         options = DummyOptions()
         options.parseOptions(['--auth', 'memory', '--auth', 'unix'])
@@ -444,7 +443,7 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_listDoesNotDisplayDuplicates(self):
         """
-        Test that the list for --help-auth does not duplicate items.
+        The list for C{--help-auth} does not duplicate items.
         """
         authTypes = []
         options = DummyOptions()
@@ -455,7 +454,7 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_displaysListCorrectly(self):
         """
-        Test that the --help-auth argument correctly displays all
+        The C{--help-auth} argument correctly displays all
         available authentication plugins, then exits.
         """
         newStdout = NativeStringIO()
@@ -468,8 +467,8 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_displaysHelpCorrectly(self):
         """
-        Test that the --help-auth-for argument will correctly display
-        the help file for a particular authentication plugin.
+        The C{--help-auth-for} argument will correctly display the help file for a
+        particular authentication plugin.
         """
         newStdout = NativeStringIO()
         options = DummyOptions()
@@ -483,7 +482,7 @@ class CheckerOptionsTests(unittest.TestCase):
 
     def test_unexpectedException(self):
         """
-        When the checker specified by --auth raises an unexpected error, it
+        When the checker specified by C{--auth} raises an unexpected error, it
         should be caught and re-raised within a L{usage.UsageError}.
         """
         options = DummyOptions()
@@ -550,7 +549,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_supportsInterface(self):
         """
-        Test that the supportsInterface method behaves appropriately.
+        The supportsInterface method behaves appropriately.
         """
         options = OptionsForUsernamePassword()
         self.assertTrue(
@@ -564,7 +563,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_supportsAllInterfaces(self):
         """
-        Test that the supportsInterface method behaves appropriately
+        The supportsInterface method behaves appropriately
         when the supportedInterfaces attribute is None.
         """
         options = OptionsSupportsAllInterfaces()
@@ -576,7 +575,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_supportsCheckerFactory(self):
         """
-        Test that the supportsCheckerFactory method behaves appropriately.
+        The supportsCheckerFactory method behaves appropriately.
         """
         options = OptionsForUsernamePassword()
         fileCF = cred_file.theFileCheckerFactory
@@ -587,9 +586,8 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_canAddSupportedChecker(self):
         """
-        Test that when addChecker is called with a checker that
-        implements at least one of the interfaces our application
-        supports, it is successful.
+        When addChecker is called with a checker that implements at least one
+        of the interfaces our application supports, it is successful.
         """
         options = OptionsForUsernamePassword()
         options.addChecker(self.goodChecker)
@@ -605,8 +603,8 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_failOnAddingUnsupportedChecker(self):
         """
-        Test that when addChecker is called with a checker that does
-        not implement any supported interfaces, it fails.
+        When addChecker is called with a checker that does not implement any
+        supported interfaces, it fails.
         """
         options = OptionsForUsernameHashedPassword()
         self.assertRaises(strcred.UnsupportedInterfaces,
@@ -615,7 +613,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_unsupportedInterfaceError(self):
         """
-        Test that the --auth command line raises an exception when it
+        The C{--auth} command line raises an exception when it
         gets a checker we don't support.
         """
         options = OptionsSupportsNoInterfaces()
@@ -627,7 +625,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_helpAuthLimitsOutput(self):
         """
-        Test that --help-auth will only list checkers that purport to
+        C{--help-auth} will only list checkers that purport to
         supply at least one of the credential interfaces our
         application can use.
         """
@@ -643,7 +641,7 @@ class LimitingInterfacesTests(unittest.TestCase):
 
     def test_helpAuthTypeLimitsOutput(self):
         """
-        Test that --help-auth-type will display a warning if you get
+        C{--help-auth-type} will display a warning if you get
         help for an authType that does not supply at least one of the
         credential interfaces our application can use.
         """

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -270,7 +270,7 @@ class CryptTests(unittest.TestCase):
         """
         password = "sample password ^%$"
 
-        for salt in (None, "$1"):
+        for salt in (None, "ab"):
             try:
                 cryptedCorrect = crypt.crypt(password, salt)
             except TypeError:

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -180,9 +180,10 @@ class UnixCheckerTests(unittest.TestCase):
         }
 
 
-    def _spwd(self, username):
-        return (username, crypt.crypt(self.users[username], 'F/'),
-                0, 0, 99999, 7, -1, -1, -1)
+    def _spwd_getspnam(self, username):
+        return spwd.struct_spwd((username,
+                                 crypt.crypt(self.users[username], 'F/'),
+                                 0, 0, 99999, 7, -1, -1, -1))
 
 
     def setUp(self):
@@ -202,13 +203,7 @@ class UnixCheckerTests(unittest.TestCase):
                     1000, 1000, username, '/home/' + username, '/bin/sh')
             self.patch(pwd, 'getpwnam', database.getpwnam)
         if spwd:
-            self._spwd_getspnam = spwd.getspnam
-            spwd.getspnam = self._spwd
-
-
-    def tearDown(self):
-        if spwd:
-            spwd.getspnam = self._spwd_getspnam
+            self.patch(spwd, 'getspnam', self._spwd_getspnam)
 
 
     def test_isChecker(self):

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -70,7 +70,12 @@ class UNIXChecker(object):
         try:
             if not isinstance(username, StringType):
                 username = username.decode('utf-8')
-            cryptedPass = spwd.getspnam(username).sp_pwdp
+            if getattr(spwd.struct_spwd, "sp_pwdp", None):
+                # Python 3
+                cryptedPass = spwd.getspnam(username).sp_pwdp
+            else:
+                # Python 2
+                cryptedPass = spwd.getspnam(username).sp_pwd
         except KeyError:
             return defer.fail(UnauthorizedLogin())
         else:

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -22,10 +22,6 @@ from twisted.python.compat import StringType
 
 
 def verifyCryptedPassword(crypted, pw):
-    if crypted[0] == '$': # md5_crypt encrypted
-        salt = '$1$' + crypted.split('$')[2]
-    else:
-        salt = crypted[:2]
     try:
         import crypt
     except ImportError:
@@ -35,7 +31,9 @@ def verifyCryptedPassword(crypted, pw):
         raise NotImplementedError("cred_unix not supported on this platform")
     if not isinstance(pw, StringType):
         pw = pw.decode('utf-8')
-    return crypt.crypt(pw, salt) == crypted
+    if not isinstance(crypted, StringType):
+        crypted = crypted.decode('utf-8')
+    return crypt.crypt(pw, crypted) == crypted
 
 
 

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -33,6 +33,8 @@ def verifyCryptedPassword(crypted, pw):
 
     if crypt is None:
         raise NotImplementedError("cred_unix not supported on this platform")
+    if not isinstance(pw, StringType):
+        pw = pw.decode('utf-8')
     return crypt.crypt(pw, salt) == crypted
 
 

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -17,6 +17,7 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import IUsernamePassword
 from twisted.cred.error import UnauthorizedLogin
 from twisted.internet import defer
+from twisted.python.compat import StringType
 
 
 
@@ -52,6 +53,8 @@ class UNIXChecker(object):
 
     def checkPwd(self, pwd, username, password):
         try:
+            if not isinstance(username, StringType):
+                username = username.decode('utf-8')
             cryptedPass = pwd.getpwnam(username).pw_passwd
         except KeyError:
             return defer.fail(UnauthorizedLogin())
@@ -65,6 +68,8 @@ class UNIXChecker(object):
 
     def checkSpwd(self, spwd, username, password):
         try:
+            if not isinstance(username, StringType):
+                username = username.decode('utf-8')
             cryptedPass = spwd.getspnam(username).sp_pwdp
         except KeyError:
             return defer.fail(UnauthorizedLogin())

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -52,7 +52,7 @@ class UNIXChecker(object):
 
     def checkPwd(self, pwd, username, password):
         try:
-            cryptedPass = pwd.getpwnam(username)[1]
+            cryptedPass = pwd.getpwnam(username).pw_passwd
         except KeyError:
             return defer.fail(UnauthorizedLogin())
         else:
@@ -65,7 +65,7 @@ class UNIXChecker(object):
 
     def checkSpwd(self, spwd, username, password):
         try:
-            cryptedPass = spwd.getspnam(username)[1]
+            cryptedPass = spwd.getspnam(username).sp_pwdp
         except KeyError:
             return defer.fail(UnauthorizedLogin())
         else:

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -22,6 +22,17 @@ from twisted.python.compat import StringType
 
 
 def verifyCryptedPassword(crypted, pw):
+    """
+    Use L{crypt.crypt} to Verify that an unencrypted
+    password matches the encrypted password.
+
+    @param crypted: The encrypted password, obtained from
+                    the Unix password database or Unix shadow
+                    password database.
+    @param pw: The unencrypted password.
+    @return: L{True} if there is successful match, else L{False}.
+    @rtype: L{bool}
+    """
     try:
         import crypt
     except ImportError:
@@ -52,6 +63,19 @@ class UNIXChecker(object):
 
 
     def checkPwd(self, pwd, username, password):
+        """
+        Obtain the encrypted password for C{username} from the Unix password
+        database using L{pwd.getpwnam}, and see if it it matches it matches
+        C{password}.
+
+        @param pwd: Module which provides functions which
+                    access to the Unix password database.
+        @type pwd: C{module}
+        @param username: The user to look up in the Unix password database.
+        @type username: L{unicode}/L{str} or L{bytes}
+        @param password: The password to compare.
+        @type username: L{unicode}/L{str} or L{bytes}
+        """
         try:
             if not isinstance(username, StringType):
                 username = username.decode('utf-8')
@@ -67,6 +91,19 @@ class UNIXChecker(object):
 
 
     def checkSpwd(self, spwd, username, password):
+        """
+        Obtain the encrypted password for C{username} from the
+        Unix shadow password database using L{spwd.getspnam},
+        and see if it it matches it matches C{password}.
+
+        @param spwd: Module which provides functions which
+                    access to the Unix shadow password database.
+        @type pwd: C{module}
+        @param username: The user to look up in the Unix password database.
+        @type username: L{unicode}/L{str} or L{bytes}
+        @param password: The password to compare.
+        @type username: L{unicode}/L{str} or L{bytes}
+        """
         try:
             if not isinstance(username, StringType):
                 username = username.decode('utf-8')


### PR DESCRIPTION
http://twistedmatrix.com/trac/ticket/9130

This fixes the following on Python 3, tested on Linux Fedora 24:

```
twistd -n conch -d /etc/ssh/ --auth=unix
```