### PR TITLE
crypt API cannot have salt value of None in python 2.

### DIFF
--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -270,7 +270,7 @@ class CryptTests(unittest.TestCase):
         """
         password = "sample password ^%$"
 
-        cryptedCorrect = crypt.crypt(password, None)
+        cryptedCorrect = crypt.crypt(password, 'badsalt')
         cryptedIncorrect = "$1x1234"
         self.assertTrue(cred_unix.verifyCryptedPassword(cryptedCorrect,
                                                         password))


### PR DESCRIPTION
API requires a string in python 2 and an optional string in python 3.
Use a bare string so that each version gets its str type.