### PR TITLE
Clarify index pages in documentation by putting protocol names in parentheses

### DIFF
--- a/docs/conch/index.rst
+++ b/docs/conch/index.rst
@@ -3,8 +3,8 @@
 :LastChangedRevision: $LastChangedRevision$
 :LastChangedBy: $LastChangedBy$
 
-Twisted Conch
-=============
+Twisted Conch (SSH and Telnet)
+==============================
 
 .. toctree::
    :hidden:

--- a/docs/mail/index.rst
+++ b/docs/mail/index.rst
@@ -3,8 +3,8 @@
 :LastChangedRevision: $LastChangedRevision$
 :LastChangedBy: $LastChangedBy$
 
-Twisted Mail
-============
+Twisted Mail (SMTP, POP, and IMAP)
+==================================
 
 .. toctree::
    :hidden:

--- a/docs/names/index.rst
+++ b/docs/names/index.rst
@@ -2,8 +2,8 @@
 :LastChangedRevision: $LastChangedRevision$
 :LastChangedBy: $LastChangedBy$
 
-Twisted Names
-=============
+Twisted Names (DNS)
+===================
 
 .. toctree::
    :hidden:

--- a/docs/words/index.rst
+++ b/docs/words/index.rst
@@ -3,8 +3,8 @@
 :LastChangedRevision: $LastChangedRevision$
 :LastChangedBy: $LastChangedBy$
 
-Twisted Words
-=============
+Twisted Words (IRC, XMPP)
+=========================
 
 .. toctree::
    :hidden:

--- a/docs/words/index.rst
+++ b/docs/words/index.rst
@@ -3,8 +3,8 @@
 :LastChangedRevision: $LastChangedRevision$
 :LastChangedBy: $LastChangedBy$
 
-Twisted Words (IRC, XMPP)
-=========================
+Twisted Words (IRC and XMPP)
+============================
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
http://twistedmatrix.com/trac/ticket/9204

@alex mentioned in ticket 9204:


> https://twistedmatrix.com/documents/current/index.html
>
> It uses the internal names for twisted packages, which are opaque to newcomers, if I'm not an
> existing twisted person I don't know that Twisted Names is DNS. Even doing as much as putting
> the protocol in parenthesis would go a long way: Twisted Conch (SSH and Telnet).

I agree with this.