### PR TITLE
[9605] Fix build (python-hyper.org is down)

### DIFF
--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -32,8 +32,8 @@ intersphinxURLs = [
     u"https://hyperlink.readthedocs.io/en/stable/objects.inv",
     u"https://twisted.github.io/constantly/docs/objects.inv",
     u"https://twisted.github.io/incremental/docs/objects.inv",
-    u"https://python-hyper.org/h2/en/stable/objects.inv",
-    u"https://python-hyper.org/priority/en/stable/objects.inv",
+    u"https://hyper-h2.readthedocs.io/en/stable/objects.inv",
+    u"https://priority.readthedocs.io/en/stable/objects.inv",
     u"https://zopeinterface.readthedocs.io/en/latest/objects.inv",
     u"https://automat.readthedocs.io/en/latest/objects.inv",
 ]


### PR DESCRIPTION
Pluck the fix from #1109: use the readthedocs.io documentation locations instead of python-hyper.org, as they work.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests. (N/A)
