### PR TITLE
Use unittest.skipIf decorator for skipping certain test functions.

### DIFF
--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -177,6 +177,21 @@ class ListingTests(TestCase):
             '!---------    0 0        0               0 Aug 29 09:33 foo')
 
 
+    # If alternate locale is not available, the next test will be
+    # skipped, please install this locale for it to run
+    currentLocale = locale.getlocale()
+    try:
+        try:
+            locale.setlocale(locale.LC_ALL, "es_AR.UTF8")
+        except locale.Error:
+            localeSkip = True
+        else:
+            localeSkip = False
+    finally:
+        locale.setlocale(locale.LC_ALL, currentLocale)
+
+
+    @skipIf(localeSkip, "The es_AR.UTF8 locale is not installed.")
     def test_localeIndependent(self):
         """
         The month name in the date is locale independent.
@@ -196,17 +211,6 @@ class ListingTests(TestCase):
         self.assertEqual(
             self._lsInTimezone('Pacific/Auckland', stat),
             '!---------    0 0        0               0 Aug 29 09:33 foo')
-
-    # If alternate locale is not available, the previous test will be
-    # skipped, please install this locale for it to run
-    currentLocale = locale.getlocale()
-    try:
-        try:
-            locale.setlocale(locale.LC_ALL, "es_AR.UTF8")
-        except locale.Error:
-            test_localeIndependent.skip = "The es_AR.UTF8 locale is not installed."
-    finally:
-        locale.setlocale(locale.LC_ALL, currentLocale)
 
 
     def test_newSingleDigitDayOfMonth(self):

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -2,10 +2,12 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
-import os, sys, socket
+import os
+import socket
 import subprocess
+import sys
 from itertools import count
-
+from unittest import skipIf
 from zope.interface import implementer
 from twisted.python.reflect import requireModule
 from twisted.conch.error import ConchError
@@ -16,14 +18,13 @@ from twisted.internet.task import LoopingCall
 from twisted.internet.utils import getProcessValue
 from twisted.python import filepath, log, runtime
 from twisted.python.compat import unicode, _PYPY
-from twisted.trial import unittest
+from twisted.trial.unittest import SkipTest, TestCase
 from twisted.conch.test.test_ssh import ConchTestRealm
 from twisted.python.procutils import which
 
 from twisted.conch.test.keydata import publicRSA_openssh, privateRSA_openssh
 from twisted.conch.test.keydata import publicDSA_openssh, privateDSA_openssh
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest
 
 try:
     from twisted.conch.test.test_ssh import ConchTestServerFactory, \
@@ -94,7 +95,7 @@ class FakeStdio(object):
 
 
 
-class StdioInteractingSessionTests(unittest.TestCase):
+class StdioInteractingSessionTests(TestCase):
     """
     Tests for L{twisted.conch.scripts.conch.SSHSession}.
     """
@@ -621,7 +622,7 @@ class OpenSSHClientMixin:
 
 
 class OpenSSHKeyExchangeTests(ConchServerSetupMixin, OpenSSHClientMixin,
-                              unittest.TestCase):
+                              TestCase):
     """
     Tests L{SSHTransportBase}'s key exchange algorithm compatibility with
     OpenSSH.
@@ -649,7 +650,7 @@ class OpenSSHKeyExchangeTests(ConchServerSetupMixin, OpenSSHClientMixin,
             pass
 
         if keyExchangeAlgo not in kexAlgorithms:
-            raise unittest.SkipTest(
+            raise SkipTest(
                 "{} not supported by ssh client".format(
                     keyExchangeAlgo))
 
@@ -717,17 +718,18 @@ class OpenSSHKeyExchangeTests(ConchServerSetupMixin, OpenSSHClientMixin,
         The list of key exchange algorithms supported
         by OpenSSH client is obtained with C{ssh -Q kex}.
         """
-        self.assertRaises(unittest.SkipTest,
+        self.assertRaises(SkipTest,
                           self.assertExecuteWithKexAlgorithm,
                           'unsupported-algorithm')
 
 
 
 class OpenSSHClientForwardingTests(ForwardingMixin, OpenSSHClientMixin,
-                                      unittest.TestCase):
+                                   TestCase):
     """
     Connection forwarding tests run against the OpenSSL command line client.
     """
+    @skipIf(not HAS_IPV6, "Requires IPv6 support")
     def test_localToRemoteForwardingV6(self):
         """
         Forwarding of arbitrary IPv6 TCP connections via SSH.
@@ -739,20 +741,18 @@ class OpenSSHClientForwardingTests(ForwardingMixin, OpenSSHClientMixin,
                          % (localPort, self.echoPortV6))
         d.addCallback(self.assertEqual, b'test\n')
         return d
-    if not HAS_IPV6:
-        test_localToRemoteForwardingV6.skip = "Requires IPv6 support"
 
 
 
 class OpenSSHClientRekeyTests(RekeyTestsMixin, OpenSSHClientMixin,
-                                 unittest.TestCase):
+                              TestCase):
     """
     Rekeying tests run against the OpenSSL command line client.
     """
 
 
 
-class CmdLineClientTests(ForwardingMixin, unittest.TestCase):
+class CmdLineClientTests(ForwardingMixin, TestCase):
     """
     Connection forwarding tests run against the Conch command line client.
     """

--- a/src/twisted/conch/test/test_default.py
+++ b/src/twisted/conch/test/test_default.py
@@ -9,17 +9,7 @@ Tests for L{twisted.conch.client.default}.
 import sys
 
 from twisted.python.reflect import requireModule
-
-if requireModule('cryptography') and requireModule('pyasn1'):
-    from twisted.conch.client.agent import SSHAgentClient
-    from twisted.conch.client.default import SSHUserAuthClient
-    from twisted.conch.client.options import ConchOptions
-    from twisted.conch.client import default
-    from twisted.conch.ssh.keys import Key
-    skip = None
-else:
-    skip = "cryptography and PyASN1 required for twisted.conch.client.default."
-
+from unittest import skipIf
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 from twisted.conch.error import ConchError
@@ -28,18 +18,33 @@ from twisted.test.proto_helpers import StringTransport
 from twisted.python.compat import nativeString
 from twisted.python.runtime import platform
 
+doSkip = False
+skipReason = ""
+
+if requireModule('cryptography') and requireModule('pyasn1'):
+    from twisted.conch.client.agent import SSHAgentClient
+    from twisted.conch.client.default import SSHUserAuthClient
+    from twisted.conch.client.options import ConchOptions
+    from twisted.conch.client import default
+    from twisted.conch.ssh.keys import Key
+else:
+    doSkip = True
+    skipReason = (
+        "cryptography and PyASN1 required for twisted.conch.client.default.")
+    skip = skipReason  # no SSL available, skip the entire module
+
 if platform.isWindows():
-    windowsSkip = (
+    doSkip = True
+    skipReason = (
         "genericAnswers and getPassword does not work on Windows."
         " Should be fixed as part of fixing bug 6409 and 6410")
-else:
-    windowsSkip = skip
 
-ttySkip = None
 if not sys.stdin.isatty():
-    ttySkip = "sys.stdin is not an interactive tty"
+    doSkip = True
+    skipReason = "sys.stdin is not an interactive tty"
 if not sys.stdout.isatty():
-    ttySkip = "sys.stdout is not an interactive tty"
+    doSkip = True
+    skipReason = "sys.stdout is not an interactive tty"
 
 
 
@@ -192,6 +197,7 @@ class SSHUserAuthClientTests(TestCase):
         return client.getPrivateKey().addCallback(_cbGetPrivateKey)
 
 
+    @skipIf(doSkip, skipReason)
     def test_getPassword(self):
         """
         Get the password using
@@ -217,9 +223,8 @@ class SSHUserAuthClientTests(TestCase):
         d.addCallback(self.assertEqual, b'bad password')
         return d
 
-    test_getPassword.skip = windowsSkip or ttySkip
 
-
+    @skipIf(doSkip, skipReason)
     def test_getPasswordPrompt(self):
         """
         Get the password using
@@ -239,9 +244,8 @@ class SSHUserAuthClientTests(TestCase):
         d.addCallback(self.assertEqual, b'bad password')
         return d
 
-    test_getPasswordPrompt.skip = windowsSkip or ttySkip
 
-
+    @skipIf(doSkip, skipReason)
     def test_getPasswordConchError(self):
         """
         Get the password using
@@ -264,9 +268,8 @@ class SSHUserAuthClientTests(TestCase):
             return fail
         self.assertFailure(d, ConchError)
 
-    test_getPasswordConchError.skip = windowsSkip or ttySkip
 
-
+    @skipIf(doSkip, skipReason)
     def test_getGenericAnswers(self):
         """
         L{twisted.conch.client.default.SSHUserAuthClient.getGenericAnswers}
@@ -291,8 +294,6 @@ class SSHUserAuthClientTests(TestCase):
         d.addCallback(
             self.assertListEqual, ["getpass", "raw_input"])
         return d
-
-    test_getGenericAnswers.skip = windowsSkip or ttySkip
 
 
 

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -10,6 +10,7 @@ Tests for L{twisted.conch.ssh.filetransfer}.
 import os
 import re
 import struct
+from unittest import skipIf
 
 from twisted.internet import defer
 from twisted.internet.error import ConnectionLost
@@ -18,7 +19,7 @@ from twisted.python import components
 from twisted.python.compat import long, _PY37PLUS
 from twisted.python.filepath import FilePath
 from twisted.python.reflect import requireModule
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 
 cryptography = requireModule("cryptography")
 unix = requireModule("twisted.conch.unix")
@@ -91,7 +92,9 @@ if unix:
                                    TestAvatar,
                                    filetransfer.ISFTPServer)
 
-class SFTPTestBase(unittest.TestCase):
+
+
+class SFTPTestBase(TestCase):
 
     def setUp(self):
         self.testDir = FilePath(self.mktemp())
@@ -113,10 +116,9 @@ class SFTPTestBase(unittest.TestCase):
             f.write(b'a')
 
 
-class OurServerOurClientTests(SFTPTestBase):
 
-    if not unix:
-        skip = "can't run on non-posix computers"
+@skipIf(not unix, "can't run on non-posix computers")
+class OurServerOurClientTests(SFTPTestBase):
 
     def setUp(self):
         SFTPTestBase.setUp(self)
@@ -513,6 +515,7 @@ class OurServerOurClientTests(SFTPTestBase):
 
 
     @defer.inlineCallbacks
+    @skipIf(_PY37PLUS, "Broken by PEP 479 and deprecated.")
     def test_openDirectoryIterator(self):
         """
         Check that the object returned by
@@ -546,11 +549,6 @@ class OurServerOurClientTests(SFTPTestBase):
                          set([b'.testHiddenFile', b'testDirectory',
                               b'testRemoveFile', b'testRenameFile',
                               b'testfile1']))
-
-
-    if _PY37PLUS:
-        test_openDirectoryIterator.skip = (
-            "Broken by PEP 479 and deprecated.")
 
 
     @defer.inlineCallbacks
@@ -626,10 +624,9 @@ class FakeConn:
         pass
 
 
-class FileTransferCloseTests(unittest.TestCase):
 
-    if not unix:
-        skip = "can't run on non-posix computers"
+@skipIf(not unix, "can't run on non-posix computers")
+class FileTransferCloseTests(TestCase):
 
     def setUp(self):
         self.avatar = TestAvatar()
@@ -732,7 +729,8 @@ class FileTransferCloseTests(unittest.TestCase):
 
 
 
-class ConstantsTests(unittest.TestCase):
+@skipIf(not cryptography, "Cannot run without cryptography")
+class ConstantsTests(TestCase):
     """
     Tests for the constants used by the SFTP protocol implementation.
 
@@ -741,9 +739,6 @@ class ConstantsTests(unittest.TestCase):
         protocol.  There are more recent drafts of the specification, but this
         one describes version 3, which is what conch (and OpenSSH) implements.
     """
-    if not cryptography:
-        skip = "Cannot run without cryptography"
-
     filexferSpecExcerpts = [
         """
            The following values are defined for packet types.
@@ -838,15 +833,12 @@ class ConstantsTests(unittest.TestCase):
 
 
 
-class RawPacketDataTests(unittest.TestCase):
+@skipIf(not cryptography, "Cannot run without cryptography")
+class RawPacketDataTests(TestCase):
     """
     Tests for L{filetransfer.FileTransferClient} which explicitly craft certain
     less common protocol messages to exercise their handling.
     """
-
-    if not cryptography:
-        skip = "Cannot run without cryptography"
-
     def setUp(self):
         self.ftc = filetransfer.FileTransferClient()
 

--- a/src/twisted/conch/test/test_scripts.py
+++ b/src/twisted/conch/test/test_scripts.py
@@ -4,56 +4,52 @@
 """
 Tests for the command-line interfaces to conch.
 """
+from unittest import skipIf
 from twisted.python.reflect import requireModule
+from twisted.python.test.test_shellcomp import ZshScriptTestMixin
+from twisted.scripts.test.test_scripts import ScriptTestsMixin
+from twisted.trial.unittest import TestCase
 
-if requireModule('pyasn1'):
-    pyasn1Skip = None
-else:
-    pyasn1Skip =  "Cannot run without PyASN1"
+doSkip = False
+skipReason = ""
 
-if requireModule('cryptography'):
-    cryptoSkip = None
-else:
+if not requireModule('pyasn1'):
+    doSkip = True
+    skipReason = "Cannot run without PyASN1"
+
+if not requireModule('cryptography'):
+    doSkip = True
     cryptoSkip = "can't run w/o cryptography"
 
-if requireModule('tty'):
-    ttySkip = None
-else:
+if not requireModule('tty'):
+    doSkip = True
     ttySkip = "can't run w/o tty"
 
 try:
-    import Tkinter
+    import tkinter
 except ImportError:
-    tkskip = "can't run w/o Tkinter"
+    doSkip = True
+    skipReason = "can't run w/o tkinter"
 else:
     try:
-        Tkinter.Tk().destroy()
-    except Tkinter.TclError as e:
-        tkskip = "Can't test Tkinter: " + str(e)
-    else:
-        tkskip = None
-
-from twisted.trial.unittest import TestCase
-from twisted.scripts.test.test_scripts import ScriptTestsMixin
-from twisted.python.test.test_shellcomp import ZshScriptTestMixin
+        tkinter.Tk().destroy()
+    except tkinter.TclError as e:
+        doSkip = True
+        skipReason = "Can't test Tkinter: " + str(e)
 
 
 
+@skipIf(doSkip, skipReason)
 class ScriptTests(TestCase, ScriptTestsMixin):
     """
     Tests for the Conch scripts.
     """
-    skip = pyasn1Skip or cryptoSkip
-
-
     def test_conch(self):
         self.scriptTest("conch/conch")
-    test_conch.skip = ttySkip or skip
 
 
     def test_cftp(self):
         self.scriptTest("conch/cftp")
-    test_cftp.skip = ttySkip or skip
 
 
     def test_ckeygen(self):
@@ -62,7 +58,6 @@ class ScriptTests(TestCase, ScriptTestsMixin):
 
     def test_tkconch(self):
         self.scriptTest("conch/tkconch")
-    test_tkconch.skip = tkskip or skip
 
 
 

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -13,6 +13,7 @@ import signal
 import struct
 import sys
 
+from unittest import skipIf
 from zope.interface import implementer
 
 from twisted.internet import defer, protocol, error
@@ -22,7 +23,7 @@ from twisted.python import components, failure
 from twisted.python.failure import Failure
 from twisted.python.reflect import requireModule
 from twisted.python.test.test_components import RegistryUsingMixin
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 
 cryptography = requireModule("cryptography")
 
@@ -452,7 +453,7 @@ class StubClient(object):
 
 
 
-class SessionInterfaceTests(RegistryUsingMixin, unittest.TestCase):
+class SessionInterfaceTests(RegistryUsingMixin, TestCase):
     """
     Tests for the SSHSession class interface.  This interface is not ideal, but
     it is tested in order to maintain backwards compatibility.
@@ -820,7 +821,7 @@ class SessionInterfaceTests(RegistryUsingMixin, unittest.TestCase):
 
 
 
-class SessionWithNoAvatarTests(RegistryUsingMixin, unittest.TestCase):
+class SessionWithNoAvatarTests(RegistryUsingMixin, TestCase):
     """
     Test for the SSHSession interface.  Several of the methods (request_shell,
     request_exec, request_pty_req, request_env, request_window_change) would
@@ -905,7 +906,7 @@ class SessionWithNoAvatarTests(RegistryUsingMixin, unittest.TestCase):
 
 
 
-class WrappersTests(unittest.TestCase):
+class WrappersTests(TestCase):
     """
     A test for the wrapProtocol and wrapProcessProtocol functions.
     """
@@ -949,7 +950,7 @@ class WrappersTests(unittest.TestCase):
 
 
 
-class HelpersTests(unittest.TestCase):
+class HelpersTests(TestCase):
     """
     Tests for the 4 helper functions: parseRequest_* and packRequest_*.
     """
@@ -1028,7 +1029,7 @@ class HelpersTests(unittest.TestCase):
 
 
 
-class SSHSessionProcessProtocolTests(unittest.TestCase):
+class SSHSessionProcessProtocolTests(TestCase):
     """
     Tests for L{SSHSessionProcessProtocol}.
     """
@@ -1096,6 +1097,8 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
         self.assertEqual(self.transport.buf, b'buffer')
 
 
+    @skipIf(not hasattr(signal, 'SIGALRM'),
+            "Not all signals available")
     def test_getSignalName(self):
         """
         _getSignalName should return the name of a signal when given the
@@ -1110,6 +1113,8 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
                                                 signalName))
 
 
+    @skipIf(not hasattr(signal, 'SIGALRM'),
+            "Not all signals available")
     def test_getSignalNameWithLocalSignal(self):
         """
         If there are signals in the signal module which aren't in the SSH RFC,
@@ -1119,12 +1124,7 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
         # Force reinitialization of signals
         self.pp._signalValuesToNames = None
         self.assertEqual(self.pp._getSignalName(signal.SIGTwistedTest),
-                          'SIGTwistedTest@' + sys.platform)
-
-
-    if getattr(signal, 'SIGALRM', None) is None:
-        test_getSignalName.skip = test_getSignalNameWithLocalSignal.skip = \
-            "Not all signals available"
+                         'SIGTwistedTest@' + sys.platform)
 
 
     def test_outReceived(self):
@@ -1218,6 +1218,8 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
         self.assertSessionClosed()
 
 
+    @skipIf(not hasattr(os, 'WCOREDUMP'),
+            "can't run this w/o os.WCOREDUMP")
     def test_processEndedWithExitSignalCoreDump(self):
         """
         When processEnded is called, if there is an exit signal in the reason
@@ -1237,6 +1239,8 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
         self.assertSessionClosed()
 
 
+    @skipIf(not hasattr(os, 'WCOREDUMP'),
+            "can't run this w/o os.WCOREDUMP")
     def test_processEndedWithExitSignalNoCoreDump(self):
         """
         When processEnded is called, if there is an exit signal in the
@@ -1253,14 +1257,8 @@ class SSHSessionProcessProtocolTests(unittest.TestCase):
         self.assertSessionClosed()
 
 
-    if getattr(os, 'WCOREDUMP', None) is None:
-        skipMsg = "can't run this w/o os.WCOREDUMP"
-        test_processEndedWithExitSignalCoreDump.skip = skipMsg
-        test_processEndedWithExitSignalNoCoreDump.skip = skipMsg
 
-
-
-class SSHSessionClientTests(unittest.TestCase):
+class SSHSessionClientTests(TestCase):
     """
     SSHSessionClient is an obsolete class used to connect standard IO to
     an SSHSession.

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -14,7 +14,7 @@ import types
 
 from hashlib import md5, sha1, sha256, sha384, sha512
 from twisted import __version__ as twisted_version
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.internet import defer
 from twisted.protocols import loopback
 from twisted.python import randbytes
@@ -390,7 +390,7 @@ def generatePredictableKey(transport):
 
 
 
-class TransportTestCase(unittest.TestCase):
+class TransportTestCase(TestCase):
     """
     Base class for transport test cases.
     """
@@ -2538,7 +2538,7 @@ class ClientSSHTransportCurve25519SHA256Tests(
 
 
 
-class GetMACTests(unittest.TestCase):
+class GetMACTests(TestCase):
     """
     Tests for L{SSHCiphers._getMAC}.
     """
@@ -2658,7 +2658,7 @@ class GetMACTests(unittest.TestCase):
 
 
 
-class SSHCiphersTests(unittest.TestCase):
+class SSHCiphersTests(TestCase):
     """
     Tests for the SSHCiphers helper class.
     """
@@ -2772,7 +2772,7 @@ class SSHCiphersTests(unittest.TestCase):
 
 
 
-class TransportLoopbackTests(unittest.TestCase):
+class TransportLoopbackTests(TestCase):
     """
     Test the server transport and client transport against each other,
     """

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -7,11 +7,12 @@ L{twisted.cred.strcred}.
 
 
 import os
-from typing import List, Sequence, Type
+from typing import Sequence, Type
 from zope.interface import Interface
+from unittest import skipIf
 
 from twisted import plugin
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.cred import credentials, checkers, error, strcred
 from twisted.plugins import cred_file, cred_anonymous, cred_unix
 from twisted.python import usage
@@ -20,20 +21,11 @@ from twisted.python.filepath import FilePath
 from twisted.python.fakepwd import UserDatabase
 from twisted.python.reflect import requireModule
 
-try:
-    import crypt
-except ImportError:
-    crypt = None
 
-try:
-    import pwd
-except ImportError:
-    pwd = None
 
-try:
-    import spwd
-except ImportError:
-    spwd = None
+crypt = requireModule("crypt")
+pwd = requireModule("pwd")
+spwd = requireModule("spwd")
 
 
 
@@ -49,7 +41,7 @@ def getInvalidAuthType():
 
 
 
-class PublicAPITests(unittest.TestCase):
+class PublicAPITests(TestCase):
 
     def test_emptyDescription(self):
         """
@@ -72,7 +64,7 @@ class PublicAPITests(unittest.TestCase):
 
 
 
-class StrcredFunctionsTests(unittest.TestCase):
+class StrcredFunctionsTests(TestCase):
 
     def test_findCheckerFactories(self):
         """
@@ -93,7 +85,7 @@ class StrcredFunctionsTests(unittest.TestCase):
 
 
 
-class MemoryCheckerTests(unittest.TestCase):
+class MemoryCheckerTests(TestCase):
 
     def setUp(self):
         self.admin = credentials.UsernamePassword('admin', 'asdf')
@@ -150,7 +142,7 @@ class MemoryCheckerTests(unittest.TestCase):
 
 
 
-class AnonymousCheckerTests(unittest.TestCase):
+class AnonymousCheckerTests(TestCase):
 
     def test_isChecker(self):
         """
@@ -174,7 +166,10 @@ class AnonymousCheckerTests(unittest.TestCase):
 
 
 
-class UnixCheckerTests(unittest.TestCase):
+@skipIf(not pwd, "Required module not available: pwd")
+@skipIf(not crypt, "Required module not available: crypt")
+@skipIf(not spwd, "Required module not available: spwd")
+class UnixCheckerTests(TestCase):
     users = {
         'admin': 'asdf',
         'alice': 'foo',
@@ -281,22 +276,8 @@ class UnixCheckerTests(unittest.TestCase):
             self.badPassBytes), error.UnauthorizedLogin)
 
 
-    if None in (pwd, spwd, crypt):
-        availability = []  # type: List[str]
-        for module, name in ((pwd, "pwd"), (spwd, "spwd"), (crypt, "crypt")):
-            if module is None:
-                availability += [name]
-        for method in (test_unixCheckerSucceeds,
-                       test_unixCheckerSucceedsBytes,
-                       test_unixCheckerFailsUsername,
-                       test_unixCheckerFailsUsernameBytes,
-                       test_unixCheckerFailsPassword,
-                       test_unixCheckerFailsPasswordBytes):
-            method.skip = ("Required module(s) are unavailable: " +
-                           ", ".join(availability))
 
-
-class CryptTests(unittest.TestCase):
+class CryptTests(TestCase):
     """
     L{crypt} has functions for encrypting password.
     """
@@ -349,7 +330,7 @@ class CryptTests(unittest.TestCase):
 
 
 
-class FileDBCheckerTests(unittest.TestCase):
+class FileDBCheckerTests(TestCase):
     """
     C{--auth=file:...} file checker.
     """
@@ -430,10 +411,10 @@ class FileDBCheckerTests(unittest.TestCase):
 
 
 
-class SSHCheckerTests(unittest.TestCase):
+class SSHCheckerTests(TestCase):
     """
-    Tests for the C{--auth=sshkey:...} checker.  The majority of the tests for the
-    ssh public key database checker are in
+    Tests for the C{--auth=sshkey:...} checker.  The majority of the tests
+    for the ssh public key database checker are in
     L{twisted.conch.test.test_checkers.SSHPublicKeyCheckerTestCase}.
     """
 
@@ -465,7 +446,7 @@ class DummyOptions(usage.Options, strcred.AuthOptionMixin):
 
 
 
-class CheckerOptionsTests(unittest.TestCase):
+class CheckerOptionsTests(TestCase):
 
     def test_createsList(self):
         """
@@ -601,7 +582,7 @@ class OptionsSupportsNoInterfaces(usage.Options, strcred.AuthOptionMixin):
 
 
 
-class LimitingInterfacesTests(unittest.TestCase):
+class LimitingInterfacesTests(TestCase):
     """
     Tests functionality that allows an application to limit the
     credential interfaces it can support. For the purposes of this

--- a/src/twisted/internet/test/test_address.py
+++ b/src/twisted/internet/test/test_address.py
@@ -5,23 +5,23 @@
 import os
 import socket
 
-from twisted.trial import unittest
+from unittest import skipIf
+
+from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.internet.address import IPv4Address, UNIXAddress, IPv6Address
 from twisted.internet.address import HostnameAddress
 from twisted.python.compat import nativeString
 from twisted.python.runtime import platform
 
-if not platform._supportsSymlinks():
-    symlinkSkip = "Platform does not support symlinks"
-else:
-    symlinkSkip = None
+symlinkSkip = not platform._supportsSymlinks()
 
 try:
     socket.AF_UNIX
 except AttributeError:
-    unixSkip = "Platform doesn't support UNIX sockets."
+    unixSkip = True
 else:
-    unixSkip = None
+    unixSkip = False
+
 
 
 class AddressTestCaseMixin(object):
@@ -76,7 +76,7 @@ class IPv4AddressTestCaseMixin(AddressTestCaseMixin):
 
 
 
-class HostnameAddressTests(unittest.TestCase, AddressTestCaseMixin):
+class HostnameAddressTests(TestCase, AddressTestCaseMixin):
     """
     Test case for L{HostnameAddress}.
     """
@@ -101,7 +101,7 @@ class HostnameAddressTests(unittest.TestCase, AddressTestCaseMixin):
 
 
 
-class IPv4AddressTCPTests(unittest.SynchronousTestCase,
+class IPv4AddressTCPTests(SynchronousTestCase,
                           IPv4AddressTestCaseMixin):
     def buildAddress(self):
         """
@@ -120,7 +120,7 @@ class IPv4AddressTCPTests(unittest.SynchronousTestCase,
 
 
 
-class IPv4AddressUDPTests(unittest.SynchronousTestCase,
+class IPv4AddressUDPTests(SynchronousTestCase,
                           IPv4AddressTestCaseMixin):
     def buildAddress(self):
         """
@@ -139,7 +139,7 @@ class IPv4AddressUDPTests(unittest.SynchronousTestCase,
 
 
 
-class IPv6AddressTests(unittest.SynchronousTestCase, AddressTestCaseMixin):
+class IPv6AddressTests(SynchronousTestCase, AddressTestCaseMixin):
     addressArgSpec = (("type", "%s"), ("host", "%r"), ("port", "%d"))
 
     def buildAddress(self):
@@ -159,8 +159,8 @@ class IPv6AddressTests(unittest.SynchronousTestCase, AddressTestCaseMixin):
 
 
 
-class UNIXAddressTests(unittest.SynchronousTestCase):
-    skip = unixSkip
+@skipIf(unixSkip, "Platform doesn't support UNIX sockets.")
+class UNIXAddressTests(SynchronousTestCase):
     addressArgSpec = (("name", "%r"),)
 
     def setUp(self):
@@ -192,6 +192,7 @@ class UNIXAddressTests(unittest.SynchronousTestCase):
             nativeString(self._socketAddress)))
 
 
+    @skipIf(symlinkSkip, "Platform does not support symlinks")
     def test_comparisonOfLinkedFiles(self):
         """
         UNIXAddress objects compare as equal if they link to the same file.
@@ -203,10 +204,9 @@ class UNIXAddressTests(unittest.SynchronousTestCase):
                              UNIXAddress(linkName))
             self.assertEqual(UNIXAddress(linkName),
                              UNIXAddress(self._socketAddress))
-    if not unixSkip:
-        test_comparisonOfLinkedFiles.skip = symlinkSkip
 
 
+    @skipIf(symlinkSkip, "Platform does not support symlinks")
     def test_hashOfLinkedFiles(self):
         """
         UNIXAddress Objects that compare as equal have the same hash value.
@@ -215,18 +215,16 @@ class UNIXAddressTests(unittest.SynchronousTestCase):
         with open(self._socketAddress, 'w') as self.fd:
             os.symlink(os.path.abspath(self._socketAddress), linkName)
             self.assertEqual(hash(UNIXAddress(self._socketAddress)),
-                            hash(UNIXAddress(linkName)))
-    if not unixSkip:
-        test_hashOfLinkedFiles.skip = symlinkSkip
+                             hash(UNIXAddress(linkName)))
 
 
 
-class EmptyUNIXAddressTests(unittest.SynchronousTestCase,
+@skipIf(unixSkip, "platform doesn't support UNIX sockets.")
+class EmptyUNIXAddressTests(SynchronousTestCase,
                             AddressTestCaseMixin):
     """
     Tests for L{UNIXAddress} operations involving a L{None} address.
     """
-    skip = unixSkip
     addressArgSpec = (("name", "%r"),)
 
     def setUp(self):
@@ -249,10 +247,11 @@ class EmptyUNIXAddressTests(unittest.SynchronousTestCase,
         return UNIXAddress(self._socketAddress)
 
 
+    @skipIf(symlinkSkip, "Platform does not support symlinks")
     def test_comparisonOfLinkedFiles(self):
         """
-        A UNIXAddress referring to a L{None} address does not compare equal to a
-        UNIXAddress referring to a symlink.
+        A UNIXAddress referring to a L{None} address does not
+        compare equal to a UNIXAddress referring to a symlink.
         """
         linkName = self.mktemp()
         with open(self._socketAddress, 'w') as self.fd:
@@ -261,8 +260,6 @@ class EmptyUNIXAddressTests(unittest.SynchronousTestCase,
                                 UNIXAddress(None))
             self.assertNotEqual(UNIXAddress(None),
                                 UNIXAddress(self._socketAddress))
-    if not unixSkip:
-        test_comparisonOfLinkedFiles.skip = symlinkSkip
 
 
     def test_emptyHash(self):

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -10,6 +10,7 @@ L{twisted.internet.endpoints}.
 from errno import EPERM
 from socket import AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, gaierror
 from unicodedata import normalize
+from unittest import skipIf
 from types import FunctionType
 
 from zope.interface import implementer, providedBy, provider
@@ -77,8 +78,10 @@ try:
     testPrivateCertificate = PrivateCertificate.loadPEM(pemPath.getContent())
 
     skipSSL = False
-except ImportError:
-    skipSSL = "OpenSSL is required to construct SSL Endpoints"
+    skipSSLReason = ""
+except ImportError as e:
+    skipSSL = True
+    skipSSLReason = str(e)
 
 
 
@@ -2697,14 +2700,12 @@ class HostnameEndpointsFasterConnectionTests(unittest.TestCase):
 
 
 
+@skipIf(skipSSL, skipSSLReason)
 class SSL4EndpointsTests(EndpointTestCaseMixin,
                          unittest.TestCase):
     """
     Tests for SSL Endpoints.
     """
-    if skipSSL:
-        skip = skipSSL
-
     def expectedServers(self, reactor):
         """
         @return: List of calls to L{IReactorSSL.listenSSL}
@@ -3076,6 +3077,7 @@ class ServerStringTests(unittest.TestCase):
         self.assertEqual(server._interface, "10.0.0.1")
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_ssl(self):
         """
         When passed an SSL strports description, L{endpoints.serverFromString}
@@ -3098,6 +3100,7 @@ class ServerStringTests(unittest.TestCase):
         self.assertIsInstance(ctx, ContextType)
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_sslWithDefaults(self):
         """
         An SSL string endpoint description with minimal arguments returns
@@ -3124,6 +3127,7 @@ class ServerStringTests(unittest.TestCase):
     SSL_CHAIN_TEMPLATE = "ssl:1234:privateKey=%s:extraCertChain=%s"
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_sslChainLoads(self):
         """
         Specifying a chain file loads the contained certificates in the right
@@ -3149,6 +3153,7 @@ class ServerStringTests(unittest.TestCase):
                          expectedChainCerts[1].digest('sha1'))
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_sslChainFileMustContainCert(self):
         """
         If C{extraCertChain} is passed, it has to contain at least one valid
@@ -3175,6 +3180,7 @@ class ServerStringTests(unittest.TestCase):
                           " certificates in PEM format.") % (fp.path,))
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_sslDHparameters(self):
         """
         If C{dhParameters} are specified, they are passed as
@@ -3192,6 +3198,7 @@ class ServerStringTests(unittest.TestCase):
         self.assertEqual(FilePath(fileName), cf.dhParameters._dhFile)
 
 
+    @skipIf(skipSSL, skipSSLReason)
     def test_sslNoTrailingNewlinePem(self):
         """
         Lack of a trailing newline in key and cert .pem files should not
@@ -3215,14 +3222,6 @@ class ServerStringTests(unittest.TestCase):
         self.assertEqual(server._sslContextFactory.method, TLSv1_METHOD)
         ctx = server._sslContextFactory.getContext()
         self.assertIsInstance(ctx, ContextType)
-
-
-    if skipSSL:
-        test_ssl.skip = test_sslWithDefaults.skip = skipSSL
-        test_sslChainLoads.skip = skipSSL
-        test_sslChainFileMustContainCert.skip = skipSSL
-        test_sslDHparameters.skip = skipSSL
-        test_sslNoTrailingNewlinePem.skip = skipSSL
 
 
     def test_unix(self):
@@ -3477,14 +3476,11 @@ class ClientStringTests(unittest.TestCase):
 
 
 
+@skipIf(skipSSL, skipSSLReason)
 class SSLClientStringTests(unittest.TestCase):
     """
     Tests for L{twisted.internet.endpoints.clientFromString} which require SSL.
     """
-
-    if skipSSL:
-        skip = skipSSL
-
     def test_ssl(self):
         """
         When passed an SSL strports description, L{clientFromString} returns a
@@ -4123,14 +4119,11 @@ def connectionCreatorFromEndpoint(memoryReactor, tlsEndpoint):
 
 
 
+@skipIf(skipSSL, skipSSLReason)
 class WrapClientTLSParserTests(unittest.TestCase):
     """
     Tests for L{_TLSClientEndpointParser}.
     """
-
-    if skipSSL:
-        skip = skipSSL
-
     def test_hostnameEndpointConstruction(self):
         """
         A L{HostnameEndpoint} is constructed from parameters passed to

--- a/src/twisted/internet/test/test_fdset.py
+++ b/src/twisted/internet/test/test_fdset.py
@@ -7,8 +7,10 @@ Tests for implementations of L{IReactorFDSet}.
 
 __metaclass__ = type
 
-import os, socket, traceback
-
+import os
+import socket
+import traceback
+from unittest import skipIf
 from zope.interface import implementer
 
 from twisted.python.runtime import platform
@@ -269,6 +271,7 @@ class ReactorFDSetTestsBuilder(ReactorBuilder):
         self.assertEqual(descriptor._received, b"x")
 
 
+    @skipIf(platform.isWindows(), "Cannot duplicate socket filenos on Windows")
     def test_lostFileDescriptor(self):
         """
         The file descriptor underlying a FileDescriptor may be closed and
@@ -338,9 +341,6 @@ class ReactorFDSetTestsBuilder(ReactorBuilder):
         # If the implementation feels like logging the exception raised by
         # MessedUp.fileno, that's fine.
         self.flushLoggedErrors(socket.error)
-    if platform.isWindows():
-        test_lostFileDescriptor.skip = (
-            "Cannot duplicate socket filenos on Windows")
 
 
     def test_connectionLostOnShutdown(self):

--- a/src/twisted/internet/test/test_gireactor.py
+++ b/src/twisted/internet/test/test_gireactor.py
@@ -8,6 +8,7 @@ GI/GTK3 reactor tests.
 
 import os
 import sys
+from unittest import skipIf
 try:
     from twisted.internet import gireactor
     from gi.repository import Gio
@@ -91,6 +92,8 @@ class GApplicationRegistrationTests(ReactorBuilder, TestCase):
         self.runReactor(app, reactor)
 
 
+    @skipIf(gtk3reactor is None,
+            "Gtk unavailable (may require running with X11 DISPLAY env set)")
     def test_gtkApplicationActivate(self):
         """
         L{Gtk.Application} instances can be registered with a gtk3reactor.
@@ -102,10 +105,6 @@ class GApplicationRegistrationTests(ReactorBuilder, TestCase):
             flags=Gio.ApplicationFlags.FLAGS_NONE)
 
         self.runReactor(app, reactor)
-
-    if gtk3reactor is None:
-        test_gtkApplicationActivate.skip = (
-            "Gtk unavailable (may require running with X11 DISPLAY env set)")
 
 
     def test_portable(self):
@@ -222,8 +221,8 @@ class PygtkCompatibilityTests(TestCase):
 
     def test_compatibilityLayer(self):
         """
-        If compatibility layer is present, importing gobject uses the gi
-        compatibility layer.
+        If compatibility layer is present, importing gobject uses
+        the gi compatibility layer.
         """
         if "gi.pygtkcompat" not in sys.modules:
             raise SkipTest("This version of gi doesn't include pygtkcompat.")
@@ -237,6 +236,8 @@ class Gtk3ReactorTests(TestCase):
     Tests for L{gtk3reactor}.
     """
 
+    @skipIf(platform.getType() != "posix" or platform.isMacOSX(),
+            "This test is only relevant when using X11")
     def test_requiresDISPLAY(self):
         """
         On X11, L{gtk3reactor} is unimportable if the C{DISPLAY} environment
@@ -251,7 +252,5 @@ class Gtk3ReactorTests(TestCase):
                                     __import__, "twisted.internet.gtk3reactor")
             self.assertEqual(
                 exc.args[0],
-                "Gtk3 requires X11, and no DISPLAY environment variable is set")
-
-    if platform.getType() != "posix" or platform.isMacOSX():
-        test_requiresDISPLAY.skip = "This test is only relevant when using X11"
+                "Gtk3 requires X11, and no DISPLAY environment "
+                "variable is set")

--- a/src/twisted/internet/test/test_iocp.py
+++ b/src/twisted/internet/test/test_iocp.py
@@ -9,10 +9,11 @@ import errno
 from array import array
 from struct import pack
 from socket import AF_INET6, AF_INET, SOCK_STREAM, SOL_SOCKET, error, socket
+from unittest import skipIf
 
 from zope.interface.verify import verifyClass
 
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.python.log import msg
 from twisted.internet.interfaces import IPushProducer
 
@@ -28,11 +29,16 @@ except ImportError:
 try:
     socket(AF_INET6, SOCK_STREAM).close()
 except error as e:
-    ipv6Skip = str(e)
-else:
-    ipv6Skip = None
+    ipv6Skip = True
+    ipv6SkipReason = str(e)
 
-class SupportTests(unittest.TestCase):
+else:
+    ipv6Skip = False
+    ipv6SkipReason = ""
+
+
+
+class SupportTests(TestCase):
     """
     Tests for L{twisted.internet.iocpreactor.iocpsupport}, low-level reactor
     implementation helpers.
@@ -84,9 +90,11 @@ class SupportTests(unittest.TestCase):
         self._acceptAddressTest(AF_INET, '127.0.0.1')
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_ipv6AcceptAddress(self):
         """
-        Like L{test_ipv4AcceptAddress}, but for IPv6 connections.  In this case:
+        Like L{test_ipv4AcceptAddress}, but for IPv6 connections.
+        In this case:
 
           - the first element is C{AF_INET6}
           - the second element is a two-tuple of a hexadecimal IPv6 address
@@ -95,12 +103,10 @@ class SupportTests(unittest.TestCase):
             connection
         """
         self._acceptAddressTest(AF_INET6, '::1')
-    if ipv6Skip is not None:
-        test_ipv6AcceptAddress.skip = ipv6Skip
 
 
 
-class IOCPReactorTests(unittest.TestCase):
+class IOCPReactorTests(TestCase):
     def test_noPendingTimerEvents(self):
         """
         Test reactor behavior (doIteration) when there are no pending time

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -17,6 +17,7 @@ import socket
 
 from functools import wraps
 from typing import Optional, Sequence, Type
+from unittest import skipIf
 
 import attr
 
@@ -78,9 +79,11 @@ try:
     s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     s.bind(('::1', 0))
 except socket.error as e:
-    ipv6Skip = str(e)
+    ipv6Skip = True
+    ipv6SkipReason = str(e)
 else:
-    ipv6Skip = None
+    ipv6Skip = False
+    ipv6SkipReason = ""
 if s is not None:
     s.close()
 
@@ -389,6 +392,7 @@ class TCPConnectionTests(TestCase):
         self.assertFalse(conn.TLS)
 
 
+    @skipIf(not useSSL, "No SSL support available")
     def test_tlsAfterStartTLS(self):
         """
         The C{TLS} attribute of a L{Connection} instance is C{True} after
@@ -400,8 +404,6 @@ class TCPConnectionTests(TestCase):
         conn._tlsClientDefault = True
         conn.startTLS(ClientContextFactory(), True)
         self.assertTrue(conn.TLS)
-    if not useSSL:
-        test_tlsAfterStartTLS.skip = "No SSL support available"
 
 
 
@@ -760,14 +762,12 @@ class TCP4ClientTestsBuilder(TCPClientTestsBase):
 
 
 
+@skipIf(ipv6Skip, ipv6SkipReason)
 class TCP6ClientTestsBuilder(TCPClientTestsBase):
     """
     Builder configured with IPv6 parameters for tests related to
     L{IReactorTCP.connectTCP}.
     """
-    if ipv6Skip:
-        skip = ipv6Skip
-
     family = socket.AF_INET6
     addressClass = IPv6Address
 
@@ -907,12 +907,10 @@ class TCP4ConnectorTestsBuilder(TCPConnectorTestsBuilder):
 
 
 
+@skipIf(ipv6Skip, ipv6SkipReason)
 class TCP6ConnectorTestsBuilder(TCPConnectorTestsBuilder):
     family = socket.AF_INET6
     addressClass = IPv6Address
-
-    if ipv6Skip:
-        skip = ipv6Skip
 
     def setUp(self):
         self.interface = getLinkLocalIPv6Address()
@@ -1041,12 +1039,11 @@ class _ExhaustsFileDescriptors(object):
 
 
 
+@skipIf(SKIP_EMFILE, SKIP_EMFILE)
 class ExhaustsFileDescriptorsTests(SynchronousTestCase):
     """
     Tests for L{_ExhaustsFileDescriptors}.
     """
-    skip = SKIP_EMFILE
-
     def setUp(self):
         self.exhauster = _ExhaustsFileDescriptors()
         # This assumes release succeeds when there are no file
@@ -1277,12 +1274,11 @@ def assertPeerClosedOnEMFILE(
 
 
 
+@skipIf(SKIP_EMFILE, SKIP_EMFILE)
 class AssertPeerClosedOnEMFILETests(SynchronousTestCase):
     """
     Tests for L{assertPeerClosedOnEMFILE}.
     """
-    skip = SKIP_EMFILE
-
     @implementer(_IExhaustsFileDescriptors)
     class NullExhauster(object):
         """
@@ -1423,6 +1419,7 @@ class StreamTransportTestsMixin(LogObserverMixin):
         self.assertFullyNewStyle(port)
 
 
+    @skipIf(SKIP_EMFILE, SKIP_EMFILE)
     def test_closePeerOnEMFILE(self):
         """
         See L{assertPeerClosedOnEMFILE}.
@@ -1435,9 +1432,6 @@ class StreamTransportTestsMixin(LogObserverMixin):
             listen=self.getListeningPort,
             connect=self.connectToListener,
         )
-
-    if SKIP_EMFILE:
-        test_closePeerOnEMFILE.skip = SKIP_EMFILE
 
 
 
@@ -1555,6 +1549,7 @@ class TCPPortTestsMixin(object):
         self.assertIsInstance(address, IPv4Address)
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_portGetHostOnIPv6(self):
         """
         When listening on an IPv6 address, L{IListeningPort.getHost} returns
@@ -1570,14 +1565,13 @@ class TCPPortTestsMixin(object):
         self.assertIsInstance(address, IPv6Address)
         self.assertEqual('::1', address.host)
         self.assertEqual(portNumber, address.port)
-    if ipv6Skip:
-        test_portGetHostOnIPv6.skip = ipv6Skip
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_portGetHostOnIPv6ScopeID(self):
         """
-        When a link-local IPv6 address including a scope identifier is passed as
-        the C{interface} argument to L{IReactorTCP.listenTCP}, the resulting
+        When a link-local IPv6 address including a scope identifier is passed
+        as the C{interface} argument to L{IReactorTCP.listenTCP}, the resulting
         L{IListeningPort} reports its address as an L{IPv6Address} with a host
         value that includes the scope identifier.
         """
@@ -1587,8 +1581,6 @@ class TCPPortTestsMixin(object):
         address = port.getHost()
         self.assertIsInstance(address, IPv6Address)
         self.assertEqual(linkLocal, address.host)
-    if ipv6Skip:
-        test_portGetHostOnIPv6ScopeID.skip = ipv6Skip
 
 
     def _buildProtocolAddressTest(self, client, interface):
@@ -1641,6 +1633,7 @@ class TCPPortTestsMixin(object):
             IPv4Address('TCP', *client.getsockname()), observedAddress)
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_buildProtocolIPv6Address(self):
         """
         When a connection is accepted to an IPv6 address, an L{IPv6Address} is
@@ -1656,10 +1649,9 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, peer[1]), observedAddress)
-    if ipv6Skip:
-        test_buildProtocolIPv6Address.skip = ipv6Skip
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_buildProtocolIPv6AddressScopeID(self):
         """
         When a connection is accepted to a link-local IPv6 address, an
@@ -1675,8 +1667,6 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, *peer[1:]), observedAddress)
-    if ipv6Skip:
-        test_buildProtocolIPv6AddressScopeID.skip = ipv6Skip
 
 
     def _serverGetConnectionAddressTest(self, client, interface, which):
@@ -1731,6 +1721,7 @@ class TCPPortTestsMixin(object):
             IPv4Address('TCP', *client.getpeername()), hostAddress)
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_serverGetHostOnIPv6(self):
         """
         When a connection is accepted over IPv6, the server
@@ -1747,10 +1738,9 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, *peer[1:]), hostAddress)
-    if ipv6Skip:
-        test_serverGetHostOnIPv6.skip = ipv6Skip
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_serverGetHostOnIPv6ScopeID(self):
         """
         When a connection is accepted over IPv6, the server
@@ -1768,8 +1758,6 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, *peer[1:]), hostAddress)
-    if ipv6Skip:
-        test_serverGetHostOnIPv6ScopeID.skip = ipv6Skip
 
 
     def test_serverGetPeerOnIPv4(self):
@@ -1786,6 +1774,7 @@ class TCPPortTestsMixin(object):
             IPv4Address('TCP', *client.getsockname()), peerAddress)
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_serverGetPeerOnIPv6(self):
         """
         When a connection is accepted over IPv6, the server
@@ -1802,10 +1791,9 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, *peer[1:]), peerAddress)
-    if ipv6Skip:
-        test_serverGetPeerOnIPv6.skip = ipv6Skip
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_serverGetPeerOnIPv6ScopeID(self):
         """
         When a connection is accepted over IPv6, the server
@@ -1823,8 +1811,6 @@ class TCPPortTestsMixin(object):
 
         self.assertEqual(
             IPv6Address('TCP', hostname, *peer[1:]), peerAddress)
-    if ipv6Skip:
-        test_serverGetPeerOnIPv6ScopeID.skip = ipv6Skip
 
 
 
@@ -2347,6 +2333,7 @@ class TCPTransportServerAddressTestMixin(object):
                                        IPv4Address)
 
 
+    @skipIf(ipv6Skip, ipv6SkipReason)
     def test_serverAddressTCP6(self):
         """
         IPv6 L{Server} instances have a string representation indicating on
@@ -2355,9 +2342,6 @@ class TCPTransportServerAddressTestMixin(object):
         """
         return self._testServerAddress(getLinkLocalIPv6Address(),
                                        socket.AF_INET6, IPv6Address)
-
-    if ipv6Skip:
-        test_serverAddressTCP6.skip = ipv6Skip
 
 
 
@@ -3011,13 +2995,11 @@ globals().update(AbortConnectionTests.makeTestCaseClasses())
 
 
 
+@skipIf(ipv6Skip, ipv6SkipReason)
 class SimpleUtilityTests(TestCase):
     """
     Simple, direct tests for helpers within L{twisted.internet.tcp}.
     """
-    if ipv6Skip:
-        skip = ipv6Skip
-
     def test_resolveNumericHost(self):
         """
         L{_resolveIPv6} raises a L{socket.gaierror} (L{socket.EAI_NONAME}) when
@@ -3029,6 +3011,9 @@ class SimpleUtilityTests(TestCase):
         self.assertEqual(err.args[0], socket.EAI_NONAME)
 
 
+    @skipIf(platform.isWindows(),
+            "The AI_NUMERICSERV flag is not supported by Microsoft providers.")
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/ms738520.aspx
     def test_resolveNumericService(self):
         """
         L{_resolveIPv6} raises a L{socket.gaierror} (L{socket.EAI_NONAME}) when
@@ -3038,11 +3023,6 @@ class SimpleUtilityTests(TestCase):
         """
         err = self.assertRaises(socket.gaierror, _resolveIPv6, "::1", "http")
         self.assertEqual(err.args[0], socket.EAI_NONAME)
-
-    if platform.isWindows():
-        test_resolveNumericService.skip = ("The AI_NUMERICSERV flag is not "
-                                           "supported by Microsoft providers.")
-        # http://msdn.microsoft.com/en-us/library/windows/desktop/ms738520.aspx
 
 
     def test_resolveIPv6(self):
@@ -3122,12 +3102,11 @@ class BuffersLogsTests(SynchronousTestCase):
 
 
 
+@skipIf(SKIP_EMFILE, SKIP_EMFILE)
 class FileDescriptorReservationTests(SynchronousTestCase):
     """
     Tests for L{_FileDescriptorReservation}.
     """
-    skip = SKIP_EMFILE
-
     def setUp(self):
         self.reservedFileObjects = []
         self.tempfile = self.mktemp()

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -14,6 +14,7 @@ from pprint import pformat
 from hashlib import md5
 from struct import pack
 from typing import Optional, Sequence, Type
+from unittest import skipIf
 
 try:
     from socket import AF_UNIX
@@ -49,11 +50,11 @@ from twisted.python.runtime import platform
 from twisted.python.reflect import requireModule
 from twisted.python.filepath import _coerceToFilesystemEncoding
 
+sendmsg = requireModule("twisted.python.sendmsg")
+sendmsgSkipReason = ""
 if requireModule("twisted.python.sendmsg") is not None:
-    sendmsgSkip = None
-else:
-    sendmsgSkip = (
-        "sendmsg extension unavailable, extended UNIX features disabled")
+    sendmsgSkipReason = ("sendmsg extension unavailable, "
+                         "extended UNIX features disabled")
 
 
 
@@ -227,20 +228,19 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         self._modeTest('listenUNIX', self.mktemp(), ServerFactory())
 
 
+    @skipIf(not platform.isLinux(), 'Abstract namespace UNIX sockets only '
+                                    'supported on Linux.')
     def test_listenOnLinuxAbstractNamespace(self):
         """
-        On Linux, a UNIX socket path may begin with C{'\0'} to indicate a socket
-        in the abstract namespace.  L{IReactorUNIX.listenUNIX} accepts such a
-        path.
+        On Linux, a UNIX socket path may begin with C{'\0'} to indicate
+        a socket in the abstract namespace.  L{IReactorUNIX.listenUNIX}
+        accepts such a path.
         """
         # Don't listen on a path longer than the maximum allowed.
         path = _abstractPath(self)
         reactor = self.buildReactor()
         port = reactor.listenUNIX('\0' + path, ServerFactory())
         self.assertEqual(port.getHost(), UNIXAddress('\0' + path))
-    if not platform.isLinux():
-        test_listenOnLinuxAbstractNamespace.skip = (
-            'Abstract namespace UNIX sockets only supported on Linux.')
 
 
     def test_listenFailure(self):
@@ -257,6 +257,8 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             reactor.listenUNIX('not-used', ServerFactory())
 
 
+    @skipIf(not platform.isLinux(), 'Abstract namespace UNIX sockets only '
+                                    'supported on Linux.')
     def test_connectToLinuxAbstractNamespace(self):
         """
         L{IReactorUNIX.connectUNIX} also accepts a Linux abstract namespace
@@ -266,9 +268,6 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         reactor = self.buildReactor()
         connector = reactor.connectUNIX('\0' + path, ClientFactory())
         self.assertEqual(connector.getDestination(), UNIXAddress('\0' + path))
-    if not platform.isLinux():
-        test_connectToLinuxAbstractNamespace.skip = (
-            'Abstract namespace UNIX sockets only supported on Linux.')
 
 
     def test_addresses(self):
@@ -292,6 +291,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         self.assertEqual(server.addresses['peer'], client.addresses['host'])
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_sendFileDescriptor(self):
         """
         L{IUNIXTransport.sendFileDescriptor} accepts an integer file descriptor
@@ -323,14 +323,13 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         d.addBoth(lambda ignored: server.transport.loseConnection())
 
         runProtocolsWithReactor(self, server, client, self.endpoints)
-    if sendmsgSkip is not None:
-        test_sendFileDescriptor.skip = sendmsgSkip
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_sendFileDescriptorTriggersPauseProducing(self):
         """
-        If a L{IUNIXTransport.sendFileDescriptor} call fills up the send buffer,
-        any registered producer is paused.
+        If a L{IUNIXTransport.sendFileDescriptor} call fills up
+        the send buffer, any registered producer is paused.
         """
         class DoesNotRead(ConnectableProtocol):
             def connectionMade(self):
@@ -372,10 +371,9 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
 
         self.assertTrue(
             server.paused, "sendFileDescriptor producer was not paused")
-    if sendmsgSkip is not None:
-        test_sendFileDescriptorTriggersPauseProducing.skip = sendmsgSkip
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_fileDescriptorOverrun(self):
         """
         If L{IUNIXTransport.sendFileDescriptor} is used to queue a greater
@@ -398,8 +396,6 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         self.assertIsInstance(result[0], Failure)
         result[0].trap(ConnectionClosed)
         self.assertIsInstance(server.reason.value, FileDescriptorOverrun)
-    if sendmsgSkip is not None:
-        test_fileDescriptorOverrun.skip = sendmsgSkip
 
 
     def _sendmsgMixinFileDescriptorReceivedDriver(self, ancillaryPacker):
@@ -495,6 +491,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             self.assertEqual(deviceInodesSent, proto.deviceInodesReceived)
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_multiFileDescriptorReceivedPerRecvmsgOneCMSG(self):
         """
         _SendmsgMixin handles multiple file descriptors per recvmsg, calling
@@ -509,10 +506,11 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             return ancillary, expectedCount
 
         self._sendmsgMixinFileDescriptorReceivedDriver(ancillaryPacker)
-    if sendmsgSkip is not None:
-        test_multiFileDescriptorReceivedPerRecvmsgOneCMSG.skip = sendmsgSkip
 
 
+    @skipIf(platform.isMacOSX(),
+            "Multi control message ancillary sendmsg not supported on Mac.")
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_multiFileDescriptorReceivedPerRecvmsgTwoCMSGs(self):
         """
         _SendmsgMixin handles multiple file descriptors per recvmsg, calling
@@ -530,13 +528,9 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             return ancillary, expectedCount
 
         self._sendmsgMixinFileDescriptorReceivedDriver(ancillaryPacker)
-    if platform.isMacOSX():
-        test_multiFileDescriptorReceivedPerRecvmsgTwoCMSGs.skip = (
-            "Multi control message ancillary sendmsg not supported on Mac.")
-    elif sendmsgSkip is not None:
-        test_multiFileDescriptorReceivedPerRecvmsgTwoCMSGs.skip = sendmsgSkip
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_multiFileDescriptorReceivedPerRecvmsgBadCMSG(self):
         """
         _SendmsgMixin handles multiple file descriptors per recvmsg, calling
@@ -573,10 +567,9 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         expectedMessage = 'received unsupported ancillary data'
         found = any(expectedMessage in e['format'] for e in events)
         self.assertTrue(found, 'Expected message not found in logged events')
-    if sendmsgSkip is not None:
-        test_multiFileDescriptorReceivedPerRecvmsgBadCMSG.skip = sendmsgSkip
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_avoidLeakingFileDescriptors(self):
         """
         If associated with a protocol which does not provide
@@ -642,10 +635,9 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             self.fail(
                 "Expected event (%s) not found in logged events (%s)" % (
                     expectedEvent, pformat(events,)))
-    if sendmsgSkip is not None:
-        test_avoidLeakingFileDescriptors.skip = sendmsgSkip
 
 
+    @skipIf(not sendmsg, sendmsgSkipReason)
     def test_descriptorDeliveredBeforeBytes(self):
         """
         L{IUNIXTransport.sendFileDescriptor} sends file descriptors before
@@ -676,8 +668,6 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             self.assertEqual(b"junk", bytes(client.events[1:]))
         else:
             self.assertEqual(b"junk", b"".join(client.events[1:]))
-    if sendmsgSkip is not None:
-        test_descriptorDeliveredBeforeBytes.skip = sendmsgSkip
 
 
 
@@ -698,19 +688,18 @@ class UNIXDatagramTestsBuilder(UNIXFamilyMixin, ReactorBuilder):
         self._modeTest('listenUNIXDatagram', self.mktemp(), DatagramProtocol())
 
 
+    @skipIf(not platform.isLinux(), 'Abstract namespace UNIX sockets only '
+                                    'supported on Linux.')
     def test_listenOnLinuxAbstractNamespace(self):
         """
-        On Linux, a UNIX socket path may begin with C{'\0'} to indicate a socket
-        in the abstract namespace.  L{IReactorUNIX.listenUNIXDatagram} accepts
-        such a path.
+        On Linux, a UNIX socket path may begin with C{'\0'} to indicate a
+        socket in the abstract namespace.  L{IReactorUNIX.listenUNIXDatagram}
+        accepts such a path.
         """
         path = _abstractPath(self)
         reactor = self.buildReactor()
         port = reactor.listenUNIXDatagram('\0' + path, DatagramProtocol())
         self.assertEqual(port.getHost(), UNIXAddress('\0' + path))
-    if not platform.isLinux():
-        test_listenOnLinuxAbstractNamespace.skip = (
-            'Abstract namespace UNIX sockets only supported on Linux.')
 
 
 

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -6,7 +6,7 @@ Tests for L{twisted.logger._json}.
 """
 
 from io import StringIO, BytesIO
-
+from unittest import skipIf
 from zope.interface.verify import verifyObject, BrokenMethodImplementation
 
 from twisted.python.compat import unicode, _PYPY, _PY3
@@ -109,6 +109,7 @@ class SaveLoadTests(TestCase):
         )
 
 
+    @skipIf(_PYPY and _PY3, "https://bitbucket.org/pypy/pypy/issues/3052/")
     def test_saveBytes(self):
         """
         Any L{bytes} objects will be saved as if they are latin-1 so they can
@@ -130,9 +131,6 @@ class SaveLoadTests(TestCase):
             eventFromJSON(self.savedEventJSON(inputEvent)),
             {u"hello": asbytes(range(255)).decode("charmap")}
         )
-
-    if _PYPY and _PY3:
-        test_saveBytes.skip = "https://bitbucket.org/pypy/pypy/issues/3052/"
 
 
     def test_saveUnPersistableThenFormat(self):

--- a/src/twisted/mail/test/test_mailmail.py
+++ b/src/twisted/mail/test/test_mailmail.py
@@ -9,6 +9,7 @@ command line program I{mailmail}.
 
 import os
 import sys
+from unittest import skipIf
 
 from twisted.copyright import version
 from twisted.internet.defer import Deferred
@@ -188,6 +189,9 @@ class OptionsTests(TestCase):
         self.assertEqual(o.sender, "invaliduser4@example.com")
 
 
+    @skipIf(platformType == "win32",
+            "mailmail.run() does not work on win32 due to lack of support for"
+            " getuid()")
     def test_runErrorsToStderr(self):
         """
         Call L{mailmail.run}, and specify I{-oep} to print errors
@@ -206,12 +210,10 @@ class OptionsTests(TestCase):
         # We should not have any failures.
         self.assertIsNone(mailmail.failed)
 
-    if platformType == "win32":
-        test_runErrorsToStderr.skip = (
+
+    @skipIf(platformType == "win32",
             "mailmail.run() does not work on win32 due to lack of support for"
             " getuid()")
-
-
     def test_readInvalidConfig(self):
         """
         Error messages for illegal UID value, illegal GID value, and illegal
@@ -260,10 +262,6 @@ class OptionsTests(TestCase):
                          "invalidgid1")
         self.assertRegex(self.out.getvalue(),
                          'Illegal entry in \\[identity\\] section: funny')
-
-    if platformType == "win32":
-        test_readInvalidConfig.skip = ("mailmail.run() does not work on win32"
-                                       " due to lack of support for getuid()")
 
 
     def getConfigFromFile(self, config):

--- a/src/twisted/mail/test/test_options.py
+++ b/src/twisted/mail/test/test_options.py
@@ -10,13 +10,8 @@ from twisted.trial.unittest import TestCase
 from twisted.python.usage import UsageError
 from twisted.mail import protocols
 from twisted.mail.tap import Options, makeService
-from twisted.python.reflect import requireModule
 from twisted.internet import endpoints, defer
 
-if requireModule('OpenSSL') is None:
-    sslSkip = 'Missing OpenSSL package.'
-else:
-    sslSkip = None
 
 
 class OptionsTests(TestCase):

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -6,7 +6,10 @@ import sys
 import inspect
 
 from typing import List
+from unittest import skipIf
 from zope.interface import directlyProvides
+
+import twisted.mail.pop3client
 
 from twisted.internet import reactor, defer, error, protocol, interfaces
 from twisted.mail.pop3 import AdvancedPOP3Client as POP3Client
@@ -17,7 +20,7 @@ from twisted.protocols import basic, loopback
 from twisted.python import log
 from twisted.python.compat import intToBytes
 from twisted.test.proto_helpers import StringTransport
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 
 
 try:
@@ -57,7 +60,7 @@ def strip(f):
 
 
 
-class POP3ClientLoginTests(unittest.TestCase):
+class POP3ClientLoginTests(TestCase):
     def testNegativeGreeting(self):
         p, t = setUp(greet=False)
         p.allowInsecureLogin = True
@@ -211,7 +214,7 @@ class MessageConsumer:
 
 
 
-class POP3ClientListTests(unittest.TestCase):
+class POP3ClientListTests(TestCase):
     def testListSize(self):
         p, t = setUp()
         d = p.listSize()
@@ -282,7 +285,7 @@ class POP3ClientListTests(unittest.TestCase):
 
 
 
-class POP3ClientMessageTests(unittest.TestCase):
+class POP3ClientMessageTests(TestCase):
     def testRetrieve(self):
         p, t = setUp()
         d = p.retrieve(7)
@@ -386,7 +389,7 @@ class POP3ClientMessageTests(unittest.TestCase):
 
 
 
-class POP3ClientMiscTests(unittest.TestCase):
+class POP3ClientMiscTests(TestCase):
     def testCapability(self):
         p, t = setUp()
         d = p.capabilities(useCache=0)
@@ -547,7 +550,9 @@ class TLSServerFactory(protocol.ServerFactory):
 
 
 
-class POP3TLSTests(unittest.TestCase):
+@skipIf(not ClientTLSContext, "OpenSSL not present")
+@skipIf(not interfaces.IReactorSSL(reactor, None), "OpenSSL not present")
+class POP3TLSTests(TestCase):
     """
     Tests for POP3Client's support for TLS connections.
     """
@@ -611,7 +616,7 @@ class POP3TLSTests(unittest.TestCase):
 
 
 
-class POP3TimeoutTests(POP3HelperMixin, unittest.TestCase):
+class POP3TimeoutTests(POP3HelperMixin, TestCase):
     def testTimeout(self):
         def login():
             d = self.client.login('test', 'twisted')
@@ -644,18 +649,7 @@ class POP3TimeoutTests(POP3HelperMixin, unittest.TestCase):
 
 
 
-if ClientTLSContext is None:
-    for case in (POP3TLSTests,):
-        case.skip = "OpenSSL not present"
-elif interfaces.IReactorSSL(reactor, None) is None:
-    for case in (POP3TLSTests,):
-        case.skip = "Reactor doesn't support SSL"
-
-
-
-import twisted.mail.pop3client
-
-class POP3ClientModuleStructureTests(unittest.TestCase):
+class POP3ClientModuleStructureTests(TestCase):
     """
     Miscellaneous tests more to do with module/package structure than
     anything to do with the POP3 client.

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -1135,8 +1135,6 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         dummyParameters['c'] = FakeParameter("fake", "fake")
         fakeSig = FakeSignature(dummyParameters)
         self.assertRaises(TypeError, _passedSignature, fakeSig, (1, 2), {})
-    if not getattr(inspect, "signature", None):
-        test_invalidParameterType.skip = "inspect.signature() not available"
 
 
 

--- a/src/twisted/python/test/test_dist3.py
+++ b/src/twisted/python/test/test_dist3.py
@@ -9,6 +9,8 @@ Tests for L{twisted.python.dist3}.
 import os
 import twisted
 
+from unittest import skipIf
+
 from twisted.trial.unittest import TestCase
 from twisted.python.compat import _PY3
 from twisted.python._setup import notPortedModules
@@ -18,6 +20,7 @@ class ModulesToInstallTests(TestCase):
     """
     Tests for L{notPortedModules}.
     """
+    @skipIf(_PY3, "Only on Python 2")
     def test_exist(self):
         """
         All modules listed in L{notPortedModules} exist on Py2.
@@ -33,6 +36,8 @@ class ModulesToInstallTests(TestCase):
                             os.path.exists(packagePath),
                             "Module {0} does not exist".format(module))
 
+
+    @skipIf(not _PY3, "Only on Python 3")
     def test_notexist(self):
         """
         All modules listed in L{notPortedModules} do not exist on Py3.
@@ -47,8 +52,3 @@ class ModulesToInstallTests(TestCase):
             self.assertFalse(os.path.exists(path) or
                              os.path.exists(packagePath),
                              "Module {0} exists".format(module))
-
-    if _PY3:
-        test_exist.skip = "Only on Python 2"
-    else:
-        test_notexist.skip = "Only on Python 3"

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -13,6 +13,8 @@ import shutil
 import sys
 import warnings
 
+from unittest import skipIf
+
 try:
     import pwd as _pwd
     import grp as _grp
@@ -23,7 +25,7 @@ else:
     pwd = _pwd
     grp = _grp
 
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase, FailTest
 from twisted.trial.util import suppress as SUPPRESS
 
 from twisted.python import util
@@ -39,11 +41,14 @@ from twisted.test.test_process import MockOS
 pyExe = FilePath(sys.executable)._asBytesPath()
 
 
-class UtilTests(unittest.TestCase):
+
+class UtilTests(TestCase):
 
     def testUniq(self):
-        l = ["a", 1, "ab", "a", 3, 4, 1, 2, 2, 4, 6]
-        self.assertEqual(util.uniquify(l), ["a", 1, "ab", 3, 4, 2, 6])
+        listWithDupes = ["a", 1, "ab", "a", 3, 4, 1, 2, 2, 4, 6]
+        self.assertEqual(util.uniquify(listWithDupes),
+                         ["a", 1, "ab", 3, 4, 2, 6])
+
 
     def testRaises(self):
         self.assertTrue(util.raises(ZeroDivisionError, divmod, 1, 0))
@@ -54,7 +59,7 @@ class UtilTests(unittest.TestCase):
         except ZeroDivisionError:
             pass
         else:
-            raise unittest.FailTest("util.raises didn't raise when it should have")
+            raise FailTest("util.raises didn't raise when it should have")
 
 
     def test_uidFromNumericString(self):
@@ -65,6 +70,7 @@ class UtilTests(unittest.TestCase):
         self.assertEqual(util.uidFromString("100"), 100)
 
 
+    @skipIf(pwd is None, "Username/UID conversion requires the pwd module.")
     def test_uidFromUsernameString(self):
         """
         When L{uidFromString} is called with a base-ten string representation
@@ -72,9 +78,6 @@ class UtilTests(unittest.TestCase):
         """
         pwent = pwd.getpwuid(os.getuid())
         self.assertEqual(util.uidFromString(pwent.pw_name), pwent.pw_uid)
-    if pwd is None:
-        test_uidFromUsernameString.skip = (
-            "Username/UID conversion requires the pwd module.")
 
 
     def test_gidFromNumericString(self):
@@ -85,6 +88,7 @@ class UtilTests(unittest.TestCase):
         self.assertEqual(util.gidFromString("100"), 100)
 
 
+    @skipIf(grp is None, "Group Name/GID conversion requires the grp module.")
     def test_gidFromGroupnameString(self):
         """
         When L{gidFromString} is called with a base-ten string representation
@@ -92,13 +96,10 @@ class UtilTests(unittest.TestCase):
         """
         grent = grp.getgrgid(os.getgid())
         self.assertEqual(util.gidFromString(grent.gr_name), grent.gr_gid)
-    if grp is None:
-        test_gidFromGroupnameString.skip = (
-            "Group Name/GID conversion requires the grp module.")
 
 
 
-class NameToLabelTests(unittest.TestCase):
+class NameToLabelTests(TestCase):
     """
     Tests for L{nameToLabel}.
     """
@@ -122,7 +123,7 @@ class NameToLabelTests(unittest.TestCase):
 
 
 
-class UntilConcludesTests(unittest.TestCase):
+class UntilConcludesTests(TestCase):
     """
     Tests for L{untilConcludes}, an C{EINTR} helper.
     """
@@ -152,15 +153,11 @@ class UntilConcludesTests(unittest.TestCase):
 
 
 
-class SwitchUIDTests(unittest.TestCase):
+@skipIf(not getattr(os, "getuid", None), "getuid/setuid not available")
+class SwitchUIDTests(TestCase):
     """
     Tests for L{util.switchUID}.
     """
-
-    if getattr(os, "getuid", None) is None:
-        skip = "getuid/setuid not available"
-
-
     def setUp(self):
         self.mockos = MockOS()
         self.patch(util, "os", self.mockos)
@@ -230,7 +227,7 @@ class SwitchUIDTests(unittest.TestCase):
 
 
 
-class MergeFunctionMetadataTests(unittest.TestCase):
+class MergeFunctionMetadataTests(TestCase):
     """
     Tests for L{mergeFunctionMetadata}.
     """
@@ -327,7 +324,7 @@ class MergeFunctionMetadataTests(unittest.TestCase):
 
 
 
-class OrderedDictTests(unittest.TestCase):
+class OrderedDictTests(TestCase):
     """
     Tests for L{util.OrderedDict}.
     """
@@ -349,7 +346,7 @@ class OrderedDictTests(unittest.TestCase):
 
 
 
-class InsensitiveDictTests(unittest.TestCase):
+class InsensitiveDictTests(TestCase):
     """
     Tests for L{util.InsensitiveDict}.
     """
@@ -436,10 +433,10 @@ class PasswordTestingProcessProtocol(ProcessProtocol):
         self.finished.callback((reason, self.output))
 
 
-class GetPasswordTests(unittest.TestCase):
-    if not IReactorProcess.providedBy(reactor):
-        skip = "Process support required to test getPassword"
 
+@skipIf(not IReactorProcess.providedBy(reactor),
+        "Process support required to test getPassword")
+class GetPasswordTests(TestCase):
     def test_stdin(self):
         """
         Making sure getPassword accepts a password from standard input by
@@ -468,7 +465,7 @@ class GetPasswordTests(unittest.TestCase):
 
 
 
-class SearchUpwardsTests(unittest.TestCase):
+class SearchUpwardsTests(TestCase):
     def testSearchupwards(self):
         os.makedirs('searchupwards/a/b/c')
         open('searchupwards/foo.txt', 'w').close()
@@ -492,7 +489,7 @@ class SearchUpwardsTests(unittest.TestCase):
 
 
 
-class IntervalDifferentialTests(unittest.TestCase):
+class IntervalDifferentialTests(TestCase):
     def testDefault(self):
         d = iter(util.IntervalDifferential([], 10))
         for i in range(100):
@@ -627,7 +624,7 @@ class EqualToNothing(object):
 
 
 
-class EqualityTests(unittest.TestCase):
+class EqualityTests(TestCase):
     """
     Tests for L{FancyEqMixin}.
     """
@@ -732,14 +729,12 @@ class EqualityTests(unittest.TestCase):
 
 
 
-class RunAsEffectiveUserTests(unittest.TestCase):
+@skipIf(not getattr(os, "geteuid", None),
+        "geteuid/seteuid not available")
+class RunAsEffectiveUserTests(TestCase):
     """
     Test for the L{util.runAsEffectiveUser} function.
     """
-
-    if getattr(os, "geteuid", None) is None:
-        skip = "geteuid/seteuid not available"
-
     def setUp(self):
         self.mockos = MockOS()
         self.patch(os, "geteuid", self.mockos.geteuid)
@@ -847,7 +842,8 @@ class RunAsEffectiveUserTests(unittest.TestCase):
 
 
 
-class InitGroupsTests(unittest.TestCase):
+@skipIf(not util._initgroups, "stdlib support for initgroups is not available")
+class InitGroupsTests(TestCase):
     """
     Tests for L{util.initgroups}.
     """
@@ -876,12 +872,9 @@ class InitGroupsTests(unittest.TestCase):
         """
         self.assertRaises(TypeError, util.initgroups, os.getuid(), None)
 
-    if util._initgroups is None:
-        skip = "stdlib support for initgroups is not available"
 
 
-
-class DeprecationTests(unittest.TestCase):
+class DeprecationTests(TestCase):
     """
     Tests for deprecations in C{twisted.python.util}.
     """
@@ -920,7 +913,7 @@ class DeprecationTests(unittest.TestCase):
 
 
 
-class SuppressedWarningsTests(unittest.TestCase):
+class SuppressedWarningsTests(TestCase):
     """
     Tests for L{util.runWithWarningsSuppressed}.
     """
@@ -972,7 +965,7 @@ class SuppressedWarningsTests(unittest.TestCase):
 
 
 
-class FancyStrMixinTests(unittest.TestCase):
+class FancyStrMixinTests(TestCase):
     """
     Tests for L{util.FancyStrMixin}.
     """
@@ -1041,7 +1034,7 @@ class FancyStrMixinTests(unittest.TestCase):
 
 
 
-class PadToTests(unittest.TestCase):
+class PadToTests(TestCase):
     """
     Tests for L{util.padTo}.
     """

--- a/src/twisted/spread/test/test_banana.py
+++ b/src/twisted/spread/test/test_banana.py
@@ -6,23 +6,23 @@ import sys
 from functools import partial
 from io import BytesIO
 
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.spread import banana
 from twisted.python import failure
-from twisted.python.compat import long, iterbytes, _bytesChr as chr, _PY3
+from twisted.python.compat import long, iterbytes, _bytesChr as chr
 from twisted.internet import protocol, main
 from twisted.test.proto_helpers import StringTransport
 
-if _PY3:
-    _maxint = 9223372036854775807
-else:
-    from sys import maxint as _maxint
 
 
-class MathTests(unittest.TestCase):
+_maxint = 9223372036854775807
+
+
+
+class MathTests(TestCase):
     def test_int2b128(self):
-        funkylist = (list(range(0,100)) + list(range(1000,1100)) +
-                    list(range(1000000,1000100)) + [1024 **10])
+        funkylist = (list(range(0, 100)) + list(range(1000, 1100)) +
+                     list(range(1000000, 1000100)) + [1024 ** 10])
         for i in funkylist:
             x = BytesIO()
             banana.int2b128(i, x.write)
@@ -71,7 +71,7 @@ def encode(bananaFactory, obj):
 
 
 
-class BananaTestBase(unittest.TestCase):
+class BananaTestBase(TestCase):
     """
     The base for test classes. It defines commonly used things and sets up a
     connection for testing.
@@ -119,10 +119,7 @@ class BananaTests(BananaTestBase):
         Banana does not support unicode.  ``Banana.sendEncoded`` raises
         ``BananaError`` if called with an instance of ``unicode``.
         """
-        if _PY3:
-            self._unsupportedTypeTest(u"hello", "builtins.str")
-        else:
-            self._unsupportedTypeTest(u"hello", "__builtin__.unicode")
+        self._unsupportedTypeTest(u"hello", "builtins.str")
 
 
     def test_unsupportedBuiltinType(self):
@@ -132,10 +129,7 @@ class BananaTests(BananaTestBase):
         with an instance of L{type}.
         """
         # type is an instance of type
-        if _PY3:
-            self._unsupportedTypeTest(type, "builtins.type")
-        else:
-            self._unsupportedTypeTest(type, "__builtin__.type")
+        self._unsupportedTypeTest(type, "builtins.type")
 
 
     def test_unsupportedUserType(self):
@@ -175,29 +169,6 @@ class BananaTests(BananaTestBase):
             self.enc.dataReceived(self.io.getvalue())
             self.assertEqual(self.result, 10151)
             self.assertIsInstance(self.result, int)
-
-
-    def test_largeLong(self):
-        """
-        Integers greater than 2 ** 32 and less than -2 ** 32 should
-        round-trip through banana without changing value and should
-        come out represented as C{int} instances if the value fits
-        into that type on the receiving platform.
-        """
-        for exp in (32, 64, 128, 256):
-            for add in (0, 1):
-                m = 2 ** exp + add
-                for n in (m, -m-1):
-                    self.enc.dataReceived(self.encode(n))
-                    self.assertEqual(self.result, n)
-                    if n > _maxint or n < -_maxint - 1:
-                        self.assertIsInstance(self.result, long)
-                    else:
-                        self.assertIsInstance(self.result, int)
-
-    if _PY3:
-        test_largeLong.skip = (
-            "Python 3 has unified int/long into an int type of unlimited size")
 
 
     def _getSmallest(self):
@@ -438,7 +409,7 @@ class DialectTests(BananaTestBase):
 
 
 
-class GlobalCoderTests(unittest.TestCase):
+class GlobalCoderTests(TestCase):
     """
     Tests for the free functions L{banana.encode} and L{banana.decode}.
     """

--- a/src/twisted/spread/test/test_jelly.py
+++ b/src/twisted/spread/test/test_jelly.py
@@ -8,10 +8,12 @@ Test cases for L{jelly} object serialization.
 
 import datetime
 import decimal
+from unittest import skipIf
 
 from twisted.python.compat import unicode
 from twisted.spread import jelly, pb
 from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.test.proto_helpers import StringTransport
 
 
@@ -114,7 +116,7 @@ class SimpleJellyTest:
 
 
 
-class JellyTests(unittest.TestCase):
+class JellyTests(TestCase):
     """
     Testcases for L{jelly} module serialization.
 
@@ -328,6 +330,7 @@ class JellyTests(unittest.TestCase):
         self._testSecurity(inputList, b"frozenset")
 
 
+    @skipIf(not jelly._sets, "sets.Set is gone in Python 3 and higher")
     def test_oldSets(self):
         """
         Test jellying C{sets.Set}: it should serialize to the same thing as
@@ -344,10 +347,9 @@ class JellyTests(unittest.TestCase):
         else:
             self.assertIsInstance(output[0], set)
 
-    if not jelly._sets:
-        test_oldSets.skip = "sets.Set is gone in Python 3 and higher"
 
-
+    @skipIf(not jelly._sets, "sets.ImmutableSets is gone in Python 3 "
+                             "and higher")
     def test_oldImmutableSets(self):
         """
         Test jellying C{sets.ImmutableSet}: it should serialize to the same
@@ -364,10 +366,6 @@ class JellyTests(unittest.TestCase):
             self.assertIsInstance(output[0], jelly._sets.ImmutableSet)
         else:
             self.assertIsInstance(output[0], frozenset)
-
-    if not jelly._sets:
-        test_oldImmutableSets.skip = (
-            "sets.ImmutableSets is gone in Python 3 and higher")
 
 
     def test_simple(self):
@@ -583,7 +581,7 @@ class JellyTests(unittest.TestCase):
 
 
 
-class JellyDeprecationTests(unittest.TestCase):
+class JellyDeprecationTests(TestCase):
     """
     Tests for deprecated Jelly things
     """
@@ -636,7 +634,7 @@ class ClassB(pb.Copyable, pb.RemoteCopy):
 
 
 
-class CircularReferenceTests(unittest.TestCase):
+class CircularReferenceTests(TestCase):
     """
     Tests for circular references handling in the jelly/unjelly process.
     """

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -13,7 +13,8 @@ import socket
 import sys
 import traceback
 
-from twisted.trial import unittest
+from unittest import skipIf
+from twisted.trial.unittest import TestCase, SynchronousTestCase
 
 from twisted.python.compat import (
     reduce, execfile, _PYPY, comparable, cmp, nativeString,
@@ -26,7 +27,7 @@ from twisted.python.runtime import platform
 
 
 
-class IOTypeTests(unittest.SynchronousTestCase):
+class IOTypeTests(SynchronousTestCase):
     """
     Test cases for determining a file-like object's type.
     """
@@ -87,7 +88,7 @@ class IOTypeTests(unittest.SynchronousTestCase):
 
 
 
-class CompatTests(unittest.SynchronousTestCase):
+class CompatTests(SynchronousTestCase):
     """
     Various utility functions in C{twisted.python.compat} provide same
     functionality as modern Python variants.
@@ -142,7 +143,7 @@ class CompatTests(unittest.SynchronousTestCase):
 
 
 
-class ExecfileCompatTests(unittest.SynchronousTestCase):
+class ExecfileCompatTests(SynchronousTestCase):
     """
     Tests for the Python 3-friendly L{execfile} implementation.
     """
@@ -194,7 +195,7 @@ class ExecfileCompatTests(unittest.SynchronousTestCase):
 
 
 
-class PYPYTest(unittest.SynchronousTestCase):
+class PYPYTest(SynchronousTestCase):
     """
     Identification of PyPy.
     """
@@ -226,7 +227,7 @@ class Comparable(object):
 
 
 
-class ComparableTests(unittest.SynchronousTestCase):
+class ComparableTests(SynchronousTestCase):
     """
     L{comparable} decorated classes emulate Python 2's C{__cmp__} semantics.
     """
@@ -290,7 +291,7 @@ class ComparableTests(unittest.SynchronousTestCase):
 
 
 
-class Python3ComparableTests(unittest.SynchronousTestCase):
+class Python3ComparableTests(SynchronousTestCase):
     """
     Python 3-specific functionality of C{comparable}.
     """
@@ -350,7 +351,7 @@ class Python3ComparableTests(unittest.SynchronousTestCase):
 
 
 
-class CmpTests(unittest.SynchronousTestCase):
+class CmpTests(SynchronousTestCase):
     """
     L{cmp} should behave like the built-in Python 2 C{cmp}.
     """
@@ -381,7 +382,7 @@ class CmpTests(unittest.SynchronousTestCase):
 
 
 
-class StringTests(unittest.SynchronousTestCase):
+class StringTests(SynchronousTestCase):
     """
     Compatibility functions and types for strings.
     """
@@ -462,7 +463,7 @@ class StringTests(unittest.SynchronousTestCase):
 
 
 
-class NetworkStringTests(unittest.SynchronousTestCase):
+class NetworkStringTests(SynchronousTestCase):
     """
     Tests for L{networkString}.
     """
@@ -493,7 +494,7 @@ class NetworkStringTests(unittest.SynchronousTestCase):
 
 
 
-class ReraiseTests(unittest.SynchronousTestCase):
+class ReraiseTests(SynchronousTestCase):
     """
     L{reraise} re-raises exceptions on both Python 2 and Python 3.
     """
@@ -541,7 +542,7 @@ class ReraiseTests(unittest.SynchronousTestCase):
 
 
 
-class Python3BytesTests(unittest.SynchronousTestCase):
+class Python3BytesTests(SynchronousTestCase):
     """
     Tests for L{iterbytes}, L{intToBytes}, L{lazyByteSlice}.
     """
@@ -594,10 +595,12 @@ class Python3BytesTests(unittest.SynchronousTestCase):
 
 
 
-class BytesEnvironTests(unittest.TestCase):
+class BytesEnvironTests(TestCase):
     """
     Tests for L{BytesEnviron}.
     """
+    @skipIf(platform.isWindows(),
+            "Environment vars are always str on Windows.")
     def test_alwaysBytes(self):
         """
         The output of L{BytesEnviron} should always be a L{dict} with L{bytes}
@@ -612,12 +615,9 @@ class BytesEnvironTests(unittest.TestCase):
 
         self.assertEqual(list(types), [bytes])
 
-    if platform.isWindows():
-        test_alwaysBytes.skip = "Environment vars are always str on Windows."
 
 
-
-class CoercedUnicodeTests(unittest.TestCase):
+class CoercedUnicodeTests(TestCase):
     """
     Tests for L{twisted.python.compat._coercedUnicode}.
     """
@@ -661,7 +661,7 @@ class CoercedUnicodeTests(unittest.TestCase):
 
 
 
-class UnichrTests(unittest.TestCase):
+class UnichrTests(TestCase):
     """
     Tests for L{unichr}.
     """
@@ -673,7 +673,8 @@ class UnichrTests(unittest.TestCase):
         self.assertEqual(unichr(0x2603), u"\N{SNOWMAN}")
 
 
-class RawInputTests(unittest.TestCase):
+
+class RawInputTests(TestCase):
     """
     Tests for L{raw_input}
     """
@@ -698,7 +699,7 @@ class RawInputTests(unittest.TestCase):
 
 
 
-class FutureBytesReprTests(unittest.TestCase):
+class FutureBytesReprTests(TestCase):
     """
     Tests for L{twisted.python.compat._bytesRepr}.
     """
@@ -722,7 +723,7 @@ class FutureBytesReprTests(unittest.TestCase):
 
 
 
-class GetAsyncParamTests(unittest.SynchronousTestCase):
+class GetAsyncParamTests(SynchronousTestCase):
     """
     Tests for L{twisted.python.compat._get_async_param}
     """

--- a/src/twisted/test/test_internet.py
+++ b/src/twisted/test/test_internet.py
@@ -11,25 +11,26 @@ import sys
 import time
 from unittest import skipIf
 
-from twisted.python.compat import _PY3
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.internet import reactor, protocol, error, abstract, defer
 from twisted.internet import interfaces, base
+from twisted.internet.defer import Deferred, passthru
 from twisted.internet.tcp import Connector
+from twisted.python import util
 
 try:
-    from twisted.internet import ssl
+    from twisted.internet import ssl as _ssl
 except ImportError:
     ssl = None
+else:
+    ssl = _ssl
+
 if ssl and not ssl.supported:
     ssl = None
 
-from twisted.internet.defer import Deferred, passthru
-if not _PY3:
-    from twisted.python import util
 
 
-class ThreePhaseEventTests(unittest.TestCase):
+class ThreePhaseEventTests(TestCase):
     """
     Tests for the private implementation helpers for system event triggers.
     """
@@ -346,7 +347,7 @@ class ThreePhaseEventTests(unittest.TestCase):
 
 
 
-class SystemEventTests(unittest.TestCase):
+class SystemEventTests(TestCase):
     """
     Tests for the reactor's implementation of the C{fireSystemEvent},
     C{addSystemEventTrigger}, and C{removeSystemEventTrigger} methods of the
@@ -650,7 +651,7 @@ class SystemEventTests(unittest.TestCase):
 
 
 
-class TimeTests(unittest.TestCase):
+class TimeTests(TestCase):
     """
     Tests for the IReactorTime part of the reactor.
     """
@@ -845,7 +846,9 @@ class TimeTests(unittest.TestCase):
 
 
 
-class CallFromThreadStopsAndWakeUpTests(unittest.TestCase):
+class CallFromThreadStopsAndWakeUpTests(TestCase):
+    @skipIf(not interfaces.IReactorThreads(reactor, None),
+            "Nothing to wake up for without thread support")
     def testWakeUp(self):
         # Make sure other threads can wake up the reactor
         d = Deferred()
@@ -856,8 +859,6 @@ class CallFromThreadStopsAndWakeUpTests(unittest.TestCase):
         reactor.callInThread(wake)
         return d
 
-    if interfaces.IReactorThreads(reactor, None) is None:
-        testWakeUp.skip = "Nothing to wake up for without thread support"
 
     def _stopCallFromThreadCallback(self):
         self.stopped = True
@@ -887,7 +888,8 @@ class CallFromThreadStopsAndWakeUpTests(unittest.TestCase):
         return d
 
 
-class DelayedTests(unittest.TestCase):
+
+class DelayedTests(TestCase):
     def setUp(self):
         self.finished = 0
         self.counter = 0
@@ -1018,7 +1020,8 @@ class ChildResolveProtocol(protocol.ProcessProtocol):
 
 @skipIf(not interfaces.IReactorProcess(reactor, None),
         "cannot run test: reactor doesn't support IReactorProcess")
-class ResolveTests(unittest.TestCase):
+class ResolveTests(TestCase):
+
     def testChildResolve(self):
         # I've seen problems with reactor.run under gtk2reactor. Spawn a
         # child which just does reactor.resolve after the reactor has
@@ -1044,30 +1047,28 @@ class ResolveTests(unittest.TestCase):
             # If the output is "done 127.0.0.1\n" we don't really care what
             # else happened.
             output = b''.join(output)
-            if _PY3:
-                expected_output = (b'done 127.0.0.1' +
-                                   os.linesep.encode("ascii"))
-            else:
-                expected_output = b'done 127.0.0.1\n'
+            expected_output = (b'done 127.0.0.1' +
+                               os.linesep.encode("ascii"))
             if output != expected_output:
                 self.fail((
-                    "The child process failed to produce the desired results:\n"
-                    "   Reason for termination was: %r\n"
-                    "   Output stream was: %r\n"
-                    "   Error stream was: %r\n") % (reason.getErrorMessage(), output, b''.join(error)))
+                    "The child process failed to produce "
+                    "the desired results:\n"
+                    "   Reason for termination was: {!r}\n"
+                    "   Output stream was: {!r}\n"
+                    "   Error stream was: {!r}\n").format(
+                    reason.getErrorMessage(), output, b''.join(error)))
 
         helperDeferred.addCallback(cbFinished)
         return helperDeferred
 
 
 
-class CallFromThreadTests(unittest.TestCase):
+@skipIf(not interfaces.IReactorThreads(reactor, None),
+        "Nothing to test without thread support")
+class CallFromThreadTests(TestCase):
     """
     Task scheduling from threads tests.
     """
-    if interfaces.IReactorThreads(reactor, None) is None:
-        skip = "Nothing to test without thread support"
-
     def setUp(self):
         self.counter = 0
         self.deferred = Deferred()
@@ -1143,7 +1144,8 @@ class MyFactory(protocol.Factory):
     protocol = MyProtocol
 
 
-class ProtocolTests(unittest.TestCase):
+
+class ProtocolTests(TestCase):
 
     def testFactory(self):
         factory = MyFactory()
@@ -1234,7 +1236,7 @@ class ReentrantProducer(DummyProducer):
 
 
 
-class ProducerTests(unittest.TestCase):
+class ProducerTests(TestCase):
     """
     Test abstract.FileDescriptor's consumer interface.
     """
@@ -1363,38 +1365,42 @@ class ProducerTests(unittest.TestCase):
 
 
 
-class PortStringificationTests(unittest.TestCase):
-    if interfaces.IReactorTCP(reactor, None) is not None:
-        def testTCP(self):
-            p = reactor.listenTCP(0, protocol.ServerFactory())
-            portNo = p.getHost().port
-            self.assertNotEqual(str(p).find(str(portNo)), -1,
-                                "%d not found in %s" % (portNo, p))
-            return p.stopListening()
-
-    if interfaces.IReactorUDP(reactor, None) is not None:
-        def testUDP(self):
-            p = reactor.listenUDP(0, protocol.DatagramProtocol())
-            portNo = p.getHost().port
-            self.assertNotEqual(str(p).find(str(portNo)), -1,
-                                "%d not found in %s" % (portNo, p))
-            return p.stopListening()
-
-    if interfaces.IReactorSSL(reactor, None) is not None and ssl:
-        def testSSL(self, ssl=ssl):
-            pem = util.sibpath(__file__, 'server.pem')
-            p = reactor.listenSSL(0, protocol.ServerFactory(), ssl.DefaultOpenSSLContextFactory(pem, pem))
-            portNo = p.getHost().port
-            self.assertNotEqual(str(p).find(str(portNo)), -1,
-                                "%d not found in %s" % (portNo, p))
-            return p.stopListening()
-
-        if _PY3:
-            testSSL.skip = ("Re-enable once the Python 3 SSL port is done.")
+class PortStringificationTests(TestCase):
+    @skipIf(not interfaces.IReactorTCP(reactor, None),
+            "IReactorTCP is needed")
+    def testTCP(self):
+        p = reactor.listenTCP(0, protocol.ServerFactory())
+        portNo = p.getHost().port
+        self.assertNotEqual(str(p).find(str(portNo)), -1,
+                            "%d not found in %s" % (portNo, p))
+        return p.stopListening()
 
 
+    @skipIf(not interfaces.IReactorUDP(reactor, None),
+            "IReactorUDP is needed")
+    def testUDP(self):
+        p = reactor.listenUDP(0, protocol.DatagramProtocol())
+        portNo = p.getHost().port
+        self.assertNotEqual(str(p).find(str(portNo)), -1,
+                            "%d not found in %s" % (portNo, p))
+        return p.stopListening()
 
-class ConnectorReprTests(unittest.TestCase):
+
+    @skipIf(not interfaces.IReactorSSL(reactor, None),
+            "IReactorSSL is needed")
+    @skipIf(not ssl, "SSL support is missing")
+    def testSSL(self, ssl=ssl):
+        pem = util.sibpath(__file__, 'server.pem')
+        p = reactor.listenSSL(0, protocol.ServerFactory(),
+                              ssl.DefaultOpenSSLContextFactory(pem, pem))
+        portNo = p.getHost().port
+        self.assertNotEqual(str(p).find(str(portNo)), -1,
+                            "%d not found in %s" % (portNo, p))
+        return p.stopListening()
+
+
+
+class ConnectorReprTests(TestCase):
     def test_tcp_repr(self):
         c = Connector('localhost', 666, object(), 0, object())
         expect = "<twisted.internet.tcp.Connector instance at 0x%x " \

--- a/src/twisted/test/test_iutils.py
+++ b/src/twisted/test/test_iutils.py
@@ -12,15 +12,17 @@ import stat
 import sys
 import warnings
 
-from twisted.python.compat import _PY3
+from unittest import skipIf
+
 from twisted.python.runtime import platform
-from twisted.trial import unittest
+from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.internet import error, reactor, utils, interfaces
 from twisted.internet.defer import Deferred
 from twisted.python.test.test_util import SuppressedWarningsTests
 
 
-class ProcessUtilsTests(unittest.TestCase):
+
+class ProcessUtilsTests(TestCase):
     """
     Test running a process using L{getProcessOutput}, L{getProcessValue}, and
     L{getProcessOutputAndValue}.
@@ -125,16 +127,13 @@ class ProcessUtilsTests(unittest.TestCase):
         def gotOutputAndValue(out_err_code):
             out, err, code = out_err_code
             self.assertEqual(out, b"hello world!\n")
-            if _PY3:
-                self.assertEqual(err, b"goodbye world!\n")
-            else:
-                self.assertEqual(err, b"goodbye world!" +
-                                      os.linesep)
+            self.assertEqual(err, b"goodbye world!\n")
             self.assertEqual(code, 1)
         d = utils.getProcessOutputAndValue(self.exe, ["-u", scriptFile])
         return d.addCallback(gotOutputAndValue)
 
 
+    @skipIf(platform.isWindows(), "Windows doesn't have real signals.")
     def test_outputSignal(self):
         """
         If the child process exits because of a signal, the L{Deferred}
@@ -162,8 +161,6 @@ class ProcessUtilsTests(unittest.TestCase):
         d = utils.getProcessOutputAndValue(self.exe, ['-u', scriptFile])
         d = self.assertFailure(d, tuple)
         return d.addCallback(gotOutputAndValue)
-    if platform.isWindows():
-        test_outputSignal.skip = "Windows doesn't have real signals."
 
 
     def _pathTest(self, utilFunc, check):
@@ -305,7 +302,7 @@ class ProcessUtilsTests(unittest.TestCase):
 
 
 
-class SuppressWarningsTests(unittest.SynchronousTestCase):
+class SuppressWarningsTests(SynchronousTestCase):
     """
     Tests for L{utils.suppressWarnings}.
     """

--- a/src/twisted/test/test_logfile.py
+++ b/src/twisted/test/test_logfile.py
@@ -8,11 +8,13 @@ import os
 import stat
 import time
 
-from twisted.trial import unittest
+from unittest import skipIf
+from twisted.trial.unittest import TestCase
 from twisted.python import logfile, runtime
 
 
-class LogFileTests(unittest.TestCase):
+
+class LogFileTests(TestCase):
     """
     Test the rotating log file.
     """
@@ -281,6 +283,7 @@ class LogFileTests(unittest.TestCase):
             self.assertEqual(mode, 0o066)
 
 
+    @skipIf(runtime.platform.isWindows(), "Can't test reopen on Windows")
     def test_reopen(self):
         """
         L{logfile.LogFile.reopen} allows to rename the currently used file and
@@ -297,9 +300,6 @@ class LogFileTests(unittest.TestCase):
             self.assertEqual(f.read(), "hello2")
         with open(savePath) as f:
             self.assertEqual(f.read(), "hello1")
-
-    if runtime.platform.isWindows():
-        test_reopen.skip = "Can't test reopen on Windows"
 
 
     def test_nonExistentDir(self):
@@ -377,7 +377,7 @@ class RiggedDailyLogFile(logfile.DailyLogFile):
 
 
 
-class DailyLogFileTests(unittest.TestCase):
+class DailyLogFileTests(TestCase):
     """
     Test rotating log file.
     """
@@ -475,6 +475,9 @@ class DailyLogFileTests(unittest.TestCase):
         self.assertEqual(previousFile, log._file)
 
 
+    @skipIf(runtime.platform.isWindows(),
+            "Making read-only directories on Windows is too complex for this "
+            "test to reasonably do.")
     def test_rotatePermissionDirectoryNotOk(self):
         """
         L{DailyLogFile.rotate} doesn't do anything if the directory containing
@@ -489,11 +492,6 @@ class DailyLogFileTests(unittest.TestCase):
         previousFile = log._file
         log.rotate()
         self.assertEqual(previousFile, log._file)
-
-    if runtime.platform.isWindows():
-        test_rotatePermissionDirectoryNotOk.skip = (
-            "Making read-only directories on Windows is too complex for this "
-            "test to reasonably do.")
 
 
     def test_rotatePermissionFileNotOk(self):

--- a/src/twisted/test/test_rebuild.py
+++ b/src/twisted/test/test_rebuild.py
@@ -2,12 +2,12 @@
 # See LICENSE for details.
 
 
-import sys, os
+import os
+import sys
 import types
 
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.python import rebuild
-from twisted.python.compat import _PY3
 
 from . import crash_test_dummy
 f = crash_test_dummy.foo
@@ -39,7 +39,7 @@ unhashableObject = None
 
 
 
-class RebuildTests(unittest.TestCase):
+class RebuildTests(TestCase):
     """
     Simple testcase for rebuilding, to at least exercise the code.
     """
@@ -176,11 +176,9 @@ class RebuildTests(unittest.TestCase):
 
         # Test rebuilding a builtin class
         newException = rebuild.latestClass(Exception)
-        if _PY3:
-            self.assertEqual(repr(Exception), repr(newException))
-        else:
-            self.assertIn('twisted.python.rebuild.Exception', repr(newException))
-        self.assertEqual(newException, testSensitive.latestVersionOf(newException))
+        self.assertEqual(repr(Exception), repr(newException))
+        self.assertEqual(newException,
+                         testSensitive.latestVersionOf(newException))
 
         # Test types.MethodType on method in class
         self.assertEqual(TestSensitive.test_method,
@@ -212,7 +210,7 @@ class RebuildTests(unittest.TestCase):
 
 
 
-class NewStyleTests(unittest.TestCase):
+class NewStyleTests(TestCase):
     """
     Tests for rebuilding new-style classes of various sorts.
     """
@@ -258,26 +256,3 @@ class NewStyleTests(unittest.TestCase):
         rebuild.updateInstance(inst)
         self.assertEqual(inst[0], 2)
         self.assertIs(type(inst), self.m.ListSubclass)
-
-
-    def test_instanceSlots(self):
-        """
-        Test that when rebuilding an instance with a __slots__ attribute, it
-        fails accurately instead of giving a L{rebuild.RebuildError}.
-        """
-        classDefinition = (
-            "class NotSlottedClass(object):\n"
-            "    pass\n")
-
-        exec(classDefinition, self.m.__dict__)
-        inst = self.m.NotSlottedClass()
-        inst.__slots__ = ['a']
-        classDefinition = (
-            "class NotSlottedClass:\n"
-            "    pass\n")
-        exec(classDefinition, self.m.__dict__)
-        # Moving from new-style class to old-style should fail.
-        self.assertRaises(TypeError, rebuild.updateInstance, inst)
-
-    if getattr(types, 'ClassType', None) is None:
-        test_instanceSlots.skip = "Old-style classes not supported on Python 3"

--- a/src/twisted/test/test_reflect.py
+++ b/src/twisted/test/test_reflect.py
@@ -11,7 +11,6 @@ import weakref
 from collections import deque
 
 from twisted.python.compat import _PY3
-from twisted.trial import unittest
 from twisted.trial.unittest import SynchronousTestCase as TestCase
 from twisted.python import reflect
 from twisted.python.reflect import (
@@ -544,15 +543,6 @@ class SafeStrTests(TestCase):
         self.assertEqual(reflect.safe_str(x), 'a')
 
 
-    def test_workingUtf8_2(self):
-        """
-        L{safe_str} for C{str} with utf-8 encoded data should return the
-        value unchanged.
-        """
-        x = b't\xc3\xbcst'
-        self.assertEqual(reflect.safe_str(x), x)
-
-
     def test_workingUtf8_3(self):
         """
         L{safe_str} for C{bytes} with utf-8 encoded data should return
@@ -560,16 +550,6 @@ class SafeStrTests(TestCase):
         """
         x = b't\xc3\xbcst'
         self.assertEqual(reflect.safe_str(x), x.decode('utf-8'))
-
-    if _PY3:
-        # TODO: after something like python.compat.nativeUtf8String is
-        # introduced, use that one for assertEqual. Then we can combine
-        # test_workingUtf8_* tests into one without needing _PY3.
-        # nativeUtf8String is needed for Python 3 anyway.
-        test_workingUtf8_2.skip = ("Skip Python 2 specific test for utf-8 str")
-    else:
-        test_workingUtf8_3.skip = (
-            "Skip Python 3 specific test for utf-8 bytes")
 
 
     def test_brokenUtf8(self):
@@ -748,7 +728,8 @@ class FullyQualifiedNameTests(TestCase):
             "%s.%s.test_unboundMethod" % (__name__, self.__class__.__name__))
 
 
-class ObjectGrepTests(unittest.TestCase):
+
+class ObjectGrepTests(TestCase):
     if _PY3:
         # This is to be removed when fixing #6986
         skip = "twisted.python.reflect.objgrep hasn't been ported to Python 3"
@@ -870,19 +851,8 @@ class ObjectGrepTests(unittest.TestCase):
         self.assertIn("[1]", reflect.objgrep(D, o, reflect.isSame))
 
 
-class GetClassTests(unittest.TestCase):
-    if _PY3:
-        oldClassNames = ['type']
-    else:
-        oldClassNames = ['class', 'classobj']
 
-    def test_old(self):
-        class OldClass:
-            pass
-        old = OldClass()
-        self.assertIn(reflect.getClass(OldClass).__name__, self.oldClassNames)
-        self.assertEqual(reflect.getClass(old).__name__, 'OldClass')
-
+class GetClassTests(TestCase):
     def test_new(self):
         class NewClass(object):
             pass

--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -6,7 +6,7 @@ Tests for twisted SSL support.
 """
 
 from twisted.python.filepath import FilePath
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.internet import protocol, reactor, interfaces, defer
 from twisted.internet.error import ConnectionDone
 from twisted.protocols import basic
@@ -271,11 +271,13 @@ if SSL is not None:
 
 
 
-class StolenTCPTests(ProperlyCloseFilesMixin, unittest.TestCase):
+class StolenTCPTests(ProperlyCloseFilesMixin, TestCase):
     """
     For SSL transports, test many of the same things which are tested for
     TCP transports.
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
 
     def createServer(self, address, portNumber, factory):
         """
@@ -327,13 +329,16 @@ class StolenTCPTests(ProperlyCloseFilesMixin, unittest.TestCase):
 
 
 
-class TLSTests(unittest.TestCase):
+class TLSTests(TestCase):
     """
     Tests for startTLS support.
 
     @ivar fillBuffer: forwarded to L{LineCollector.fillBuffer}
     @type fillBuffer: C{bool}
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
+
     fillBuffer = False
 
     clientProto = None
@@ -436,11 +441,18 @@ class SpammyTLSTests(TLSTests):
     """
     Test TLS features with bytes sitting in the out buffer.
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
+
     fillBuffer = True
 
 
 
-class BufferingTests(unittest.TestCase):
+class BufferingTests(TestCase):
+
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
+
     serverProto = None
     clientProto = None
 
@@ -480,10 +492,12 @@ class BufferingTests(unittest.TestCase):
 
 
 
-class ConnectionLostTests(unittest.TestCase, ContextGeneratingMixin):
+class ConnectionLostTests(TestCase, ContextGeneratingMixin):
     """
     SSL connection closing tests.
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
 
     def testImmediateDisconnect(self):
         org = "twisted.test.test_ssl"
@@ -632,10 +646,13 @@ class FakeContext:
 
 
 
-class DefaultOpenSSLContextFactoryTests(unittest.TestCase):
+class DefaultOpenSSLContextFactoryTests(TestCase):
     """
     Tests for L{ssl.DefaultOpenSSLContextFactory}.
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
+
     def setUp(self):
         # pyOpenSSL Context objects aren't introspectable enough.  Pass in
         # an alternate context factory so we can inspect what is done to it.
@@ -684,10 +701,13 @@ class DefaultOpenSSLContextFactoryTests(unittest.TestCase):
 
 
 
-class ClientContextFactoryTests(unittest.TestCase):
+class ClientContextFactoryTests(TestCase):
     """
     Tests for L{ssl.ClientContextFactory}.
     """
+    if interfaces.IReactorSSL(reactor, None) is None:
+        skip = "Reactor does not support SSL, cannot run SSL tests"
+
     def setUp(self):
         self.contextFactory = ssl.ClientContextFactory()
         self.contextFactory._contextFactory = FakeContext
@@ -704,12 +724,3 @@ class ClientContextFactoryTests(unittest.TestCase):
                          SSL.OP_NO_SSLv2)
         self.assertFalse(self.context._options & SSL.OP_NO_SSLv3)
         self.assertFalse(self.context._options & SSL.OP_NO_TLSv1)
-
-
-
-if interfaces.IReactorSSL(reactor, None) is None:
-    for tCase in [StolenTCPTests, TLSTests, SpammyTLSTests,
-                  BufferingTests, ConnectionLostTests,
-                  DefaultOpenSSLContextFactoryTests,
-                  ClientContextFactoryTests]:
-        tCase.skip = "Reactor does not support SSL, cannot run SSL tests"

--- a/src/twisted/test/test_strerror.py
+++ b/src/twisted/test/test_strerror.py
@@ -8,6 +8,8 @@ Test strerror
 import socket
 import os
 
+from unittest import skipIf
+
 from twisted.trial.unittest import TestCase
 from twisted.internet.tcp import ECONNABORTED
 from twisted.python.win32 import _ErrorFormatter, formatError
@@ -96,6 +98,7 @@ class ErrorFormatingTests(TestCase):
         self.assertEqual(message, self.probeMessage)
 
 
+    @skipIf(platform.getType() != "win32", "Test will run only on Windows.")
     def test_fromEnvironment(self):
         """
         L{_ErrorFormatter.fromEnvironment} should create an L{_ErrorFormatter}
@@ -123,10 +126,8 @@ class ErrorFormatingTests(TestCase):
                 formatter.formatError(self.probeErrorCode),
                 errorTab[self.probeErrorCode])
 
-    if platform.getType() != "win32":
-        test_fromEnvironment.skip = "Test will run only on Windows."
 
-
+    @skipIf(platform.getType() != "win32", "Test will run only on Windows.")
     def test_correctLookups(self):
         """
         Given a known-good errno, make sure that formatMessage gives results
@@ -146,6 +147,3 @@ class ErrorFormatingTests(TestCase):
             pass
 
         self.assertIn(formatError(ECONNABORTED), acceptable)
-
-    if platform.getType() != "win32":
-        test_correctLookups.skip = "Test will run only on Windows."

--- a/src/twisted/test/test_tcp_internals.py
+++ b/src/twisted/test/test_tcp_internals.py
@@ -37,6 +37,7 @@ class PlatformAssumptionsTests(TestCase):
     """
     Test assumptions about platform behaviors.
     """
+
     socketLimit = 8192
 
     def setUp(self):
@@ -78,6 +79,9 @@ class PlatformAssumptionsTests(TestCase):
         return s
 
 
+    @skipIf(platform.getType() == "win32",
+            "Windows requires an unacceptably large amount of resources to "
+            "provoke this behavior in the naive manner.")
     def test_acceptOutOfFiles(self):
         """
         Test that the platform accept(2) call fails with either L{EMFILE} or
@@ -115,10 +119,6 @@ class PlatformAssumptionsTests(TestCase):
         # Make sure that the accept call fails in the way we expect.
         exc = self.assertRaises(socket.error, port.accept)
         self.assertIn(exc.args[0], (EMFILE, ENOBUFS))
-    if platform.getType() == "win32":
-        test_acceptOutOfFiles.skip = (
-            "Windows requires an unacceptably large amount of resources to "
-            "provoke this behavior in the naive manner.")
 
 
 
@@ -224,6 +224,8 @@ class SelectReactorTests(TestCase):
         return self._acceptFailureTest(ECONNABORTED)
 
 
+    @skipIf(platform.getType() == 'win32',
+            "Windows accept(2) cannot generate ENFILE")
     def test_noFilesFromAccept(self):
         """
         Similar to L{test_tooManyFilesFromAccept}, but test the case where
@@ -233,10 +235,10 @@ class SelectReactorTests(TestCase):
         of inodes.
         """
         return self._acceptFailureTest(ENFILE)
-    if platform.getType() == 'win32':
-        test_noFilesFromAccept.skip = "Windows accept(2) cannot generate ENFILE"
 
 
+    @skipIf(platform.getType() == 'win32',
+            "Windows accept(2) cannot generate ENOMEM")
     def test_noMemoryFromAccept(self):
         """
         Similar to L{test_tooManyFilesFromAccept}, but test the case where
@@ -249,11 +251,10 @@ class SelectReactorTests(TestCase):
         memory).
         """
         return self._acceptFailureTest(ENOMEM)
-    if platform.getType() == 'win32':
-        test_noMemoryFromAccept.skip = (
-            "Windows accept(2) cannot generate ENOMEM")
 
 
+    @skipIf(os.environ.get("INFRASTRUCTURE") == "AZUREPIPELINES",
+            "Hangs on Azure Pipelines due to firewall")
     def test_acceptScaling(self):
         """
         L{tcp.Port.doRead} increases the number of consecutive
@@ -295,10 +296,9 @@ class SelectReactorTests(TestCase):
         # accept should be tried next.
         self.assertEqual(port.numberAccepts, 1)
 
-    if os.environ.get("INFRASTRUCTURE") == "AZUREPIPELINES":
-        test_acceptScaling.skip = "Hangs on Azure Pipelines due to firewall"
 
-
+    @skipIf(platform.getType() == 'win32',
+            "Windows accept(2) cannot generate EPERM")
     def test_permissionFailure(self):
         """
         C{accept(2)} returning C{EPERM} is treated as a transient
@@ -342,10 +342,6 @@ class SelectReactorTests(TestCase):
         # This is scaled down to 1 because no accept(2)s returned
         # successfully.
         self.assertEquals(port.numberAccepts, 1)
-
-    if platform.getType() == 'win32':
-        test_permissionFailure.skip = (
-            "Windows accept(2) cannot generate EPERM")
 
 
     def test_unknownSocketErrorRaise(self):

--- a/src/twisted/test/test_unix.py
+++ b/src/twisted/test/test_unix.py
@@ -8,14 +8,13 @@ Tests for implementations of L{IReactorUNIX} and L{IReactorUNIXDatagram}.
 
 import os
 import sys
-import types
 import socket
 from unittest import skipIf
 
 from twisted.internet import interfaces, reactor, protocol, error, address
 from twisted.internet import defer, utils
 from twisted.python import lockfile
-from twisted.python.compat import _PY3, networkString
+from twisted.python.compat import networkString
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
@@ -37,6 +36,10 @@ class UnixSocketTests(unittest.TestCase):
     """
     Test unix sockets.
     """
+
+    if not interfaces.IReactorUNIX(reactor, None):
+        skip = "This reactor does not support UNIX domain sockets"
+
     def test_peerBind(self):
         """
         The address passed to the server factory's C{buildProtocol} method and
@@ -215,31 +218,6 @@ class UnixSocketTests(unittest.TestCase):
         return d
 
 
-    def test_reprWithClassicFactory(self):
-        """
-        The two string representations of the L{IListeningPort} returned by
-        L{IReactorUNIX.listenUNIX} contains the name of the classic factory
-        class being used and the filename on which the port is listening or
-        indicates that the port is not listening.
-        """
-        class ClassicFactory:
-            def doStart(self):
-                pass
-
-            def doStop(self):
-                pass
-
-        # Sanity check
-        self.assertIsInstance(ClassicFactory, types.ClassType)
-
-        return self._reprTest(
-            ClassicFactory(), "twisted.test.test_unix.ClassicFactory")
-
-    if _PY3:
-        test_reprWithClassicFactory.skip = (
-            "Classic classes do not exist on Python 3.")
-
-
     def test_reprWithNewStyleFactory(self):
         """
         The two string representations of the L{IListeningPort} returned by
@@ -312,6 +290,7 @@ class DatagramUnixSocketTests(unittest.TestCase):
     """
     Test datagram UNIX sockets.
     """
+
     def test_exchange(self):
         """
         Test that a datagram can be sent to and received by a server and vice
@@ -377,31 +356,6 @@ class DatagramUnixSocketTests(unittest.TestCase):
             self.assertEqual(str(unixPort), unconnectedString)
         stopDeferred.addCallback(stoppedListening)
         return stopDeferred
-
-
-    def test_reprWithClassicProtocol(self):
-        """
-        The two string representations of the L{IListeningPort} returned by
-        L{IReactorUNIXDatagram.listenUNIXDatagram} contains the name of the
-        classic protocol class being used and the filename on which the port is
-        listening or indicates that the port is not listening.
-        """
-        class ClassicProtocol:
-            def makeConnection(self, transport):
-                pass
-
-            def doStop(self):
-                pass
-
-        # Sanity check
-        self.assertIsInstance(ClassicProtocol, types.ClassType)
-
-        return self._reprTest(
-            ClassicProtocol(), "twisted.test.test_unix.ClassicProtocol")
-
-    if _PY3:
-        test_reprWithClassicProtocol.skip = (
-            "Classic classes do not exist on Python 3.")
 
 
     def test_reprWithNewStyleProtocol(self):

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -184,7 +184,7 @@ class TimeoutTests(unittest.TestCase):
     def test_skip(self):
         return defer.Deferred()
     test_skip.timeout = 0.1
-    test_skip.skip = "i will get it right, eventually"
+    test_skip.skip = "i will get it right, eventually"  # type: ignore[attr-defined]  # noqa
 
     def test_errorPropagation(self):
         def timedOut(err):

--- a/src/twisted/trial/test/skipping.py
+++ b/src/twisted/trial/test/skipping.py
@@ -20,13 +20,15 @@ class SkippingMixin(object):
     def test_skip1(self):
         raise SkipTest('skip1')
 
+
     def test_skip2(self):
         raise RuntimeError("I should not get raised")
-    test_skip2.skip = 'skip2'
+    test_skip2.skip = 'skip2'  # type: ignore
+
 
     def test_skip3(self):
         self.fail('I should not fail')
-    test_skip3.skip = 'skip3'
+    test_skip3.skip = 'skip3'  # type: ignore
 
 
 
@@ -44,11 +46,14 @@ class SkippingSetUpMixin(object):
     def setUp(self):
         raise SkipTest('skipSetUp')
 
+
     def test_1(self):
         pass
 
+
     def test_2(self):
         pass
+
 
 
 class SynchronousSkippingSetUp(SkippingSetUpMixin, SynchronousTestCase):
@@ -81,15 +86,25 @@ class AsynchronousDeprecatedReasonlessSkip(
 
 class SkippedClassMixin(object):
     skip = 'class'
+
     def setUp(self):
         self.__class__._setUpRan = True
+
+
     def test_skip1(self):
         raise SkipTest('skip1')
+
+
     def test_skip2(self):
         raise RuntimeError("Ought to skip me")
-    test_skip2.skip = 'skip2'
+
+    test_skip2.skip = 'skip2'  # type: ignore
+
+
     def test_skip3(self):
         pass
+
+
     def test_skip4(self):
         raise RuntimeError("Skip me too")
 
@@ -108,15 +123,17 @@ class AsynchronousSkippedClass(SkippedClassMixin, TestCase):
 class TodoMixin(object):
     def test_todo1(self):
         self.fail("deliberate failure")
-    test_todo1.todo = "todo1"
+    test_todo1.todo = "todo1"  # type: ignore
+
 
     def test_todo2(self):
         raise RuntimeError("deliberate error")
-    test_todo2.todo = "todo2"
+    test_todo2.todo = "todo2"  # type: ignore
+
 
     def test_todo3(self):
         """unexpected success"""
-    test_todo3.todo = 'todo3'
+    test_todo3.todo = 'todo3'  # type: ignore
 
 
 
@@ -135,9 +152,10 @@ class SetUpTodoMixin(object):
     def setUp(self):
         raise RuntimeError("deliberate error")
 
+
     def test_todo1(self):
         pass
-    test_todo1.todo = "setUp todo1"
+    test_todo1.todo = "setUp todo1"  # type: ignore
 
 
 
@@ -155,9 +173,10 @@ class TearDownTodoMixin(object):
     def tearDown(self):
         raise RuntimeError("deliberate error")
 
+
     def test_todo1(self):
         pass
-    test_todo1.todo = "tearDown todo1"
+    test_todo1.todo = "tearDown todo1"  # type: ignore
 
 
 

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -749,7 +749,7 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
         """
         self.assertDictEqual({'a': 1}, {'a': 1})
     if getattr(unittest.SynchronousTestCase, 'assertDictEqual', None) is None:
-        test_assertDictEqual.skip = (
+        test_assertDictEqual.skip = (  # type: ignore[attr-defined]
             "assertDictEqual is not available on this version of Python")
 
 

--- a/src/twisted/trial/test/test_pyunitcompat.py
+++ b/src/twisted/trial/test/test_pyunitcompat.py
@@ -5,6 +5,7 @@
 import sys
 import traceback
 
+from unittest import skipIf
 from zope.interface import implementer
 
 from twisted.python.failure import Failure
@@ -227,9 +228,9 @@ class PyUnitResultTests(SynchronousTestCase):
         the L{pyunit.TestResult}.
         """
         class SkipTest(SynchronousTestCase):
+            @skipIf(True, "Let's skip!")
             def test_skip(self):
                 1/0
-            test_skip.skip = "Let's skip!"
 
         test = SkipTest('test_skip')
         result = pyunit.TestResult()

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -844,6 +844,8 @@ class UnhandledDeferredTests(unittest.SynchronousTestCase):
         self.assertEqual(len(result.errors), 1,
                          'Unhandled deferred passed without notice')
 
+
+    @pyunit.skipIf(_PYPY, "GC works differently on PyPy.")
     def test_doesntBleed(self):
         """
         Forcing garbage collection in the test should mean that there are
@@ -860,8 +862,6 @@ class UnhandledDeferredTests(unittest.SynchronousTestCase):
         x = self.flushLoggedErrors()
         self.assertEqual(len(x), 0, 'Errors logged after gc.collect')
 
-    if _PYPY:
-        test_doesntBleed.skip = "GC works differently on PyPy."
 
     def tearDown(self):
         """

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -8,7 +8,7 @@ Tests for L{twisted.web.client.Agent} and related new client APIs.
 import zlib
 
 from io import BytesIO
-
+from unittest import skipIf
 from zope.interface.verify import verifyObject
 
 from twisted.trial.unittest import TestCase, SynchronousTestCase
@@ -62,12 +62,10 @@ try:
     from twisted.internet import ssl as _ssl
 except ImportError:
     ssl = None
-    skipWhenNoSSL = "SSL not present, cannot run SSL tests."
-    skipWhenSSLPresent = None
+    sslPresent = False
 else:
     ssl = _ssl
-    skipWhenSSLPresent = "SSL present."
-    skipWhenNoSSL = None
+    sslPresent = True
     from twisted.internet._sslverify import ClientTLSOptions, IOpenSSLTrustRoot
     from twisted.internet.ssl import optionsForClientTLS
     from twisted.protocols.tls import TLSMemoryBIOProtocol, TLSMemoryBIOFactory
@@ -1247,6 +1245,7 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         self.assertEqual(5, timeout)
 
 
+    @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_connectTimeoutHTTPS(self):
         """
         L{Agent} takes a C{connectTimeout} argument which is forwarded to the
@@ -1256,8 +1255,6 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         agent.request(b'GET', b'https://foo/')
         timeout = self.reactor.tcpClients.pop()[3]
         self.assertEqual(5, timeout)
-
-    test_connectTimeoutHTTPS.skip = skipWhenNoSSL
 
 
     def test_bindAddress(self):
@@ -1271,6 +1268,7 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         self.assertEqual('192.168.0.1', address)
 
 
+    @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_bindAddressSSL(self):
         """
         L{Agent} takes a C{bindAddress} argument which is forwarded to the
@@ -1280,8 +1278,6 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
         agent.request(b'GET', b'https://foo/')
         address = self.reactor.tcpClients.pop()[4]
         self.assertEqual('192.168.0.1', address)
-
-    test_bindAddressSSL.skip = skipWhenNoSSL
 
 
     def test_responseIncludesRequest(self):
@@ -1416,13 +1412,12 @@ class AgentURIInjectionTests(
 
 
 
+@skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
 class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin,
                       IntegrationTestingMixin):
     """
     Tests for the new HTTP client API that depends on SSL.
     """
-    skip = skipWhenNoSSL
-
     def makeEndpoint(self, host=b'example.com', port=443):
         """
         Create an L{Agent} with an https scheme and return its endpoint
@@ -1657,6 +1652,7 @@ class WebClientContextFactoryTests(TestCase):
         )
 
 
+    @skipIf(sslPresent, "SSL Present.")
     def test_missingSSL(self):
         """
         If C{getContext} is called and SSL is not available, raise
@@ -1669,6 +1665,7 @@ class WebClientContextFactoryTests(TestCase):
         )
 
 
+    @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_returnsContext(self):
         """
         If SSL is present, C{getContext} returns a L{OpenSSL.SSL.Context}.
@@ -1677,6 +1674,7 @@ class WebClientContextFactoryTests(TestCase):
         self.assertIsInstance(ctx, ssl.SSL.Context)
 
 
+    @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_setsTrustRootOnContextToDefaultTrustRoot(self):
         """
         The L{CertificateOptions} has C{trustRoot} set to the default trust
@@ -1686,11 +1684,6 @@ class WebClientContextFactoryTests(TestCase):
         certificateOptions = ctx._getCertificateOptions('example.com', 443)
         self.assertIsInstance(
             certificateOptions.trustRoot, ssl.OpenSSLDefaultPaths)
-
-    test_returnsContext.skip \
-        = test_setsTrustRootOnContextToDefaultTrustRoot.skip \
-        = skipWhenNoSSL
-    test_missingSSL.skip = skipWhenSSLPresent
 
 
 
@@ -2117,6 +2110,7 @@ class CookieAgentTests(TestCase, CookieTestsMixin, FakeReactorAndConnectMixin,
         self.assertEqual(req.headers.getRawHeaders(b'cookie'), [cookie])
 
 
+    @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_secureCookie(self):
         """
         L{CookieAgent} is able to handle secure cookies, ie cookies which
@@ -2135,8 +2129,6 @@ class CookieAgentTests(TestCase, CookieTestsMixin, FakeReactorAndConnectMixin,
 
         req, res = self.protocol.requests.pop()
         self.assertEqual(req.headers.getRawHeaders(b'cookie'), [b'foo=1'])
-
-    test_secureCookie.skip = skipWhenNoSSL
 
 
     def test_secureCookieOnInsecureConnection(self):
@@ -3199,9 +3191,8 @@ class ReadBodyTests(TestCase):
 
 
 
+@skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
 class HostnameCachingHTTPSPolicyTests(TestCase):
-
-    skip = skipWhenNoSSL
 
     def test_cacheIsUsed(self):
         """

--- a/src/twisted/web/test/test_distrib.py
+++ b/src/twisted/web/test/test_distrib.py
@@ -14,11 +14,12 @@ except ImportError:
 else:
     pwd = _pwd
 
+from unittest import skipIf
 from zope.interface.verify import verifyObject
 
 from twisted.python import filepath, failure
 from twisted.internet import reactor, defer
-from twisted.trial import unittest
+from twisted.trial.unittest import TestCase
 from twisted.spread import pb
 from twisted.spread.banana import SIZE_LIMIT
 from twisted.web import distrib, client, resource, static, server
@@ -56,7 +57,7 @@ class ArbitraryError(Exception):
 
 
 
-class DistribTests(unittest.TestCase):
+class DistribTests(TestCase):
     port1 = None
     port2 = None
     sub = None
@@ -392,7 +393,7 @@ class _PasswordDatabase:
 
 
 
-class UserDirectoryTests(unittest.TestCase):
+class UserDirectoryTests(TestCase):
     """
     Tests for L{UserDirectory}, a resource for listing all user resources
     available on a system.
@@ -517,6 +518,7 @@ class UserDirectoryTests(unittest.TestCase):
         return result
 
 
+    @skipIf(not pwd, "pwd module required")
     def test_passwordDatabase(self):
         """
         If L{UserDirectory} is instantiated with no arguments, it uses the
@@ -524,6 +526,3 @@ class UserDirectoryTests(unittest.TestCase):
         """
         directory = distrib.UserDirectory()
         self.assertIdentical(directory._pwd, pwd)
-    if pwd is None:
-        test_passwordDatabase.skip = "pwd module required"
-

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -8,6 +8,7 @@ L{twisted.web._flatten}.
 
 import sys
 import traceback
+from unittest import skipIf
 
 from xml.etree.cElementTree import XML
 
@@ -344,6 +345,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         ])
 
 
+    @skipIf(not _PY35PLUS, "coroutines not available before Python 3.5")
     def test_serializeCoroutine(self):
         """
         Test that a coroutine returning a value is substituted with the that
@@ -361,12 +363,8 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         return self.assertFlattensTo(coro('four'), b'four')
 
-    if not _PY35PLUS:
-        test_serializeCoroutine.skip = (
-            "coroutines not available before Python 3.5"
-        )
 
-
+    @skipIf(not _PY35PLUS, "coroutines not available before Python 3.5")
     def test_serializeCoroutineWithAwait(self):
         """
         Test that a coroutine returning an awaited deferred value is
@@ -383,11 +381,6 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         coro = namespace["coro"]
 
         return self.assertFlattensTo(coro('four'), b'four')
-
-    if not _PY35PLUS:
-        test_serializeCoroutineWithAwait.skip = (
-            "coroutines not available before Python 3.5"
-        )
 
 
     def test_serializeIRenderable(self):

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -13,6 +13,7 @@ import random
 import hamcrest
 
 from urllib.parse import urlparse, urlunsplit, clear_cache, parse_qs
+from unittest import skipIf
 
 from io import BytesIO
 from itertools import cycle
@@ -771,6 +772,7 @@ class GenericHTTPChannelTests(unittest.TestCase):
         return a._negotiatedProtocol
 
 
+    @skipIf(not http.H2_ENABLED, "HTTP/2 support not present")
     def test_h2CancelsH11Timeout(self):
         """
         When the transport is switched to H2, the HTTPChannel timeouts are
@@ -820,9 +822,6 @@ class GenericHTTPChannelTests(unittest.TestCase):
             ),
         )
 
-    if not http.H2_ENABLED:
-        test_h2CancelsH11Timeout.skip = "HTTP/2 support not present"
-
 
     def test_protocolUnspecified(self):
         """
@@ -856,6 +855,7 @@ class GenericHTTPChannelTests(unittest.TestCase):
         self.assertEqual(negotiatedProtocol, b'http/1.1')
 
 
+    @skipIf(not http.H2_ENABLED, "HTTP/2 support not present")
     def test_http2_present(self):
         """
         If the transport reports that HTTP/2 is negotiated and HTTP/2 is
@@ -865,10 +865,9 @@ class GenericHTTPChannelTests(unittest.TestCase):
         b.negotiatedProtocol = b'h2'
         negotiatedProtocol = self._negotiatedProtocolForTransportInstance(b)
         self.assertEqual(negotiatedProtocol, b'h2')
-    if not http.H2_ENABLED:
-        test_http2_present.skip = "HTTP/2 support not present"
 
 
+    @skipIf(http.H2_ENABLED, "HTTP/2 support present")
     def test_http2_absent(self):
         """
         If the transport reports that HTTP/2 is negotiated and HTTP/2 is not
@@ -881,8 +880,6 @@ class GenericHTTPChannelTests(unittest.TestCase):
             self._negotiatedProtocolForTransportInstance,
             b,
         )
-    if http.H2_ENABLED:
-        test_http2_absent.skip = "HTTP/2 support present"
 
 
     def test_unknownProtocol(self):
@@ -921,6 +918,7 @@ class GenericHTTPChannelTests(unittest.TestCase):
         self.assertEqual(protocol._channel.callLater, clock.callLater)
 
 
+    @skipIf(not http.H2_ENABLED, "HTTP/2 support not present")
     def test_genericHTTPChannelCallLaterUpgrade(self):
         """
         If C{callLater} is patched onto the L{http._GenericHTTPChannelProtocol}
@@ -944,12 +942,9 @@ class GenericHTTPChannelTests(unittest.TestCase):
 
         self.assertEqual(protocol.callLater, clock.callLater)
         self.assertEqual(protocol._channel.callLater, clock.callLater)
-    if not http.H2_ENABLED:
-        test_genericHTTPChannelCallLaterUpgrade.skip = (
-            "HTTP/2 support not present"
-        )
 
 
+    @skipIf(not http.H2_ENABLED, "HTTP/2 support not present")
     def test_unregistersProducer(self):
         """
         The L{_GenericHTTPChannelProtocol} will unregister its proxy channel
@@ -977,9 +972,6 @@ class GenericHTTPChannelTests(unittest.TestCase):
 
         # ...it should have the new H2 channel as its producer
         self.assertIs(transport.producer, genericProtocol._channel)
-
-    if not http.H2_ENABLED:
-        test_unregistersProducer.skip = "HTTP/2 support not present"
 
 
 

--- a/src/twisted/web/test/test_soap.py
+++ b/src/twisted/web/test/test_soap.py
@@ -14,9 +14,11 @@ else:
     from twisted.web import soap
     SOAPPublisher = soap.SOAPPublisher
 
-from twisted.trial import unittest
+from unittest import skipIf
+from twisted.trial.unittest import TestCase
 from twisted.web import server, error
 from twisted.internet import reactor, defer
+
 
 
 class Test(SOAPPublisher):
@@ -24,12 +26,15 @@ class Test(SOAPPublisher):
     def soap_add(self, a, b):
         return a + b
 
+
     def soap_kwargs(self, a=1, b=2):
         return a + b
-    soap_kwargs.useKeywords=True
+    soap_kwargs.useKeywords = True
+
 
     def soap_triple(self, string, num):
         return [string, num, None]
+
 
     def soap_struct(self):
         return SOAPpy.structType({"a": "c"})
@@ -37,23 +42,30 @@ class Test(SOAPPublisher):
     def soap_defer(self, x):
         return defer.succeed(x)
 
+
     def soap_deferFail(self):
         return defer.fail(ValueError())
+
 
     def soap_fail(self):
         raise RuntimeError
 
+
     def soap_deferFault(self):
         return defer.fail(ValueError())
 
+
     def soap_complex(self):
         return {"a": ["b", "c", 12, []], "D": "foo"}
+
 
     def soap_dict(self, map, key):
         return map[key]
 
 
-class SOAPTests(unittest.TestCase):
+
+@skipIf(not SOAPpy, "SOAPpy not installed")
+class SOAPTests(TestCase):
 
     def setUp(self):
         self.publisher = Test()
@@ -61,11 +73,14 @@ class SOAPTests(unittest.TestCase):
                                    interface="127.0.0.1")
         self.port = self.p.getHost().port
 
+
     def tearDown(self):
         return self.p.stopListening()
 
+
     def proxy(self):
         return soap.Proxy("http://127.0.0.1:%d/" % self.port)
+
 
     def testResults(self):
         inputOutput = [
@@ -86,8 +101,10 @@ class SOAPTests(unittest.TestCase):
         d.addCallback(self.assertEqual, {"a": ["b", "c", 12, []], "D": "foo"})
         dl.append(d)
 
-        # We now return to our regularly scheduled program, already in progress.
+        # We now return to our regularly scheduled program,
+        # already in progress.
         return defer.DeferredList(dl, fireOnOneErrback=True)
+
 
     def testMethodNotFound(self):
         """
@@ -100,6 +117,7 @@ class SOAPTests(unittest.TestCase):
         d.addCallback(cb)
         return d
 
+
     def testLookupFunction(self):
         """
         Test lookupFunction method on publisher, to see available remote
@@ -108,7 +126,3 @@ class SOAPTests(unittest.TestCase):
         self.assertTrue(self.publisher.lookupFunction("add"))
         self.assertTrue(self.publisher.lookupFunction("fail"))
         self.assertFalse(self.publisher.lookupFunction("foobar"))
-
-if not SOAPpy:
-    SOAPTests.skip = "SOAPpy not installed"
-

--- a/src/twisted/web/test/test_stan.py
+++ b/src/twisted/web/test/test_stan.py
@@ -9,7 +9,8 @@ implementation.
 
 from twisted.web.template import Comment, CDATA, CharRef, Tag
 from twisted.trial.unittest import TestCase
-from twisted.python.compat import _PY3
+
+
 
 def proto(*a, **kw):
     """
@@ -113,24 +114,6 @@ class TagTests(TestCase):
         self.assertEqual(tag.attributes, {'class': 'a'})
 
 
-    def test_commentReprPy2(self):
-        """
-        L{Comment.__repr__} returns a value which makes it easy to see what's
-        in the comment.
-        """
-        self.assertEqual(repr(Comment(u"hello there")),
-                          "Comment(u'hello there')")
-
-
-    def test_cdataReprPy2(self):
-        """
-        L{CDATA.__repr__} returns a value which makes it easy to see what's in
-        the comment.
-        """
-        self.assertEqual(repr(CDATA(u"test data")),
-                          "CDATA(u'test data')")
-
-
     def test_commentReprPy3(self):
         """
         L{Comment.__repr__} returns a value which makes it easy to see what's
@@ -146,14 +129,7 @@ class TagTests(TestCase):
         the comment.
         """
         self.assertEqual(repr(CDATA(u"test data")),
-                          "CDATA('test data')")
-
-    if not _PY3:
-        test_commentReprPy3.skip = "Only relevant on Python 3."
-        test_cdataReprPy3.skip = "Only relevant on Python 3."
-    else:
-        test_commentReprPy2.skip = "Only relevant on Python 2."
-        test_cdataReprPy2.skip = "Only relevant on Python 2."
+                         "CDATA('test data')")
 
 
     def test_charrefRepr(self):

--- a/src/twisted/web/test/test_static.py
+++ b/src/twisted/web/test/test_static.py
@@ -14,7 +14,7 @@ import warnings
 
 
 from io import BytesIO as StringIO
-
+from unittest import skipIf
 from zope.interface.verify import verifyObject
 
 from twisted.internet import abstract, interfaces
@@ -199,6 +199,7 @@ class StaticFileTests(TestCase):
         return d
 
 
+    @skipIf(platform.isWindows(), "Cannot remove read permission on Windows")
     def test_forbiddenResource(self):
         """
         If the file in the filesystem which would satisfy a request cannot be
@@ -219,8 +220,6 @@ class StaticFileTests(TestCase):
             self.assertEqual(request.responseCode, 403)
         d.addCallback(cbRendered)
         return d
-    if platform.isWindows():
-        test_forbiddenResource.skip = "Cannot remove read permission on Windows"
 
 
     def test_undecodablePath(self):
@@ -333,6 +332,9 @@ class StaticFileTests(TestCase):
         return d
 
 
+    @skipIf(sys.getfilesystemencoding().lower() not in ('utf-8', 'mcbs'),
+            "Cannot write unicode filenames with file system encoding of"
+            " {}".format(sys.getfilesystemencoding()))
     def test_staticFileUnicodeFileName(self):
         """
         A request for a existing unicode file path encoded as UTF-8
@@ -357,10 +359,6 @@ class StaticFileTests(TestCase):
                 networkString(str(len(content))))
         d.addCallback(cbRendered)
         return d
-    if sys.getfilesystemencoding().lower() not in ('utf-8', 'mcbs'):
-        test_staticFileUnicodeFileName.skip = (
-            "Cannot write unicode filenames with file system encoding of"
-            " %s" % (sys.getfilesystemencoding(),))
 
 
     def test_staticFileDeletedGetChild(self):
@@ -1714,6 +1712,7 @@ class DirectoryListerTests(TestCase):
              'type': '[text/diff]'}])
 
 
+    @skipIf(not platform._supportsSymlinks(), "No symlink support")
     def test_brokenSymlink(self):
         """
         If on the file in the listing points to a broken symlink, it should not
@@ -1732,9 +1731,6 @@ class DirectoryListerTests(TestCase):
         dirs, files = lister._getFilesAndDirectories(directory)
         self.assertEqual(dirs, [])
         self.assertEqual(files, [])
-
-    if not platform._supportsSymlinks():
-        test_brokenSymlink.skip = "No symlink support"
 
 
     def test_childrenNotFound(self):

--- a/src/twisted/web/test/test_tap.py
+++ b/src/twisted/web/test/test_tap.py
@@ -9,6 +9,8 @@ Tests for L{twisted.web.tap}.
 import os
 import stat
 
+from unittest import skipIf
+
 from twisted.internet import reactor, endpoints
 from twisted.internet.interfaces import IReactorUNIX
 from twisted.python.filepath import FilePath
@@ -63,6 +65,8 @@ class ServiceTests(TestCase):
         self.assertEqual(root.path, path.path)
 
 
+    @skipIf(not IReactorUNIX.providedBy(reactor),
+            "The reactor does not support UNIX domain sockets")
     def test_pathServer(self):
         """
         The I{--path} option to L{makeService} causes it to return a service
@@ -80,10 +84,6 @@ class ServiceTests(TestCase):
         self.assertEqual(service.services[0].factory.resource.path, path.path)
         self.assertTrue(os.path.exists(port))
         self.assertTrue(stat.S_ISSOCK(os.stat(port).st_mode))
-
-    if not IReactorUNIX.providedBy(reactor):
-        test_pathServer.skip = (
-            "The reactor does not support UNIX domain sockets")
 
 
     def test_cgiProcessor(self):
@@ -136,6 +136,8 @@ class ServiceTests(TestCase):
         self.assertIdentical(serverFactory.root.site, site)
 
 
+    @skipIf(not IReactorUNIX.providedBy(reactor),
+            "The reactor does not support UNIX domain sockets")
     def test_personalServer(self):
         """
         The I{--personal} option to L{makeService} causes it to return a
@@ -151,11 +153,9 @@ class ServiceTests(TestCase):
         self.assertTrue(os.path.exists(port))
         self.assertTrue(stat.S_ISSOCK(os.stat(port).st_mode))
 
-    if not IReactorUNIX.providedBy(reactor):
-        test_personalServer.skip = (
+
+    @skipIf(not IReactorUNIX.providedBy(reactor),
             "The reactor does not support UNIX domain sockets")
-
-
     def test_defaultPersonalPath(self):
         """
         If the I{--port} option not specified but the I{--personal} option is,
@@ -168,10 +168,6 @@ class ServiceTests(TestCase):
             os.path.join('~', UserDirectory.userSocketName))
         self.assertEqual(options['ports'][0],
                          'unix:{}'.format(path))
-
-    if not IReactorUNIX.providedBy(reactor):
-        test_defaultPersonalPath.skip = (
-            "The reactor does not support UNIX domain sockets")
 
 
     def test_defaultPort(self):
@@ -232,6 +228,8 @@ class ServiceTests(TestCase):
                              "No such WSGI application: %r" % (name,))
 
 
+    @skipIf(requireModule('OpenSSL.SSL') is not None,
+            'SSL module is available.')
     def test_HTTPSFailureOnMissingSSL(self):
         """
         An L{UsageError} is raised when C{https} is requested but there is no
@@ -244,10 +242,9 @@ class ServiceTests(TestCase):
 
         self.assertEqual('SSL support not installed', exception.args[0])
 
-    if requireModule('OpenSSL.SSL') is not None:
-        test_HTTPSFailureOnMissingSSL.skip = 'SSL module is available.'
 
-
+    @skipIf(requireModule('OpenSSL.SSL') is None,
+            'SSL module is not available.')
     def test_HTTPSAcceptedOnAvailableSSL(self):
         """
         When SSL support is present, it accepts the --https option.
@@ -258,9 +255,6 @@ class ServiceTests(TestCase):
 
         self.assertIn('ssl', options['ports'][0])
         self.assertIn('443', options['ports'][0])
-
-    if requireModule('OpenSSL.SSL') is None:
-        test_HTTPSAcceptedOnAvailableSSL.skip = 'SSL module is not available.'
 
 
     def test_add_header_parsing(self):

--- a/src/twisted/web/test/test_webclient.py
+++ b/src/twisted/web/test/test_webclient.py
@@ -866,6 +866,13 @@ class WebClientTests(unittest.TestCase):
 
 
 class WebClientSSLTests(WebClientTests):
+
+    if ssl is None or not hasattr(ssl, 'DefaultOpenSSLContextFactory'):
+        skip = "OpenSSL not present"
+
+    if not interfaces.IReactorSSL(reactor, None):
+        skip = "Reactor doesn't support SSL"
+
     def _listen(self, site):
         return reactor.listenSSL(
             0, site,
@@ -890,12 +897,21 @@ class WebClientSSLTests(WebClientTests):
 class WebClientRedirectBetweenSSLandPlainTextTests(unittest.TestCase):
     suppress = [util.suppress(category=DeprecationWarning)]
 
+    if ssl is None or not hasattr(ssl, 'DefaultOpenSSLContextFactory'):
+        skip = "OpenSSL not present"
+
+    if not interfaces.IReactorSSL(reactor, None):
+        skip = "Reactor doesn't support SSL"
 
     def getHTTPS(self, path):
-        return networkString("https://127.0.0.1:%d/%s" % (self.tlsPortno, path))
+        return networkString("https://127.0.0.1:{}/{}".format(
+            self.tlsPortno, path))
+
 
     def getHTTP(self, path):
-        return networkString("http://127.0.0.1:%d/%s" % (self.plainPortno, path))
+        return networkString("http://127.0.0.1:{}/{}".format(
+            self.plainPortno, path))
+
 
     def setUp(self):
         plainRoot = Data(b'not me', 'text/plain')
@@ -1098,16 +1114,7 @@ class HostHeaderTests(unittest.TestCase):
         proto = factory.buildProtocol('127.42.42.42')
         proto.makeConnection(StringTransport())
         self.assertEqual(self._getHost(proto.transport.value()),
-                          b'foo.example.com:8080')
-
-
-if ssl is None or not hasattr(ssl, 'DefaultOpenSSLContextFactory'):
-    for case in [WebClientSSLTests, WebClientRedirectBetweenSSLandPlainTextTests]:
-        case.skip = "OpenSSL not present"
-
-if not interfaces.IReactorSSL(reactor, None):
-    for case in [WebClientSSLTests, WebClientRedirectBetweenSSLandPlainTextTests]:
-        case.skip = "Reactor doesn't support SSL"
+                         b'foo.example.com:8080')
 
 
 

--- a/src/twisted/web/test/test_xmlrpc.py
+++ b/src/twisted/web/test/test_xmlrpc.py
@@ -9,6 +9,7 @@ Tests for  XML-RPC support in L{twisted.web.xmlrpc}.
 
 from twisted.python.compat import nativeString, networkString, NativeStringIO
 from io import BytesIO
+from unittest import skipIf
 
 import datetime
 
@@ -28,9 +29,10 @@ from twisted.logger import (globalLogPublisher, FilteringLogObserver,
 try:
     namedModule('twisted.internet.ssl')
 except ImportError:
-    sslSkip = "OpenSSL not present"
+    sslSkip = True
 else:
-    sslSkip = None
+    sslSkip = False
+
 
 
 class AsyncXMLRPCTests(unittest.TestCase):
@@ -522,6 +524,7 @@ class XMLRPCTests(unittest.TestCase):
         self.assertEqual(reactor.tcpClients[0][3], 2.0)
 
 
+    @skipIf(sslSkip, "OpenSSL not present")
     def test_sslTimeout(self):
         """
         For I{HTTPS} URIs, L{xmlrpc.Proxy.callRemote} passes the value it
@@ -533,7 +536,6 @@ class XMLRPCTests(unittest.TestCase):
                              reactor=reactor)
         proxy.callRemote("someMethod")
         self.assertEqual(reactor.sslClients[0][4], 3.0)
-    test_sslTimeout.skip = sslSkip
 
 
 

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -8,7 +8,7 @@ Tests for L{twisted.words.xish.domish}, a DOM-like library for XMPP.
 
 from zope.interface.verify import verifyObject
 
-from twisted.python.compat import _PY3, unicode
+from twisted.python.compat import unicode
 from twisted.python.reflect import requireModule
 from twisted.trial import unittest
 from twisted.words.xish import domish
@@ -188,20 +188,6 @@ class ElementTests(unittest.TestCase):
         """
         element = domish.Element((u"testns", u"foo"))
         self.assertRaises(TypeError, element.addContent, b'bytes')
-    if not _PY3:
-        test_addContentBytes.skip = (
-            "Bytes behavior of addContent only provided on Python 3.")
-
-
-    def test_addContentBytesNonASCII(self):
-        """
-        Non-ASCII byte strings passed to C{addContent} yield L{UnicodeError}.
-        """
-        element = domish.Element((u"testns", u"foo"))
-        self.assertRaises(UnicodeError, element.addContent, b'\xe2\x98\x83')
-    if _PY3:
-        test_addContentBytesNonASCII.skip = (
-            "Bytes behavior of addContent only provided on Python 2.")
 
 
     def test_addElementContent(self):

--- a/src/twisted/words/test/test_jabberclient.py
+++ b/src/twisted/words/test/test_jabberclient.py
@@ -8,6 +8,8 @@ Tests for L{twisted.words.protocols.jabber.client}
 
 from hashlib import sha1
 
+from unittest import skipIf
+
 from twisted.internet import defer
 from twisted.python.compat import unicode
 from twisted.trial import unittest
@@ -19,9 +21,9 @@ try:
     from twisted.internet import ssl
 except ImportError:
     ssl = None
-    skipWhenNoSSL = "SSL not available"
+    skipWhenNoSSL = (True, "SSL not available")
 else:
-    skipWhenNoSSL = None
+    skipWhenNoSSL = (False, "")
 
 IQ_AUTH_GET = '/iq[@type="get"]/query[@xmlns="jabber:iq:auth"]'
 IQ_AUTH_SET = '/iq[@type="set"]/query[@xmlns="jabber:iq:auth"]'
@@ -465,6 +467,7 @@ class XMPPAuthenticatorTests(unittest.TestCase):
         self.assertFalse(session.required)
 
 
+    @skipIf(*skipWhenNoSSL)
     def test_tlsConfiguration(self):
         """
         A TLS configuration is passed to the TLS initializer.
@@ -491,6 +494,3 @@ class XMPPAuthenticatorTests(unittest.TestCase):
 
         self.assertIsInstance(tls, xmlstream.TLSInitiatingInitializer)
         self.assertIs(configurationForTLS, configs[0])
-
-
-    test_tlsConfiguration.skip = skipWhenNoSSL

--- a/src/twisted/words/test/test_jabberxmlstream.py
+++ b/src/twisted/words/test/test_jabberxmlstream.py
@@ -5,7 +5,7 @@
 Tests for L{twisted.words.protocols.jabber.xmlstream}.
 """
 
-
+from unittest import skipIf
 from twisted.trial import unittest
 
 from zope.interface.verify import verifyObject
@@ -21,12 +21,13 @@ from twisted.words.xish import domish
 from twisted.words.protocols.jabber import error, ijabber, jid, xmlstream
 
 try:
-    from twisted.internet import ssl
+    from twisted.internet import ssl as _ssl
 except ImportError:
     ssl = None
-    skipWhenNoSSL = "SSL not available"
+    skipWhenNoSSL = (True, "SSL not available")
 else:
-    skipWhenNoSSL = None
+    ssl = _ssl
+    skipWhenNoSSL = (False, "")
     from twisted.internet.ssl import CertificateOptions
     from twisted.internet._sslverify import ClientTLSOptions
 
@@ -695,6 +696,7 @@ class TLSInitiatingInitializerTests(unittest.TestCase):
         self.assertTrue(self.init.required)
 
 
+    @skipIf(*skipWhenNoSSL)
     def test_wantedSupported(self):
         """
         When TLS is wanted and SSL available, StartTLS is initiated.
@@ -715,9 +717,8 @@ class TLSInitiatingInitializerTests(unittest.TestCase):
 
         return d
 
-    test_wantedSupported.skip = skipWhenNoSSL
 
-
+    @skipIf(*skipWhenNoSSL)
     def test_certificateVerify(self):
         """
         The server certificate will be verified.
@@ -738,9 +739,8 @@ class TLSInitiatingInitializerTests(unittest.TestCase):
         self.assertEqual(['TLS', 'reset', 'header'], self.done)
         return d
 
-    test_certificateVerify.skip = skipWhenNoSSL
 
-
+    @skipIf(*skipWhenNoSSL)
     def test_certificateVerifyContext(self):
         """
         A custom contextFactory is passed through to startTLS.
@@ -764,8 +764,6 @@ class TLSInitiatingInitializerTests(unittest.TestCase):
         self.xmlstream.dataReceived("<proceed xmlns='%s'/>" % NS_XMPP_TLS)
         self.assertEqual(['TLS', 'reset', 'header'], self.done)
         return d
-
-    test_certificateVerifyContext.skip = skipWhenNoSSL
 
 
     def test_wantedNotSupportedNotRequired(self):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9812

This reduces errors reported by mypy of the form:

```
src/twisted/words/test/test_domish.py:193:9: error: "Callable[[ElementTests], Any]" has no attribute "skip"  [attr-defined]
            test_addContentBytes.skip = (
```