### PR TITLE
[9341] Implement HostnameEndpoint.__repr__

### DIFF
--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -796,6 +796,27 @@ class HostnameEndpoint(object):
         self._attemptDelay = attemptDelay
 
 
+    def __repr__(self):
+        """
+        Produce a string representation of the L{HostnameEndpoint}.
+
+        @return: A L{str}
+        """
+        if self._badHostname:
+            # Use the backslash-encoded version of the string passed to the
+            # constructor, which is already a native string.
+            host = self._hostStr
+        elif isIPv6Address(self._hostStr):
+            host = '[{}]'.format(self._hostStr)
+        else:
+            # Convert the bytes representation to a native string to ensure
+            # that we display the punycoded version of the hostname, which is
+            # more useful than any IDN version as it can be easily copy-pasted
+            # into debugging tools.
+            host = nativeString(self._hostBytes)
+        return "".join(["<HostnameEndpoint ", host, ":", str(self._port), ">"])
+
+
     def _getNameResolverAndMaybeWarn(self, reactor):
         """
         Retrieve a C{nameResolver} callable and warn the caller's

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2491,7 +2491,10 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
             'example.com', 80,
         )
 
-        self.assertEqual("<HostnameEndpoint example.com:80>", repr(endpoint))
+        rep = repr(endpoint)
+
+        self.assertEqual("<HostnameEndpoint example.com:80>", rep)
+        self.assertIs(str, type(rep))
 
 
     def test_idnaHostname(self):
@@ -2504,10 +2507,10 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
             u'b\xfccher.ch', 443,
         )
 
-        self.assertEqual(
-            "<HostnameEndpoint xn--bcher-kva.ch:443>",
-            repr(endpoint),
-        )
+        rep = repr(endpoint)
+
+        self.assertEqual("<HostnameEndpoint xn--bcher-kva.ch:443>", rep)
+        self.assertIs(str, type(rep))
 
 
     def test_hostIPv6Address(self):
@@ -2522,7 +2525,10 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
             b'::1', 22,
         )
 
-        self.assertEqual("<HostnameEndpoint [::1]:22>", repr(endpoint))
+        rep = repr(endpoint)
+
+        self.assertEqual("<HostnameEndpoint [::1]:22>", rep)
+        self.assertIs(str, type(rep))
 
 
     def test_badEncoding(self):

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2504,7 +2504,10 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
             u'b\xfccher.ch', 443,
         )
 
-        self.assertEqual("<HostnameEndpoint xn--bcher-kva.ch:443>", repr(endpoint))
+        self.assertEqual(
+            "<HostnameEndpoint xn--bcher-kva.ch:443>",
+            repr(endpoint),
+        )
 
 
     def test_hostIPv6Address(self):
@@ -2532,7 +2535,10 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
             b'\xff-garbage-\xff', 80
         )
 
-        self.assertEqual('<HostnameEndpoint \\xff-garbage-\\xff:80>', repr(endpoint))
+        self.assertEqual(
+            '<HostnameEndpoint \\xff-garbage-\\xff:80>',
+            repr(endpoint),
+        )
 
 
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2476,6 +2476,58 @@ class HostnameEndpointIDNATests(unittest.SynchronousTestCase):
         self.assertIn("\\u2ff0-garbage-\\u2ff0", str(err))
 
 
+class HostnameEndpointReprTests(unittest.SynchronousTestCase):
+    def test_allASCII(self):
+        """
+        The string representation of L{HostnameEndpoint} includes the host and
+        port passed to the constructor.
+        """
+        endpoint = endpoints.HostnameEndpoint(
+            deterministicResolvingReactor(Clock(), []),
+            'example.com', 80,
+        )
+
+        self.assertEqual("<HostnameEndpoint example.com:80>", repr(endpoint))
+
+    def test_idnaHostname(self):
+        """
+        When IDN is passed to the L{HostnameEndpoint} constructor the string
+        representation includes the punycode version of the host.
+        """
+        endpoint = endpoints.HostnameEndpoint(
+            deterministicResolvingReactor(Clock(), []),
+            u'b\xfccher.ch', 443,
+        )
+
+        self.assertEqual("<HostnameEndpoint xn--bcher-kva.ch:443>", repr(endpoint))
+
+    def test_hostIPv6Address(self):
+        """
+        When the host passed to L{HostnameEndpoint} is an IPv6 address it is
+        wrapped in brackets in the string representation, like in a URI. This
+        prevents the colon separating the host from the port from being
+        ambiguous.
+        """
+        endpoint = endpoints.HostnameEndpoint(
+            deterministicResolvingReactor(Clock(), []),
+            b'::1', 22,
+        )
+
+        self.assertEqual("<HostnameEndpoint [::1]:22>", repr(endpoint))
+
+    def test_badEncoding(self):
+        """
+        When a bad hostname is passed to L{HostnameEndpoint}, the string
+        representation displays invalid characters in backslash-escaped form.
+        """
+        endpoint = endpoints.HostnameEndpoint(
+            deterministicResolvingReactor(Clock(), []),
+            b'\xff-garbage-\xff', 80
+        )
+
+        self.assertEqual('<HostnameEndpoint \\xff-garbage-\\xff:80>', repr(endpoint))
+
+
 
 class HostnameEndpointsGAIFailureTests(unittest.TestCase):
     """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2476,7 +2476,11 @@ class HostnameEndpointIDNATests(unittest.SynchronousTestCase):
         self.assertIn("\\u2ff0-garbage-\\u2ff0", str(err))
 
 
+
 class HostnameEndpointReprTests(unittest.SynchronousTestCase):
+    """
+    Tests for L{HostnameEndpoint}'s string representation.
+    """
     def test_allASCII(self):
         """
         The string representation of L{HostnameEndpoint} includes the host and
@@ -2489,6 +2493,7 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
 
         self.assertEqual("<HostnameEndpoint example.com:80>", repr(endpoint))
 
+
     def test_idnaHostname(self):
         """
         When IDN is passed to the L{HostnameEndpoint} constructor the string
@@ -2500,6 +2505,7 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
         )
 
         self.assertEqual("<HostnameEndpoint xn--bcher-kva.ch:443>", repr(endpoint))
+
 
     def test_hostIPv6Address(self):
         """
@@ -2514,6 +2520,7 @@ class HostnameEndpointReprTests(unittest.SynchronousTestCase):
         )
 
         self.assertEqual("<HostnameEndpoint [::1]:22>", repr(endpoint))
+
 
     def test_badEncoding(self):
         """

--- a/src/twisted/newsfragments/9341.feature
+++ b/src/twisted/newsfragments/9341.feature
@@ -1,0 +1,1 @@
+twisted.internet.endpoints.HostnameEndpoint now has a __repr__ method which includes the host and port to which the endpoint connects.


### PR DESCRIPTION
Implement `HostnameEndpoint.__repr__` which produces output like `<HostnameEndpoint example.com:80>`.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9341
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
