### PR TITLE
[#9656] Disable traceback printing by default in Site and update twisted.web.tap to have an enable flag instead of a disable flag

### DIFF
--- a/src/twisted/newsfragments/9656.bugfix
+++ b/src/twisted/newsfragments/9656.bugfix
@@ -1,0 +1,1 @@
+twisted.web.server.Site's instance variable displayTracebacks is now set to False by default.

--- a/src/twisted/newsfragments/9656.feature
+++ b/src/twisted/newsfragments/9656.feature
@@ -1,0 +1,1 @@
+twisted.web.tap, the module that is run by `twist web`, now accepts --display-tracebacks to render tracebacks on uncaught exceptions.

--- a/src/twisted/newsfragments/9656.removal
+++ b/src/twisted/newsfragments/9656.removal
@@ -1,0 +1,1 @@
+Passing --notracebacks/-n to twisted.web.tap, the module that is run by `twist web`, is now deprecated due to traceback rendering being disabled by default.

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -768,14 +768,14 @@ class Site(http.HTTPFactory):
     @ivar counter: increment value used for generating unique sessions ID.
     @ivar requestFactory: A factory which is called with (channel)
         and creates L{Request} instances. Default to L{Request}.
-    @ivar displayTracebacks: if set, Twisted internal errors are displayed on
-        rendered pages. Default to C{True}.
+    @ivar displayTracebacks: If set, unhandled exceptions raised during
+        rendering are returned to the client as HTML. Default to C{False}.
     @ivar sessionFactory: factory for sessions objects. Default to L{Session}.
     @ivar sessionCheckTime: Deprecated.  See L{Session.sessionTimeout} instead.
     """
     counter = 0
     requestFactory = Request
-    displayTracebacks = True
+    displayTracebacks = False
     sessionFactory = Session
     sessionCheckTime = 1800
     _entropy = os.urandom

--- a/src/twisted/web/tap.py
+++ b/src/twisted/web/tap.py
@@ -39,8 +39,12 @@ class Options(usage.Options):
 
     optFlags = [
         ["notracebacks", "n", (
-            "Do not display tracebacks in broken web pages. Displaying "
-            "tracebacks to users may be security risk!")],
+            "(DEPRECATED: Tracebacks are disabled by default. "
+            "See --enable-tracebacks to turn them on.")],
+        ["display-tracebacks", "", (
+            "Show uncaught exceptions during rendering tracebacks to "
+            "the client. WARNING: This may be a security risk and "
+            "expose private data!")],
     ]
 
     optFlags.append([
@@ -295,7 +299,14 @@ def makeService(config):
     else:
         site = server.Site(root)
 
-    site.displayTracebacks = not config["notracebacks"]
+    if config["display-tracebacks"]:
+        site.displayTracebacks = True
+
+    # Deprecate --notracebacks/-n
+    if config["notracebacks"]:
+        msg = deprecate._getDeprecationWarningString(
+            "--notracebacks", incremental.Version('Twisted', "NEXT", 0, 0))
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
     if config['personal']:
         site = makePersonalServerFactory(site)

--- a/src/twisted/web/test/test_tap.py
+++ b/src/twisted/web/test/test_tap.py
@@ -291,6 +291,45 @@ class ServiceTests(TestCase):
         self.assertIsInstance(resource._originalResource, demo.Test)
 
 
+    def test_noTracebacksDeprecation(self):
+        """
+        Passing --notracebacks is deprecated.
+        """
+        options = Options()
+        options.parseOptions(["--notracebacks"])
+        makeService(options)
+
+        warnings = self.flushWarnings([self.test_noTracebacksDeprecation])
+        self.assertEqual(warnings[0]['category'], DeprecationWarning)
+        self.assertEqual(
+            warnings[0]['message'],
+            "--notracebacks was deprecated in Twisted NEXT"
+        )
+        self.assertEqual(len(warnings), 1)
+
+
+    def test_displayTracebacks(self):
+        """
+        Passing --display-tracebacks will enable traceback rendering on the
+        generated Site.
+        """
+        options = Options()
+        options.parseOptions(["--display-tracebacks"])
+        service = makeService(options)
+        self.assertTrue(service.services[0].factory.displayTracebacks)
+
+
+    def test_displayTracebacksNotGiven(self):
+        """
+        Not passing --display-tracebacks will leave traceback rendering on the
+        generated Site off.
+        """
+        options = Options()
+        options.parseOptions([])
+        service = makeService(options)
+        self.assertFalse(service.services[0].factory.displayTracebacks)
+
+
 
 class AddHeadersResourceTests(TestCase):
     def test_getChildWithDefault(self):

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -597,6 +597,39 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.prePathURL(), b'http://example.com/foo%2Fbar')
 
 
+    def test_processingFailedNoTracebackByDefault(self):
+        """
+        By default, L{Request.processingFailed} does not write out the failure,
+        but give a generic error message, as L{Site.displayTracebacks} is
+        disabled by default.
+        """
+        logObserver = EventLoggingObserver.createWithCleanup(
+            self,
+            globalLogPublisher
+        )
+
+        d = DummyChannel()
+        request = server.Request(d, 1)
+        request.site = server.Site(resource.Resource())
+        fail = failure.Failure(Exception("Oh no!"))
+        request.processingFailed(fail)
+
+        self.assertNotIn(b"Oh no!", request.transport.written.getvalue())
+        self.assertIn(
+            b"Processing Failed", request.transport.written.getvalue()
+        )
+        self.assertEquals(1, len(logObserver))
+
+        event = logObserver[0]
+        f = event["log_failure"]
+        self.assertIsInstance(f.value, Exception)
+        self.assertEquals(f.getErrorMessage(), "Oh no!")
+
+        # Since we didn't "handle" the exception, flush it to prevent a test
+        # failure
+        self.assertEqual(1, len(self.flushLoggedErrors()))
+
+
     def test_processingFailedNoTraceback(self):
         """
         L{Request.processingFailed} when the site has C{displayTracebacks} set


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9656#ticket