### PR TITLE
CramMD5ClientAuthenticator now specifies the digestmod argument to hmac.HMAC constructor explicitly.

### DIFF
--- a/src/twisted/mail/_cred.py
+++ b/src/twisted/mail/_cred.py
@@ -8,6 +8,7 @@ Credential managers for L{twisted.mail}.
 from __future__ import absolute_import, division
 
 import hmac
+import hashlib
 
 from zope.interface import implementer
 
@@ -28,7 +29,7 @@ class CramMD5ClientAuthenticator:
 
 
     def challengeResponse(self, secret, chal):
-        response = hmac.HMAC(secret, chal).hexdigest().encode('ascii')
+        response = hmac.HMAC(secret, chal, digestmod = hashlib.md5).hexdigest().encode('ascii')
         return self.user + b' ' + response
 
 

--- a/src/twisted/mail/_cred.py
+++ b/src/twisted/mail/_cred.py
@@ -29,8 +29,8 @@ class CramMD5ClientAuthenticator:
 
 
     def challengeResponse(self, secret, chal):
-        response = hmac.HMAC(secret, chal, digestmod = hashlib.md5).hexdigest().encode('ascii')
-        return self.user + b' ' + response
+        response = hmac.HMAC(secret, chal, digestmod=hashlib.md5).hexdigest()
+        return self.user + b' ' + response.encode('ascii')
 
 
 

--- a/src/twisted/mail/newsfragments/9733.bugfix
+++ b/src/twisted/mail/newsfragments/9733.bugfix
@@ -1,1 +1,0 @@
-twisted.mail._cred.CramMD5ClientAuthenticator.challengeResponse(...) now calls hmac.HMAC.new(...) with explicit MD5 digestmod.

--- a/src/twisted/mail/newsfragments/9733.bugfix
+++ b/src/twisted/mail/newsfragments/9733.bugfix
@@ -1,0 +1,1 @@
+twisted.mail._cred.CramMD5ClientAuthenticator.challengeResponse(...) now calls hmac.HMAC.new(...) with explicit MD5 digestmod.


### PR DESCRIPTION
The e-mail CramMD5ClientAuthenticator class now calls the hmac.HMAC constructor with the digestmod argument, as python 3.8 requires it to be specified explicitly.

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/9733
* [x] The changes pass minimal style checks
* [x] I have created a newsfragment in src/twisted/newsfragments/ 
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
