### PR TITLE
Cleanup some dependencies in tox.ini targets on Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,9 +133,6 @@ commands =
     pycodestylediff: /bin/sh -c "git diff trunk | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
 
 
-[testenv:twistedchecker]
-basepython=python3.6
-
 [testenv:pyflakes]
 basepython=python2.7
 # Static checkers don't need to install the source code.
@@ -147,23 +144,21 @@ basepython=python3.6
 skip_install = true
 
 [testenv:apidocs]
-basepython=python2.7
-
-[testenv:newsfragment]
+# Epydoc and pydoctor currently on work on Python 2
 basepython=python2.7
 
 [testenv:manifest-checker]
-basepython=python2.7
 skip_install = true
 
 [testenv:pycodestyle]
-basepython=python2.7
 skip_install = true
 
 [testenv:pycodestylediff]
-basepython=python2.7
 skip_install = true
 
+# TwistedChecker needs to be 3.5
+[testenv:twistedchecker]
+basepython=python3.5
 
 # TwistedChecker needs to be 3.5
 [testenv:txchecker-travis-required]


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9394

 * apidocs must run only on Python 2, because epydoc and pydoctor do not work on Python 3,
   so add a clarifying comment
 * manifest-checker, pycodestyle, pycodestylediff work on Python 2 or 3, so remove basepython
   from their targets
 * twistedchecker doesn't work on Python 3.6, and must be on Python 3.5, so change basepython
   version accordingly
