### PR TITLE
Change iterkeys() to keys(), since iterkeys() does not exist in Python 3

### DIFF
--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -305,7 +305,7 @@ class PySourceAuthority(FileAuthority):
 
     def setupConfigNamespace(self):
         r = {}
-        items = dns.__dict__.iterkeys()
+        items = dns.__dict__.keys()
         for record in [x for x in items if x.startswith('Record_')]:
             type = getattr(dns, record)
             f = self.wrapRecord(type)

--- a/src/twisted/names/newsfragments/9783.bugfix
+++ b/src/twisted/names/newsfragments/9783.bugfix
@@ -1,0 +1,1 @@
+twistd -n dns --pyzone example-domain.com will no longer throw an exception on startup with Python 3.


### PR DESCRIPTION
 Author: rodrigc
 Reviewer: twm
 Fixes: ticket:9783

Without this fix, this example: https://twisted.readthedocs.io/en/twisted-18.9.0/names/howto/names.html#creating-an-authoritative-server

Then this command:

```
twistd -n dns --pyzone example-domain.com
```

fails with:

```
Traceback (most recent call last):
  File "/Users/craigrodrigues/twisted-venv/lib/python3.7/site-packages/twisted/names/tap.py", line 95, in postOptions
    self.zones.append(authority.PySourceAuthority(f))
  File "/Users/craigrodrigues/twisted-venv/lib/python3.7/site-packages/twisted/names/authority.py", line 90, in __init__
    self.loadFile(filename)
  File "/Users/craigrodrigues/twisted-venv/lib/python3.7/site-packages/twisted/names/authority.py", line 290, in loadFile
    g, l = self.setupConfigNamespace(), {}
  File "/Users/craigrodrigues/twisted-venv/lib/python3.7/site-packages/twisted/names/authority.py", line 308, in setupConfigNamespace
    items = dns.__dict__.iterkeys()
```