### PR TITLE
made twisted.internet.endpoints importable on Windows when pywin32 is…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,11 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: py37-alldeps-withcov-windows,codecov-publish
       TWISTED_REACTOR: "select"
+    - PYTHON_HOME: C:\\PYTHON37-x64
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      TOXENV: py37-nodeps-withcov-windows,codecov-publish
+      TWISTED_REACTOR: "select"
 
     # IOCPReactor tests
     - PYTHON_HOME: C:\\Python27-x64

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -38,7 +38,14 @@ from twisted.internet.interfaces import (
 )
 from twisted.internet.protocol import ClientFactory, Factory
 from twisted.internet.protocol import ProcessProtocol, Protocol
-from twisted.internet.stdio import StandardIO, PipeAddress
+
+try:
+    from twisted.internet.stdio import StandardIO, PipeAddress
+except ImportError:
+    # fallback if pywin32 is not installed
+    StandardIO = None
+    PipeAddress = None
+
 from twisted.internet.task import LoopingCall
 from twisted.internet._resolver import HostResolution
 from twisted.logger import Logger

--- a/src/twisted/newsfragments/6032.bugfix
+++ b/src/twisted/newsfragments/6032.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.endpoints is now importable on Windows when pywin32 is not installed

--- a/src/twisted/newsfragments/6032.bugfix
+++ b/src/twisted/newsfragments/6032.bugfix
@@ -1,1 +1,1 @@
-twisted.internet.endpoints is now importable on Windows when pywin32 is not installed
+twisted.internet.endpoints is now importable on Windows when pywin32 is not installed.


### PR DESCRIPTION
See ticket: https://twistedmatrix.com/trac/ticket/6032

* [x ] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
