### PR TITLE
9615 pin version of tox used in CI to work around an upstream regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
             echo 'export PATH=/usr/local/bin:$PATH:/Users/distiller/Library/Python/2.7/bin' >> $BASH_ENV
             python2 --version
             pip2 install -q --user --ignore-installed --upgrade virtualenv
-            pip2 install -q tox --user
+            pip2 install -q tox==3.7 --user
 
       # Run tests with tox without any cached dependencies.
       - run:
@@ -167,7 +167,7 @@ jobs:
             echo 'export PATH=/usr/local/bin:$PATH:/Users/distiller/Library/Python/3.7/bin' >> $BASH_ENV
             python3 --version
             pip3 install -q --user --ignore-installed --upgrade virtualenv
-            pip3 install -q tox --user
+            pip3 install -q tox==3.7 --user
 
       # Run tests with tox without any cached dependencies.
       - run:


### PR DESCRIPTION
## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9615
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
