### PR TITLE
[9289] Fix twistedchecker diff tool.

### DIFF
--- a/.travis/twistedchecker-trunk-diff.sh
+++ b/.travis/twistedchecker-trunk-diff.sh
@@ -35,7 +35,7 @@ mkdir -p build/;
 twistedchecker \
     --ignore="raiser.so,portmap.so,_sendmsg.so" \
     --disable="${TWISTEDCHECKER_SKIP_WARNINGS:-}" \
-    --output-format=parseable \
+    --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}' \
     "${target}" \
     > "build/twistedchecker-branch.report" || true;
 

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ deps =
     manifest-checker: check-manifest
 
     {twistedchecker,txchecker-travis}: twistedchecker>=0.7.1
-    txchecker-travis: diff_cover
+    txchecker-travis: diff-cover==0.9.12
 
 ; All environment variables are passed.
 passenv = *


### PR DESCRIPTION
Scope
=====

This fixed the .travis/twistedchecker-trunk-diff.sh

Why we got this
============

* I guess that at some point twistedchecker and diff-cover were updated and ran out of sync
* the versions are not pinned in tox.ini
* the `parseable` format produced by twistedchecker is not what pylint's `parseable` format produces

Changes
=======

Use the parseable format as described at https://docs.pylint.org/en/1.6.0/output.html


How to test
========

You can manually trigger this for a module

```
$ .travis/twistedchecker-trunk-diff.sh twisted.web.test.test_web
```

For example with this diff

```
diff --git a/src/twisted/web/test/test_web.py b/src/twisted/web/test/test_web.py
index 1356ac2..42cabe1 100644
--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -786,11 +786,7 @@ class RequestTests(unittest.TestCase):
         self.assertIn(b'Content-Length: 0\r\n', response)
         self.assertIn(b'Allow: OPTIONS\r\n', response)
 
-
-    def test_noDefaultContentTypeOnZeroLengthResponse(self):
-        """
-        Responses with no length do not have a default content-type applied.
-        """
+    def test__noDefaultContentTypeOnZeroLengthResponse(self):
         resrc = ZeroLengthResource()
         resrc.putChild(b'', resrc)
         site = server.Site(resrc)
```

And you should get an error.

If you just delete the docstring, it will not work as the error is reported for the line where function starts, and the function name was not changed.