### PR TITLE
Use the undeprecated API in iosim

### DIFF
--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -26,6 +26,7 @@ from twisted.internet import interfaces
 from twisted.internet.testing import MemoryReactorClock
 
 
+
 class TLSNegotiation:
     def __init__(self, obj, connectState):
         self.obj = obj

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -23,8 +23,7 @@ from twisted.internet.error import ConnectionRefusedError
 from twisted.python.failure import Failure
 from twisted.internet import error
 from twisted.internet import interfaces
-
-from .proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 
 
 class TLSNegotiation:


### PR DESCRIPTION
## Contributor Checklist:

* [x] There is an associated ticket in Trac. https://twistedmatrix.com/trac/ticket/9684
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )

I have not updated the automated tests because none seem to cover deprecation warning.  I want to believe there used to be CI for deprecations but this might not really be true.  In any case, I see no such thing now.  If there is one, I'd be happy to be pointed at it.
