### PR TITLE
9757 fix coverage version mismatch again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,9 @@ extras =
 deps =
     py27-alldeps-{posix,macos}: pysqlite
 
-    ; Coverage 5.0 does not work with codecov.
-    {withcov}: coverage<5.0
-    {coverage-prepare,codecov-publish}: coverage<5.0
+    {withcov}: coverage
+
+    {coverage-prepare,codecov-publish}: coverage
 
     {codecov-push,codecov-publish}: codecov
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9757
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
