### PR TITLE
9333 default logger

### DIFF
--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -287,3 +287,33 @@ def formatWithCall(formatString, mapping):
     return unicode(
         aFormatter.vformat(formatString, (), CallMapping(mapping))
     )
+
+
+
+def formatEventWithTraceback(event):
+    """
+    Format an event as a unicode string and append a traceback if the event
+    contains a C{event["log_failure"]} key.
+
+    This implementation will always attempt to append a traceback, even if
+    formatting the C{event["log_format"]} fails.  The traceback, if bytes, will
+    be assumed to be UTF-8.
+
+    @param event: A logging event.
+    @type event: L{dict}
+
+    @return: A formatted string with a traceback if applicable.
+    @rtype: L{unicode}
+    """
+    eventText = formatEvent(event)
+    try:
+        traceback = event["log_failure"].getTraceback()
+        if isinstance(traceback, bytes):
+            traceback = traceback.decode('utf-8')
+    except KeyError:
+        return eventText
+    except:
+        traceback = u"(UNABLE TO OBTAIN TRACEBACK FROM EVENT)\n"
+
+    eventText = u"\n".join((eventText, traceback))
+    return eventText

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -17,7 +17,7 @@ from ._buffer import LimitedHistoryLogObserver
 from ._observer import LogPublisher
 from ._filter import FilteringLogObserver, LogLevelFilterPredicate
 from ._logger import Logger
-from ._format import formatEvent, formatEventWithTraceback
+from ._format import formatEventWithTraceback
 from ._levels import LogLevel
 from ._io import LoggingFile
 from ._file import FileLogObserver

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -17,7 +17,7 @@ from ._buffer import LimitedHistoryLogObserver
 from ._observer import LogPublisher
 from ._filter import FilteringLogObserver, LogLevelFilterPredicate
 from ._logger import Logger
-from ._format import formatEvent
+from ._format import formatEvent, formatEventWithTraceback
 from ._levels import LogLevel
 from ._io import LoggingFile
 from ._file import FileLogObserver
@@ -102,7 +102,8 @@ class LogBeginner(object):
             self._initialBuffer,
             FilteringLogObserver(
                 FileLogObserver(
-                    errorStream, lambda event: formatEvent(event) + u"\n"
+                    errorStream,
+                    lambda event: formatEventWithTraceback(event) + u"\n"
                 ),
                 [LogLevelFilterPredicate(defaultLogLevel=LogLevel.critical)]
             )

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -18,6 +18,7 @@ from .._global import LogBeginner
 from .._global import MORE_THAN_ONCE_WARNING
 from .._levels import LogLevel
 from ..test.test_stdlib import nextLine
+from twisted.python.failure import Failure
 
 
 
@@ -356,3 +357,16 @@ class LogBeginnerTests(unittest.TestCase):
                 filename=__file__, lineno=2,
             )]
         )
+
+
+    def test_failuresAppendTracebacks(self):
+        """
+        The string resulting from a logged failure contains a traceback.
+        """
+        f = Failure(Exception("this is not the behavior you are looking for"))
+        log = Logger(observer=self.publisher)
+        log.failure('a failure', failure=f)
+        msg = self.errorStream.getvalue()
+        self.assertIn('a failure', msg)
+        self.assertIn('this is not the behavior you are looking for', msg)
+        self.assertIn('Traceback', msg)

--- a/src/twisted/newsfragments/9333.bugfix
+++ b/src/twisted/newsfragments/9333.bugfix
@@ -1,0 +1,1 @@
+twisted.logger.LogBeginner's default critical observer now prints tracebacks for new and legacy log system events.


### PR DESCRIPTION
This is a fix for 9333: https://twistedmatrix.com/trac/ticket/9333

Some items of note for reviewers:
1.  The new `formatEventWithTracebacks` API was deliberately kept private to avoid adding new public APIs to maintain.  Additionally, its easy to make it public if so specified in review.

2.  The existing formatEventAsClassicLogText has similar code that can be replaced.  Rather than assume that was desired, I kept the change as focused as possible.  Easy to change if desired.

As noted in the ticket, there are cases where duplicate tracebacks result, specifically if observers are appended to the globalLogPublisher, rather than overwrite with a `beginLoggingTo` call on the `globalLogBeginner`.  This is documented in the logger docs.
