### PR TITLE
Add toBytes() helper method

### DIFF
--- a/src/twisted/newsfragments/9343.feature
+++ b/src/twisted/newsfragments/9343.feature
@@ -1,0 +1,1 @@
+twisted.python.compat.toBytes is a convenience function for converting unicode strings to bytes.

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -822,6 +822,32 @@ def _bytesRepr(bytestring):
         return 'b' + repr(bytestring)
 
 
+
+def toBytes(s, encoding="ascii", errors="strict"):
+    """
+    Convert L{unicode} string to L{bytes}.
+
+    @param s: The string to convert.
+    @param encoding: The encoding to pass to L{str.encode}.
+    @param errors: The error handling scheme to pass to L{str.encode).
+
+    @raise TypeError: The input is not L{unicode} or L{bytes}.
+
+    @return: The encoded string.  If I{s} is L{bytes} or L{None}, just return
+             I{s}.
+    @rtype: L{bytes}
+    """
+    if s is None:
+        return s
+    elif isinstance(s, bytes):
+        return s
+    elif isinstance(s, unicode):
+        return s.encode(encoding=encoding, errors=errors)
+    else:
+        raise TypeError("Expected {} to be unicode or bytes, not: {}".format(
+            s, type(s)))
+
+
 if _PY3:
     _tokenize = tokenize.tokenize
 else:
@@ -868,5 +894,6 @@ __all__ = [
     "intern",
     "unichr",
     "raw_input",
-    "_tokenize"
+    "_tokenize",
+    "toBytes"
 ]

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -829,9 +829,9 @@ def toBytes(s, encoding="ascii", errors="strict"):
 
     @param s: The string to convert.
     @param encoding: The encoding to pass to L{str.encode}.
-    @param errors: The error handling scheme to pass to L{str.encode).
+    @param errors: The error handling scheme to pass to L{str.encode}.
 
-    @raise TypeError: The input is not L{unicode} or L{bytes}.
+    @raise TypeError: The input is not L{unicode}, L{bytes} or L{None}.
 
     @return: The encoded string.  If I{s} is L{bytes} or L{None}, just return
              I{s}.
@@ -844,8 +844,8 @@ def toBytes(s, encoding="ascii", errors="strict"):
     elif isinstance(s, unicode):
         return s.encode(encoding=encoding, errors=errors)
     else:
-        raise TypeError("Expected {} to be unicode or bytes, not: {}".format(
-            s, type(s)))
+        raise TypeError("Expected {} to be unicode, bytes, or None not: "
+            "{}".format(s, type(s)))
 
 
 if _PY3:

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -928,7 +928,7 @@ class FutureBytesReprTests(unittest.TestCase):
 
 class ToBytesTests(unittest.TestCase):
     """
-    L{toBytes}
+    L{twisted.python.compat.toBytes} is used to convert L{unicode} to L{bytes}.
     """
 
     def test_toBytesUnicode(self):

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -937,11 +937,33 @@ class ToBytesTests(unittest.TestCase):
         to L{bytes} and returned.
         """
         self.assertEqual(toBytes(u"hello"), b"hello")
+
+
+    def test_toBytesEncodingParameter(self):
+        """
+        The I{encoding} parameter is passed to L{str.encode} and selects the
+        codec to use when converting L{unicode} to L{bytes}.
+        """
         self.assertEqual(toBytes(u'\N{SNOWMAN}', encoding="utf-8"),
                          b'\xe2\x98\x83')
+
+
+    def test_toBytesErrorsParameter(self):
+        """
+        The I{errors} parameter is passed to L{str.encode} and specifies the
+        response when the input string cannot be converted according to the
+        encoding’s rules.
+        """
         self.assertEqual(
             toBytes(u'\N{SNOWMAN}', encoding="ascii", errors="ignore"),
             b'')
+
+
+    def test_toBytesUnicodeEncodeError(self):
+        """
+        L{UnicodeEncodedError} will be raised if the input string cannot be
+        converted using the encoding's rules.
+        """
         self.assertRaises(UnicodeEncodeError,
             toBytes, u'\N{SNOWMAN}', encoding="ascii")
 

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -794,7 +794,7 @@ class OrderedDictTests(unittest.TestCase):
         L{twisted.python.compat.OrderedDict} is deprecated.
         """
         from twisted.python.compat import OrderedDict
-        OrderedDict # Shh pyflakes
+        OrderedDict  # Shh pyflakes
 
         currentWarnings = self.flushWarnings(offendingFunctions=[
             self.test_deprecated])
@@ -874,6 +874,7 @@ class UnichrTests(unittest.TestCase):
         unichar exists and returns a unicode string with the given code point.
         """
         self.assertEqual(unichr(0x2603), u"\N{SNOWMAN}")
+
 
 
 class RawInputTests(unittest.TestCase):

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -328,7 +328,7 @@ class PY3Tests(unittest.SynchronousTestCase):
 
 
 
-class PYPYTest(unittest.SynchronousTestCase):
+class PYPYTests(unittest.SynchronousTestCase):
     """
     Identification of PyPy.
     """

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
@@ -16,7 +17,7 @@ from twisted.python.compat import (
     reduce, execfile, _PY3, _PYPY, comparable, cmp, nativeString,
     networkString, unicode as unicodeCompat, lazyByteSlice, reraise,
     NativeStringIO, iterbytes, intToBytes, ioType, bytesEnviron, iteritems,
-    _coercedUnicode, unichr, raw_input, _bytesRepr
+    _coercedUnicode, unichr, raw_input, _bytesRepr, toBytes
 )
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
@@ -921,3 +922,46 @@ class FutureBytesReprTests(unittest.TestCase):
         ``b`` to the returned repr on both Python 2 and 3.
         """
         self.assertEqual(_bytesRepr(b'\x00'), "b'\\x00'")
+
+
+
+class ToBytesTests(unittest.TestCase):
+    """
+    L{toBytes}
+    """
+
+    def test_toBytesUnicode(self):
+        """
+        If L{unicode} is passed to L{toBytes}, the L{unicode} is converted
+        to L{bytes} and returned.
+        """
+        self.assertEqual(toBytes(u"hello"), b"hello")
+        self.assertEqual(toBytes(u'\N{SNOWMAN}', encoding="utf-8"),
+                         b'\xe2\x98\x83')
+        self.assertEqual(
+            toBytes(u'\N{SNOWMAN}', encoding="ascii", errors="ignore"),
+            b'')
+        self.assertRaises(UnicodeEncodeError,
+            toBytes, u'\N{SNOWMAN}', encoding="ascii")
+
+
+    def test_toBytesBytes(self):
+        """
+        L{toBytes} just returns any L{bytes} passed to it.
+        """
+        self.assertEqual(toBytes(b'\xe2\x98\x83'), b'\xe2\x98\x83')
+
+
+    def test_toBytesNone(self):
+        """
+        L{toBytes} just returns L{None} if L{None} was passed to it.
+        """
+        self.assertEqual(toBytes(None), None)
+
+
+    def test_toBytesTypeError(self):
+        """
+        L{toBytes} will raise L{TypeError} if passed anything which
+        is not L{unicode}, L{bytes}, or L{None}.
+        """
+        self.assertRaises(TypeError, toBytes, ["foo", "bar"])


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9343

We can replace:

```
if isinstance(foo, unicode):
    foo = foo.encode("ascii")
```

with:

```
foo = toBytes(foo)
```