### PR TITLE
[9418] IReactorTime.getDelayedCalls() return type

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1267,9 +1267,9 @@ class IReactorTime(Interface):
         """
         Retrieve all currently scheduled delayed calls.
 
-        @return: A tuple of all L{IDelayedCall} providers representing all
+        @return: A list of L{IDelayedCall} providers representing all
                  currently scheduled calls. This is everything that has been
-                 returned by C{callLater} but not yet called or canceled.
+                 returned by C{callLater} but not yet called or cancelled.
         """
 
 

--- a/src/twisted/newsfragments/9418.bugfix
+++ b/src/twisted/newsfragments/9418.bugfix
@@ -1,0 +1,1 @@
+The documentation of IReactorTime.getDelayedCalls() has been corrected to indicate that the method returns a list, not a tuple.


### PR DESCRIPTION
This updates the IReactorTime.getDelayedCalls() docstring to reflect what all the implementations in Twisted return: a list, not a tuple.

This is the simplest change I could make to resolve the issue. There are other possibilities which we could discuss:

* The interface could be documented as returning a sequence, leaving the concrete type up to the reactor implementation.
* All of the implementations could be changed to return a tuple. (I don't suggest this, as it breaks backward compatibility because tuples and lists don't compare equal.)

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9418
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] (N/A) I have updated the automated tests.
