### PR TITLE
[9404] Use only socket.AI_NUMERICHOST in t.i.tcp._resolveIPv6.

### DIFF
--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -631,6 +631,15 @@ def _resolveIPv6(ip, port):
     @raise socket.gaierror: if either the IP or port is not numeric as it
         should be.
     """
+    try:
+        int(port)
+    except ValueError:
+        # This raises a similar error to the error raised when using
+        # the socket.AI_NUMERICSERV flag.
+        # The socket.AI_NUMERICSERV flag is not used as it fails on Solaris
+        # even when a numeric port is provided.
+        raise socket.gaierror(-2, 'Name or service not known')
+
     return socket.getaddrinfo(
         ip,
         port,

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -638,7 +638,7 @@ def _resolveIPv6(ip, port):
         # the socket.AI_NUMERICSERV flag.
         # The socket.AI_NUMERICSERV flag is not used as it fails on Solaris
         # even when a numeric port is provided.
-        raise socket.gaierror(-2, 'Name or service not known')
+        raise socket.gaierror(socket.EAI_NONAME, 'Name or service not known')
 
     return socket.getaddrinfo(
         ip,

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -89,9 +89,6 @@ from twisted.internet.error import CannotListenError
 from twisted.internet import abstract, main, interfaces, error
 from twisted.internet.protocol import Protocol
 
-# Not all platforms have, or support, this flag.
-_AI_NUMERICSERV = getattr(socket, "AI_NUMERICSERV", 0)
-
 
 # The type for service names passed to socket.getservbyname:
 _portNameType = (str, unicode)
@@ -613,8 +610,6 @@ class BaseClient(_BaseBaseClient, _TLSClientMixin, Connection):
 
 
 
-_NUMERIC_ONLY = socket.AI_NUMERICHOST | _AI_NUMERICSERV
-
 def _resolveIPv6(ip, port):
     """
     Resolve an IPv6 literal into an IPv6 address.
@@ -636,7 +631,14 @@ def _resolveIPv6(ip, port):
     @raise socket.gaierror: if either the IP or port is not numeric as it
         should be.
     """
-    return socket.getaddrinfo(ip, port, 0, 0, 0, _NUMERIC_ONLY)[0][4]
+    return socket.getaddrinfo(
+        ip,
+        port,
+        socket.AF_UNSPEC,  # Any family.
+        0,  # Any socket type.
+        0,  # Any protocol.
+        socket.AI_NUMERICHOST,
+    )[0][4]
 
 
 

--- a/src/twisted/newsfragments/9404.bugfix
+++ b/src/twisted/newsfragments/9404.bugfix
@@ -1,0 +1,3 @@
+twisted.internet.tcp.Port and twisted.internet.tcp.Client now work with IPv6
+addressed on Solaris.
+Previously it failed to recognize an IPv6 address literal.

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,9 @@ commands =
 
     pycodestyle: python {toxinidir}/admin/pycodestyle-twisted.py {posargs:admin src/twisted}
     ; Travis-CI version is executing in diff mode without any input arguments.
-    pycodestylediff: /bin/sh -c "git diff trunk | python {toxinidir}/admin/pycodestyle-twisted.py --diff"
+    ; Ignore:
+    ; * E402 module level import not at top of file
+    pycodestylediff: /bin/sh -c "git diff trunk | python {toxinidir}/admin/pycodestyle-twisted.py --diff --ignore E402"
 
 
 [testenv:pyflakes]


### PR DESCRIPTION
Scope
=====

See https://twistedmatrix.com/trac/ticket/9404

In Solaris (10 and 11) you can't use listenTCP with IPv6 as it fails to get the address info.

This tries to fix that :)

Changes
=======

I have removed the `AI_NUMERICSERV` flag used in _resolveIPv6 since the port is never specified as a service name.
`twisted.internet.interfaces.IReactorTCP` ask for a port number and does not document that service names are supported.

I have emulated the AI_NUMERICSERV... not sure if that is ok, instead of an if/else to check for Solaris.

I have updated pycodestyle to ignore the top module imports, as we have many if/else imports so this will create false positives.



Contributor Checklist
=================

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9404
* [x] The changes pass minimal style checks.
* [x] I have created a newsfragment in src/twisted/newsfragments
* [ ]  Automated tests were not updated as I expect that this refactoring don't need extra tests.


How to test
=========

This code should continue to work and now it also works on Solaris.

```
from twisted.internet import reactor
from twisted.internet.protocol import Factory
reactor.listenTCP(12345, Factory(), interface='::1')
```