### PR TITLE
test_closePeerOnEMFILE allows ConnectionLost on client's end.

### DIFF
--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -1266,7 +1266,7 @@ def assertPeerClosedOnEMFILE(
     testCase.assertNoResult(clientFactory.failDeferred)
     testCase.successResultOf(clientFactory.deferred)
     testCase.assertRaises(
-        testCase.lostConnectionReason,
+        (ConnectionDone, ConnectionLost),
         clientFactory.lostReason.raiseException,
     )
 
@@ -1357,7 +1357,6 @@ class StreamTransportTestsMixin(LogObserverMixin):
     """
     Mixin defining tests which apply to any port/connection based transport.
     """
-    lostConnectionReason = ConnectionDone
 
     def test_startedListeningLogMessage(self):
         """

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -33,7 +33,7 @@ from twisted.trial.unittest import SkipTest, SynchronousTestCase, TestCase
 from twisted.internet.error import (
     ConnectionLost, UserError, ConnectionRefusedError, ConnectionDone,
     ConnectionAborted, DNSLookupError, NoProtocol,
-    ConnectBindError,
+    ConnectBindError, ConnectionClosed,
 )
 from twisted.internet.test.connectionmixins import (
     LogObserverMixin, ConnectionTestsMixin, StreamClientTestsMixin,
@@ -1266,7 +1266,7 @@ def assertPeerClosedOnEMFILE(
     testCase.assertNoResult(clientFactory.failDeferred)
     testCase.successResultOf(clientFactory.deferred)
     testCase.assertRaises(
-        (ConnectionDone, ConnectionLost),
+        ConnectionClosed,
         clientFactory.lostReason.raiseException,
     )
 


### PR DESCRIPTION
Whether the client's connectionLost method is called with
ConnectionDone or ConnectionLost depends on its internal state, which
the test cannot directly control; for example, a TLS handshake might
not have completed by the time the server disconnects the client.

Make the test more robust by allowing both ConnectionDone and
ConnectionLost.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9439#ticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
