### PR TITLE
[9619] Test Hyperlink less

### DIFF
--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -476,20 +476,6 @@ class TestURL(SynchronousTestCase):
         )
 
 
-    def test_parseEqualSignInParamValue(self):
-        """
-        Every C{=}-sign after the first in a query parameter is simply included
-        in the value of the parameter.
-        """
-        u = URL.fromText('http://localhost/?=x=x=x')
-        self.assertEqual(u.get(u''), ['x=x=x'])
-        self.assertEqual(u.asText(), 'http://localhost/?=x%3Dx%3Dx')
-        u = URL.fromText('http://localhost/?foo=x=x=x&bar=y')
-        self.assertEqual(u.query, (('foo', 'x=x=x'),
-                                             ('bar', 'y')))
-        self.assertEqual(u.asText(), 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
-
-
     def test_empty(self):
         """
         An empty L{URL} should serialize as the empty string.


### PR DESCRIPTION
I'm putting this up as a straw man... perhaps an acceptable straw man. https://github.com/python-hyper/hyperlink/pull/39 discusses changes to Hyperlink present in version 19.0.0 (released April 7) that break Twisted's tests. The words "gross violation of specification" have been invoked.

Really Twisted only tests Hyperlink's behavior so deeply because Hyperlink was once `twisted.python.url`. That's not so necessary anymore, so this PR just deletes the failing test.

I created a .misc newsfragment, but I'm not sure that's correct. We may want to highlight this in the release notes. Though, as Hyperlink 19.0.0 is already out, anyone affected is likely to see breakage before the next Twisted release. :man_shrugging: 

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9619
* [ ] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
