### PR TITLE
pywin32 breaks virtualenv and thus our builds

### DIFF
--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -109,11 +109,11 @@ _EXTRA_OPTIONS = dict(
     ],
     soap=['soappy'],
     serial=['pyserial >= 3.0',
-            'pywin32; platform_system == "Windows"'],
+            'pywin32 != 226; platform_system == "Windows"'],
     macos=['pyobjc-core',
            'pyobjc-framework-CFNetwork',
            'pyobjc-framework-Cocoa'],
-    windows=['pywin32'],
+    windows=['pywin32 != 226'],
     http2=['h2 >= 3.0, < 4.0',
            'priority >= 1.1.0, < 2.0'],
 )

--- a/src/twisted/python/test/test_setup.py
+++ b/src/twisted/python/test/test_setup.py
@@ -259,7 +259,7 @@ class OptionalDependenciesTests(SynchronousTestCase):
         self.assertIn('pyserial >= 3.0', deps)
         self.assertIn('h2 >= 3.0, < 4.0', deps)
         self.assertIn('priority >= 1.1.0, < 2.0', deps)
-        self.assertIn('pywin32', deps)
+        self.assertIn('pywin32 != 226', deps)
 
 
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9729
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
