### PR TITLE
[4964] Object `trans` inconsistent after exception

### DIFF
--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -47,7 +47,7 @@ class Connection(object):
         pass
 
 
-    def rollback(self, exValue):
+    def rollback(self, exValue=None):
         if not self._pool.reconnect:
             self._connection.rollback()
             return

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -47,7 +47,7 @@ class Connection(object):
         pass
 
 
-    def rollback(self):
+    def rollback(self, exValue):
         if not self._pool.reconnect:
             self._connection.rollback()
             return
@@ -300,7 +300,7 @@ class ConnectionPool:
         except:
             excType, excValue, excTraceback = sys.exc_info()
             try:
-                conn.rollback()
+                conn.rollback(excValue)
             except:
                 log.err(None, "Rollback failed")
             compat.reraise(excValue, excTraceback)
@@ -458,8 +458,8 @@ class ConnectionPool:
 
     def _runInteraction(self, interaction, *args, **kw):
         conn = self.connectionFactory(self)
-        trans = self.transactionFactory(self, conn)
         try:
+            trans = self.transactionFactory(self, conn)
             result = interaction(trans, *args, **kw)
             trans.close()
             conn.commit()
@@ -467,7 +467,7 @@ class ConnectionPool:
         except:
             excType, excValue, excTraceback = sys.exc_info()
             try:
-                conn.rollback()
+                conn.rollback(excValue)
             except:
                 log.err(None, "Rollback failed")
             compat.reraise(excValue, excTraceback)

--- a/src/twisted/newsfragments/4964.bugfix
+++ b/src/twisted/newsfragments/4964.bugfix
@@ -1,0 +1,1 @@
+twisted.adbapi.ConnectionPool correct destroy transaction object

--- a/src/twisted/test/test_adbapi.py
+++ b/src/twisted/test/test_adbapi.py
@@ -676,7 +676,7 @@ class ConnectionTests(unittest.TestCase):
         the original error is logged.
         """
         class ConnectionRollbackRaise(object):
-            def rollback(self):
+            def rollback(self, exValue=None):
                 raise RuntimeError("problem!")
 
         pool = FakePool(ConnectionRollbackRaise)
@@ -791,7 +791,7 @@ class ConnectionPoolTests(unittest.TestCase):
             def __init__(self, pool):
                 pass
 
-            def rollback(self):
+            def rollback(self, exValue=None):
                 raise RuntimeError("problem!")
 
         def raisingFunction(connection):
@@ -834,7 +834,7 @@ class ConnectionPoolTests(unittest.TestCase):
             def __init__(self, pool):
                 pass
 
-            def rollback(self):
+            def rollback(self, exValue=None):
                 raise RuntimeError("problem!")
 
         class DummyTransaction(object):


### PR DESCRIPTION
In method `_runInteraction` object `trans` inconsistent after raise exception in interaction.
See https://twistedmatrix.com/trac/ticket/4964 for example.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/4964
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
