### PR TITLE
don't return fail() from callRemote(String) on closed connections

### DIFF
--- a/src/twisted/newsfragments/9756.bugfix
+++ b/src/twisted/newsfragments/9756.bugfix
@@ -1,0 +1,1 @@
+twisted.protocols.amp.BoxDispatcher.callRemote and callRemoteString will no longer return failing Deferreds for requiresAnswer=False commands when the transport they're operating on has been disconnected.

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -889,7 +889,10 @@ class BoxDispatcher:
         @raise ProtocolSwitched: if the protocol has been switched.
         """
         if self._failAllReason is not None:
-            return fail(self._failAllReason)
+            if requiresAnswer:
+                return fail(self._failAllReason)
+            else:
+                return None
         box[COMMAND] = command
         tag = self._nextTag()
         if requiresAnswer:

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -1545,6 +1545,21 @@ class AMPTests(unittest.TestCase):
         self.assertFalse(s.greeted)
 
 
+    def test_requiresNoAnswerAfterFail(self):
+        """
+        No-answer commands sent after the connection has been torn down do not
+        return a L{Deferred}.
+        """
+        c, s, p = connectedServerAndClient(
+            ServerClass=SimpleSymmetricCommandProtocol,
+            ClientClass=SimpleSymmetricCommandProtocol,
+        )
+        c.transport.loseConnection()
+        p.flush()
+        result = c.callRemote(NoAnswerHello, hello=b'ignored')
+        self.assertIs(result, None)
+
+
     def test_noAnswerResponderBadAnswer(self):
         """
         Verify that responders of requiresAnswer=False commands have to return


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9756
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
