### PR TITLE
Fix conch MSG_DEBUG parsing on Python 2

### DIFF
--- a/src/twisted/conch/newsfragments/9422.bugfix
+++ b/src/twisted/conch/newsfragments/9422.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.ssh.transport.SSHTransportBase now correctly handles MSG_DEBUG with a false alwaysDisplay field on Python 2 (broken since 8.0.0).

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -967,7 +967,7 @@ class SSHTransportBase(protocol.Protocol):
         @type packet: L{bytes}
         @param packet: The message data.
         """
-        alwaysDisplay = bool(packet[0])
+        alwaysDisplay = bool(ord(packet[0:1]))
         message, lang, foo = getNS(packet[1:], 2)
         self.receiveDebug(alwaysDisplay, message, lang)
 

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -774,7 +774,12 @@ class BaseSSHTransportTests(BaseSSHTransportBaseCase, TransportTestCase):
         self.proto.dispatchMessage(
             transport.MSG_DEBUG,
             b'\x01\x00\x00\x00\x04test\x00\x00\x00\x02en')
-        self.assertEqual(self.proto.debugs, [(True, b'test', b'en')])
+        self.proto.dispatchMessage(
+            transport.MSG_DEBUG,
+            b'\x00\x00\x00\x00\x06silent\x00\x00\x00\x02en')
+        self.assertEqual(
+            self.proto.debugs,
+            [(True, b'test', b'en'), (False, b'silent', b'en')])
 
 
     def test_sendIgnore(self):


### PR DESCRIPTION
`bool(b'\x00...'[0])` returns `True`, which isn't what's needed here.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9422
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/conch/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.