### PR TITLE
fix NEWS 404 link with proper link to NEWS.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Twisted 17.9.0
     <lukasa> It's midday here and frankly lunchtime is a perfect time to have a few moments of existential horror
     <exarkun> or, in the immortal words of robin williams, goooooood mooooooorning #twisted-dev
 
-For information on what's new in Twisted 17.9.0, see the `NEWS <NEWS>`_ file that comes with the distribution.
+For information on what's new in Twisted 17.9.0, see the `NEWS <NEWS.rst>`_ file that comes with the distribution.
 
 
 What is this?


### PR DESCRIPTION
README.rst links to NEWS which is great, but it doesn't link to NEWS.rst so it's 404ing now. This should fix that.