### PR TITLE
Do not crash if we try to run wsgi over a Unix socket

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1333,7 +1333,11 @@ class Request:
         host = self.getHeader(b'host')
         if host:
             return host.split(b':', 1)[0]
-        return networkString(self.getHost().host)
+        hostAddress = self.getHost()
+        if isinstance(hostAddress, address.UNIXAddress):
+            return b"unix-socket"
+        else:
+            return networkString(self.getHost().host)
 
 
     def getHost(self):

--- a/src/twisted/web/newsfragments/5304.bugfix
+++ b/src/twisted/web/newsfragments/5304.bugfix
@@ -1,0 +1,1 @@
+Running a wsgi server over a Unix socket now works.  This can be tested with: twist web --port=unix:/tmp/sock  --wsgi wsgiref.simple_server.demo_app


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/5406

I tested this patch by using this testcase mentioned by @markrwilliams here: https://github.com/twisted/twisted/pull/975#discussion_r176917494

Start a server with:

```
twist web --port=unix:/tmp/sock --wsgi wsgiref.simple_server.demo_app
```

Connect to it like so:

```
curl --unix-socket /tmp/sock http://example.invalid/
```