### PR TITLE
[9538] Fix eventAsText epytext

### DIFF
--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -346,7 +346,7 @@ def eventAsText(
         includeSystem=True,
         formatTime=formatTime,
 ):
-    """
+    r"""
     Format an event as a unicode string.  Optionally, attach timestamp,
     traceback, and system information.
 


### PR DESCRIPTION
epydoc didn't like the newlines in the middle of the ``C{u"{timeStamp} [{system}] {event}\n{traceback}\n"}`` literal. Making the docstring a raw string changes them to the backslash escapes that were intended anyway.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. [#9538 (eventAsText docstring is not valid epytext) – Twisted](https://twistedmatrix.com/trac/ticket/9538#comment:1)
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests. (N/A)
