### PR TITLE
For class DatagramPort's write method a failure to write is suppressed.

### DIFF
--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -502,8 +502,13 @@ class DatagramPort(_UNIXPort, udp.Port):
 
     def write(self, datagram, address):
         """Write a datagram.
+
            @param datagram: the data to be sent
+           @type datagram: L{bytes}
+
            @param address: the address to send the datagram to
+           @type address: L{bytes}
+
            @raise socket.error: when socket is full with arg[0] == EAGAIN
         """
         try:

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -502,7 +502,7 @@ class DatagramPort(_UNIXPort, udp.Port):
 
     def write(self, datagram, address):
         """Write a datagram.
-           raises socket.error EAGAIN
+           @raise socket.error: when socket is full with arg[0] == EAGAIN
         """
         try:
             return self.socket.sendto(datagram, address)

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -501,7 +501,9 @@ class DatagramPort(_UNIXPort, udp.Port):
         self.fileno = self.socket.fileno
 
     def write(self, datagram, address):
-        """Write a datagram."""
+        """Write a datagram.
+           raises socket.error EAGAIN
+        """
         try:
             return self.socket.sendto(datagram, address)
         except socket.error as se:
@@ -510,11 +512,6 @@ class DatagramPort(_UNIXPort, udp.Port):
                 return self.write(datagram, address)
             elif no == EMSGSIZE:
                 raise error.MessageLengthError("message too long")
-            elif no == EAGAIN:
-                # oh, well, drop the data. The only difference from UDP
-                # is that UDP won't ever notice.
-                # TODO: add TCP-like buffering
-                pass
             else:
                 raise
 

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -501,15 +501,16 @@ class DatagramPort(_UNIXPort, udp.Port):
         self.fileno = self.socket.fileno
 
     def write(self, datagram, address):
-        """Write a datagram.
+        """
+        Write a datagram.
 
-           @param datagram: the data to be sent
-           @type datagram: L{bytes}
+        @param datagram: the data to be sent
+        @type datagram: L{bytes}
 
-           @param address: the address to send the datagram to
-           @type address: L{bytes}
+        @param address: the address to send the datagram to
+        @type address: L{bytes}
 
-           @raise socket.error: when socket is full with arg[0] == EAGAIN
+        @raise socket.error: when socket is full with arg[0] == EAGAIN
         """
         try:
             return self.socket.sendto(datagram, address)

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -502,6 +502,8 @@ class DatagramPort(_UNIXPort, udp.Port):
 
     def write(self, datagram, address):
         """Write a datagram.
+           @param datagram: the data to be sent
+           @param address: the address to send the datagram to
            @raise socket.error: when socket is full with arg[0] == EAGAIN
         """
         try:

--- a/src/twisted/newsfragments/9504.bugfix
+++ b/src/twisted/newsfragments/9504.bugfix
@@ -1,0 +1,2 @@
+class twisted.internet.unix.DatagramPort() no longer ignores EAGAIN errors in write()
+as this prevents an application from knowing that it needs to retransmit the datagram.


### PR DESCRIPTION
Unix-domain-sockets are expected to be reliable.
    
This means that it is not possible to arrange to retry a failed write and
the datagram is lost silently.
    
Allow the EAGAIN to be handled by the caller to write().

Fixes #9504