### PR TITLE
Make the sendmsg tests more resillient to a large kernel buffer

### DIFF
--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -397,12 +397,13 @@ class CModuleSendmsgTests(TestCase):
         """
         L{send1msg} returns the number of bytes which it was able to send.
         """
-        message = "x" * 1024 * 1024
+        message = "x" * 1024 * 1024 * 8
         self.input.setblocking(False)
         sent = send1msg(self.input.fileno(), message)
         # Sanity check - make sure the amount of data we sent was less than the
         # message, but not the whole message, as we should have filled the send
-        # buffer. This won't work if the send buffer is more than 1MB, though.
+        # buffer. This won't work if the send buffer is large enough for
+        # message, though.
         self.assertTrue(sent < len(message))
         received = recv1msg(self.output.fileno(), 0, len(message))
         self.assertEqual(len(received[0]), sent)
@@ -428,7 +429,7 @@ class CModuleSendmsgTests(TestCase):
         # Just exercise one flag with simple, well-known behavior. MSG_DONTWAIT
         # makes the send a non-blocking call, even if the socket is in blocking
         # mode.  See also test_flags in RecvmsgTests
-        for i in range(1024):
+        for i in range(8 * 1024):
             try:
                 send1msg(self.input.fileno(), "x" * 1024, MSG_DONTWAIT)
             except error as e:
@@ -692,12 +693,13 @@ class SendmsgTests(TestCase):
         """
         L{sendmsg} returns the number of bytes which it was able to send.
         """
-        message = b"x" * 1024 * 1024
+        message = b"x" * 1024 * 1024 * 8
         self.input.setblocking(False)
         sent = sendmsg(self.input, message)
         # Sanity check - make sure the amount of data we sent was less than the
         # message, but not the whole message, as we should have filled the send
-        # buffer. This won't work if the send buffer is more than 1MB, though.
+        # buffer. This won't work if the send buffer is large enough for
+        # message, though.
         self.assertTrue(sent < len(message))
         received = recvmsg(self.output, len(message))
         self.assertEqual(len(received[0]), sent)
@@ -723,7 +725,7 @@ class SendmsgTests(TestCase):
         # Just exercise one flag with simple, well-known behavior. MSG_DONTWAIT
         # makes the send a non-blocking call, even if the socket is in blocking
         # mode.  See also test_flags in RecvmsgTests
-        for i in range(1024):
+        for i in range(8 * 1024):
             try:
                 sendmsg(self.input, b"x" * 1024, flags=MSG_DONTWAIT)
             except error as e:


### PR DESCRIPTION
## Contributor Checklist:

* [x] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
