### PR TITLE
Potential race condition in _startRunCallbacks

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -563,8 +563,8 @@ class Deferred:
             if self._debugInfo is None:
                 self._debugInfo = DebugInfo()
             self._debugInfo.invoker = traceback.format_stack()[:-2]
-        self.called = True
         self.result = result
+        self.called = True
         self._runCallbacks()
 
 


### PR DESCRIPTION
When creating a Deferred in a separate thread, then chaining that deferred into the callback chain of another Deferred, and then adding that deferred to a DeferredList to wait for completion, _runCallbacks can be executed on the chained deferred before the result has been set. This change seems to prevent that issue. I've attached some example code and an example traceback of the error to ticket #9469. 

