### PR TITLE
[9786] Fix PySourceAuthority on Python 3

### DIFF
--- a/docs/names/howto/listings/names/example-domain.com
+++ b/docs/names/howto/listings/names/example-domain.com
@@ -33,5 +33,6 @@ zone = [
     CNAME('ftp.example-domain.com', 'example-domain.com'),
 
     MX('example-domain.com', 0, 'mail.example-domain.com'),
-    A('mail.example-domain.com', '123.0.16.43')
+    A('mail.example-domain.com', '123.0.16.43'),
+    PTR('43.16.0.123.in-addr.arpa', 'mail.example-domain.com'),
 ]

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -300,7 +300,9 @@ class PySourceAuthority(FileAuthority):
 
 
     def wrapRecord(self, type):
-        return lambda name, *arg, **kw: (name, type(*arg, **kw))
+        def wrapRecordFunc(name, *arg, **kw):
+            return (dns.domainString(name), type(*arg, **kw))
+        return wrapRecordFunc
 
 
     def setupConfigNamespace(self):

--- a/src/twisted/names/newsfragments/9786.bugfix
+++ b/src/twisted/names/newsfragments/9786.bugfix
@@ -1,0 +1,1 @@
+twist dns --pyzone example-domain.com now works on Python 3.


### PR DESCRIPTION
Author: rodrigc
Reviewer:
Fixes: ticket:9786

Without this fix, trying to use follow the example at: https://twisted.readthedocs.io/en/twisted-18.9.0/names/howto/names.html#creating-an-authoritative-server

with:

```
 twistd -n dns --pyzone example-domain.com
```

and then:

```
dig -t any example-domain.com @127.0.0.1
```

will result in an error:

```
2020-03-25T23:38:56-0700 [DNSDatagramProtocol (UDP)] Unhandled Error
	Traceback (most recent call last):
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/dns.py", line 3098, in datagramReceived
	    self.controller.messageReceived(m, self, addr)
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/server.py", line 554, in messageReceived
	    self.handleQuery(message, proto, address)
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/server.py", line 381, in handleQuery
	    return self.resolver.query(query).addCallback(
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/common.py", line 78, in query
	    return defer.maybeDeferred(method, query.name.name, timeout)
	--- <exception caught here> ---
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/internet/defer.py", line 151, in maybeDeferred
	    result = f(*args, **kw)
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/resolve.py", line 94, in lookupAllRecords
	    d = self.resolvers[0].lookupAllRecords(name, timeout)
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/common.py", line 175, in lookupAllRecords
	    timeout)
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/authority.py", line 228, in _lookup
	    if dns._isSubdomainOf(name, self.soa[0]):
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/dns.py", line 310, in _isSubdomainOf
	    ancestorLabels = _nameToLabels(ancestorName.lower())
	  File "/Users/crodrigues/venv-twisted/lib/python3.7/site-packages/Twisted-20.3.0.dev0-py3.7-macosx-10.15-x86_64.egg/twisted/names/dns.py", line 245, in _nameToLabels
	    labels = name.split(b'.')
	builtins.TypeError: must be str or None, not bytes
```