### PR TITLE
[9411] Remove OSX build from Circle-CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI 2.0 configuration file for running Python on macOS.
+# CircleCI 2.0 configuration file for running Twisted checks.
 #
 # Email notifications are configured only from web.
 # See "Email Preferences by Organization" in
@@ -109,48 +109,11 @@ jobs:
           command: |
             tox -r -e pyflakes3
 
-  #
-  # MacOS with Python2.7 and default reactor.
-  #
-  macos_py27_default_reactor:
-    macos:
-      # We don't use the xcode, but we need to put something here.
-      xcode: "9.0"
 
-    working_directory: ~/repo
-
-    steps:
-      # Get the source.
-      - checkout
-
-      - run:
-          name: Prepare the macOS environment.
-          command: |
-            python --version
-            pip install -q --user --ignore-installed --upgrade virtualenv
-            pip install -q tox --user
-            echo 'export PATH=/usr/local/bin:$PATH:/Users/distiller/Library/Python/2.7/bin' >> $BASH_ENV
-
-      # Run tests with tox without any cached dependencies.
-      - run:
-          name: Test with the default reactor.
-          command: |
-            tox -r -e py27-alldeps-withcov-posix twisted
-
-
-# First we run the static checkers, and only if they pass we spin the macOS.
-# in this way we should save some macOS minutes.
 workflows:
   version: 2
   all-tests:
     jobs:
       - static_checkers
-      - macos_py27_default_reactor:
-          requires:
-            - static_checkers
-      - documentation:
-          requires:
-            - static_checkers
-      - pyflakes3:
-          requires:
-            - static_checkers
+      - documentation
+      - pyflakes3


### PR DESCRIPTION
For now this disables OSX on circle-ci as we run out of minutes for this month.

After 19 Apr, we can try to re-enable it only for forks... as for own branches, we have the osx buildslave.


## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9411
* [ ] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )

