### PR TITLE
[9597] Use 'is'/'is not' instead of '==' to avoid Py3 warnings about comparing disparate types

### DIFF
--- a/src/twisted/web/distrib.py
+++ b/src/twisted/web/distrib.py
@@ -114,7 +114,7 @@ class Issue:
         self.request = request
 
     def finished(self, result):
-        if result != server.NOT_DONE_YET:
+        if result is not server.NOT_DONE_YET:
             assert isinstance(result, str), "return value not a string"
             self.request.write(result)
             self.request.finish()

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -311,7 +311,7 @@ class Request(Copyable, http.Request, components.Componentized):
                 body = epage.render(self)
         # end except UnsupportedMethod
 
-        if body == NOT_DONE_YET:
+        if body is NOT_DONE_YET:
             return
         if not isinstance(body, bytes):
             body = resource.ErrorPage(


### PR DESCRIPTION
* [X] There is [an associated ticket in Trac](https://twistedmatrix.com/trac/ticket/9597)
* [X] The changes pass minimal style checks
* [X] I have created a newsfragment
* [-] I have updated the automated tests.
