### PR TITLE
[9752] Cope better with malformed /etc/hosts

### DIFF
--- a/src/twisted/names/hosts.py
+++ b/src/twisted/names/hosts.py
@@ -47,7 +47,12 @@ def searchFileForAll(hostsFile, name):
         parts = line.split()
 
         if name.lower() in [s.lower() for s in parts[1:]]:
-            results.append(nativeString(parts[0]))
+            try:
+                maybeIP = nativeString(parts[0])
+            except ValueError:  # Not ASCII.
+                continue
+            if isIPAddress(maybeIP) or isIPv6Address(maybeIP):
+                results.append(maybeIP)
     return results
 
 
@@ -150,4 +155,5 @@ class Resolver(common.ResolverBase):
     # Someday this should include IPv6 addresses too, but that will cause
     # problems if users of the API (mainly via getHostByName) aren't updated to
     # know about IPv6 first.
+    # FIXME - getHostByName knows about IPv6 now.
     lookupAllRecords = lookupAddress

--- a/src/twisted/names/hosts.py
+++ b/src/twisted/names/hosts.py
@@ -17,6 +17,8 @@ from twisted.internet.abstract import isIPAddress, isIPv6Address
 
 from twisted.names import common
 
+
+
 def searchFileForAll(hostsFile, name):
     """
     Search the given file, which is in hosts(5) standard format, for addresses

--- a/src/twisted/names/hosts.py
+++ b/src/twisted/names/hosts.py
@@ -13,14 +13,14 @@ from twisted.names import dns
 from twisted.python import failure
 from twisted.python.filepath import FilePath
 from twisted.internet import defer
-from twisted.internet.abstract import isIPAddress
+from twisted.internet.abstract import isIPAddress, isIPv6Address
 
 from twisted.names import common
 
 def searchFileForAll(hostsFile, name):
     """
-    Search the given file, which is in hosts(5) standard format, for an address
-    entry with a given name.
+    Search the given file, which is in hosts(5) standard format, for addresses
+    associated with a given name.
 
     @param hostsFile: The name of the hosts(5)-format file to search.
     @type hostsFile: L{FilePath}
@@ -107,7 +107,7 @@ class Resolver(common.ResolverBase):
                          dns.Record_AAAA(addr, self.ttl))
             for addr
             in searchFileForAll(FilePath(self.file), name)
-            if not isIPAddress(addr)])
+            if isIPv6Address(addr)])
 
 
     def _respond(self, name, records):

--- a/src/twisted/names/newsfragments/9752.feature
+++ b/src/twisted/names/newsfragments/9752.feature
@@ -1,0 +1,1 @@
+twisted.names.hosts.Resolver and twisted.names.hosts.searchFileForAll() now ignore malformed lines in hosts files like /etc/hosts

--- a/src/twisted/names/test/test_hosts.py
+++ b/src/twisted/names/test/test_hosts.py
@@ -7,7 +7,7 @@ Tests for the I{hosts(5)}-based resolver, L{twisted.names.hosts}.
 
 from __future__ import division, absolute_import
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 from twisted.internet.defer import gatherResults
 
@@ -22,7 +22,7 @@ class GoodTempPathMixin(object):
 
 
 
-class SearchHostsFileTests(TestCase, GoodTempPathMixin):
+class SearchHostsFileTests(SynchronousTestCase, GoodTempPathMixin):
     """
     Tests for L{searchFileFor}, a helper which finds the first address for a
     particular hostname in a I{hosts(5)}-style file.
@@ -81,7 +81,7 @@ class SearchHostsFileTests(TestCase, GoodTempPathMixin):
 
 
 
-class SearchHostsFileForAllTests(TestCase, GoodTempPathMixin):
+class SearchHostsFileForAllTests(SynchronousTestCase, GoodTempPathMixin):
     """
     Tests for L{searchFileForAll}, a helper which finds all addresses for a
     particular hostname in a I{hosts(5)}-style file.
@@ -121,7 +121,7 @@ class SearchHostsFileForAllTests(TestCase, GoodTempPathMixin):
 
 
 
-class HostsTests(TestCase, GoodTempPathMixin):
+class HostsTests(SynchronousTestCase, GoodTempPathMixin):
     """
     Tests for the I{hosts(5)}-based L{twisted.names.hosts.Resolver}.
     """
@@ -162,7 +162,7 @@ class HostsTests(TestCase, GoodTempPathMixin):
                 ]
         ds = [self.resolver.getHostByName(n).addCallback(self.assertEqual, ip)
               for n, ip in data]
-        return gatherResults(ds)
+        self.successResultOf(gatherResults(ds))
 
 
     def test_lookupAddress(self):
@@ -171,16 +171,13 @@ class HostsTests(TestCase, GoodTempPathMixin):
         records from the hosts file.
         """
         d = self.resolver.lookupAddress(b'multiple')
-        def resolved(results):
-            answers, authority, additional = results
-            self.assertEqual(
-                (RRHeader(b"multiple", A, IN, self.ttl,
-                          Record_A("1.1.1.3", self.ttl)),
-                 RRHeader(b"multiple", A, IN, self.ttl,
-                          Record_A("1.1.1.4", self.ttl))),
-                answers)
-        d.addCallback(resolved)
-        return d
+        answers, authority, additional = self.successResultOf(d)
+        self.assertEqual(
+            (RRHeader(b"multiple", A, IN, self.ttl,
+                      Record_A("1.1.1.3", self.ttl)),
+             RRHeader(b"multiple", A, IN, self.ttl,
+                      Record_A("1.1.1.4", self.ttl))),
+            answers)
 
 
     def test_lookupIPV6Address(self):
@@ -189,16 +186,13 @@ class HostsTests(TestCase, GoodTempPathMixin):
         with AAAA records from the hosts file.
         """
         d = self.resolver.lookupIPV6Address(b'ip6-multiple')
-        def resolved(results):
-            answers, authority, additional = results
-            self.assertEqual(
-                (RRHeader(b"ip6-multiple", AAAA, IN, self.ttl,
-                          Record_AAAA("::3", self.ttl)),
-                 RRHeader(b"ip6-multiple", AAAA, IN, self.ttl,
-                          Record_AAAA("::4", self.ttl))),
-                answers)
-        d.addCallback(resolved)
-        return d
+        answers, authority, additional = self.successResultOf(d)
+        self.assertEqual(
+            (RRHeader(b"ip6-multiple", AAAA, IN, self.ttl,
+                      Record_AAAA("::3", self.ttl)),
+             RRHeader(b"ip6-multiple", AAAA, IN, self.ttl,
+                      Record_AAAA("::4", self.ttl))),
+            answers)
 
 
     def test_lookupAllRecords(self):
@@ -207,26 +201,26 @@ class HostsTests(TestCase, GoodTempPathMixin):
         with A records from the hosts file.
         """
         d = self.resolver.lookupAllRecords(b'mixed')
-        def resolved(results):
-            answers, authority, additional = results
-            self.assertEqual(
-                (RRHeader(b"mixed", A, IN, self.ttl,
-                          Record_A("1.1.1.2", self.ttl)),),
-                answers)
-        d.addCallback(resolved)
-        return d
+        answers, authority, additional = self.successResultOf(d)
+        self.assertEqual(
+            (RRHeader(b"mixed", A, IN, self.ttl,
+                      Record_A("1.1.1.2", self.ttl)),),
+            answers)
 
 
     def test_notImplemented(self):
-        return self.assertFailure(self.resolver.lookupMailExchange(b'EXAMPLE'),
-                                  NotImplementedError)
+        """
+        L{hosts.Resolver} fails with L{NotImplementedError} for L{IResolver}
+        methods it doesn't implement.
+        """
+        self.failureResultOf(self.resolver.lookupMailExchange(b'EXAMPLE'),
+                             NotImplementedError)
 
 
     def test_query(self):
         d = self.resolver.query(Query(b'EXAMPLE'))
-        d.addCallback(lambda x: self.assertEqual(x[0][0].payload.dottedQuad(),
-                                                 '1.1.1.1'))
-        return d
+        [answer], authority, additional = self.successResultOf(d)
+        self.assertEqual(answer.payload.dottedQuad(), '1.1.1.1')
 
 
     def test_lookupAddressNotFound(self):
@@ -235,8 +229,8 @@ class HostsTests(TestCase, GoodTempPathMixin):
         L{dns.DomainError} if the name passed in has no addresses in the hosts
         file.
         """
-        return self.assertFailure(self.resolver.lookupAddress(b'foueoa'),
-                                  DomainError)
+        self.failureResultOf(self.resolver.lookupAddress(b'foueoa'),
+                             DomainError)
 
 
     def test_lookupIPV6AddressNotFound(self):
@@ -244,8 +238,8 @@ class HostsTests(TestCase, GoodTempPathMixin):
         Like L{test_lookupAddressNotFound}, but for
         L{hosts.Resolver.lookupIPV6Address}.
         """
-        return self.assertFailure(self.resolver.lookupIPV6Address(b'foueoa'),
-                                  DomainError)
+        self.failureResultOf(self.resolver.lookupIPV6Address(b'foueoa'),
+                             DomainError)
 
 
     def test_lookupAllRecordsNotFound(self):
@@ -253,5 +247,5 @@ class HostsTests(TestCase, GoodTempPathMixin):
         Like L{test_lookupAddressNotFound}, but for
         L{hosts.Resolver.lookupAllRecords}.
         """
-        return self.assertFailure(self.resolver.lookupAllRecords(b'foueoa'),
-                                  DomainError)
+        self.failureResultOf(self.resolver.lookupAllRecords(b'foueoa'),
+                             DomainError)


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9752
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
