### PR TITLE
docs: render deferToThread example as code

### DIFF
--- a/docs/core/howto/threading.rst
+++ b/docs/core/howto/threading.rst
@@ -99,6 +99,8 @@ When we run some code, we often want to know what its result was.  For this, Twi
 
 To get a result from some blocking code back into the reactor thread, we can use :api:`twisted.internet.threads.deferToThread <deferToThread>` to execute it instead of callFromThread.
 
+::
+
     from __future__ import print_function
     from twisted.internet import reactor, threads
 


### PR DESCRIPTION
Prior to this change, the documentation was not rendering this example as a code block. The documentation simply displayed indented text here.

You can see this here: http://twistedmatrix.com/documents/current/core/howto/threading.html#getting-results

Add a double-colon to signify that this is code.

https://twistedmatrix.com/trac/ticket/9396