### PR TITLE
7927 unhandled error tb

### DIFF
--- a/src/twisted/logger/__init__.py
+++ b/src/twisted/logger/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     # From ._format
     "formatEvent", "formatEventAsClassicLogText",
     "formatTime", "timeFormatRFC3339",
+    "formatEventWithTraceback",
 
     # From ._flatten
     "extractField",
@@ -92,6 +93,7 @@ from ._flatten import extractField
 
 from ._format import (
     formatEvent, formatEventAsClassicLogText, formatTime, timeFormatRFC3339,
+    formatEventWithTraceback
 )
 
 from ._logger import Logger, _loggerFor

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -312,7 +312,7 @@ def formatEventWithTraceback(event):
             traceback = traceback.decode('utf-8')
     except KeyError:
         return eventText
-    except:
+    except Exception:
         traceback = u"(UNABLE TO OBTAIN TRACEBACK FROM EVENT)\n"
 
     eventText = u"\n".join((eventText, traceback))

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -287,3 +287,33 @@ def formatWithCall(formatString, mapping):
     return unicode(
         aFormatter.vformat(formatString, (), CallMapping(mapping))
     )
+
+
+
+def formatEventWithTraceback(event):
+    """
+    Format an event as a unicode string and append a traceback if the event
+    contains a C{event["log_failure"]} key.
+
+    This implementation will always attempt to append a traceback, even if
+    formatting the C{event["log_format"]} fails.  The traceback, if bytes, will
+    be assumed to be UTF-8.
+
+    @param event: A logging event.
+    @type event: L{dict}
+
+    @return: A formatted string with a traceback if applicable.
+    @rtype: L{unicode}
+    """
+    eventText = formatEvent(event)
+    try:
+        traceback = event["log_failure"].getTraceback()
+        if isinstance(traceback, bytes):
+            traceback = traceback.decode('utf-8')
+    except KeyError:
+        return eventText
+    except:
+        traceback = u"(UNABLE TO OBTAIN TRACEBACK FROM EVENT)\n"
+
+    eventText = u"\n".join((eventText, traceback))
+    return eventText

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -312,8 +312,8 @@ def formatEventWithTraceback(event):
             traceback = traceback.decode('utf-8')
     except KeyError:
         return eventText
-    except Exception:
-        traceback = u"(UNABLE TO OBTAIN TRACEBACK FROM EVENT)\n"
+    except Exception as e:
+        traceback = u"(unable to obtain traceback from event):" + unicode(e) + u"\n"
 
     eventText = u"\n".join((eventText, traceback))
     return eventText

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -313,7 +313,7 @@ def formatEventWithTraceback(event):
     except KeyError:
         return eventText
     except Exception as e:
-        traceback = u"(unable to obtain traceback from event):" + unicode(e) + u"\n"
+        traceback = u"(unable to obtain traceback from event):" + unicode(e)
 
     eventText = u"\n".join((eventText, traceback))
     return eventText

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -17,7 +17,7 @@ from ._buffer import LimitedHistoryLogObserver
 from ._observer import LogPublisher
 from ._filter import FilteringLogObserver, LogLevelFilterPredicate
 from ._logger import Logger
-from ._format import formatEvent
+from ._format import formatEventWithTraceback
 from ._levels import LogLevel
 from ._io import LoggingFile
 from ._file import FileLogObserver
@@ -102,7 +102,8 @@ class LogBeginner(object):
             self._initialBuffer,
             FilteringLogObserver(
                 FileLogObserver(
-                    errorStream, lambda event: formatEvent(event) + u"\n"
+                    errorStream,
+                    lambda event: formatEventWithTraceback(event) + u"\n"
                 ),
                 [LogLevelFilterPredicate(defaultLogLevel=LogLevel.critical)]
             )

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -502,10 +502,12 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         self.assertIn(unicode(f.getTraceback()), eventText)
         self.assertIn(u'This is a fake error', eventText)
 
+
     def test_formatUnformattableErrorWithTraceback(self):
         """
         An event with an unformattable value in the C{log_format} key, that
-        throws an exception when __repr__ is invoked still has a traceback appended.
+        throws an exception when __repr__ is invoked still has a traceback
+        appended.
         """
         try:
             raise CapturedError("This is a fake error")

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -443,7 +443,7 @@ class CapturedError(Exception):
 class FormatEventWithTracebackTests(unittest.TestCase):
     """
     Tests for L{formatEventWithTraceback}, all of which ensure that the
-    returned type is a UTF-8.
+    returned type is UTF-8 decoded text.
     """
 
     def test_formatEventWithTraceback(self):

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -458,8 +458,8 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         eventText = formatEventWithTraceback(event)
         self.assertIsInstance(eventText, unicode)
         self.assertIn('Traceback', eventText)
-        self.assertIn('This is a fake error', eventText)
-        self.assertIn('This is a test log message', eventText)
+        self.assertIn(u'This is a fake error', eventText)
+        self.assertIn(u'This is a test log message', eventText)
 
 
     def test_formatEmptyEventWithTraceback(self):
@@ -475,7 +475,7 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         eventText = formatEventWithTraceback(event)
         self.assertIsInstance(eventText, unicode)
         self.assertIn('Traceback', eventText)
-        self.assertIn('This is a fake error', eventText)
+        self.assertIn(u'This is a fake error', eventText)
 
 
     def test_formatUnformattableWithTraceback(self):
@@ -492,9 +492,9 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         event["log_failure"] = f
         eventText = formatEventWithTraceback(event)
         self.assertIsInstance(eventText, unicode)
-        self.assertIn('MESSAGE LOST', eventText)
-        self.assertIn('Traceback', eventText)
-        self.assertIn('This is a fake error', eventText)
+        self.assertIn(u'MESSAGE LOST', eventText)
+        self.assertIn(u'Traceback', eventText)
+        self.assertIn(u'This is a fake error', eventText)
 
 
     def test_formatEventUnformattableTraceback(self):
@@ -520,4 +520,4 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         }
         eventText = formatEventWithTraceback(event)
         self.assertIsInstance(eventText, unicode)
-        self.assertIn('This is a test log message', eventText)
+        self.assertIn(u'This is a test log message', eventText)

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -450,15 +450,17 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         """
         An event with a C{log_failure} key will have a traceback appended.
         """
-        f = Failure(CapturedError("This is a fake error"))
+        try:
+            raise CapturedError("This is a fake error")
+        except CapturedError:
+            f = Failure()
+
         event = {
             "log_format": u"This is a test log message"
         }
         event["log_failure"] = f
         eventText = formatEventWithTraceback(event)
-        self.assertIsInstance(eventText, unicode)
-        self.assertIn('Traceback', eventText)
-        self.assertIn(u'This is a fake error', eventText)
+        self.assertIn(unicode(f.getTraceback()), eventText)
         self.assertIn(u'This is a test log message', eventText)
 
 
@@ -467,14 +469,16 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         An event with an empty C{log_format} key appends a traceback from
         the accompanying failure.
         """
-        f = Failure(CapturedError("This is a fake error"))
+        try:
+            raise CapturedError("This is a fake error")
+        except CapturedError:
+            f = Failure()
         event = {
             "log_format": u""
         }
         event["log_failure"] = f
         eventText = formatEventWithTraceback(event)
-        self.assertIsInstance(eventText, unicode)
-        self.assertIn('Traceback', eventText)
+        self.assertIn(unicode(f.getTraceback()), eventText)
         self.assertIn(u'This is a fake error', eventText)
 
 

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -536,7 +536,7 @@ class FormatEventWithTracebackTests(unittest.TestCase):
         event["log_failure"] = object()
         eventText = formatEventWithTraceback(event)
         self.assertIsInstance(eventText, unicode)
-        self.assertIn("(UNABLE TO OBTAIN TRACEBACK FROM EVENT)", eventText)
+        self.assertIn(u"(unable to obtain traceback from event)", eventText)
 
 
     def test_formatEventNonCritical(self):

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -18,6 +18,7 @@ from .._global import LogBeginner
 from .._global import MORE_THAN_ONCE_WARNING
 from .._levels import LogLevel
 from ..test.test_stdlib import nextLine
+from twisted.python.failure import Failure
 
 
 
@@ -356,3 +357,16 @@ class LogBeginnerTests(unittest.TestCase):
                 filename=__file__, lineno=2,
             )]
         )
+
+
+    def test_failuresAppendTracebacks(self):
+        """
+        The string resulting from a logged failure contains a traceback.
+        """
+        f = Failure(Exception("this is not the behavior you are looking for"))
+        log = Logger(observer=self.publisher)
+        log.failure('a failure', failure=f)
+        msg = self.errorStream.getvalue()
+        self.assertIn('a failure', msg)
+        self.assertIn('this is not the behavior you are looking for', msg)
+        self.assertIn('Traceback', msg)

--- a/src/twisted/newsfragments/7927.bugfix
+++ b/src/twisted/newsfragments/7927.bugfix
@@ -1,0 +1,1 @@
+twisted.logger.LogBeginner's default critical observer now prints tracebacks for new and legacy log system events through the use of a new formatEventWithTraceback API.  This API also does not raise an error for non-ascii encoded data in Python2, it attempts as well as possible to format the traceback.

--- a/src/twisted/newsfragments/9333.bugfix
+++ b/src/twisted/newsfragments/9333.bugfix
@@ -1,1 +1,0 @@
-twisted.logger.LogBeginner's default critical observer now prints tracebacks for new and legacy log system events.

--- a/src/twisted/newsfragments/9333.bugfix
+++ b/src/twisted/newsfragments/9333.bugfix
@@ -1,0 +1,1 @@
+twisted.logger.LogBeginner's default critical observer now prints tracebacks for new and legacy log system events.


### PR DESCRIPTION
This changeset addresses ticket 7927 [1].  Much of this code started with a PR for ticket 9333 [2], now closed as a duplicate.  In the interest of preserving the review comments and feedback, the original commit changes and messages are preserved, while the content has been rebased onto trunk.  I'm happy to clean the history up as needed.

Another key part of this is the creation of a new API instead of modifying formatEvent() directly.  The rationale is that modifying formatEvent will likely result in duplicate tracebacks for any users who have made changes to append tracebacks to the exising result of formatEvent.

[1] https://twistedmatrix.com/trac/ticket/7927
[2] https://github.com/twisted/twisted/pull/939