### PR TITLE
9374  Fixing circular references in t.p.policies and t.p.tls

### DIFF
--- a/src/twisted/newsfragments/9374.bugfix
+++ b/src/twisted/newsfragments/9374.bugfix
@@ -1,1 +1,1 @@
-t.p.p.ProtocolWrapper and t.p.t.TLSMemoryBIOProtocol no longer create circular references that still alive after connection is closed
+twisted.protocols.policies.ProtocolWrapper and twisted.protocols.tls.TLSMemoryBIOProtocol no longer create circular references that still alive after connection is closed.

--- a/src/twisted/newsfragments/9374.bugfix
+++ b/src/twisted/newsfragments/9374.bugfix
@@ -1,1 +1,1 @@
-twisted.protocols.policies.ProtocolWrapper and twisted.protocols.tls.TLSMemoryBIOProtocol no longer create circular references that still alive after connection is closed.
+twisted.protocols.policies.ProtocolWrapper and twisted.protocols.tls.TLSMemoryBIOProtocol no longer create circular references that keep protocol instances in memory after connection is closed.

--- a/src/twisted/newsfragments/9374.bugfix
+++ b/src/twisted/newsfragments/9374.bugfix
@@ -1,0 +1,1 @@
+t.p.p.ProtocolWrapper and t.p.t.TLSMemoryBIOProtocol no longer create circular references that still alive after connection is closed

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -124,7 +124,7 @@ class ProtocolWrapper(Protocol):
         self.factory.unregisterProtocol(self)
         self.wrappedProtocol.connectionLost(reason)
 
-        # breaking reference cycle between self and wrappedProtocol
+        # Breaking reference cycle between self and wrappedProtocol
         self.wrappedProtocol = None
 
 

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -124,6 +124,9 @@ class ProtocolWrapper(Protocol):
         self.factory.unregisterProtocol(self)
         self.wrappedProtocol.connectionLost(reason)
 
+        # breaking reference cycle between self and wrappedProtocol
+        self.wrappedProtocol = None
+
 
 
 class WrappingFactory(ClientFactory):

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -124,7 +124,7 @@ class ProtocolWrapper(Protocol):
         self.factory.unregisterProtocol(self)
         self.wrappedProtocol.connectionLost(reason)
 
-        # Breaking reference cycle between self and wrappedProtocol
+        # Breaking reference cycle between self and wrappedProtocol.
         self.wrappedProtocol = None
 
 

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -128,7 +128,6 @@ class ProtocolWrapper(Protocol):
         self.wrappedProtocol = None
 
 
-
 class WrappingFactory(ClientFactory):
     """
     Wraps a factory and its protocols, and keeps track of them.

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -1003,7 +1003,7 @@ class TLSMemoryBIOTests(TestCase):
         gc.disable()
 
         try:
-            class ConnectionCloserProtocol(Protocol):
+            class CloserProtocol(Protocol):
                 def dataReceived(self, data):
                     self.transport.loseConnection()
 
@@ -1013,24 +1013,24 @@ class TLSMemoryBIOTests(TestCase):
                     self.transport.write(b'hello')
 
             origTLSProtos = nObjectsOfType(TLSMemoryBIOProtocol)
-            origServerProtos = nObjectsOfType(ConnectionCloserProtocol)
+            origServerProtos = nObjectsOfType(CloserProtocol)
 
             authCert, serverCert = certificatesForAuthorityAndServer()
             serverFactory = TLSMemoryBIOFactory(
                 serverCert.options(), False,
-                Factory.forProtocol(ConnectionCloserProtocol)
+                Factory.forProtocol(CloserProtocol)
             )
             clientFactory = TLSMemoryBIOFactory(
                 optionsForClientTLS(u'example.com', trustRoot=authCert), True,
                 Factory.forProtocol(GreeterProtocol)
             )
             loopbackAsync(
-                TLSMemoryBIOProtocol(serverFactory, ConnectionCloserProtocol()),
+                TLSMemoryBIOProtocol(serverFactory, CloserProtocol()),
                 TLSMemoryBIOProtocol(clientFactory, GreeterProtocol())
             )
 
             newTLSProtos = nObjectsOfType(TLSMemoryBIOProtocol)
-            newServerProtos = nObjectsOfType(ConnectionCloserProtocol)
+            newServerProtos = nObjectsOfType(CloserProtocol)
             self.assertEqual(newTLSProtos, origTLSProtos)
             self.assertEqual(newServerProtos, origServerProtos)
         finally:

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -44,7 +44,8 @@ from twisted.internet.interfaces import (
 
 from twisted.internet.error import ConnectionDone, ConnectionLost
 from twisted.internet.defer import Deferred, gatherResults
-from twisted.internet.protocol import Protocol, ClientFactory, ServerFactory, Factory
+from twisted.internet.protocol import (Protocol, ClientFactory, ServerFactory,
+                                       Factory)
 from twisted.internet.task import TaskStopped
 from twisted.protocols.loopback import loopbackAsync, collapsingPumpPolicy
 from twisted.trial.unittest import TestCase, SynchronousTestCase
@@ -1020,8 +1021,10 @@ class TLSMemoryBIOTests(TestCase):
                 TLSMemoryBIOProtocol(clientFactory, DummyClientProtocol())
             )
 
-            self.assertEqual(nObjectsOfType(TLSMemoryBIOProtocol), origTLSProtos)
-            self.assertEqual(nObjectsOfType(DummyServerProtocol), origServerProtos)
+            newTLSProtos = nObjectsOfType(TLSMemoryBIOProtocol)
+            newServerProtos = nObjectsOfType(DummyServerProtocol)
+            self.assertEqual(newTLSProtos, origTLSProtos)
+            self.assertEqual(newServerProtos, origServerProtos)
         finally:
             gc.enable()
 

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -993,6 +993,10 @@ class TLSMemoryBIOTests(TestCase):
         def nObjectsOfType(type):
             """
             Return the number of instances of a given type in memory.
+
+            @param type: Type whose instances to find.
+
+            @return: The number of instances found.
             """
             return sum(1 for x in gc.get_objects() if isinstance(x, type))
 

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -38,6 +38,8 @@ transports, such as UNIX sockets and stdio.
 
 from __future__ import division, absolute_import
 
+import weakref
+
 from OpenSSL.SSL import Error, ZeroReturnError, WantReadError
 from OpenSSL.SSL import TLSv1_METHOD, Context, Connection
 
@@ -196,7 +198,8 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         Connect this wrapper to the given transport and initialize the
         necessary L{OpenSSL.SSL.Connection} with a memory BIO.
         """
-        self._tlsConnection = self.factory._createConnection(self)
+        # using weakref.proxy to avoid circular references
+        self._tlsConnection = self.factory._createConnection(weakref.proxy(self))
         self._appSendBuffer = []
 
         # Add interfaces provided by the transport we are wrapping:

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -401,6 +401,8 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         self._reason = None
         self.connected = False
         ProtocolWrapper.connectionLost(self, reason)
+
+        # Breaking reference cycle between self._tlsConnection and self.
         self._tlsConnection = None
 
 

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -410,7 +410,7 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         """
         Send a TLS close alert and close the underlying connection.
         """
-        if self.disconnecting:
+        if self.disconnecting or not self.connected:
             return
         # If connection setup has not finished, OpenSSL 1.0.2f+ will not shut
         # down the connection until we write some data to the connection which

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -38,8 +38,6 @@ transports, such as UNIX sockets and stdio.
 
 from __future__ import division, absolute_import
 
-import weakref
-
 from OpenSSL.SSL import Error, ZeroReturnError, WantReadError
 from OpenSSL.SSL import TLSv1_METHOD, Context, Connection
 
@@ -198,9 +196,7 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         Connect this wrapper to the given transport and initialize the
         necessary L{OpenSSL.SSL.Connection} with a memory BIO.
         """
-        # Using weakref.proxy to avoid circular references
-        selfProxy = weakref.proxy(self)
-        self._tlsConnection = self.factory._createConnection(selfProxy)
+        self._tlsConnection = self.factory._createConnection(self)
         self._appSendBuffer = []
 
         # Add interfaces provided by the transport we are wrapping:
@@ -405,6 +401,7 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         self._reason = None
         self.connected = False
         ProtocolWrapper.connectionLost(self, reason)
+        self._tlsConnection = None
 
 
     def loseConnection(self):

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -198,8 +198,9 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         Connect this wrapper to the given transport and initialize the
         necessary L{OpenSSL.SSL.Connection} with a memory BIO.
         """
-        # using weakref.proxy to avoid circular references
-        self._tlsConnection = self.factory._createConnection(weakref.proxy(self))
+        # Using weakref.proxy to avoid circular references
+        selfProxy = weakref.proxy(self)
+        self._tlsConnection = self.factory._createConnection(selfProxy)
         self._appSendBuffer = []
 
         # Add interfaces provided by the transport we are wrapping:

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -113,6 +113,9 @@ class FakeTransport:
 
 
     def write(self, data):
+        if self.disconnected:
+            return
+
         if self.tls is not None:
             self.tlsbuf.append(data)
         else:

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -113,7 +113,8 @@ class FakeTransport:
 
 
     def write(self, data):
-        if self.disconnected:
+        # If transport is closed, we should accept writes but drop the data.
+        if self.disconnecting:
             return
 
         if self.tls is not None:

--- a/src/twisted/test/test_iosim.py
+++ b/src/twisted/test/test_iosim.py
@@ -46,6 +46,19 @@ class FakeTransportTests(TestCase):
         self.assertEqual(b"".join(a.stream), b"abcd")
 
 
+    def test_writeAfterClose(self):
+        """
+        L{FakeTransport.write} will accept writes after transport was closed,
+        but the data will be silently discarded.
+        """
+        a = FakeTransport(object(), False)
+        a.write(b"before")
+        a.loseConnection()
+        a.write(b"after")
+
+        self.assertEqual(b"".join(a.stream), b"before")
+
+
 
 @implementer(IPushProducer)
 class StrictPushProducer(object):

--- a/src/twisted/test/test_policies.py
+++ b/src/twisted/test/test_policies.py
@@ -341,6 +341,24 @@ class WrapperTests(unittest.TestCase):
         self.assertEqual(result, [(connector, reason)])
 
 
+    def test_breakReferenceCycle(self):
+        """
+        L{policies.ProtocolWrapper.connectionLost} sets C{wrappedProtocol} to
+        C{None} in order to break reference cycle between wrapper and wrapped
+        protocols.
+        :return:
+        """
+        wrapper = policies.ProtocolWrapper(policies.WrappingFactory(Server()),
+                                           protocol.Protocol())
+        transport = StringTransportWithDisconnection()
+        transport.protocol = wrapper
+        wrapper.makeConnection(transport)
+
+        self.assertIsNotNone(wrapper.wrappedProtocol)
+        transport.loseConnection()
+        self.assertIsNone(wrapper.wrappedProtocol)
+
+
 
 class WrappingFactory(policies.WrappingFactory):
     protocol = lambda s, f, p: p

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -1858,26 +1858,26 @@ class ServiceIdentityTests(unittest.SynchronousTestCase):
         serverWrappedProto = GreetingServer()
         clientWrappedProto = GreetingClient()
 
-        cF = protocol.Factory()
-        cF.protocol = lambda: clientWrappedProto
-        sF = protocol.Factory()
-        sF.protocol = lambda: serverWrappedProto
+        clientFactory = protocol.Factory()
+        clientFactory.protocol = lambda: clientWrappedProto
+        serverFactory = protocol.Factory()
+        serverFactory.protocol = lambda: serverWrappedProto
 
         self.serverOpts = serverOpts
         self.clientOpts = clientOpts
 
-        clientFactory = TLSMemoryBIOFactory(
+        clientTLSFactory = TLSMemoryBIOFactory(
             clientOpts, isClient=True,
-            wrappedFactory=cF
+            wrappedFactory=clientFactory
         )
-        serverFactory = TLSMemoryBIOFactory(
+        serverTLSFactory = TLSMemoryBIOFactory(
             serverOpts, isClient=False,
-            wrappedFactory=sF
+            wrappedFactory=serverFactory
         )
 
         cProto, sProto, pump = connectedServerAndClient(
-            lambda: serverFactory.buildProtocol(None),
-            lambda: clientFactory.buildProtocol(None),
+            lambda: serverTLSFactory.buildProtocol(None),
+            lambda: clientTLSFactory.buildProtocol(None),
         )
         return cProto, sProto, clientWrappedProto, serverWrappedProto, pump
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -271,18 +271,18 @@ def _loopbackTLSConnection(serverOpts, clientOpts):
     clientWrappedProto = ListeningClient()
     serverWrappedProto = GreetingServer()
 
-    cF = protocol.Factory()
-    cF.protocol = lambda: clientWrappedProto
-    sF = protocol.Factory()
-    sF.protocol = lambda: serverWrappedProto
+    plainClientFactory = protocol.Factory()
+    plainClientFactory.protocol = lambda: clientWrappedProto
+    plainServerFactory = protocol.Factory()
+    plainServerFactory.protocol = lambda: serverWrappedProto
 
     clientFactory = TLSMemoryBIOFactory(
         clientOpts, isClient=True,
-        wrappedFactory=sF
+        wrappedFactory=plainServerFactory
     )
     serverFactory = TLSMemoryBIOFactory(
         serverOpts, isClient=False,
-        wrappedFactory=cF
+        wrappedFactory=plainClientFactory
     )
 
     sProto, cProto, pump = connectedServerAndClient(


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9374

ProtocolWrapper creates the circular reference between itself and its wrappedProtocol. Also TLSMemoryBIOProtocol creates the circular reference between itself and its _tlsConnection.

Both circles are never broken and still alive after connections are closed until garbage collector collects them.

This seems like a performance issue especially for apps handling many short-lived TLS connections. For default GC thresholds this will cause GC to be called very often wasting CPU time. For loosened GC thresholds (for the sake of performance) this leads to eating RAM very quickly.

Discussed in mailing list: ​https://twistedmatrix.com/pipermail/twisted-python/2018-January/031798.html

* [X] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [X] I have updated the automated tests.