### PR TITLE
[9485] Skip CModuleSendmsgTests.test_shortsend

### DIFF
--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -408,6 +408,11 @@ class CModuleSendmsgTests(TestCase):
         received = recv1msg(self.output.fileno(), 0, len(message))
         self.assertEqual(len(received[0]), sent)
 
+    test_shortsend.skip = (
+        'Intermittently fails (due to kernel buffer sizing?).'
+        ' See #9485 and #9452.'
+    )
+
 
     def test_roundtripEmptyAncillary(self):
         """

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -393,27 +393,6 @@ class CModuleSendmsgTests(TestCase):
         self.assertEqual(result, (message, 0, []))
 
 
-    def test_shortsend(self):
-        """
-        L{send1msg} returns the number of bytes which it was able to send.
-        """
-        message = "x" * 1024 * 1024 * 8
-        self.input.setblocking(False)
-        sent = send1msg(self.input.fileno(), message)
-        # Sanity check - make sure the amount of data we sent was less than the
-        # message, but not the whole message, as we should have filled the send
-        # buffer. This won't work if the send buffer is large enough for
-        # message, though.
-        self.assertTrue(sent < len(message))
-        received = recv1msg(self.output.fileno(), 0, len(message))
-        self.assertEqual(len(received[0]), sent)
-
-    test_shortsend.skip = (
-        'Intermittently fails (due to kernel buffer sizing?).'
-        ' See issues 9485 and 9452.'
-    )
-
-
     def test_roundtripEmptyAncillary(self):
         """
         L{send1msg} treats an empty ancillary data list the same way it treats

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -410,7 +410,7 @@ class CModuleSendmsgTests(TestCase):
 
     test_shortsend.skip = (
         'Intermittently fails (due to kernel buffer sizing?).'
-        ' See #9485 and #9452.'
+        ' See issues 9485 and 9452.'
     )
 
 


### PR DESCRIPTION
As discussed on the mailing list. I opted for a .misc newsfile as I don't think this is likely to interest anyone reading the changelog.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9485#comment:1
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
