### PR TITLE
NPNAndALPNAbsentTests skip iff both are absent

### DIFF
--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2385,12 +2385,13 @@ class NPNAndALPNAbsentTests(unittest.TestCase):
     NPN/ALPN operations fail on platforms that do not support them.
 
     These tests only run on platforms that have a PyOpenSSL version < 0.15,
-    or an OpenSSL version earlier than 1.0.1
+    an OpenSSL version earlier than 1.0.1, or an OpenSSL/cryptography built
+    without NPN support.
     """
     if skipSSL:
         skip = skipSSL
-    elif not skipNPN:
-        skip = "NPN/ALPN is present on this platform"
+    elif not skipNPN or not skipALPN:
+        skip = "NPN and/or ALPN is present on this platform"
 
 
     def test_nextProtocolMechanismsNoNegotiationSupported(self):


### PR DESCRIPTION
Previously these tests only skipped if they failed to detect NPN on the assumption that ALPN would never be present if NPN was missing. However, NPN is deprecated and we'd like to remove it from cryptography/pyOpenSSL so this test needs to be smarter.

refs https://github.com/pyca/cryptography/pull/4765

I didn't make a ticket or a news fragment because high friction contribution for janitoring like this is a bit frustrating. Let's fight about it @glyph!