### PR TITLE
[9525] correct python.test.test_zipstream.ZipstreamTests.test_extraData

### DIFF
--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -6,7 +6,6 @@ Tests for L{twisted.python.zipstream}
 """
 
 import random
-import sys
 import zipfile
 from hashlib import md5
 

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -6,6 +6,8 @@ Tests for L{twisted.python.zipstream}
 """
 
 import random
+import unittest
+import sys
 import zipfile
 from hashlib import md5
 
@@ -245,6 +247,9 @@ class ZipstreamTests(unittest.TestCase):
         """
         readfile() should skip over 'extra' data present in the zip metadata.
         """
+        if sys.version_info >= (3, 7):
+            raise unittest.SkipTest("likely unused and broken in Python 3.7")
+
         fn = self.mktemp()
         with zipfile.ZipFile(fn, 'w') as zf:
             zi = zipfile.ZipInfo("0")

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -6,7 +6,6 @@ Tests for L{twisted.python.zipstream}
 """
 
 import random
-import unittest
 import sys
 import zipfile
 from hashlib import md5

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -246,13 +246,15 @@ class ZipstreamTests(unittest.TestCase):
         """
         readfile() should skip over 'extra' data present in the zip metadata.
         """
-        if sys.version_info >= (3, 7):
-            raise unittest.SkipTest("likely unused and broken in Python 3.7")
-
         fn = self.mktemp()
         with zipfile.ZipFile(fn, 'w') as zf:
             zi = zipfile.ZipInfo("0")
-            zi.extra = b"hello, extra"
+            extra_data = b"hello, extra"
+            zi.extra = (
+                (42).to_bytes(2, 'little')
+                + len(extra_data).to_bytes(2, 'little')
+                + extra_data
+            )
             zf.writestr(zi, b"the real data")
         with zipstream.ChunkingZipFile(fn) as czf, czf.readfile("0") as zfe:
             self.assertEqual(zfe.read(), b"the real data")

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -6,6 +6,7 @@ Tests for L{twisted.python.zipstream}
 """
 
 import random
+import struct
 import zipfile
 from hashlib import md5
 
@@ -250,8 +251,7 @@ class ZipstreamTests(unittest.TestCase):
             zi = zipfile.ZipInfo("0")
             extra_data = b"hello, extra"
             zi.extra = (
-                (42).to_bytes(2, 'little')
-                + len(extra_data).to_bytes(2, 'little')
+                struct.pack('<hh', 42, len(extra_data))
                 + extra_data
             )
             zf.writestr(zi, b"the real data")


### PR DESCRIPTION
It was suggested that zipstream is likely little used and the issue seems to be in CPython 3.7 itself.

https://twistedmatrix.com/trac/ticket/9525