### PR TITLE
Add the stackLevel kwarg to STDLibLogObserver._findCaller

### DIFF
--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -78,7 +78,7 @@ class STDLibLogObserver(object):
         self.stackDepth = stackDepth
 
 
-    def _findCaller(self, stackInfo=False):
+    def _findCaller(self, stackInfo=False, stackLevel=1):
         """
         Based on the stack depth passed to this L{STDLibLogObserver}, identify
         the calling function.
@@ -86,6 +86,10 @@ class STDLibLogObserver(object):
         @param stackInfo: Whether or not to construct stack information.
             (Currently ignored.)
         @type stackInfo: L{bool}
+
+        @param stackLevel: The number of stack frames to skip when determining
+            the caller (currently ignored; use stackDepth on the instance).
+        @type stackLevel: L{int}
 
         @return: Depending on Python version, either a 3-tuple of (filename,
             lineno, name) or a 4-tuple of that plus stack information.

--- a/src/twisted/newsfragments/9668.bugfix
+++ b/src/twisted/newsfragments/9668.bugfix
@@ -1,0 +1,1 @@
+Add the stackLevel keyword argument to twisted.logger.STDLibLogObserver._findCaller to fix an incompatibility with Python 3.8.


### PR DESCRIPTION
Python 3.8 adds a new keyword argument, stacklevel, to its findCaller function in commit dde9fdbe4539 ("bpo-33165: Added stacklevel parameter to logging APIs. (GH-7424)" - https://github.com/python/cpython/pull/7424). As Twisted is replacing this method with its own method, logging with STDLibLogObserver fails in Python 3.8. This patch adds the argument, but does not use it as there is already a stackDepth instance variable and the stackInfo on the method is also ignored.

This patch fixes all the failures in twisted.logger.test.test_stdlib in Python 3.8.

Signed-off-by: Jeremy Cline <jcline@redhat.com>

## Contributor Checklist:

* [x] There is an associated ticket in Trac. Create a new one at https://twistedmatrix.com/trac/newticket
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [ ] I have updated the automated tests.
