### PR TITLE
9389 Add external pycodestyle checker.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,5 +7,6 @@ https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch
 ## Contributor Checklist:
 
 * [ ] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
+* [ ] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
 * [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
 * [ ] I have updated the automated tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,23 +36,17 @@ matrix:
     # For now all non-trial tests are in a single job to reduce the time spent
     # on starting separate jobs.
     - python: 2.7
-      env: TOXENV=narrativedocs,apidocs,pyflakes,newsfragment,manifest-checker
+      env: TOXENV=narrativedocs,apidocs,pyflakes,newsfragment,manifest-checker,cipycodestyle
     - python: 3.6
       env: TOXENV=pyflakes3
-    # Twistedchecker is running as a separate job so that we can ignore if it
-    # fails. This needs to be on Python 3.5 for the moment, due to astroid
-    # changes.
+    # This needs to be on Python 3.5 for the moment, due to astroid changes.
     - python: 3.5
       env: TOXENV=txchecker-travis-required
-    - python: 3.5
-      env: TOXENV=txchecker-travis-all
     # We need a builder without IPv6. This is going to be slower than all the
     # others, but that's ok.
     - python: 3.6
       env: TOXENV=py36-alldeps-withcov-posix,codecov-publish DISABLE_IPV6=yes
       sudo: true
-  allow_failures:
-    - env: TOXENV=txchecker-travis-all
 
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # For now all non-trial tests are in a single job to reduce the time spent
     # on starting separate jobs.
     - python: 2.7
-      env: TOXENV=narrativedocs,apidocs,pyflakes,newsfragment,manifest-checker,cipycodestyle
+      env: TOXENV=narrativedocs,apidocs,pyflakes,newsfragment,manifest-checker,pycodestylediff
     - python: 3.6
       env: TOXENV=pyflakes3
     # This needs to be on Python 3.5 for the moment, due to astroid changes.

--- a/admin/README.rst
+++ b/admin/README.rst
@@ -1,0 +1,5 @@
+Twisted Developer Helper Scripts
+================================
+
+Here you can find various scripts used during the development of Twisted.
+There are not found in the released versions of Twisted.

--- a/admin/pycodestyle-twisted.py
+++ b/admin/pycodestyle-twisted.py
@@ -1,6 +1,32 @@
 #!/usr/bin/env python
 
 """
+Copyright © 2006-2009 Johann C. Rocholl <johann@rocholl.net>
+Copyright © 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>
+Copyright © 2014-2018 Ian Lee <IanLee1521@gmail.com>
+
+Licensed under the terms of the Expat License
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 A patched version for pycodestyle which uses the blank line conversion from
 Twisted.
 
@@ -106,5 +132,6 @@ pycodestyle._checks['logical_line'][blank_lines] = _previousValue
 
 
 if __name__ == '__main__':
+    # Calling main in a similar was as the upstream script.
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
     sys.exit(pycodestyle._main())

--- a/admin/pycodestyle-twisted.py
+++ b/admin/pycodestyle-twisted.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """
-Copyright © 2006-2009 Johann C. Rocholl <johann@rocholl.net>
-Copyright © 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>
-Copyright © 2014-2018 Ian Lee <IanLee1521@gmail.com>
+Copyright 2006-2009 Johann C. Rocholl <johann@rocholl.net>
+Copyright 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>
+Copyright 2014-2018 Ian Lee <IanLee1521@gmail.com>
 
 Licensed under the terms of the Expat License
 

--- a/admin/pycodestyle-twisted.py
+++ b/admin/pycodestyle-twisted.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+"""
+A patched version for pycodestyle which uses the blank line conversion from
+Twisted.
+
+Upstream integration is pending.
+See https://github.com/PyCQA/pycodestyle/issues/732
+"""
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+    )
+
+import re
+import sys
+
+import pycodestyle
+
+
+
+def blank_lines(logical_line, blank_lines, indent_level, line_number,
+                blank_before, previous_logical,
+                previous_unindented_logical_line, previous_indent_level,
+                lines):
+    r"""Separate top-level function and class definitions with two blank lines.
+
+    Method definitions inside a class are separated by a single blank line.
+
+    Extra blank lines may be used (sparingly) to separate groups of related
+    functions.  Blank lines may be omitted between a bunch of related
+    one-liners (e.g. a set of dummy implementations).
+
+    Use blank lines in functions, sparingly, to indicate logical sections.
+
+    Okay: def a():\n    pass\n\n\ndef b():\n    pass
+    Okay: def a():\n    pass\n\n\nasync def b():\n    pass
+    Okay: def a():\n    pass\n\n\n# Foo\n# Bar\n\ndef b():\n    pass
+    Okay: default = 1\nfoo = 1
+    Okay: classify = 1\nfoo = 1
+
+    E301: class Foo:\n    b = 0\n    def bar():\n        pass
+    E302: def a():\n    pass\n\ndef b(n):\n    pass
+    E302: def a():\n    pass\n\nasync def b(n):\n    pass
+    E303: def a():\n    pass\n\n\n\ndef b(n):\n    pass
+    E303: def a():\n\n\n\n    pass
+    E304: @decorator\n\ndef a():\n    pass
+    E305: def a():\n    pass\na()
+    E306: def a():\n    def b():\n        pass\n    def c():\n        pass
+    """
+    top_level_lines = 3
+    method_lines = 2
+    if line_number < 3 and not previous_logical:
+        return  # Don't expect blank lines before the first line
+    if previous_logical.startswith('@'):
+        if blank_lines:
+            yield 0, "E304 blank lines found after function decorator"
+    elif (
+        (blank_lines > top_level_lines + 1) or
+        (indent_level and blank_lines == method_lines + 1)
+            ):
+        yield 0, "E303 too many blank lines (%d)" % blank_lines
+    elif pycodestyle.STARTSWITH_TOP_LEVEL_REGEX.match(logical_line):
+        if indent_level:
+            if not (blank_before or previous_indent_level < indent_level or
+                    pycodestyle.DOCSTRING_REGEX.match(previous_logical)):
+                ancestor_level = indent_level
+                nested = False
+                # Search backwards for a def ancestor or tree root (top level).
+                for line in lines[line_number - 2::-1]:
+                    if (
+                        line.strip() and
+                        pycodestyle.expand_indent(line) < ancestor_level
+                            ):
+                        ancestor_level = pycodestyle.expand_indent(line)
+                        nested = line.lstrip().startswith('def ')
+                        if nested or ancestor_level == 0:
+                            break
+                if nested:
+                    yield 0, "E306 expected 1 blank line before a " \
+                        "nested definition, found 0"
+                else:
+                    yield 0, "E301 expected 1 blank line, found 0"
+        elif blank_before != top_level_lines:
+            yield 0, "E302 expected %s blank lines, found %d" % (
+                top_level_lines, blank_before)
+    elif (
+        logical_line and
+        not indent_level and
+        blank_before != top_level_lines and
+        previous_unindented_logical_line.startswith(('def ', 'class '))
+            ):
+        yield 0, "E305 expected %s blank lines after " \
+            "class or function definition, found %d" % (
+                top_level_lines, blank_before)
+
+
+
+# Replace the upstream blank_lines implementation, with our fork.
+_previousValue = pycodestyle._checks['logical_line'][pycodestyle.blank_lines]
+del pycodestyle._checks['logical_line'][pycodestyle.blank_lines]
+pycodestyle._checks['logical_line'][blank_lines] = _previousValue
+
+
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(pycodestyle._main())

--- a/admin/pycodestyle-twisted.py
+++ b/admin/pycodestyle-twisted.py
@@ -1,32 +1,32 @@
 #!/usr/bin/env python
+#
+# Copyright 2006-2009 Johann C. Rocholl <johann@rocholl.net>
+# Copyright 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>
+# Copyright 2014-2018 Ian Lee <IanLee1521@gmail.com>
+
+# Licensed under the terms of the Expat License
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 """
-Copyright 2006-2009 Johann C. Rocholl <johann@rocholl.net>
-Copyright 2009-2014 Florent Xicluna <florent.xicluna@gmail.com>
-Copyright 2014-2018 Ian Lee <IanLee1521@gmail.com>
-
-Licensed under the terms of the Expat License
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software,
-and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 A patched version for pycodestyle which uses the blank line conversion from
 Twisted.
 

--- a/src/twisted/test/test_shortcut.py
+++ b/src/twisted/test/test_shortcut.py
@@ -44,12 +44,14 @@ class ShortcutTests(unittest.TestCase):
         testFilename = sys.executable
         baseFileName = os.path.basename(testFilename)
         tempDir = tempfile.gettempdir()
-        s1 = shortcut.Shortcut(path=testFilename,
-                               arguments="-V",
-                               description="The Python executable",
-			       workingdir=tempDir,
-			       iconpath=tempDir,
-                               iconidx=1)
+        s1 = shortcut.Shortcut(
+            path=testFilename,
+            arguments="-V",
+            description="The Python executable",
+            workingdir=tempDir,
+            iconpath=tempDir,
+            iconidx=1,
+            )
         tempname = self.mktemp() + '.lnk'
         s1.save(tempname)
         self.assertTrue(os.path.exists(tempname))

--- a/src/twisted/test/testutils.py
+++ b/src/twisted/test/testutils.py
@@ -18,6 +18,8 @@ from xml.dom import minidom as dom
 
 from twisted.internet.protocol import FileWrapper
 
+
+
 class IOPump:
     """Utility to pump data between clients and servers for protocol testing.
 
@@ -55,6 +57,7 @@ class IOPump:
             return 1
         else:
             return 0
+
 
 
 def returnConnected(server, client):
@@ -142,8 +145,8 @@ class ComparisonTestsMixin(object):
         equal to C{valueOne} and that it defines equality cooperatively with
         other types it doesn't know about.
 
-        @param firstValueOne: An object which is expected to compare as equal to
-            C{secondValueOne} and not equal to C{valueTwo}.
+        @param firstValueOne: An object which is expected to compare as equal
+            to C{secondValueOne} and not equal to C{valueTwo}.
 
         @param secondValueOne: A different object than C{firstValueOne} but
             which is expected to compare equal to that object.

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@
 ; coverage results to codecov.io. It should be called after running the
 ; standard coverage environment.
 ;
-; A non-default `txchecker-travis` and `cipycodestyle` environments are
-; used to run on Travis-CI in --diff mode
+; A non-default `txchecker-travis` environment is used to run twistedchecker
+; on travis in --diff mode
 ;
 [tox]
 minversion=2.4

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ extras =
 
     {alldeps,tests}-macos: osx_platform
 
-    ; Documentation
+    ; Documentation needs Twisted install to get the version.
     narrativedocs: dev
 
 ;; dependencies that are not specified as extras
@@ -150,6 +150,9 @@ skip_install = true
 [testenv:apidocs]
 basepython=python2.7
 
+[testenv:newsfragment]
+basepython=python2.7
+
 [testenv:manifest-checker]
 basepython=python2.7
 skip_install = true
@@ -162,10 +165,6 @@ skip_install = true
 basepython=python2.7
 skip_install = true
 
-# Sphinx documentation also don't need the code installed.
-[testenv:narrativedocs]
-basepython=python2.7
-skip_install = true
 
 # TwistedChecker needs to be 3.5
 [testenv:txchecker-travis-required]

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@
 ; coverage results to codecov.io. It should be called after running the
 ; standard coverage environment.
 ;
-; A non-default `txchecker-travis` environment is used to run twistedchecker
-; on travis in --diff mode
+; A non-default `txchecker-travis` and `cipycodestyle` environments are
+; used to run on Travis-CI in --diff mode
 ;
 [tox]
 minversion=2.4
@@ -63,6 +63,11 @@ deps =
     ; Code quality checkers
     pyflakes{,3}: pyflakes
     manifest-checker: check-manifest
+    ; We go with unreleased version as PyPI version is 1 year old.
+    ; Also, I hope that the Twisted blank_lines will be supported soon upstream
+    ; and also released soon on PyPI, so that we no longer have to use a
+    ; commit.
+    {pycodestyle,cipycodestyle}: https://github.com/pycqa/pycodestyle/archive/eb91b79ab38aad4d44a3b52b02605412f32ba5ae.zip
 
     {twistedchecker,txchecker-travis}: twistedchecker>=0.7.1
     txchecker-travis: diff-cover==0.9.12
@@ -124,6 +129,11 @@ commands =
 
     manifest-checker: check-manifest --ignore "docs/_build*,docs/historic/*,admin*,bin/admin*,twisted/topfiles/*.Old"
 
+    pycodestyle: python {toxinidir}/admin/pycodestyle-twisted.py {posargs:admin src/twisted}
+    ; Travis-CI version is executing in diff mode without any input arguments.
+    cipycodestyle: /bin/sh -c "git diff trunk... | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
+
+
 [testenv:twistedchecker]
 basepython=python3.6
 [testenv:pyflakes]
@@ -139,8 +149,5 @@ basepython=python2.7
 
 # TwistedChecker needs to be 3.5
 [testenv:txchecker-travis-required]
-basepython=python3.5
-usedevelop=True
-[testenv:txchecker-travis-all]
 basepython=python3.5
 usedevelop=True

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ commands =
 
     pycodestyle: python {toxinidir}/admin/pycodestyle-twisted.py {posargs:admin src/twisted}
     ; Travis-CI version is executing in diff mode without any input arguments.
-    pycodestylediff: /bin/sh -c "git diff trunk... | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
+    pycodestylediff: /bin/sh -c "git diff trunk | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
 
 
 [testenv:twistedchecker]
@@ -146,6 +146,25 @@ basepython=python2.7
 basepython=python2.7
 [testenv:manifest-checker]
 basepython=python2.7
+
+
+# Static checkers don't need to install the source code.
+[testenv:pyflakes3]
+skip_install = true
+[testenv:pyflakes]
+skip_install = true
+[testenv:pycodestyle]
+skip_install = true
+[testenv:pycodestylediff]
+skip_install = true
+[testenv:newsfragment]
+skip_install = true
+
+
+# Sphinx documentation also don't need the code installed.
+[testenv:narrativedocs]
+skip_install = true
+
 
 # TwistedChecker needs to be 3.5
 [testenv:txchecker-travis-required]

--- a/tox.ini
+++ b/tox.ini
@@ -136,35 +136,40 @@ commands =
 
 [testenv:twistedchecker]
 basepython=python3.6
+
 [testenv:pyflakes]
 basepython=python2.7
+# Static checkers don't need to install the source code.
+skip_install = true
+
 [testenv:pyflakes3]
 basepython=python3.6
+# Static checkers don't need to install the source code.
+skip_install = true
+
 [testenv:apidocs]
 basepython=python2.7
+
 [testenv:newsfragment]
 basepython=python2.7
+skip_install = true
+
 [testenv:manifest-checker]
 basepython=python2.7
-
-
-# Static checkers don't need to install the source code.
-[testenv:pyflakes3]
 skip_install = true
-[testenv:pyflakes]
-skip_install = true
+
 [testenv:pycodestyle]
-skip_install = true
-[testenv:pycodestylediff]
-skip_install = true
-[testenv:newsfragment]
+basepython=python2.7
 skip_install = true
 
+[testenv:pycodestylediff]
+basepython=python2.7
+skip_install = true
 
 # Sphinx documentation also don't need the code installed.
 [testenv:narrativedocs]
+basepython=python2.7
 skip_install = true
-
 
 # TwistedChecker needs to be 3.5
 [testenv:txchecker-travis-required]

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     ; Also, I hope that the Twisted blank_lines will be supported soon upstream
     ; and also released soon on PyPI, so that we no longer have to use a
     ; commit.
-    {pycodestyle,cipycodestyle}: https://github.com/pycqa/pycodestyle/archive/eb91b79ab38aad4d44a3b52b02605412f32ba5ae.zip
+    {pycodestyle,pycodestylediff}: https://github.com/pycqa/pycodestyle/archive/eb91b79ab38aad4d44a3b52b02605412f32ba5ae.zip
 
     {twistedchecker,txchecker-travis}: twistedchecker>=0.7.1
     txchecker-travis: diff-cover==0.9.12
@@ -131,7 +131,7 @@ commands =
 
     pycodestyle: python {toxinidir}/admin/pycodestyle-twisted.py {posargs:admin src/twisted}
     ; Travis-CI version is executing in diff mode without any input arguments.
-    cipycodestyle: /bin/sh -c "git diff trunk... | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
+    pycodestylediff: /bin/sh -c "git diff trunk... | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
 
 
 [testenv:twistedchecker]

--- a/tox.ini
+++ b/tox.ini
@@ -150,10 +150,6 @@ skip_install = true
 [testenv:apidocs]
 basepython=python2.7
 
-[testenv:newsfragment]
-basepython=python2.7
-skip_install = true
-
 [testenv:manifest-checker]
 basepython=python2.7
 skip_install = true


### PR DESCRIPTION
Scope
=====

Trac ticket https://twistedmatrix.com/trac/ticket/9389

This adds an external tool for running pycodestyle on Twisted code.
Previously the pycodestyle fork was part of twistedcheker... but twistedchecker is slow and it looks like contributors are not using twistedchecker that often on local system.

I hope that by making it easier to run pycodestyle on local system, we reduce the load on the CI systems.

I also hope that with a more standard pycodestyle reporting we can use tools like https://github.com/hhatto/autopep8 to automatically update the code.

Here is a statistic with current errors https://gist.github.com/adiroiban/ccfb1283bd7d8641e726a06e36c40cde

I hope that soon we can clean the whole code (as we did with pyflakes) and then contributors should no longer care about existing errors (as there are none:) 


Changes
=======

Created a fork of pycodestyle with custom blank_lines.
I placed it in 'admin' and called it `pycodestyle-twisted.py`.
I went for latest `master` as I hope that in this way we can the latest checks...and I hope that we will have soon a version of pycodestyle which works out of the box with the Twisted blank lines.

I added a pycodestyle tox environment for Travis and for local usage.
The Travis-CI version only checks the diff... and any change should be PEP8 complaint.

I have removed the txchecker-travis-all, as it was set it ignore. And since Travis reports a green build even when it fails, I don't know if anybody was checking it... so it is just a waste of time.

As a drive-by, I added admin/README file, as I am confused about the scope of `admin` vs `bin/admin`

While testing the changes, I fixed a few files.
For example we no longer have mixed tabs and spaces (which were found in a single file) 


How to test
=========

Check that Travis-CI build fails, when the diff has codestyle validations.

--------------

Run local for a specific file and with specific arguments
```
$ admin/pycodestyle-twisted.py --help
$ admin/pycodestyle-twisted.py --select=E272 src/twisted/web/test/test_static.py
```

Run local and check only for changes since trunk.
```
$ git diff trunk... | admin/pycodestyle-twisted.py --diff
```

-----------

Run from Tox
```
$ tox -e pycodestyle admin/pycodestyle-twisted.py  --select=E272 src/twisted/web/test/test_static.py
$ tox -e cipycodestyle
```