### PR TITLE
Fix shell completion on Python 3

### DIFF
--- a/src/twisted/newsfragments/9303.bugfix
+++ b/src/twisted/newsfragments/9303.bugfix
@@ -1,0 +1,1 @@
+The "--_shell-completion" argument to twistd now works on Python 3.

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -28,6 +28,7 @@ Options howto.
 import itertools, getopt, inspect
 
 from twisted.python import reflect, util, usage
+from twisted.python.compat import ioType, unicode
 
 
 
@@ -157,6 +158,8 @@ class ZshBuilder(object):
         self.options = options
         self.cmdName = cmdName
         self.file = file
+        if file and ioType(file) == unicode:
+            self.file = file.buffer
 
 
     def write(self, genSubs=True):
@@ -269,6 +272,8 @@ class ZshArgumentsGenerator(object):
         self.options = options
         self.cmdName = cmdName
         self.file = file
+        if file and ioType(file) == unicode:
+            self.file = file.buffer
 
         self.descriptions = {}
         self.multiUse = set()

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -22,7 +22,7 @@ functions for your own commands. You should only need to change the first line
 to something like C{#compdef mycommand}.
 
 The main public documentation exists in the L{twisted.python.usage.Options}
-docstring, the L{twisted.python.usage.Completions} docstring, and the 
+docstring, the L{twisted.python.usage.Completions} docstring, and the
 Options howto.
 """
 import itertools, getopt, inspect
@@ -60,6 +60,12 @@ def shellComplete(config, cmdName, words, shellCompFile):
     @type shellCompFile: C{file}
     @param shellCompFile: The file to write completion data to.
     """
+
+    # If given a file with unicode semantics, such as sys.stdout on Python 3,
+    # we must get at the the underlying buffer which has bytes semantics.
+    if shellCompFile and ioType(shellCompFile) == unicode:
+        shellCompFile = shellCompFile.buffer
+
     # shellName is provided for forward-compatibility. It is not used,
     # since we currently only support zsh.
     shellName, position = words[-1].split(":")
@@ -152,14 +158,13 @@ class ZshBuilder(object):
     @ivar cmdName: The name of the command we're generating completions for.
 
     @type file: C{file}
-    @ivar file: The C{file} to write the completion function to.
+    @ivar file: The C{file} to write the completion function to.  The C{file}
+        must have L{bytes} I/O semantics.
     """
     def __init__(self, options, cmdName, file):
         self.options = options
         self.cmdName = cmdName
         self.file = file
-        if file and ioType(file) == unicode:
-            self.file = file.buffer
 
 
     def write(self, genSubs=True):
@@ -230,7 +235,8 @@ class ZshArgumentsGenerator(object):
     @ivar cmdName: The name of the command we're generating completions for.
 
     @type file: C{file}
-    @ivar file: The C{file} to write the completion function to
+    @ivar file: The C{file} to write the completion function to.  The C{file}
+        must have L{bytes} I/O semantics.
 
     The following non-constructor variables are populated by this class
     with data gathered from the C{Options} instance passed in, and its
@@ -272,8 +278,6 @@ class ZshArgumentsGenerator(object):
         self.options = options
         self.cmdName = cmdName
         self.file = file
-        if file and ioType(file) == unicode:
-            self.file = file.buffer
 
         self.descriptions = {}
         self.multiUse = set()

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -137,7 +137,7 @@ class ZshTests(unittest.TestCase):
         picked up correctly?
         """
         opts = FighterAceExtendedOptions()
-        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', 'dummy_value')
+        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', BytesIO())
 
         descriptions = FighterAceOptions.compData.descriptions.copy()
         descriptions.update(FighterAceExtendedOptions.compData.descriptions)
@@ -173,7 +173,7 @@ class ZshTests(unittest.TestCase):
                                                 'spad', 'bristol']])
 
         opts = OddFighterAceOptions()
-        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', 'dummy_value')
+        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', BytesIO())
 
         expected = {
              'albatros': set(['anatra', 'b', 'bristol', 'f',
@@ -197,7 +197,7 @@ class ZshTests(unittest.TestCase):
         e.g. def opt_foo(self, foo)
         """
         opts = FighterAceExtendedOptions()
-        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', 'dummy_value')
+        ag = _shellcomp.ZshArgumentsGenerator(opts, 'ace', BytesIO())
 
         self.assertIn('nocrash', ag.flagNameToDefinition)
         self.assertIn('nocrash', ag.allOptionsNameToDefinition)
@@ -216,7 +216,7 @@ class ZshTests(unittest.TestCase):
             compData = Completions(optActions={'detaill' : None})
 
         self.assertRaises(ValueError, _shellcomp.ZshArgumentsGenerator,
-                          TmpOptions(), 'ace', 'dummy_value')
+                          TmpOptions(), 'ace', BytesIO())
 
         class TmpOptions2(FighterAceExtendedOptions):
             # Note that 'foo' and 'bar' are not real option
@@ -225,7 +225,7 @@ class ZshTests(unittest.TestCase):
                            mutuallyExclusive=[("foo", "bar")])
 
         self.assertRaises(ValueError, _shellcomp.ZshArgumentsGenerator,
-                          TmpOptions2(), 'ace', 'dummy_value')
+                          TmpOptions2(), 'ace', BytesIO())
 
 
     def test_zshCode(self):


### PR DESCRIPTION
http://twistedmatrix.com/trac/ticket/9303

This now works on Python 3:
`twistd --_shell-completion zsh:1`

