### PR TITLE
[9481] Change DelayedCall repr to include details

### DIFF
--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -47,7 +47,7 @@ class DelayedCall:
     # enable .debug to record creator call stack, and it will be logged if
     # an exception occurs while the function is being run
     debug = False
-    _str = None
+    _repr = None
 
     def __init__(self, time, func, args, kw, cancel, reset,
                  seconds=runtimeSeconds):
@@ -101,7 +101,7 @@ class DelayedCall:
             self.canceller(self)
             self.cancelled = 1
             if self.debug:
-                self._str = str(self)
+                self._repr = repr(self)
             del self.func, self.args, self.kw
 
     def reset(self, secondsFromNow):
@@ -181,15 +181,15 @@ class DelayedCall:
         return self.time < other.time
 
 
-    def __str__(self):
+    def __repr__(self):
         """
-        Implement C{str()} and C{repr()} for L{DelayedCall} instances.
+        Implement C{repr()} for L{DelayedCall} instances.
 
         @rtype: C{str}
         @returns: String containing details of the L{DelayedCall}.
         """
-        if self._str is not None:
-            return self._str
+        if self._repr is not None:
+            return self._repr
         if hasattr(self, 'func'):
             # This code should be replaced by a utility function in reflect;
             # see ticket #6066:
@@ -223,16 +223,6 @@ class DelayedCall:
         L.append('>')
 
         return "".join(L)
-
-
-    def __repr__(self):
-        """
-        Implement C{repr()} in terms of C{str()} for backwards compatibility.
-
-        @rtype: C{str}
-        @returns: String containing details of the L{DelayedCall}.
-        """
-        return self.__str__()
 
 
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -225,7 +225,14 @@ class DelayedCall:
         return "".join(L)
 
 
-    __repr__ = __str__
+    def __repr__(self):
+        """
+        Implement C{repr()} in terms of C{str()} for backwards compatibility.
+
+        @rtype: C{str}
+        @returns: String containing details of the L{DelayedCall}
+        """
+        return self.__str__()
 
 
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -230,7 +230,7 @@ class DelayedCall:
         Implement C{repr()} in terms of C{str()} for backwards compatibility.
 
         @rtype: C{str}
-        @returns: String containing details of the L{DelayedCall}
+        @returns: String containing details of the L{DelayedCall}.
         """
         return self.__str__()
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -182,6 +182,12 @@ class DelayedCall:
 
 
     def __str__(self):
+        """
+        Implement C{str()} and C{repr()} for L{DelayedCall} instances.
+
+        @rtype: C{str}
+        @returns: String containing details of the L{DelayedCall}.
+        """
         if self._str is not None:
             return self._str
         if hasattr(self, 'func'):
@@ -217,6 +223,9 @@ class DelayedCall:
         L.append('>')
 
         return "".join(L)
+
+
+    __repr__ = __str__
 
 
 

--- a/src/twisted/internet/test/test_base.py
+++ b/src/twisted/internet/test/test_base.py
@@ -242,7 +242,17 @@ class DelayedCallMixin(object):
         self.assertEqual(
             str(dc),
             "<DelayedCall 0x%x [10.5s] called=0 cancelled=0 nothing(3, A=5)>"
-                % (id(dc),))
+            % (id(dc),),
+        )
+
+
+    def test_repr(self):
+        """
+        The string representation of a L{DelayedCall} instance, as returned by
+        {repr}, is identical to that returned by L{str}.
+        """
+        dc = DelayedCall(13, nothing, (6, ), {"A": 9}, None, None, lambda: 1.6)
+        self.assertEqual(str(dc), repr(dc))
 
 
     def test_lt(self):

--- a/src/twisted/newsfragments/9481.feature
+++ b/src/twisted/newsfragments/9481.feature
@@ -1,0 +1,1 @@
+The repr() of a twisted.internet.base.DelayedCall now encodes the same information as its str(), exposing details of its scheduling and target callable.


### PR DESCRIPTION
This turns out to be quite simple, as there is already a `__str__` implementation that does the necessary: we can just alias `__repr__` to `__str__`.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. [#9481 t.i.b.DelayedCall repr should include useful information](https://twistedmatrix.com/trac/ticket/9481)
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
