### PR TITLE
Bugfix: slot data stack is badly cleaned in templating

### DIFF
--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -241,6 +241,7 @@ def _flattenElement(request, root, write, slotData, renderFactory,
 
         if not root.tagName:
             yield keepGoing(root.children)
+            slotData.pop()
             return
 
         write(b'<')
@@ -273,6 +274,8 @@ def _flattenElement(request, root, write, slotData, renderFactory,
             write(b'</' + tagName + b'>')
         else:
             write(b' />')
+
+        slotData.pop()
 
     elif isinstance(root, (tuple, list, GeneratorType)):
         for element in root:

--- a/src/twisted/web/newsfragments/9383.bugfix
+++ b/src/twisted/web/newsfragments/9383.bugfix
@@ -1,0 +1,1 @@
+twisted.web._flatten._flattenElement, slot data stack is cleaned after flattening a node tree.

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -433,6 +433,28 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         return self.assertFlattensTo(t, b'<p><em>four&gt;</em></p>')
 
 
+    def test_slotDataPropagation(self):
+        """
+        slot data propagation is only made to child nodes.
+        Before #9383 fix, slot datas were not correctly clean during tree
+        traversal and some elements that are not directly child nodes can
+        reach forbidden slot data.
+        """
+        span1 = tags.span(slot('test'))
+        span2 = tags.span(slot('test', default='17'))
+        tree = tags.div(
+            tags.p(span1).fillSlots(test='42'),
+            tags.p(span2)
+        )
+        result = (
+            b'<div>'
+            b'<p><span>42</span></p>'
+            b'<p><span>17</span></p>'  # '42' was written before #9383
+            b'</div>'
+        )
+        return self.assertFlattensTo(tree, result)
+
+
     def test_unknownTypeRaises(self):
         """
         Test that flattening an unknown type of thing raises an exception.


### PR DESCRIPTION
see ticket #9383 in trac. - https://twistedmatrix.com/trac/ticket/9383

In the templating module, more precisely in the '_flattenElement' method, when getting through elements in the tree, some cleanings of the slot data stack are missing in some cases.