### PR TITLE
Separate collections from collections.abc

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -173,7 +173,7 @@ class IHostnameResolver(Interface):
             practice, this means an iterable containing
             L{twisted.internet.address.IPv4Address},
             L{twisted.internet.address.IPv6Address}, both, or neither.
-        @type addressTypes: L{collections.Iterable} of L{type}
+        @type addressTypes: L{collections.abc.Iterable} of L{type}
 
         @param transportSemantics: A string describing the semantics of the
             transport; either C{'TCP'} for stream-oriented transports or

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -10,7 +10,11 @@ from __future__ import division, absolute_import
 
 from socket import AF_INET, AF_INET6
 from io import BytesIO
-from collections import Sequence
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from zope.interface import implementer, implementedBy
 from zope.interface.verify import verifyClass

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -19,7 +19,10 @@ __all__ = [
     'RedirectWithNoLocation',
     ]
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from twisted.web._responses import RESPONSES
 from twisted.python.compat import unicode, nativeString, intToBytes

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -8,7 +8,10 @@ U{Python Web Server Gateway Interface v1.0.1<http://www.python.org/dev/peps/pep-
 
 __metaclass__ = type
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from sys import exc_info
 from warnings import warn
 


### PR DESCRIPTION
In Python 3.7, there is a warning that the abstract bases in collections.abc will no longer be accessible through the regular collections module in Python 3.8.