### PR TITLE
[9539] Tidy up Deferred.fromFuture() intersphinx references

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -805,7 +805,7 @@ class Deferred:
         @note: This creates a L{Deferred} from a L{asyncio.Future}, I{not} from
             a C{coroutine}; in other words, you will need to call
             L{asyncio.async}, L{asyncio.ensure_future},
-            L{asyncio.AbstractEventLoop.create_task} or create an
+            L{asyncio.loop.create_task} or create an
             L{asyncio.Task} yourself to get from a C{coroutine} to a
             L{asyncio.Future} if what you have is an awaitable coroutine and
             not a L{asyncio.Future}.  (The length of this list of techniques is

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -804,7 +804,7 @@ class Deferred:
 
         @note: This creates a L{Deferred} from a L{asyncio.Future}, I{not} from
             a C{coroutine}; in other words, you will need to call
-            L{asyncio.async}, L{asyncio.ensure_future},
+            L{asyncio.ensure_future},
             L{asyncio.loop.create_task} or create an
             L{asyncio.Task} yourself to get from a C{coroutine} to a
             L{asyncio.Future} if what you have is an awaitable coroutine and

--- a/src/twisted/newsfragments/9539.doc
+++ b/src/twisted/newsfragments/9539.doc
@@ -1,1 +1,1 @@
-The documentation of asyncio.Deferred.fromFuture() has been updated to reflect upstream changes.
+The documentation of twisted.internet.defer.Deferred.fromFuture() has been updated to reflect upstream changes.

--- a/src/twisted/newsfragments/9539.doc
+++ b/src/twisted/newsfragments/9539.doc
@@ -1,0 +1,1 @@
+The documentation of asyncio.Deferred.fromFuture() has been updated to reflect upstream changes.


### PR DESCRIPTION
* Change `asyncio.AbstractEventLoop.create_task()` &rarr; `asyncio.loop.create_task()`, as it has moved upstream. Resolves this warning:

      twisted.internet.defer.Deferred.fromFuture: invalid ref to 'asyncio.AbstractEventLoop.create_task' resolved as 'asyncio.AbstractEventLoop.create_task'

* Remove reference to `asyncio.async` as it was deprecated in Python 3.4.4 and produced this warning:

      twisted.internet.defer.Deferred.fromFuture: invalid ref to 'asyncio.async' resolved as 'asyncio.async'

In combination with #1069 this should get us a clean documentation build.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. [#9539 (Deferred.fromFuture() docstring has invalid intersphinx reference to asyncio.AbstractEventLoop.create_task) – Twisted](https://twistedmatrix.com/trac/ticket/9539#comment:1)
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests. N/A
