### PR TITLE
9504 barry scott forcepoint uds write failure hidden

### DIFF
--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -801,9 +801,9 @@ class Server(_TLSServerMixin, Connection):
 
     _addressType = address.IPv4Address
 
-    def __init__(self, sock, protocol, client, server, sessionno, reactor):
+    def __init__(self, sock, protocol, client, server, sessionno, reactor=None):
         """
-        Server(sock, protocol, client, server, sessionno)
+        Server(sock, protocol, client, server, sessionno, reactor=None)
 
         Initialize it with a socket, a protocol, a descriptor for my peer (a
         tuple of host, port describing the other end of the connection), an

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -801,7 +801,8 @@ class Server(_TLSServerMixin, Connection):
 
     _addressType = address.IPv4Address
 
-    def __init__(self, sock, protocol, client, server, sessionno, reactor=None):
+    def __init__(self, sock, protocol, client, server, sessionno,
+                 reactor=None):
         """
         Server(sock, protocol, client, server, sessionno, reactor=None)
 

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -501,7 +501,8 @@ class DatagramPort(_UNIXPort, udp.Port):
         self.fileno = self.socket.fileno
 
     def write(self, datagram, address):
-        """Write a datagram."""
+        """Write a datagram.
+           raises socket.error EAGAIN"""
         try:
             return self.socket.sendto(datagram, address)
         except socket.error as se:
@@ -510,11 +511,6 @@ class DatagramPort(_UNIXPort, udp.Port):
                 return self.write(datagram, address)
             elif no == EMSGSIZE:
                 raise error.MessageLengthError("message too long")
-            elif no == EAGAIN:
-                # oh, well, drop the data. The only difference from UDP
-                # is that UDP won't ever notice.
-                # TODO: add TCP-like buffering
-                pass
             else:
                 raise
 

--- a/src/twisted/newsfragments/9503.bugfix
+++ b/src/twisted/newsfragments/9503.bugfix
@@ -1,0 +1,1 @@
+class twisted.internet.tcp.Server defaults reactor to None

--- a/src/twisted/newsfragments/9504.bugfix
+++ b/src/twisted/newsfragments/9504.bugfix
@@ -1,0 +1,2 @@
+class twisted.internet.unix.DatagramPort() no longer ignores EAGAIN errors in write()
+as this prevents an application from knowing that it needs to retransmit the datagram.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9504#ticket

For class DatagramPort's write method a failure to write is suppressed.

Unix-domain-sockets are expected to reliable.

This means that it is not possible to arrange to retry a failed write and the datagram is lost silently.
