### PR TITLE
9362 Remove “terrible hack” in t.c.ssh.filetransfer.FileTransferClient 

### DIFF
--- a/src/twisted/conch/newsfragments/9362.removal
+++ b/src/twisted/conch/newsfragments/9362.removal
@@ -1,1 +1,1 @@
-twisted.conch.ssh.filetransfer.FileTransferClient no longer has a "wasAFile" attribute.
+twisted.conch.ssh.filetransfer.FileTransferClient.wasAFile attribute has been removed as it serves no purpose.

--- a/src/twisted/conch/newsfragments/9362.removal
+++ b/src/twisted/conch/newsfragments/9362.removal
@@ -1,0 +1,1 @@
+twisted.conch.ssh.filetransfer.FileTransferClient no longer has a "wasAFile" attribute.

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -538,8 +538,20 @@ class FileTransferClient(FileTransferBase):
         return d
 
 
-    def _cbOpenHandle(self, handle, wrapperClass, name):
-        cb = wrapperClass(self, handle)
+    def _cbOpenHandle(self, handle, handleClass, name):
+        """
+        Callback invoked when an OPEN or OPENDIR request succeeds.
+
+        @param handle: The handle returned by the server
+        @type handle: L{bytes}
+        @param handleClass: The class that will represent the
+        newly-opened file or directory to the user (either L{ClientFile} or
+        L{ClientDirectory}).
+        @param name: The name of the file or directory represented
+        by C{handle}.
+        @type name: L{bytes}
+        """
+        cb = handleClass(self, handle)
         cb.name = name
         return cb
 


### PR DESCRIPTION
Instead of using the `wasAFile` dict to store the information needed to wrap a file-handle response in a client-side object, store that information as arguments to the callback which does the wrapping.

This is a fix for https://twistedmatrix.com/trac/ticket/9362 . All of the changed code is covered by existing tests, and there should be no visible change in behavior or exposed api.