### PR TITLE
[9643] Agent.request(method) must be bytes

### DIFF
--- a/src/twisted/newsfragments/9643.bugfix
+++ b/src/twisted/newsfragments/9643.bugfix
@@ -1,1 +1,1 @@
-twisted.web.client.Agent.request() now produces TypeError when the method argument is not bytes, rather than failing to generate the request.
+twisted.web.client.Agent.request() and twisted.web.client.ProxyAgent.request() now produce TypeError when the method argument is not bytes, rather than failing to generate the request.

--- a/src/twisted/newsfragments/9643.bugfix
+++ b/src/twisted/newsfragments/9643.bugfix
@@ -1,0 +1,1 @@
+twisted.web.client.Agent.request() now produces TypeError when the method argument is not bytes, rather than failing to generate the request.

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1714,6 +1714,9 @@ class Agent(_AgentBase):
 
         @see: L{twisted.web.iweb.IAgent.request}
         """
+        if not isinstance(method, bytes):
+            raise TypeError('method={!r} is {}, but must be bytes'.format(
+                    method, type(method)))
         parsedURI = URI.fromBytes(uri)
         try:
             endpoint = self._getEndpoint(parsedURI)

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1490,6 +1490,9 @@ class _AgentBase(object):
         Issue a new request, given the endpoint and the path sent as part of
         the request.
         """
+        if not isinstance(method, bytes):
+            raise TypeError('method={!r} is {}, but must be bytes'.format(
+                    method, type(method)))
         # Create minimal headers, if necessary:
         if headers is None:
             headers = Headers()
@@ -1714,9 +1717,6 @@ class Agent(_AgentBase):
 
         @see: L{twisted.web.iweb.IAgent.request}
         """
-        if not isinstance(method, bytes):
-            raise TypeError('method={!r} is {}, but must be bytes'.format(
-                    method, type(method)))
         parsedURI = URI.fromBytes(uri)
         try:
             endpoint = self._getEndpoint(parsedURI)

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -2484,6 +2484,15 @@ class ProxyAgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin):
         self.agent._proxyEndpoint = self.StubEndpoint(oldEndpoint, self)
 
 
+    def test_nonBytesMethod(self):
+        """
+        L{ProxyAgent.request} raises L{TypeError} when the C{method} argument
+        isn't L{bytes}.
+        """
+        self.assertRaises(TypeError, self.agent.request,
+                          u'GET', b'http://foo.example/')
+
+
     def test_proxyRequest(self):
         """
         L{client.ProxyAgent} issues an HTTP request against the proxy, with the

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -994,7 +994,8 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         L{Agent.request} raises L{TypeError} when the C{method} argument isn't
         L{bytes}.
         """
-        self.assertRaises(TypeError, self.agent.request, u'GET', b'http://foo.example/')
+        self.assertRaises(TypeError, self.agent.request,
+                          u'GET', b'http://foo.example/')
 
 
     def test_unsupportedScheme(self):

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -989,6 +989,14 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         self.assertEqual(agent._pool.connected, True)
 
 
+    def test_nonBytesMethod(self):
+        """
+        L{Agent.request} raises L{TypeError} when the C{method} argument isn't
+        L{bytes}.
+        """
+        self.assertRaises(TypeError, self.agent.request, u'GET', b'http://foo.example/')
+
+
     def test_unsupportedScheme(self):
         """
         L{Agent.request} returns a L{Deferred} which fails with


### PR DESCRIPTION
Raise `TypeError` when the `method` argument of `Agent.request()` isn't `bytes`.

It would be more usable to make it accept `str` as well, but that would require changes to `IAgent.request()` which is explicit about it being `bytes`. Since third party `IAgent` implementations are actually a thing, I don't think that we should make that change.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9643#comment:2
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
