### PR TITLE
Fix bytes issues on Python 3 for "trial -j" 

### DIFF
--- a/src/twisted/newsfragments/9264.bugfix
+++ b/src/twisted/newsfragments/9264.bugfix
@@ -1,0 +1,1 @@
+twisted.trial._dist.worker and twisted.trial._dist.workertrial consistently pass bytes, not unicode to AMP.  This fixes "trial -j" on Python 3.

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -7,6 +7,8 @@ Test for distributed trial worker side.
 
 import os
 
+from io import BytesIO
+
 from zope.interface.verify import verifyObject
 
 from twisted.trial.reporter import TestResult
@@ -22,7 +24,7 @@ from twisted.internet.interfaces import ITransport, IAddress
 from twisted.internet.defer import fail, succeed
 from twisted.internet.main import CONNECTION_DONE
 from twisted.internet.error import ConnectionDone
-from twisted.python.compat import NativeStringIO as StringIO, unicode
+from twisted.python.compat import unicode
 from twisted.python.reflect import fullyQualifiedName
 from twisted.python.failure import Failure
 from twisted.protocols.amp import AMP
@@ -237,16 +239,18 @@ class LocalWorkerAMPTests(TestCase):
         stream.
         """
         results = []
-        stream = StringIO()
+        stream = BytesIO()
         self.managerAMP.setTestStream(stream)
 
-
-        d = self.worker.callRemote(managercommands.TestWrite,
+        command = managercommands.TestWrite
+        if isinstance(command, unicode):
+            command = command.encode("utf-8")
+        d = self.worker.callRemote(command,
                                    out=b"Some output")
         d.addCallback(lambda result: results.append(result['success']))
         self.pumpTransports()
 
-        self.assertEqual("Some output\n", stream.getvalue())
+        self.assertEqual(b"Some output\n", stream.getvalue())
         self.assertTrue(results)
 
 
@@ -323,11 +327,11 @@ class LocalWorkerTests(TestCase):
         fakeTransport = FakeTransport()
         localWorker = LocalWorker(FakeAMProtocol(), '.', 'test.log')
         localWorker.makeConnection(fakeTransport)
-        localWorker._outLog = StringIO()
-        localWorker.childDataReceived(4, "foo")
-        localWorker.childDataReceived(1, "bar")
-        self.assertEqual("foo", localWorker._ampProtocol.dataString)
-        self.assertEqual("bar", localWorker._outLog.getvalue())
+        localWorker._outLog = BytesIO()
+        localWorker.childDataReceived(4, b"foo")
+        localWorker.childDataReceived(1, b"bar")
+        self.assertEqual(b"foo", localWorker._ampProtocol.dataString)
+        self.assertEqual(b"bar", localWorker._outLog.getvalue())
 
 
     def test_outReceived(self):
@@ -338,7 +342,7 @@ class LocalWorkerTests(TestCase):
         fakeTransport = FakeTransport()
         localWorker = LocalWorker(FakeAMProtocol(), '.', 'test.log')
         localWorker.makeConnection(fakeTransport)
-        localWorker._outLog = StringIO()
+        localWorker._outLog = BytesIO()
         data = "The quick brown fox jumps over the lazy dog"
         localWorker.outReceived(data)
         self.assertEqual(data, localWorker._outLog.getvalue())
@@ -352,8 +356,8 @@ class LocalWorkerTests(TestCase):
         fakeTransport = FakeTransport()
         localWorker = LocalWorker(FakeAMProtocol(), '.', 'test.log')
         localWorker.makeConnection(fakeTransport)
-        localWorker._errLog = StringIO()
-        data = "The quick brown fox jumps over the lazy dog"
+        localWorker._errLog = BytesIO()
+        data = b"The quick brown fox jumps over the lazy dog"
         localWorker.errReceived(data)
         self.assertEqual(data, localWorker._errLog.getvalue())
 
@@ -365,7 +369,7 @@ class LocalWorkerTests(TestCase):
         """
         transport = FakeTransport()
         localTransport = LocalWorkerTransport(transport)
-        data = "The quick brown fox jumps over the lazy dog"
+        data = b"The quick brown fox jumps over the lazy dog"
         localTransport.write(data)
         self.assertEqual(data, transport.dataString)
 
@@ -377,9 +381,9 @@ class LocalWorkerTests(TestCase):
         """
         transport = FakeTransport()
         localTransport = LocalWorkerTransport(transport)
-        data = ("The quick ", "brown fox jumps ", "over the lazy dog")
+        data = (b"The quick ", b"brown fox jumps ", b"over the lazy dog")
         localTransport.writeSequence(data)
-        self.assertEqual("".join(data), transport.dataString)
+        self.assertEqual(b"".join(data), transport.dataString)
 
 
     def test_loseConnection(self):

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -284,7 +284,7 @@ class FakeAMProtocol(AMP):
     A fake implementation of L{AMP} for testing.
     """
     id = 0
-    dataString = ""
+    dataString = b""
 
     def dataReceived(self, data):
         self.dataString += data
@@ -299,12 +299,10 @@ class FakeTransport(object):
     """
     A fake process transport implementation for testing.
     """
-    dataString = ""
+    dataString = b""
     calls = 0
 
     def writeToChild(self, fd, data):
-        if isinstance(self.dataString, unicode) and isinstance(data, bytes):
-            data = data.decode("utf-8")
         self.dataString += data
 
 
@@ -343,7 +341,7 @@ class LocalWorkerTests(TestCase):
         localWorker = LocalWorker(FakeAMProtocol(), '.', 'test.log')
         localWorker.makeConnection(fakeTransport)
         localWorker._outLog = BytesIO()
-        data = "The quick brown fox jumps over the lazy dog"
+        data = b"The quick brown fox jumps over the lazy dog"
         localWorker.outReceived(data)
         self.assertEqual(data, localWorker._outLog.getvalue())
 

--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -45,9 +45,9 @@ class WorkerLogObserverTests(TestCase):
                 calls.append((method, kwargs))
 
         observer = WorkerLogObserver(FakeClient())
-        observer.emit({'message': ['Some log']})
+        observer.emit({'message': [b'Some log']})
         self.assertEqual(
-            calls, [(managercommands.TestWrite, {'out': 'Some log'})])
+            calls, [(managercommands.TestWrite, {'out': b'Some log'})])
 
 
 
@@ -71,10 +71,10 @@ class MainTests(TestCase):
         the stdin fd and C{self.writeStream} for the stdout fd.
         """
         if fd == _WORKER_AMP_STDIN:
-            self.assertIdentical(None, mode)
+            self.assertIdentical('rb', mode)
             return self.readStream
         elif fd == _WORKER_AMP_STDOUT:
-            self.assertEqual('w', mode)
+            self.assertEqual('wb', mode)
             return self.writeStream
         else:
             raise AssertionError("Unexpected fd %r" % (fd,))
@@ -127,7 +127,7 @@ class MainTests(TestCase):
                     raise IOError(errno.EINTR)
                 else:
                     excInfos.append(sys.exc_info())
-                return ''
+                return b''
 
         self.readStream = FakeStream()
         main(self.fdopen)

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -161,9 +161,7 @@ class LocalWorkerAMP(AMP):
         """
         Print test output from the worker.
         """
-        if _PY3 and isinstance(out, bytes):
-            out = out.decode("utf-8")
-        self._testStream.write(out + '\n')
+        self._testStream.write(out + b'\n')
         self._testStream.flush()
         return {'success': True}
 
@@ -185,7 +183,10 @@ class LocalWorkerAMP(AMP):
         self._testCase = testCase
         self._result = result
         self._result.startTest(testCase)
-        d = self.callRemote(workercommands.Run, testCase=testCase.id())
+        testCaseId = testCase.id()
+        if isinstance(testCaseId, unicode):
+            testCaseId = testCaseId.encode("utf-8")
+        d = self.callRemote(workercommands.Run, testCase=testCaseId)
         return d.addCallback(self._stopTest)
 
 
@@ -281,9 +282,9 @@ class LocalWorker(ProcessProtocol):
         self._ampProtocol.makeConnection(LocalWorkerTransport(self.transport))
         if not os.path.exists(self._logDirectory):
             os.makedirs(self._logDirectory)
-        self._outLog = open(os.path.join(self._logDirectory, 'out.log'), 'w')
-        self._errLog = open(os.path.join(self._logDirectory, 'err.log'), 'w')
-        testLog = open(os.path.join(self._logDirectory, self._logFile), 'w')
+        self._outLog = open(os.path.join(self._logDirectory, 'out.log'), 'wb')
+        self._errLog = open(os.path.join(self._logDirectory, 'err.log'), 'wb')
+        testLog = open(os.path.join(self._logDirectory, self._logFile), 'wb')
         self._ampProtocol.setTestStream(testLog)
         logDirectory = self._logDirectory
         if isinstance(logDirectory, unicode):

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -58,6 +58,8 @@ class WorkerLogObserver(object):
         text = textFromEventDict(eventDict)
         if text is None:
             return
+        if isinstance(text, unicode):
+            text = text.encode("utf-8")
         self.protocol.callRemote(managercommands.TestWrite, out=text)
 
 
@@ -75,8 +77,8 @@ def main(_fdopen=os.fdopen):
     from twisted.trial._dist.worker import WorkerProtocol
     workerProtocol = WorkerProtocol(config['force-gc'])
 
-    protocolIn = _fdopen(_WORKER_AMP_STDIN)
-    protocolOut = _fdopen(_WORKER_AMP_STDOUT, 'w')
+    protocolIn = _fdopen(_WORKER_AMP_STDIN, 'rb')
+    protocolOut = _fdopen(_WORKER_AMP_STDOUT, 'wb')
     workerProtocol.makeConnection(FileWrapper(protocolOut))
 
     observer = WorkerLogObserver(workerProtocol)

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -87,8 +87,6 @@ def main(_fdopen=os.fdopen):
     while True:
         try:
             r = protocolIn.read(1)
-            if isinstance(r, unicode):
-                r = r.encode("utf-8")
         except IOError as e:
             if e.args[0] == errno.EINTR:
                 if sys.version_info < (3, 0):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9264

I did some debugging, and without this fix, there are a bunch of errors related to bytes vs. unicode that are happening with *trial -j* such as this one:

```
<twisted.python.failure.Failure builtins.TypeError: Unicode value for key   
b'testCase' not allowed:
'twisted.test.test_abstract.AddressTests.test_emptyString'>
```

These errors are not making it into the logs, which makes things quite difficult to debug.

I went through a few round of fixing the bytes vs. unicode issues with respect to trial and AMP, and got things to work.