### PR TITLE
Strip whitespaces from ip address before parsing

### DIFF
--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -521,7 +521,7 @@ def isIPAddress(addr, family=AF_INET):
     try:
         # This might be a native implementation or the one from
         # twisted.python.compat.
-        inet_pton(family, addr)
+        inet_pton(family, addr.strip())
     except (ValueError, error):
         return False
     return True


### PR DESCRIPTION
Any whitespaces present in the ip address will throw ValueError on line 525 even though on line 517 the address got validated. In version 14.0.2 were any extra spaces ignored and address was validated. This may cause issues with compatibility of older projects.

## Remove this paragraph

Please have a look at our developer documentation before submitting your Pull Request.

https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch

## Contributor Checklist:

* [ ] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [ ] I have updated the automated tests.
