### PR TITLE
Prevent opening new filexfer requests after the connection is closed.

### DIFF
--- a/src/twisted/conch/newsfragments/9572.bugfix
+++ b/src/twisted/conch/newsfragments/9572.bugfix
@@ -1,1 +1,1 @@
-t.c.ssh.filetransfer.FileTransferClient immediately errbacks any attempt to end a request on a closed channel.
+t.c.ssh.filetransfer.FileTransferClient immediately errbacks any attempt to send a request on a closed channel.

--- a/src/twisted/conch/newsfragments/9572.bugfix
+++ b/src/twisted/conch/newsfragments/9572.bugfix
@@ -1,0 +1,1 @@
+t.c.ssh.filetransfer.FileTransferClient immediately errbacks any attempt to end a request on a closed channel.

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -564,6 +564,18 @@ class FileTransferClient(FileTransferBase):
 
 
     def _sendRequest(self, msg, data):
+        """
+        Send a request and return a deferred which waits for the result.
+
+        @type msg: L{int}
+        @param msg: The request type (e.g., C{FXP_READ}).
+
+        @type data: L{bytes}
+        @param data: The body of the request.
+        """
+        if not self.connected:
+            return defer.fail(error.ConnectionLost())
+
         data = struct.pack('!L', self.counter) + data
         d = defer.Deferred()
         self.openRequests[self.counter] = d

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -172,7 +172,7 @@ class OurServerOurClientTests(SFTPTestBase):
 
     def test_openedFileClosedWithConnection(self):
         """
-        A file opened with C{openFile} is close when the connection is lost.
+        A file opened with C{openFile} is closed when the connection is lost.
         """
         d = self.client.openFile(b"testfile1", filetransfer.FXF_READ |
                                  filetransfer.FXF_WRITE, {})
@@ -613,6 +613,11 @@ class OurServerOurClientTests(SFTPTestBase):
         self._emptyBuffers()
 
         self.assertFalse(self.client.connected)
+        self.failureResultOf(d, ConnectionLost)
+
+        # Further attempts to use the filetransfer session should fail
+        # immediately
+        d = fh.getAttrs()
         self.failureResultOf(d, ConnectionLost)
 
 


### PR DESCRIPTION
## Contributor Checklist:

* [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9572
* [X] The changes pass minimal style checks
* [X] I have created a newsfragment in `src/twisted/conch/newsfragments/9572.bugfix`
* [X] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review
