### PR TITLE
Create a utility function for converting unicode to bytes

### DIFF
--- a/src/twisted/newsfragments/9343.feature
+++ b/src/twisted/newsfragments/9343.feature
@@ -1,1 +1,1 @@
-twisted.python.bytes.toBytes is a convenience function for converting unicode strings to bytes.
+twisted.python.bytes.ensureBytes is a convenience function for converting unicode strings to bytes.

--- a/src/twisted/newsfragments/9343.feature
+++ b/src/twisted/newsfragments/9343.feature
@@ -1,0 +1,1 @@
+twisted.python.bytes.toBytes is a convenience function for converting unicode strings to bytes.

--- a/src/twisted/newsfragments/9343.feature
+++ b/src/twisted/newsfragments/9343.feature
@@ -1,1 +1,1 @@
-twisted.python.bytes.ensureBytes is a convenience function for converting unicode strings to bytes.
+twisted.python.bytes.ensureBytes was added for converting Unicode to bytes.

--- a/src/twisted/python/bytes.py
+++ b/src/twisted/python/bytes.py
@@ -25,13 +25,9 @@ def ensureBytes(s, encoding="ascii", errors="strict"):
     @return: The encoded string.  If I{s} is L{bytes} just return I{s}.
     @rtype: L{bytes}
     """
-    if isinstance(s, bytes):
-        return s
-    elif isinstance(s, unicode):
+    if isinstance(s, unicode):
         return s.encode(encoding=encoding, errors=errors)
-    else:
-        raise TypeError("Expected {} to be unicode or bytes not: "
-            "{}".format(s, type(s)))
+    return s
 
 
 

--- a/src/twisted/python/bytes.py
+++ b/src/twisted/python/bytes.py
@@ -1,0 +1,37 @@
+# -*- test-case-name: twisted.python.test.test_bytes -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Utility for converting between L{unicode} and L{bytes}
+"""
+
+from __future__ import division, absolute_import, print_function
+
+from twisted.python.compat import unicode
+
+
+def ensureBytes(s, encoding="ascii", errors="strict"):
+    """
+    Convert L{unicode} string to L{bytes}.
+
+    @param s: The string to convert.
+    @param encoding: The encoding to pass to L{str.encode}.
+    @param errors: The error handling scheme to pass to L{str.encode}.
+
+    @raise TypeError: The input is not L{unicode}, L{bytes}.
+
+    @return: The encoded string.  If I{s} is L{bytes} just return I{s}.
+    @rtype: L{bytes}
+    """
+    if isinstance(s, bytes):
+        return s
+    elif isinstance(s, unicode):
+        return s.encode(encoding=encoding, errors=errors)
+    else:
+        raise TypeError("Expected {} to be unicode or bytes not: "
+            "{}".format(s, type(s)))
+
+
+
+__all__ = ['ensureBytes']

--- a/src/twisted/python/bytes.py
+++ b/src/twisted/python/bytes.py
@@ -16,10 +16,11 @@ def ensureBytes(s, encoding="ascii", errors="strict"):
     Convert L{unicode} string to L{bytes}.
 
     @param s: The string to convert.
+    @type s: L{unicode} or L{bytes}
     @param encoding: The encoding to pass to L{str.encode}.
     @param errors: The error handling scheme to pass to L{str.encode}.
 
-    @raise TypeError: The input is not L{unicode}, L{bytes}.
+    @raise TypeError: The input is not L{unicode} or L{bytes}.
 
     @return: The encoded string.  If I{s} is L{bytes} just return I{s}.
     @rtype: L{bytes}

--- a/src/twisted/python/test/test_bytes.py
+++ b/src/twisted/python/test/test_bytes.py
@@ -14,7 +14,8 @@ from twisted.trial.unittest import TestCase
 
 class EnsureBytesTests(TestCase):
     """
-    L{twisted.python.bytes.ensureBytes} is used to convert L{unicode} to L{bytes}.
+    L{twisted.python.bytes.ensureBytes} is used to convert L{unicode} to
+    L{bytes}.
     """
 
     def test_ensureBytesUnicode(self):

--- a/src/twisted/python/test/test_bytes.py
+++ b/src/twisted/python/test/test_bytes.py
@@ -64,6 +64,6 @@ class EnsureBytesTests(TestCase):
     def test_ensureBytesTypeError(self):
         """
         L{ensureBytes} will raise L{TypeError} if passed anything which
-        is not L{unicode}, L{bytes}, or L{None}.
+        is not L{unicode} or L{bytes}.
         """
         self.assertRaises(TypeError, ensureBytes, ["foo", "bar"])

--- a/src/twisted/python/test/test_bytes.py
+++ b/src/twisted/python/test/test_bytes.py
@@ -1,0 +1,69 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Tests for L{twisted.python.bytes}.
+"""
+
+from __future__ import division, absolute_import, print_function
+
+from twisted.python.bytes import ensureBytes
+from twisted.trial.unittest import TestCase
+
+
+
+class EnsureBytesTests(TestCase):
+    """
+    L{twisted.python.bytes.ensureBytes} is used to convert L{unicode} to L{bytes}.
+    """
+
+    def test_ensureBytesUnicode(self):
+        """
+        If L{unicode} is passed to L{ensureBytes}, the L{unicode} is converted
+        to L{bytes} and returned.
+        """
+        self.assertEqual(ensureBytes(u"hello"), b"hello")
+
+
+    def test_ensureBytesEncodingParameter(self):
+        """
+        The I{encoding} parameter is passed to L{str.encode} and selects the
+        codec to use when converting L{unicode} to L{bytes}.
+        """
+        self.assertEqual(ensureBytes(u'\N{SNOWMAN}', encoding="utf-8"),
+                         b'\xe2\x98\x83')
+
+
+    def test_ensureBytesErrorsParameter(self):
+        """
+        The I{errors} parameter is passed to L{str.encode} and specifies the
+        response when the input string cannot be converted according to the
+        encoding’s rules.
+        """
+        self.assertEqual(
+            ensureBytes(u'\N{SNOWMAN}', encoding="ascii", errors="ignore"),
+            b'')
+
+
+    def test_ensureBytesUnicodeEncodeError(self):
+        """
+        L{UnicodeEncodedError} will be raised if the input string cannot be
+        converted using the encoding's rules.
+        """
+        self.assertRaises(UnicodeEncodeError,
+            ensureBytes, u'\N{SNOWMAN}', encoding="ascii")
+
+
+    def test_ensureBytesBytes(self):
+        """
+        L{ensureBytes} just returns any L{bytes} passed to it.
+        """
+        self.assertEqual(ensureBytes(b'\xe2\x98\x83'), b'\xe2\x98\x83')
+
+
+    def test_ensureBytesTypeError(self):
+        """
+        L{ensureBytes} will raise L{TypeError} if passed anything which
+        is not L{unicode}, L{bytes}, or L{None}.
+        """
+        self.assertRaises(TypeError, ensureBytes, ["foo", "bar"])

--- a/src/twisted/python/test/test_bytes.py
+++ b/src/twisted/python/test/test_bytes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
@@ -23,7 +24,7 @@ class EnsureBytesTests(TestCase):
         If L{unicode} is passed to L{ensureBytes}, the L{unicode} is converted
         to L{bytes} and returned.
         """
-        self.assertEqual(ensureBytes(u"hello"), b"hello")
+        self.assertEqual(b"hello", ensureBytes(u"hello"))
 
 
     def test_ensureBytesEncodingParameter(self):
@@ -32,8 +33,8 @@ class EnsureBytesTests(TestCase):
         codec to use when converting L{unicode} to L{bytes}.
         """
         self.assertEqual(
-            ensureBytes(u'\N{SNOWMAN}', encoding="utf-8"),
-            b'\xe2\x98\x83')
+            b'\xe2\x98\x83',
+            ensureBytes(u'\N{SNOWMAN}', encoding="utf-8"))
 
 
     def test_ensureBytesErrorsParameter(self):
@@ -43,8 +44,8 @@ class EnsureBytesTests(TestCase):
         encoding’s rules.
         """
         self.assertEqual(
-            ensureBytes(u'\N{SNOWMAN}', encoding="ascii", errors="ignore"),
-            b'')
+            b'',
+            ensureBytes(u'\N{SNOWMAN}', encoding="ascii", errors="ignore"))
 
 
     def test_ensureBytesUnicodeEncodeError(self):
@@ -61,4 +62,4 @@ class EnsureBytesTests(TestCase):
         """
         L{ensureBytes} just returns any L{bytes} passed to it.
         """
-        self.assertEqual(ensureBytes(b'\xe2\x98\x83'), b'\xe2\x98\x83')
+        self.assertEqual(b'\xe2\x98\x83', ensureBytes(b'\xe2\x98\x83'))

--- a/src/twisted/python/test/test_bytes.py
+++ b/src/twisted/python/test/test_bytes.py
@@ -31,8 +31,9 @@ class EnsureBytesTests(TestCase):
         The I{encoding} parameter is passed to L{str.encode} and selects the
         codec to use when converting L{unicode} to L{bytes}.
         """
-        self.assertEqual(ensureBytes(u'\N{SNOWMAN}', encoding="utf-8"),
-                         b'\xe2\x98\x83')
+        self.assertEqual(
+            ensureBytes(u'\N{SNOWMAN}', encoding="utf-8"),
+            b'\xe2\x98\x83')
 
 
     def test_ensureBytesErrorsParameter(self):
@@ -51,7 +52,8 @@ class EnsureBytesTests(TestCase):
         L{UnicodeEncodedError} will be raised if the input string cannot be
         converted using the encoding's rules.
         """
-        self.assertRaises(UnicodeEncodeError,
+        self.assertRaises(
+            UnicodeEncodeError,
             ensureBytes, u'\N{SNOWMAN}', encoding="ascii")
 
 
@@ -60,11 +62,3 @@ class EnsureBytesTests(TestCase):
         L{ensureBytes} just returns any L{bytes} passed to it.
         """
         self.assertEqual(ensureBytes(b'\xe2\x98\x83'), b'\xe2\x98\x83')
-
-
-    def test_ensureBytesTypeError(self):
-        """
-        L{ensureBytes} will raise L{TypeError} if passed anything which
-        is not L{unicode} or L{bytes}.
-        """
-        self.assertRaises(TypeError, ensureBytes, ["foo", "bar"])


### PR DESCRIPTION
http://twistedmatrix.com/trac/ticket/9343

There are several places in the Twisted source where a pattern like:

```
if isinstance(s, unicode):
    s = s.encode("ascii")
```

This attempts to encapsulate this pattern in a function.

Based on this feedback from an earlier PR, I did not put this in `twisted.python.compat`: https://github.com/twisted/twisted/pull/936#discussion_r153816654


My motivation for this is to fix some problems I found in `twisted.web` when I found this problem when trying to port https://github.com/LeastAuthority/txkube to Python 3:
https://github.com/twisted/twisted/pull/936#discussion_r153823007

Specifically if I have:
```
networkString(foo)
```
if `foo` is of type `bytes` on Python 2, it will work fine, but if `foo` is of type `bytes` on Python 3,
this `networkString` will throw an exception.

If this code goes in, I would also like to delete the `_ensureBytes()` private function in https://github.com/twisted/twisted/blob/trunk/src/twisted/web/http.py#L1154

