### PR TITLE
9324 memoryview buffer

### DIFF
--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -30,6 +30,8 @@ if _PY3:
         def _concatenate(bObj, offset, bArray):
             return b''.join([memoryview(bObj)[offset:]] + bArray)
 else:
+    from __builtin__ import buffer
+
     def _concatenate(bObj, offset, bArray):
         # Avoid one extra string copy by using a buffer to limit what
         # we include in the result.

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -13,21 +13,13 @@ from socket import AF_INET, AF_INET6, inet_pton, error
 from zope.interface import implementer
 
 # Twisted Imports
-from twisted.python.compat import unicode, lazyByteSlice
+from twisted.python.compat import unicode, lazyByteSlice, _PY3
 from twisted.python import reflect, failure
 from twisted.internet import interfaces, main
 
 import sys
 
-try:
-    # Python 2
-    from __builtin__ import buffer
-
-    def _concatenate(bObj, offset, bArray):
-        # Avoid one extra string copy by using a buffer to limit what we include
-        # in the result.
-        return buffer(bObj, offset) + b"".join(bArray)
-except ImportError:
+if _PY3:
     if (sys.version_info.major, sys.version_info.minor) == (3, 3):
         # Python 3.3 cannot join bytes and memoryviews
         def _concatenate(bObj, offset, bArray):
@@ -37,6 +29,12 @@ except ImportError:
         # memoryview prevents the slice from copying
         def _concatenate(bObj, offset, bArray):
             return b''.join([memoryview(bObj)[offset:]] + bArray)
+else:
+    def _concatenate(bObj, offset, bArray):
+        # Avoid one extra string copy by using a buffer to limit what
+        # we include in the result.
+        return buffer(bObj, offset) + b"".join(bArray)
+
 
 
 class _ConsumerMixin(object):

--- a/src/twisted/newsfragments/9324.bugfix
+++ b/src/twisted/newsfragments/9324.bugfix
@@ -1,0 +1,1 @@
+Writing large amounts of data no longer implies repeated, expensive copying under Python 3.  Python 3's write speeds are now as fast as Python 2's.

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -497,10 +497,6 @@ if _PY3:
         return ("%d" % i).encode("ascii")
 
 
-    # Ideally we would use memoryview, but it has a number of differences from
-    # the Python 2 buffer() that make that impractical
-    # (http://bugs.python.org/issue15945, incompatibility with pyOpenSSL due to
-    # PyArg_ParseTuple differences.)
     def lazyByteSlice(object, offset=0, size=None):
         """
         Return a copy of the given bytes-like object.
@@ -515,10 +511,11 @@ if _PY3:
         @param size: Optional, if an C{int} is given limit the length of copy
             to this size.
         """
+        view = memoryview(object)
         if size is None:
-            return object[offset:]
+            return view[offset:]
         else:
-            return object[offset:(offset + size)]
+            return view[offset:(offset + size)]
 
 
     def networkString(s):


### PR DESCRIPTION
`lazyByteSlice` can use `memoryview`s now because:

1) PyOpenSSL uses cryptography now, which in turn uses cffi's
   `from_buffer` to slurp in binary data. from_buffer fully supports the
   new buffer protocol used by `memoryview`.

2) It's used in `FileDescriptor` implementations. For PyOpenSSL to be
   involved, Twisted would have to use wrapped sockets, but it uses
   memory BIOs above `FileDescriptor`s instead.

`twisted.internet.abstract._concatenate` can use `memoryview`s on Python 3.4+
because `memoryview`s can be joined with bytes, even though
`memoryview(...) + bytes(...)` still doesn't work.  Using a `memoryview`
prevents the slice from copying in the same was a buffer does under
Python 2.

This fixes a major performance regression under Python 3.