### PR TITLE
Work around buggy Cygwin behavior w.r.t. broken pipes.

### DIFF
--- a/src/twisted/newsfragments/9323.bugfix
+++ b/src/twisted/newsfragments/9323.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.process.Process no longer causes the reactor to hang on Cygwin while waiting for the process's stdin to close.


### PR DESCRIPTION
Ensure that the parent end of the stdin pipe gets closed on Cygwin and
doesn't cause the reactor to hang.  See
https://twistedmatrix.com/trac/ticket/9323