### PR TITLE
Fix errback documentation for twisted.names.client.getHostByName()

### DIFF
--- a/src/twisted/names/client.py
+++ b/src/twisted/names/client.py
@@ -624,8 +624,9 @@ def getHostByName(name, timeout=None, effort=10):
     """
     Resolve a name to a valid ipv4 or ipv6 address.
 
-    Will errback with C{DNSQueryTimeoutError} on a timeout, C{DomainError} or
-    C{AuthoritativeDomainError} (or subclasses) on other errors.
+    Will errback with C{twisted.internet.defer.TimeoutError} on a timeout,
+    C{DomainError} or C{AuthoritativeDomainError} (or subclasses) on other
+    errors.
 
     @type name: C{str}
     @param name: DNS name to resolve.


### PR DESCRIPTION
If we follow this to `Resolver._lookup()` and `Resolver.queryUDP()`, we can see that this will always return a `twisted.internet.defer.TimeoutError`, as `twisted.names.error.DNSQueryTimeoutError` is trapped by [`Resolver._reissue()`](https://github.com/twisted/twisted/blob/trunk/src/twisted/names/client.py#L277-L336). It seems to have been this way for a while, possibly over a decade.