### PR TITLE
[#9785] Use Python 3 for building API and narrative documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ jobs:
   documentation:
     working_directory: ~/documentation
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
     environment:
-      PYTHON: python2
+      PYTHON: python3
     steps:
       # Get the source.
       - checkout

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -16,6 +16,7 @@ from pydoctor import model, zopeinterface, astbuilder
 from pydoctor.sphinx import SphinxInventory
 
 
+
 class HeadRequest(urllib.request.Request, object):
     """
     A request for the HEAD HTTP method.
@@ -137,8 +138,8 @@ def getDeprecated(self, decorators):
 
             if fn == "twisted.python.deprecate.deprecated":
                 try:
-                    self._deprecated_info = deprecatedToUsefulText(self,
-                        self.name, a)
+                    self._deprecated_info = deprecatedToUsefulText(
+                        self, self.name, a)
                 except AttributeError:
                     raise
                     # It's a reference or something that we can't figure out

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -118,7 +118,7 @@ class TwistedSphinxInventory(SphinxInventory):
         @rtype: urllib2 response or L{None}
         """
         try:
-            return urllib.urlopen(HeadRequest(url))
+            return urllib.request.urlopen(HeadRequest(url))
         except Exception as e:
             print("Error opening {}: {}".format(url, e))
             return None

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -9,14 +9,14 @@ FIXME: https://github.com/twisted/pydoctor/issues/106
 This documentation does not link to pydoctor API as there is no public API yet.
 """
 
-import urllib2
+import ast
+import urllib
 
-from compiler import ast
-from pydoctor import model, zopeinterface
+from pydoctor import model, zopeinterface, astbuilder
 from pydoctor.sphinx import SphinxInventory
 
 
-class HeadRequest(urllib2.Request, object):
+class HeadRequest(urllib.request.Request, object):
     """
     A request for the HEAD HTTP method.
     """
@@ -118,7 +118,7 @@ class TwistedSphinxInventory(SphinxInventory):
         @rtype: urllib2 response or L{None}
         """
         try:
-            return urllib2.urlopen(HeadRequest(url))
+            return urllib.urlopen(HeadRequest(url))
         except Exception as e:
             print("Error opening {}: {}".format(url, e))
             return None
@@ -132,22 +132,15 @@ def getDeprecated(self, decorators):
     decorator.
     """
     for a in decorators:
-        if isinstance(a, ast.CallFunc):
-            decorator = a.asList()
-
-            # Getattr is used when the decorator is @foo.bar, not @bar
-            if isinstance(decorator[0], ast.Getattr):
-                getAttr = decorator[0].asList()
-                name = getAttr[0].name
-                fn = self.expandName(name) + "." + getAttr[1]
-            else:
-                fn = self.expandName(decorator[0].name)
+        if isinstance(a, ast.Call):
+            fn = self.expandName(''.join(astbuilder.node2dottedname(a.func)))
 
             if fn == "twisted.python.deprecate.deprecated":
                 try:
-                    self._deprecated_info = deprecatedToUsefulText(
-                        self.name, decorator)
+                    self._deprecated_info = deprecatedToUsefulText(self,
+                        self.name, a)
                 except AttributeError:
+                    raise
                     # It's a reference or something that we can't figure out
                     # from the AST.
                     pass
@@ -185,23 +178,22 @@ def versionToUsefulObject(version):
     Change an AST C{Version()} to a real one.
     """
     from incremental import Version
-
-    return Version(*[x.value for x in version.asList()[1:] if x])
-
+    return Version(version.args[0].s, *[x.n for x in version.args[1:] if x])
 
 
-def deprecatedToUsefulText(name, deprecated):
+
+def deprecatedToUsefulText(visitor, name, deprecated):
     """
     Change a C{@deprecated} to a display string.
     """
     from twisted.python.deprecate import _getDeprecationWarningString
 
-    version = versionToUsefulObject(deprecated[1])
-    if deprecated[2]:
-        if isinstance(deprecated[2], ast.Keyword):
-            replacement = deprecated[2].asList()[1].value
+    version = versionToUsefulObject(deprecated.args[0])
+    if len(deprecated.args) > 1 and deprecated.args[1]:
+        if isinstance(deprecated.args[1], ast.Name):
+            replacement = visitor.resolveName(deprecated.args[1].id)
         else:
-            replacement = deprecated[2].value
+            replacement = deprecated.args[1].s
     else:
         replacement = None
 

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -327,15 +327,16 @@ class APIBuilder(object):
 
         from pydoctor.driver import main
 
-        args = ["--project-name", projectName,
-                "--project-url", projectURL,
-                "--system-class", "twisted.python._pydoctor.TwistedSystem",
-                "--project-base-dir", packagePath.parent().path,
-                "--html-viewsource-base", sourceURL,
-                "--add-package", packagePath.path,
-                "--html-output", outputPath.path,
-                "--html-write-function-pages", "--quiet", "--make-html",
-               ] + intersphinxes
+        args = [
+            "--project-name", projectName,
+            "--project-url", projectURL,
+            "--system-class", "twisted.python._pydoctor.TwistedSystem",
+            "--project-base-dir", packagePath.parent().path,
+            "--html-viewsource-base", sourceURL,
+            "--add-package", packagePath.path,
+            "--html-output", outputPath.path,
+            "--html-write-function-pages", "--quiet", "--make-html",
+        ] + intersphinxes
         main(args)
 
         monkeyPatch.restore()

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -327,16 +327,15 @@ class APIBuilder(object):
 
         from pydoctor.driver import main
 
-        args = [u"--project-name", projectName,
-                u"--project-url", projectURL,
-                u"--system-class", u"twisted.python._pydoctor.TwistedSystem",
-                u"--project-base-dir", packagePath.parent().path,
-                u"--html-viewsource-base", sourceURL,
-                u"--add-package", packagePath.path,
-                u"--html-output", outputPath.path,
-                u"--html-write-function-pages", u"--quiet", u"--make-html",
+        args = ["--project-name", projectName,
+                "--project-url", projectURL,
+                "--system-class", "twisted.python._pydoctor.TwistedSystem",
+                "--project-base-dir", packagePath.parent().path,
+                "--html-viewsource-base", sourceURL,
+                "--add-package", packagePath.path,
+                "--html-output", outputPath.path,
+                "--html-write-function-pages", "--quiet", "--make-html",
                ] + intersphinxes
-        args = [arg.encode("utf-8") for arg in args]
         main(args)
 
         monkeyPatch.restore()

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -440,7 +440,6 @@ notPortedModules = [
     "twisted.plugins.twisted_mail",
     "twisted.plugins.twisted_news",
     "twisted.protocols.shoutcast",
-    "twisted.python._pydoctor",
     "twisted.python.finalize",
     "twisted.python.hook",
     "twisted.python.test.cmodulepullpipe",

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -9,8 +9,7 @@ from __future__ import unicode_literals
 
 from ..url import URL
 
-unicode = type(u'')
-
+from twisted.python.compat import unicode
 from twisted.trial.unittest import SynchronousTestCase
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -142,9 +142,8 @@ commands =
     wheels: ls -l {toxinidir}/wheelhouse
 
 [testenv:apidocs]
-# Epydoc and pydoctor currently on work on Python 2
-basepython=python2.7
-deps=pydoctor
+basepython=python3.6
+deps=https://github.com/twisted/pydoctor/archive/3f9c64829dfa040b334c9ae27c332c7078356e79.zip
 
 [testenv:manifest-checker]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,6 @@ commands =
     wheels: ls -l {toxinidir}/wheelhouse
 
 [testenv:apidocs]
-basepython=python3.6
 deps=https://github.com/twisted/pydoctor/archive/3f9c64829dfa040b334c9ae27c332c7078356e79.zip
 
 [testenv:manifest-checker]


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9785

This uses a hash of pydoctor while it's unreleased.