### PR TITLE
Adding BrowserLikePolicyForHTTPS to __all__

### DIFF
--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -2310,6 +2310,7 @@ def readBody(response):
 
 __all__ = [
     'Agent',
+    'BrowserLikePolicyForHTTPS',
     'BrowserLikeRedirectAgent',
     'ContentDecoderAgent',
     'CookieAgent',

--- a/src/twisted/web/newsfragments/9769.bugfix
+++ b/src/twisted/web/newsfragments/9769.bugfix
@@ -1,0 +1,1 @@
+twisted.web.client.BrowserLikePolicyForHTTPS is now listed in __all__, since it's a user-facing class that anyone could import and extend. 


### PR DESCRIPTION
On twisted.web.client, `BrowserLikePolicyForHTTPS` is not listed on `__all__`, although the user is explicitly told to use it on `WebClientContextFactory` comments, for example. The ticket on trac is here: https://twistedmatrix.com/trac/ticket/9769 .

I know this is a super small kind of irrelevant PR, but I'm proposing it for the sake of consistency and to suppress some warning messages I'm having in Launchpad.net development. :-)