### PR TITLE
[9377] Don't remove trailing spaces from SSH version string comment.

### DIFF
--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -737,7 +737,7 @@ class SSHTransportBase(protocol.Protocol):
                     self.gotVersion = True
                     # Since the line was split on '\n' and most of the time
                     # it uses '\r\n' we may get an extra '\r'.
-                    self.otherVersionString = p.rstrip('\r')
+                    self.otherVersionString = p.rstrip(b'\r')
                     remoteVersion = p.split(b'-')[1]
                     if remoteVersion not in self.supportedVersions:
                         self._unsupportedVersionReceived(remoteVersion)

--- a/src/twisted/newsfragments/9377.bugfix
+++ b/src/twisted/newsfragments/9377.bugfix
@@ -1,0 +1,2 @@
+twisted.conch.ssh.transport.SSHTransportBase no longer strips trailing spaces
+from the SSH version string of the connected peer.


### PR DESCRIPTION
Scope
====

See https://twistedmatrix.com/trac/ticket/9377 for a description of the bug.

Conch should keep the SSH version string as provided by the peer, even if it has trailing spaces.


Changes
=======

Update the code to only remove LF character

As a drive by, I have updated the comments to inform that Twisted also support simple Unix new line separate and  wrote a test to explicitly cover this behavior

How to test / What to check
======================

For backward compatibility, I left the non-RFC behaviour in place and just documented.
Let me know if you think that Twisted conch should be more strict and reject peers which only use unix new line... this will be done in a separate ticket as we will need to update some tests.

I wrote unit tests and I think that they are good enough.

To manual test this in the wild you need a Bitvise server which advertise the version with spaces

See https://github.com/mscdex/ssh2/issues/488#issuecomment-329085866 for more details.