### PR TITLE
[9292] Add template for GitHub PR.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,11 @@
+## Remove this paragraph
+
+Please have a look at our developer documentation before submitting your Pull Request.
+
+https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch
+
+## Contributor Checklist:
+
+* [ ] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
+* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
+* [ ] I have updated the automated tests.

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -15,8 +15,6 @@ https://twistedmatrix.com/trac/wiki/ContributingToTwistedLabs
 
 Twisted has a Code of Conduct, available at code_of_conduct.md.
 
-**Warning: pull requests are ignored** unless they have an associated ticket in trac.
-
 File a ticket at:
 
 https://twistedmatrix.com/trac/newticket
@@ -24,6 +22,7 @@ https://twistedmatrix.com/trac/newticket
 Twisted uses Trac to keep track of bugs, feature requests, and associated
 patches because GitHub doesn't provide adequate tooling for its community.
 
+Contributions are managed using GitHub's Pull Requests.
 For a PR to be accepted it needs to have:
 
 * all Travis CI tests passing

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ exclude appveyor.yml
 prune bin
 prune admin
 prune .travis
+prune .github
 
 # Include test-running utilities for downstream packagers
 include tox.ini .coveragerc


### PR DESCRIPTION
Scope
====

This adds a template for the GitHub PR description. See https://twistedmatrix.com/trac/ticket/9292


Changes
======

Added the GitHub template.

I went for `.github` to reduce the numbers of files in root and to make it clear that those files are only for GitHub. (Ex can be removed if we move to something else)

This is based on the template suggested by Craig.

I went for "automated tests" not just "unit tests" to make it clear that integration tests (or other forms of tests) are needed :)

There is the full path to newsfragments.

Maybe in a separate PR we can create src/twisted/newsfragments/README which explains how this folder is managed, and in this way we have the docs in the souce code.


How to test
=========

Unless this is merged in master, the template will not appear for PR requests... so for now, just check that the information is ok.