### PR TITLE
move the `chmod` back to the parent, simplify, fix

### DIFF
--- a/src/twisted/test/test_iutils.py
+++ b/src/twisted/test/test_iutils.py
@@ -221,23 +221,27 @@ class ProcessUtilsTests(unittest.TestCase):
         os.makedirs(dir)
 
         scriptFile = self.makeSourceFile([
-                "import os, sys, stat",
-                # Fix the permissions so we can report the working directory.
-                # On macOS (and maybe elsewhere), os.getcwd() fails with EACCES
-                # if +x is missing from the working directory.
-                "os.chmod(%r, stat.S_IXUSR)" % (dir,),
-                "sys.stdout.write(os.getcwd())"])
+            "import os, sys",
+            "cdir = os.getcwd()",
+            "sys.stdout.write(cdir)"]
+        )
 
         # Switch to it, but make sure we switch back
         self.addCleanup(os.chdir, os.getcwd())
         os.chdir(dir)
 
-        # Get rid of all its permissions, but make sure they get cleaned up
-        # later, because otherwise it might be hard to delete the trial
-        # temporary directory.
-        self.addCleanup(
-            os.chmod, dir, stat.S_IMODE(os.stat('.').st_mode))
-        os.chmod(dir, 0)
+        # Remember its default permissions.
+        originalMode = stat.S_IMODE(os.stat('.').st_mode)
+
+        # On macOS Catalina (and maybe elsewhere), os.getcwd() sometimes fails
+        # with EACCES if u+rx is missing from the working directory, so don't
+        # reduce it further than this.
+        os.chmod(dir, stat.S_IXUSR | stat.S_IRUSR)
+
+        # Restore the permissions to their original state later (probably
+        # adding at least u+w), because otherwise it might be hard to delete
+        # the trial temporary directory.
+        self.addCleanup(os.chmod, dir, originalMode)
 
         # Pass in -S so that if run using the coverage .pth trick, it won't be
         # loaded and cause Coverage to try and get the current working


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9728
* [ ] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
