### PR TITLE
Minor typo fix in _sentence.py

### DIFF
--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -27,7 +27,7 @@ class _BaseSentence(object):
             \"\"\"
             ALLOWED_ATTRIBUTES = FooProtocol.getSentenceAttributes()
 
-    @ivar presentAttribues: An iterable containing the names of the
+    @ivar presentAttributes: An iterable containing the names of the
         attributes that are present in this sentence.
     @type presentAttributes: iterable of C{str}
 


### PR DESCRIPTION
Fix typo from 'presentAttribues' to 'presentAttributes'

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>