### PR TITLE
Avoid using recursion when building tracebacks

### DIFF
--- a/src/twisted/newsfragments/9301.bugfix
+++ b/src/twisted/newsfragments/9301.bugfix
@@ -1,0 +1,1 @@
+twisted.python.failure now handles long stacktraces better; in particular it will log tracebacks for stack overflow errors.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -100,7 +100,7 @@ def _Traceback(frames):
     @param frames: [(methodname, filename, lineno, locals, globals), ...]
     """
     assert len(frames) > 0, "Must pass some frames"
-    # we deliberately avoid using recursion here, as the frames list may be
+    # We deliberately avoid using recursion here, as the frames list may be
     # long.
     tb = None
     for frame in reversed(frames):


### PR DESCRIPTION
The list of frames in a Failure may be very long - particularly if the failure
was due to a stack overflow. It is unhelpful if our error-handling functions
themselves fail with stack overflows when handling a stack overflow situation.

To fix one particular failure mode, avoid using recursion to handle the frames
list.

Fixes https://twistedmatrix.com/trac/ticket/9301.
