### PR TITLE
9463 _sslverify uses md5 to generate unique session identifiers

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -38,6 +38,8 @@ from twisted.python.util import FancyEqMixin
 
 from twisted.python.deprecate import deprecated
 
+
+
 class TLSVersion(Names):
     """
     TLS versions that we can negotiate with the client/server.
@@ -172,7 +174,10 @@ def _selectVerifyImplementation():
     return simpleVerifyHostname, SimpleVerificationError
 
 
+
 verifyHostname, VerificationError = _selectVerifyImplementation()
+
+
 
 class ProtocolNegotiationSupport(Flags):
     """

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -5,7 +5,6 @@
 
 from __future__ import division, absolute_import
 
-import itertools
 import warnings
 
 from constantly import Names, NamedConstant
@@ -177,15 +176,6 @@ from twisted.python.failure import Failure
 from twisted.python.util import FancyEqMixin
 
 from twisted.python.deprecate import deprecated
-
-
-def _sessionCounter(counter=itertools.count()):
-    """
-    Private - shared between all OpenSSLCertificateOptions, counts up to
-    provide a unique session id for each context.
-    """
-    return next(counter)
-
 
 
 class ProtocolNegotiationSupport(Flags):

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -9,7 +9,7 @@ import itertools
 import warnings
 
 from constantly import Names, NamedConstant
-from hashlib import md5
+from hashlib import md5, sha256
 
 from OpenSSL import SSL, crypto
 from OpenSSL._util import lib as pyOpenSSLlib
@@ -1698,9 +1698,9 @@ class OpenSSLCertificateOptions(object):
 
         if self.enableSessions:
             name = "%s-%d" % (reflect.qual(self.__class__), _sessionCounter())
-            sessionName = md5(networkString(name)).hexdigest()
+            sessionName = sha256(networkString(name)).digest()
 
-            ctx.set_session_id(sessionName.encode('ascii'))
+            ctx.set_session_id(sessionName)
 
         if self.dhParameters:
             ctx.load_tmp_dh(self.dhParameters._dhFile.path)

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -9,13 +9,14 @@ import itertools
 import warnings
 
 from constantly import Names, NamedConstant
-from hashlib import md5, sha256
+from hashlib import md5
 
 from OpenSSL import SSL, crypto
 from OpenSSL._util import lib as pyOpenSSLlib
 
 from twisted.internet.abstract import isIPAddress, isIPv6Address
 from twisted.python import log
+from twisted.python.randbytes import secureRandom
 from twisted.python._oldstyle import _oldStyle
 from ._idna import _idnaBytes
 
@@ -1697,9 +1698,9 @@ class OpenSSLCertificateOptions(object):
             ctx.set_verify_depth(self.verifyDepth)
 
         if self.enableSessions:
-            name = "%s-%d" % (reflect.qual(self.__class__), _sessionCounter())
-            sessionName = sha256(networkString(name)).digest()
-
+            # 32 bytes is the maximum length supported
+            # Unfortunately pyOpenSSL doesn't provide SSL_MAX_SESSION_ID_LENGTH
+            sessionName = secureRandom(32)
             ctx.set_session_id(sessionName)
 
         if self.dhParameters:

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -170,9 +170,9 @@ from twisted.internet.interfaces import (
     IOpenSSLContextFactory
 )
 
-from twisted.python import reflect, util
+from twisted.python import util
 from twisted.python.deprecate import _mutuallyExclusiveArguments
-from twisted.python.compat import nativeString, networkString, unicode
+from twisted.python.compat import nativeString, unicode
 from twisted.python.failure import Failure
 from twisted.python.util import FancyEqMixin
 

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -19,7 +19,24 @@ from twisted.python.randbytes import secureRandom
 from twisted.python._oldstyle import _oldStyle
 from ._idna import _idnaBytes
 
+from zope.interface import Interface, implementer
+from constantly import Flags, FlagConstant
+from incremental import Version
 
+from twisted.internet.defer import Deferred
+from twisted.internet.error import VerifyError, CertificateError
+from twisted.internet.interfaces import (
+    IAcceptableCiphers, ICipher, IOpenSSLClientConnectionCreator,
+    IOpenSSLContextFactory
+)
+
+from twisted.python import util
+from twisted.python.deprecate import _mutuallyExclusiveArguments
+from twisted.python.compat import nativeString, unicode
+from twisted.python.failure import Failure
+from twisted.python.util import FancyEqMixin
+
+from twisted.python.deprecate import deprecated
 
 class TLSVersion(Names):
     """
@@ -156,27 +173,6 @@ def _selectVerifyImplementation():
 
 
 verifyHostname, VerificationError = _selectVerifyImplementation()
-
-
-from zope.interface import Interface, implementer
-from constantly import Flags, FlagConstant
-from incremental import Version
-
-from twisted.internet.defer import Deferred
-from twisted.internet.error import VerifyError, CertificateError
-from twisted.internet.interfaces import (
-    IAcceptableCiphers, ICipher, IOpenSSLClientConnectionCreator,
-    IOpenSSLContextFactory
-)
-
-from twisted.python import util
-from twisted.python.deprecate import _mutuallyExclusiveArguments
-from twisted.python.compat import nativeString, unicode
-from twisted.python.failure import Failure
-from twisted.python.util import FancyEqMixin
-
-from twisted.python.deprecate import deprecated
-
 
 class ProtocolNegotiationSupport(Flags):
     """

--- a/src/twisted/newsfragments/9463.feature
+++ b/src/twisted/newsfragments/9463.feature
@@ -1,0 +1,1 @@
+twisted.internet._sslverify now uses SHA256 instead of MD5 for ssl session identifier generation by default.

--- a/src/twisted/newsfragments/9463.feature
+++ b/src/twisted/newsfragments/9463.feature
@@ -1,1 +1,1 @@
-twisted.internet.ssl.CertificateOptions now uses SHA256 instead of MD5 for ssl session identifier generation by default.
+twisted.internet.ssl.CertificateOptions now uses SHA256 instead of MD5 for ssl session identifier generation.

--- a/src/twisted/newsfragments/9463.feature
+++ b/src/twisted/newsfragments/9463.feature
@@ -1,1 +1,1 @@
-twisted.internet._sslverify now uses SHA256 instead of MD5 for ssl session identifier generation by default.
+twisted.internet.ssl.CertificateOptions now uses SHA256 instead of MD5 for ssl session identifier generation by default.

--- a/src/twisted/newsfragments/9463.feature
+++ b/src/twisted/newsfragments/9463.feature
@@ -1,1 +1,1 @@
-twisted.internet.ssl.CertificateOptions now uses SHA256 instead of MD5 for ssl session identifier generation.
+twisted.internet.ssl.CertificateOptions now uses 32 random bytes instead of an MD5 hash for the ssl session identifier context.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9463

Switch to random session identifier generation

Fixes problems w/ FIPS-mode OpenSSL and increases uniqueness of session identifiers.

## Contributor Checklist:

* [X] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [X] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [X] I have updated the automated tests.
