### PR TITLE
[9751] Fix pydoctor warnings about SSHTransportBase

### DIFF
--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -1235,8 +1235,8 @@ class SSHTransportBase(protocol.Protocol):
         Generate an private key for ECDH key exchange.
 
         @rtype: The appropriate private key type matching C{self.kexAlg}:
-            L{EllipticCurvePrivateKey} for C{ecdh-sha2-nistp*}, or
-            L{X25519PrivateKey} for C{curve25519-sha256}.
+            L{ec.EllipticCurvePrivateKey} for C{ecdh-sha2-nistp*}, or
+            L{x25519.X25519PrivateKey} for C{curve25519-sha256}.
         @return: The generated private key.
         """
         if self.kexAlg.startswith(b'ecdh-sha2-nistp'):
@@ -1260,8 +1260,8 @@ class SSHTransportBase(protocol.Protocol):
         Encode an elliptic curve public key to bytes.
 
         @type ecPub: The appropriate public key type matching
-            C{self.kexAlg}: L{EllipticCurvePublicKey} for
-            C{ecdh-sha2-nistp*}, or L{X25519PublicKey} for
+            C{self.kexAlg}: L{ec.EllipticCurvePublicKey} for
+            C{ecdh-sha2-nistp*}, or L{x25519.X25519PublicKey} for
             C{curve25519-sha256}.
         @param ecPub: The public key to encode.
 
@@ -1290,8 +1290,8 @@ class SSHTransportBase(protocol.Protocol):
         Generate a shared secret for ECDH key exchange.
 
         @type ecPriv: The appropriate private key type matching
-            C{self.kexAlg}: L{EllipticCurvePrivateKey} for
-            C{ecdh-sha2-nistp*}, or L{X25519PrivateKey} for
+            C{self.kexAlg}: L{ec.EllipticCurvePrivateKey} for
+            C{ecdh-sha2-nistp*}, or L{x25519.X25519PrivateKey} for
             C{curve25519-sha256}.
         @param ecPriv: Our private key.
 

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -28,6 +28,7 @@ NEWSFRAGMENT_TYPES = ["doc", "bugfix", "misc", "feature", "removal"]
 intersphinxURLs = [
     u"https://docs.python.org/2/objects.inv",
     u"https://docs.python.org/3/objects.inv",
+    u"https://cryptography.io/en/latest/objects.inv",
     u"https://pyopenssl.readthedocs.io/en/stable/objects.inv",
     u"https://hyperlink.readthedocs.io/en/stable/objects.inv",
     u"https://twisted.github.io/constantly/docs/objects.inv",


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9751
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests. (N/A)
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
