### PR TITLE
Remove IRequest.getClient and its implementations.

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1466,17 +1466,6 @@ class Request:
         return self.password
 
 
-    def getClient(self):
-        """
-        Get the client's IP address, if it has one.  No attempt is made to
-        resolve the address to a hostname.
-
-        @return: The same value as C{getClientIP}.
-        @rtype: L{bytes}
-        """
-        return self.getClientIP()
-
-
     def connectionLost(self, reason):
         """
         There is no longer a connection for this request to respond over.
@@ -1548,11 +1537,6 @@ class Request:
         """
         return id(self)
 
-
-
-Request.getClient = deprecated(
-    Version("Twisted", 15, 0, 0),
-    "Twisted Names to resolve hostnames")(Request.getClient)
 
 
 Request.noLongerQueued = deprecated(

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -108,19 +108,6 @@ class IRequest(Interface):
         """
 
 
-    def getClient():
-        """
-        Return the hostname of the IP address of the client who submitted this
-        request, if possible.
-
-        This method is B{deprecated}.  See L{getClientIP} instead.
-
-        @rtype: L{None} or L{str}
-        @return: The canonical hostname of the client, as determined by
-            performing a name lookup on the IP address of the client.
-        """
-
-
     def getUser():
         """
         Return the HTTP user sent with this request, if any.

--- a/src/twisted/web/newsfragments/9395.removal
+++ b/src/twisted/web/newsfragments/9395.removal
@@ -1,0 +1,1 @@
+twisted.web.iweb.IRequest.getClient and its implementations (deprecated in #2552) have been removed.

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -14,8 +14,6 @@ from io import BytesIO
 from zope.interface import implementer
 
 from twisted.python.compat import intToBytes
-from twisted.python.deprecate import deprecated
-from incremental import Version
 from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address
 from twisted.internet.interfaces import ISSLTransport
@@ -357,16 +355,6 @@ class DummyRequest(object):
         self.requestHeaders.addRawHeader(b"host", hostHeader)
 
 
-    def getClient(self):
-        """
-        Get the client's IP address, if it has one.
-
-        @return: The same value as C{getClientIP}.
-        @rtype: L{bytes}
-        """
-        return self.getClientIP()
-
-
     def redirect(self, url):
         """
         Utility function that does a redirect.
@@ -375,7 +363,3 @@ class DummyRequest(object):
         """
         self.setResponseCode(FOUND)
         self.setHeader(b"location", url)
-
-DummyRequest.getClient = deprecated(
-    Version("Twisted", 15, 0, 0),
-    "Twisted Names to resolve hostnames")(DummyRequest.getClient)

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -3347,28 +3347,6 @@ class DeprecatedRequestAttributesTests(unittest.TestCase):
     """
     Tests for deprecated attributes of L{twisted.web.http.Request}.
     """
-    def test_getClient(self):
-        """
-        L{Request.getClient} is deprecated in favor of resolving the hostname
-        in application code.
-        """
-        channel = DummyChannel()
-        request = http.Request(channel, True)
-        request.gotLength(123)
-        request.requestReceived(b"GET", b"/", b"HTTP/1.1")
-        expected = channel.transport.getPeer().host
-        self.assertEqual(expected, request.getClient())
-        warnings = self.flushWarnings(
-            offendingFunctions=[self.test_getClient])
-
-        self.assertEqual({
-                "category": DeprecationWarning,
-                "message": (
-                    "twisted.web.http.Request.getClient was deprecated "
-                    "in Twisted 15.0.0; please use Twisted Names to "
-                    "resolve hostnames instead")},
-                         sub(["category", "message"], warnings[0]))
-
 
     def test_noLongerQueued(self):
         """


### PR DESCRIPTION
These were deprecated in ticket 2552.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9395
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
