### PR TITLE
[9644] Don't TypeError on multiline headers

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2051,7 +2051,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
 
     length = 0
     persistent = 1
-    __header = ''
+    __header = b''
     __first_line = 1
     __content = None
 
@@ -2140,7 +2140,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
                 # with processing. We'll have sent a 400 anyway, so just stop.
                 if not ok:
                     return
-            self.__header = ''
+            self.__header = b''
             self.allHeadersReceived()
             if self.length == 0:
                 self.allContentReceived()
@@ -2148,7 +2148,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
                 self.setRawMode()
         elif line[0] in b' \t':
             # Continuation of a multi line header.
-            self.__header = self.__header + '\n' + line
+            self.__header = self.__header + b'\n' + line
         # Regular header line.
         # Processing of header line is delayed to allow accumulating multi
         # line headers.

--- a/src/twisted/web/newsfragments/9644.bugfix
+++ b/src/twisted/web/newsfragments/9644.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http.HTTPChannel no longer raises TypeError internally when receiving a line-folded HTTP header on Python 3.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1485,6 +1485,7 @@ class ParsingTests(unittest.TestCase):
         See RFC 7230 section 3.2.4.
         """
         processed = []
+
         class MyRequest(http.Request):
             def process(self):
                 processed.append(self)

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1493,7 +1493,7 @@ class ParsingTests(unittest.TestCase):
         requestLines = [
             b"GET / HTTP/1.0",
             b"nospace: ",
-            b" nospace",
+            b" nospace\t",
             b"space:space",
             b" space",
             b"spaces: spaces",
@@ -1508,6 +1508,12 @@ class ParsingTests(unittest.TestCase):
 
         self.runRequest(b"\n".join(requestLines), MyRequest, 0)
         [request] = processed
+        # All leading and trailing whitespace is stripped from the
+        # header-value.
+        self.assertEqual(
+            request.requestHeaders.getRawHeaders(b"nospace"),
+            [b"nospace"],
+        )
         self.assertEqual(
             request.requestHeaders.getRawHeaders(b"space"),
             [b"space  space"],

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -527,6 +527,28 @@ class HTTPClientParserTests(TestCase):
         self.assertIdentical(protocol.response.length, UNKNOWN_LENGTH)
 
 
+    def test_responseHeadersMultiline(self):
+        """
+        The multi-line response headers are folded and added to the response
+        object's C{headers} L{Headers} instance.
+        """
+        protocol = HTTPClientParser(
+            Request(b'GET', b'/', _boringHeaders, None),
+            lambda rest: None)
+        protocol.makeConnection(StringTransport())
+        protocol.dataReceived(b'HTTP/1.1 200 OK\r\n')
+        protocol.dataReceived(b'X-Multiline: a\r\n')
+        protocol.dataReceived(b'    b\r\n')
+        protocol.dataReceived(b'\r\n')
+        self.assertEqual(
+            protocol.connHeaders,
+            Headers({}))
+        self.assertEqual(
+            protocol.response.headers,
+            Headers({b'x-multiline': [b'a    b']}))
+        self.assertIdentical(protocol.response.length, UNKNOWN_LENGTH)
+
+
     def test_connectionHeaders(self):
         """
         The connection control headers are added to the parser's C{connHeaders}


### PR DESCRIPTION
This PR:

1. Adds tests to validate that our client and server implementations handle line folding per [RFC 7230 section 3.2.4](https://tools.ietf.org/html/rfc7230#section-3.2.4):

```
   Historically, HTTP header field values could be extended over
   multiple lines by preceding each extra line with at least one space
   or horizontal tab (obs-fold).  This specification deprecates such
   line folding except within the message/http media type
   (Section 8.3.1).  A sender MUST NOT generate a message that includes
   line folding (i.e., that has any field-value that contains a match to
   the obs-fold rule) unless the message is intended for packaging
   within the message/http media type.

   A server that receives an obs-fold in a request message that is not
   within a message/http container MUST either reject the message by
   sending a 400 (Bad Request), preferably with a representation
   explaining that obsolete line folding is unacceptable, or replace
   each received obs-fold with one or more SP octets prior to
   interpreting the field value or forwarding the message downstream.
```

2. Fixes the resulting failure due to type confusion in `HTTPChannel` reported by @markrwilliams in [#9644](https://twistedmatrix.com/trac/ticket/9644).

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9644
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
