### PR TITLE
Fixed punctuation in Conch documentation.

### DIFF
--- a/docs/conch/howto/conch_client.rst
+++ b/docs/conch/howto/conch_client.rst
@@ -332,8 +332,8 @@ will take the filename of a key in the supported format, and  and generate a new
 
 ``getPassword()`` and ``getPrivateKey()`` return ``Deferreds`` because they may need to ask the user for input.
 
-Once the authentication is complete, ``SSHUserAuthClient`` takes care of starting the code ``SSHConnection`` object given to it. Next, we'll
-look at how to use the ``SSHConnection``
+Once the authentication is complete, ``SSHUserAuthClient`` takes care of starting the ``SSHConnection`` object given to it. Next, we'll
+look at how to use the ``SSHConnection``.
 
 
 

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -4,7 +4,7 @@
 
 """
 The parent class for all the SSH Channels.  Currently implemented channels
-are session. direct-tcp, and forwarded-tcp.
+are session, direct-tcp, and forwarded-tcp.
 
 Maintainer: Paul Swartz
 """


### PR DESCRIPTION
Some trivial documentation fixes.