### PR TITLE
[9648] Pretty PyPI page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,10 +41,10 @@ Additional instructions for installing this software are in `the installation in
 Documentation and Support
 -------------------------
 
-Twisted's documentation is available from the `Twisted Matrix website <http://twistedmatrix.com/documents/current/>`_.
+Twisted's documentation is available from the `Twisted Matrix website <https://twistedmatrix.com/documents/current/>`_.
 This documentation contains how-tos, code examples, and an API reference.
 
-Help is also available on the `Twisted mailing list <http://twistedmatrix.com/cgi-bin/mailman/listinfo/twisted-python>`_.
+Help is also available on the `Twisted mailing list <https://twistedmatrix.com/cgi-bin/mailman/listinfo/twisted-python>`_.
 
 There is also a pair of very lively IRC channels, ``#twisted`` (for general Twisted questions) and ``#twisted.web`` (for Twisted Web), on ``chat.freenode.net``.
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,6 @@ Twisted
 =======
 
 |pypi|_
-|coverage|_
 |travis|_
 |circleci|_
 
@@ -94,9 +93,6 @@ Warranty
 
 Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 
-
-.. |coverage| image:: https://codecov.io/github/twisted/twisted/coverage.svg?branch=trunk
-.. _coverage: https://codecov.io/github/twisted/twisted
 
 .. |pypi| image:: http://img.shields.io/pypi/v/twisted.svg
 .. _pypi: https://pypi.python.org/pypi/twisted

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,6 @@ Twisted
 |pypi|_
 |coverage|_
 |travis|_
-|appveyor|_
 |circleci|_
 
 For information on what's new in Twisted 19.2.0, see the `NEWS <NEWS.rst>`_ file that comes with the distribution.
@@ -104,9 +103,6 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 
 .. |travis| image:: https://travis-ci.org/twisted/twisted.svg?branch=trunk
 .. _travis: https://travis-ci.org/twisted/twisted
-
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/x4oyqtl9cqc2i2l8
-.. _appveyor: https://ci.appveyor.com/project/adiroiban/twisted
 
 .. |circleci| image:: https://circleci.com/gh/twisted/twisted.svg?style=svg
 .. _circleci: https://circleci.com/gh/twisted/twisted

--- a/src/twisted/newsfragments/9648.feature
+++ b/src/twisted/newsfragments/9648.feature
@@ -1,0 +1,1 @@
+The PyPI page for Twisted has been enhanced to include more information and useful links.

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -57,6 +57,11 @@ STATIC_PACKAGE_METADATA = dict(
     maintainer="Glyph Lefkowitz",
     maintainer_email="glyph@twistedmatrix.com",
     url="https://twistedmatrix.com/",
+    project_urls={
+        'Documentation': 'https://twistedmatrix.com/documents/current/',
+        'Source': 'https://github.com/twisted/twisted',
+        'Issues': 'https://twistedmatrix.com/trac/report',
+    },
     license="MIT",
     long_description="""\
 An extensible framework for Python programming, with special focus

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -56,7 +56,7 @@ STATIC_PACKAGE_METADATA = dict(
     author_email="twisted-python@twistedmatrix.com",
     maintainer="Glyph Lefkowitz",
     maintainer_email="glyph@twistedmatrix.com",
-    url="http://twistedmatrix.com/",
+    url="https://twistedmatrix.com/",
     license="MIT",
     long_description="""\
 An extensible framework for Python programming, with special focus
@@ -307,7 +307,7 @@ class build_ext_twisted(build_ext.build_ext, object):
         # _XOPEN_SOURCE_EXTENDED macros to build in order to gain access to
         # the msg_control, msg_controllen, and msg_flags members in
         # sendmsg.c. (according to
-        # http://stackoverflow.com/questions/1034587).  See the documentation
+        # https://stackoverflow.com/questions/1034587).  See the documentation
         # of X/Open CAE in the standards(5) man page of Solaris.
         if sys.platform.startswith('sunos'):
             self.define_macros.append(('_XOPEN_SOURCE', 1))

--- a/src/twisted/python/test/test_setup.py
+++ b/src/twisted/python/test/test_setup.py
@@ -38,7 +38,7 @@ class SetupTests(SynchronousTestCase):
         good_ext = ConditionalExtension("whatever", ["whatever.c"],
                                         condition=lambda b: True)
         bad_ext = ConditionalExtension("whatever", ["whatever.c"],
-                                        condition=lambda b: False)
+                                       condition=lambda b: False)
 
         args = getSetupArgs(extensions=[good_ext, bad_ext], readme=None)
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@
 minversion=2.4
 skip_missing_interpreters=True
 toxworkdir=build/
-envlist=lint,pyflakes,apidocs,narrativedocs,newsfragment,manifest-checker,py27-alldeps-nocov,py36-alldeps-nocov
+envlist=lint,pyflakes,apidocs,narrativedocs,newsfragment,manifest-checker,twine,py27-alldeps-nocov,py36-alldeps-nocov
 
 [testenv]
 ;; dependencies managed by extras in t.p._setup.py._EXTRAS_REQUIRE
@@ -59,6 +59,8 @@ deps =
 
     ; Code quality checkers
     manifest-checker: check-manifest
+
+    twine: twine
 
     lint: pyflakes
     lint: twistedchecker>=0.7.1
@@ -130,6 +132,8 @@ commands =
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
     manifest-checker: check-manifest --ignore "docs/_build*,docs/historic/*,admin*,bin/admin*,twisted/topfiles/*.Old"
+
+    twine: twine check {distdir}/*.*
 
     wheels: cibuildwheel --output-dir {toxinidir}/wheelhouse {toxinidir}
     wheels: python setup.py sdist --formats=gztar,zip --dist-dir={toxinidir}/wheelhouse


### PR DESCRIPTION
## Summary

* Adjust URLs to HTTPS instead of HTTP
* Add project URLs for documentation, source, and issues. They will display on PyPI like this: 
<img alt="screenshot" width="252" src="https://user-images.githubusercontent.com/43662/58916136-95279280-86d7-11e9-8fa5-c39a01dc66ae.png">

* Generate the long description of the package from README.rst. A slightly hackish regex replacement is used to make relative URLs absolute so that they will work when it is displayed at https://pypi.org/project/Twisted/ . Refer to https://packaging.python.org/specifications/core-metadata/#description-content-type.
* Add a Tox environment that runs the `twine check` command. This validates that the reStructuredText of the long description is valid. (I explored adding a test in `test_setup.py` for this, but [readme_renderer](https://pypi.org/project/readme_renderer/) isn't really documented for API use and has a pretty hefty dependency tree, so I found it a bit much for the assurance it would offer.)
* Remove some badges that were rendered obsolete by the switch to Coveralls and Azure Piplelines.

## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9648#comment:1
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
