### PR TITLE
9470 Update combinedLogFormatter for getClientIP deprecation

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2639,6 +2639,7 @@ def combinedLogFormatter(timestamp, request):
     return line
 
 
+
 @implementer(interfaces.IAddress)
 class _XForwardedForAddress(object):
     """
@@ -2652,6 +2653,7 @@ class _XForwardedForAddress(object):
     """
     def __init__(self, host):
         self.host = host
+
 
 
 class _XForwardedForRequest(proxyForInterface(IRequest, "_request")):

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2615,12 +2615,18 @@ def combinedLogFormatter(timestamp, request):
 
     @see: L{IAccessLogFormatter}
     """
+    clientAddr = request.getClientAddress()
+    if isinstance(clientAddr, (address.IPv4Address, address.IPv6Address,
+                               _XForwardedForAddress)):
+        ip = clientAddr.host
+    else:
+        ip = b'-'
     referrer = _escape(request.getHeader(b"referer") or b"-")
     agent = _escape(request.getHeader(b"user-agent") or b"-")
     line = (
         u'"%(ip)s" - - %(timestamp)s "%(method)s %(uri)s %(protocol)s" '
         u'%(code)d %(length)s "%(referrer)s" "%(agent)s"' % dict(
-            ip=_escape(request.getClientIP() or b"-"),
+            ip=_escape(ip),
             timestamp=timestamp,
             method=_escape(request.method),
             uri=_escape(request.uri),
@@ -2633,20 +2639,38 @@ def combinedLogFormatter(timestamp, request):
     return line
 
 
+@implementer(interfaces.IAddress)
+class _XForwardedForAddress(object):
+    """
+    L{IAddress} which represents the client IP to log for a request, as gleaned
+    from an X-Forwarded-For header.
+
+    @ivar host: An IP address or C{b"-"}.
+    @type host: L{bytes}
+
+    @see: L{proxiedLogFormatter}
+    """
+    def __init__(self, host):
+        self.host = host
+
 
 class _XForwardedForRequest(proxyForInterface(IRequest, "_request")):
     """
     Add a layer on top of another request that only uses the value of an
     X-Forwarded-For header as the result of C{getClientIP}.
     """
-    def getClientIP(self):
+    def getClientAddress(self):
         """
-        @return: The client address (the first address) in the value of the
-            I{X-Forwarded-For header}.  If the header is not present, return
-            C{b"-"}.
+        The client address (the first address) in the value of the
+        I{X-Forwarded-For header}.  If the header is not present, the IP is
+        considered to be C{b"-"}.
+
+        @return: L{_XForwardedForAddress} which wraps the client address as
+            expected by L{combinedLogFormatter}.
         """
-        return self._request.requestHeaders.getRawHeaders(
+        host = self._request.requestHeaders.getRawHeaders(
             b"x-forwarded-for", [b"-"])[0].split(b",")[0].strip()
+        return _XForwardedForAddress(host)
 
     # These are missing from the interface.  Forward them manually.
     @property

--- a/src/twisted/web/newsfragments/9470.bugfix
+++ b/src/twisted/web/newsfragments/9470.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http.combinedLogFormatter (used by t.w.http.Server and t.w.server.Site) no longer produces DeprecationWarning about Request.getClientIP.

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -17,7 +17,7 @@ from twisted.python.compat import intToBytes
 from twisted.python.deprecate import deprecated
 from incremental import Version
 from twisted.internet.defer import Deferred
-from twisted.internet.address import IPv4Address
+from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.interfaces import ISSLTransport, IAddress
 
 from twisted.trial import unittest
@@ -333,7 +333,7 @@ class DummyRequest(object):
         Return the IPv4 address of the client which made this request, if there
         is one, otherwise L{None}.
         """
-        if isinstance(self.client, IPv4Address):
+        if isinstance(self.client, (IPv4Address, IPv6Address)):
             return self.client.host
         return None
 
@@ -437,6 +437,18 @@ class DummyRequestTests(unittest.SynchronousTestCase):
              "was deprecated in Twisted 18.4.0; "
              "please use getClientAddress instead"),
         )
+
+
+    def test_getClientIPSupportsIPv6(self):
+        """
+        L{DummyRequest.getClientIP} supports IPv6 addresses, just like
+        L{twisted.web.http.Request.getClientIP}.
+        """
+        request = DummyRequest([])
+        client = IPv6Address("TCP", "::1", 12345)
+        request.client = client
+
+        self.assertEqual("::1", request.getClientIP())
 
 
     def test_getClientAddressWithoutClient(self):

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1513,7 +1513,6 @@ class CombinedLogFormatterTests(unittest.TestCase):
 
 
 
-
 class ProxiedLogFormatterTests(unittest.TestCase):
     """
     Tests for L{twisted.web.http.proxiedLogFormatter}.

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -15,8 +15,8 @@ from twisted.python import reflect, failure
 from twisted.python.compat import unichr
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
-from twisted.internet import reactor
-from twisted.internet.address import IPv4Address
+from twisted.internet import reactor, interfaces
+from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.task import Clock
 from twisted.web import server, resource
 from twisted.web import iweb, http, error
@@ -1329,6 +1329,13 @@ class DummyRequestForLogTest(DummyRequest):
     sentLength = None
     client = IPv4Address('TCP', '1.2.3.4', 12345)
 
+    def getClientIP(self):
+        """
+        As L{getClientIP} is deprecated, no log formatter should call it.
+        """
+        raise NotImplementedError('Call to deprecated getClientIP method'
+                                  ' (use getClientAddress instead)')
+
 
 
 class AccessLogTestsMixin(object):
@@ -1463,6 +1470,47 @@ class CombinedLogFormatterTests(unittest.TestCase):
             u'"evil x-forwarded-for \\x80" - - [13/Feb/2009:23:31:30 +0000] '
             u'"POS\\x81 /dummy HTTP/1.0" 123 - "evil \\x83" "evil \\x84"',
             line)
+
+
+    def test_clientAddrIPv6(self):
+        """
+        A request from an IPv6 client is logged with that IP address.
+        """
+        reactor = Clock()
+        reactor.advance(1234567890)
+
+        timestamp = http.datetimeToLogString(reactor.seconds())
+        request = DummyRequestForLogTest(http.HTTPFactory(reactor=reactor))
+        request.client = IPv6Address("TCP", b"::1", 12345)
+
+        line = http.combinedLogFormatter(timestamp, request)
+        self.assertEqual(
+            u'"::1" - - [13/Feb/2009:23:31:30 +0000] '
+            u'"GET /dummy HTTP/1.0" 123 - "-" "-"',
+            line)
+
+
+    def test_clientAddrUnknown(self):
+        """
+        A request made from an unknown address type is logged as C{"-"}.
+        """
+        @implementer(interfaces.IAddress)
+        class UnknowableAddress(object):
+            """
+            An L{IAddress} which L{combinedLogFormatter} cannot have
+            foreknowledge of.
+            """
+
+        reactor = Clock()
+        reactor.advance(1234567890)
+
+        timestamp = http.datetimeToLogString(reactor.seconds())
+        request = DummyRequestForLogTest(http.HTTPFactory(reactor=reactor))
+        request.client = UnknowableAddress()
+
+        line = http.combinedLogFormatter(timestamp, request)
+        self.assertTrue(line.startswith(u'"-" '))
+
 
 
 


### PR DESCRIPTION
`IRequest.getClientIP()` was deprecated in #981. Twisted 18.4.0 logs a deprecation warning on every request because `combinedLogFormatter` was using this API instead of the new `getClientAddr()` method. It took me a while to notice this, as I don't find combined logging terribly useful and disable it in most of my services, but here is a fix nonetheless.

All of the logging test cases use a subclass of `requesthelper.DummyRequest`, so I altered that subclass to have a `getClientIP()` which raises &mdash; nothing inside Twisted should use the deprecated API, after all. I am not sure what effect this will have on coverage, but I see the same technique used in the same file, so... :crossed_fingers: 

## Contributor Checklist:

* [x] There is an associated ticket in Trac: https://twistedmatrix.com/trac/ticket/9470#trac-add-comment
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
