### PR TITLE
Add digestmod parameter to HMAC.__init__() to fix Python 3.8+

### DIFF
--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -441,7 +441,8 @@ class CramMD5Credentials(object):
 
 
     def checkPassword(self, password):
-        verify = hexlify(hmac.HMAC(password, self.challenge).digest())
+        verify = hexlify(hmac.HMAC(password, self.challenge,
+                         digestmod=md5).digest())
         return verify == self.response
 
 

--- a/src/twisted/cred/test/test_cramauth.py
+++ b/src/twisted/cred/test/test_cramauth.py
@@ -7,6 +7,8 @@ Tests for L{twisted.cred}'s implementation of CRAM-MD5.
 
 from __future__ import division, absolute_import
 
+import hashlib
+
 from hmac import HMAC
 from binascii import hexlify
 
@@ -39,7 +41,8 @@ class CramMD5CredentialsTests(TestCase):
         """
         c = CramMD5Credentials()
         chal = c.getChallenge()
-        c.response = hexlify(HMAC(b'secret', chal).digest())
+        c.response = hexlify(HMAC(b'secret', chal,
+                             digestmod=hashlib.md5).digest())
         self.assertTrue(c.checkPassword(b'secret'))
 
 
@@ -61,7 +64,8 @@ class CramMD5CredentialsTests(TestCase):
         """
         c = CramMD5Credentials()
         chal = c.getChallenge()
-        c.response = hexlify(HMAC(b'thewrongsecret', chal).digest())
+        c.response = hexlify(HMAC(b'thewrongsecret', chal,
+                             digestmod=hashlib.md5).digest())
         self.assertFalse(c.checkPassword(b'secret'))
 
 
@@ -75,7 +79,8 @@ class CramMD5CredentialsTests(TestCase):
         chal = c.getChallenge()
         c.setResponse(b" ".join(
             (b"squirrel",
-             hexlify(HMAC(b'supersecret', chal).digest()))))
+             hexlify(HMAC(b'supersecret', chal,
+                     digestmod=hashlib.md5).digest()))))
         self.assertTrue(c.checkPassword(b'supersecret'))
         self.assertEqual(c.username, b"squirrel")
 

--- a/src/twisted/mail/test/test_pop3.py
+++ b/src/twisted/mail/test/test_pop3.py
@@ -11,6 +11,7 @@ import hmac
 import base64
 import itertools
 
+from hashlib import md5
 from collections import OrderedDict
 from io import BytesIO
 
@@ -1097,7 +1098,8 @@ class SASLTests(unittest.TestCase):
         p.lineReceived(b"AUTH CRAM-MD5")
         chal = s.getvalue().splitlines()[-1][2:]
         chal = base64.decodestring(chal)
-        response = hmac.HMAC(b'testpassword', chal).hexdigest().encode("ascii")
+        response = hmac.HMAC(b'testpassword', chal,
+                             digestmod=md5).hexdigest().encode("ascii")
 
         p.lineReceived(
             base64.encodestring(b'testuser ' + response).rstrip(b'\n'))


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9800

In Python 3.4+ if you did not specify a `digestmod` parameter to `HMAC.__init__()`, the digestmod would default to md5.

In Python 3.8+, if you don't specify a digestmod, you get an error:

​https://github.com/python/cpython/commit/8bb0b5b03cffa2a2e74f248ef479a9e7fbe95cf4 ​https://github.com/python/cpython/commit/f33c57d5c780da1500619f548585792bb5b750ee

This is similar to the fix that was done in https://github.com/twisted/twisted/pull/1219