### PR TITLE
[9375] Update Sequence import for Python3.7 warning.

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -173,7 +173,7 @@ class IHostnameResolver(Interface):
             practice, this means an iterable containing
             L{twisted.internet.address.IPv4Address},
             L{twisted.internet.address.IPv6Address}, both, or neither.
-        @type addressTypes: L{collections.Iterable} of L{type}
+        @type addressTypes: L{collections.abc.Iterable} of L{type}
 
         @param transportSemantics: A string describing the semantics of the
             transport; either C{'TCP'} for stream-oriented transports or

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -827,6 +827,10 @@ if _PY3:
 else:
     _tokenize = tokenize.generate_tokens
 
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 
 __all__ = [
@@ -868,5 +872,6 @@ __all__ = [
     "intern",
     "unichr",
     "raw_input",
-    "_tokenize"
+    "_tokenize",
+    "Sequence",
 ]

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -10,7 +10,11 @@ from __future__ import division, absolute_import
 
 from socket import AF_INET, AF_INET6
 from io import BytesIO
-from collections import Sequence
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from zope.interface import implementer, implementedBy
 from zope.interface.verify import verifyClass

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -11,16 +11,11 @@ from __future__ import division, absolute_import
 from socket import AF_INET, AF_INET6
 from io import BytesIO
 
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
-
 from zope.interface import implementer, implementedBy
 from zope.interface.verify import verifyClass
 
 from twisted.python import failure
-from twisted.python.compat import unicode, intToBytes
+from twisted.python.compat import unicode, intToBytes, Sequence
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import (
     ITransport, IConsumer, IPushProducer, IConnector,

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -19,7 +19,10 @@ __all__ = [
     'RedirectWithNoLocation',
     ]
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from twisted.web._responses import RESPONSES
 from twisted.python.compat import unicode, nativeString, intToBytes

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -19,13 +19,10 @@ __all__ = [
     'RedirectWithNoLocation',
     ]
 
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
 
 from twisted.web._responses import RESPONSES
-from twisted.python.compat import unicode, nativeString, intToBytes
+from twisted.python.compat import unicode, nativeString, intToBytes, Sequence
+
 
 
 def _codeToMessage(code):

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -8,7 +8,10 @@ U{Python Web Server Gateway Interface v1.0.1<http://www.python.org/dev/peps/pep-
 
 __metaclass__ = type
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from sys import exc_info
 from warnings import warn
 

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -8,17 +8,13 @@ U{Python Web Server Gateway Interface v1.0.1<http://www.python.org/dev/peps/pep-
 
 __metaclass__ = type
 
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
 from sys import exc_info
 from warnings import warn
 
 from zope.interface import implementer
 
 from twisted.internet.threads import blockingCallFromThread
-from twisted.python.compat import reraise
+from twisted.python.compat import reraise, Sequence
 from twisted.python.failure import Failure
 from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET


### PR DESCRIPTION
Scope
=====

See https://twistedmatrix.com/trac/ticket/9375

Use Sequence from ABC as soon it will be removed .

Based on #956

Changes
=======

Put the import move in twisted.python.compat and use it from there.


How to test
==========

There should be no working and no other place importing Sequence from outside of compat.