### PR TITLE
Don't use ctypes.util.find_library()

### DIFF
--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -13,7 +13,6 @@ from socket import AF_INET, AF_INET6, inet_ntop
 from ctypes import (
     CDLL, POINTER, Structure, c_char_p, c_ushort, c_int,
     c_uint32, c_uint8, c_void_p, c_ubyte, pointer, cast)
-from ctypes.util import find_library
 
 from twisted.python.compat import _PY3, nativeString
 
@@ -28,7 +27,7 @@ if _PY3:
         return bytes([i])
 
 
-libc = CDLL(find_library("c"))
+libc = CDLL(None)
 
 if sys.platform.startswith('freebsd') or sys.platform == 'darwin':
     _sockaddrCommon = [

--- a/src/twisted/python/_inotify.py
+++ b/src/twisted/python/_inotify.py
@@ -10,7 +10,6 @@ required.
 """
 
 import ctypes
-import ctypes.util
 
 
 
@@ -103,8 +102,5 @@ def initializeModule(libc):
 
 
 
-name = ctypes.util.find_library('c')
-if not name:
-    raise ImportError("Can't find C library.")
-libc = ctypes.cdll.LoadLibrary(name)
+libc = ctypes.CDLL(None)
 initializeModule(libc)


### PR DESCRIPTION
[ctypes.util.find_library()](https://docs.python.org/3/library/ctypes.html#ctypes.util.find_library) is [buggy](https://github.com/docker-library/python/issues/111), and unnecessary for Twisted. Let's get rid of it.

This PR is provided as-is. It wasn't tested. I don't even use Twisted.