### PR TITLE
Use @classmethod decorator, to eliminate mypy warnings

### DIFF
--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -86,6 +86,8 @@ class LoopingCall:
 
         return self._deferred
 
+
+    @classmethod
     def withCount(cls, countCallable):
         """
         An alternate constructor for L{LoopingCall} that makes available the
@@ -142,8 +144,6 @@ class LoopingCall:
         self._realLastTime = None
 
         return self
-
-    withCount = classmethod(withCount)
 
 
     def _intervalOf(self, t):

--- a/src/twisted/mail/mail.py
+++ b/src/twisted/mail/mail.py
@@ -77,6 +77,7 @@ class DomainWithDefaultDict:
         return 1
 
 
+    @classmethod
     def fromkeys(klass, keys, value=None):
         """
         Create a new L{DomainWithDefaultDict} with the specified keys.
@@ -95,7 +96,6 @@ class DomainWithDefaultDict:
         for k in keys:
             d[k] = value
         return d
-    fromkeys = classmethod(fromkeys)
 
 
     def __contains__(self, name):

--- a/src/twisted/plugins/twisted_words.py
+++ b/src/twisted/plugins/twisted_words.py
@@ -28,10 +28,10 @@ class RelayChatInterface(object):
 
     name = 'irc'
 
+    @classmethod
     def getFactory(cls, realm, portal):
         from twisted.words import service
         return service.IRCFactory(realm, portal)
-    getFactory = classmethod(getFactory)
 
 
 
@@ -40,8 +40,7 @@ class PBChatInterface(object):
 
     name = 'pb'
 
+    @classmethod
     def getFactory(cls, realm, portal):
         from twisted.spread import pb
         return pb.PBServerFactory(portal, True)
-    getFactory = classmethod(getFactory)
-

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1861,6 +1861,7 @@ class Command:
         forgotten = []
 
 
+    @classmethod
     def makeResponse(cls, objects, proto):
         """
         Serialize a mapping of arguments using this L{Command}'s
@@ -1879,9 +1880,9 @@ class Command:
         except:
             return fail()
         return _objectsToStrings(objects, cls.response, responseType, proto)
-    makeResponse = classmethod(makeResponse)
 
 
+    @classmethod
     def makeArguments(cls, objects, proto):
         """
         Serialize a mapping of arguments using this L{Command}'s
@@ -1905,9 +1906,9 @@ class Command:
                     "%s is not a valid argument" % (intendedArg,))
         return _objectsToStrings(objects, cls.arguments, cls.commandType(),
                                  proto)
-    makeArguments = classmethod(makeArguments)
 
 
+    @classmethod
     def parseResponse(cls, box, protocol):
         """
         Parse a mapping of serialized arguments using this
@@ -1921,9 +1922,9 @@ class Command:
         forms.
         """
         return _stringsToObjects(box, cls.response, protocol)
-    parseResponse = classmethod(parseResponse)
 
 
+    @classmethod
     def parseArguments(cls, box, protocol):
         """
         Parse a mapping of serialized arguments using this
@@ -1936,9 +1937,9 @@ class Command:
         @return: A mapping of argument names to the parsed forms.
         """
         return _stringsToObjects(box, cls.arguments, protocol)
-    parseArguments = classmethod(parseArguments)
 
 
+    @classmethod
     def responder(cls, methodfunc):
         """
         Declare a method to be a responder for a particular command.
@@ -1972,7 +1973,6 @@ class Command:
         """
         CommandLocator._currentClassCommands.append((cls, methodfunc))
         return methodfunc
-    responder = classmethod(responder)
 
 
     # Our only instance method
@@ -2199,9 +2199,9 @@ class ProtocolSwitchCommand(Command):
         super(ProtocolSwitchCommand, self).__init__(**kw)
 
 
+    @classmethod
     def makeResponse(cls, innerProto, proto):
         return _SwitchBox(innerProto)
-    makeResponse = classmethod(makeResponse)
 
 
     def _doCommand(self, proto):
@@ -2690,6 +2690,7 @@ class _ParserHelper:
 
 
     # Synchronous helpers
+    @classmethod
     def parse(cls, fileObj):
         """
         Parse some amp data stored in a file.
@@ -2703,9 +2704,9 @@ class _ParserHelper:
         bbp.makeConnection(parserHelper)
         bbp.dataReceived(fileObj.read())
         return parserHelper.boxes
-    parse = classmethod(parse)
 
 
+    @classmethod
     def parseString(cls, data):
         """
         Parse some amp data stored in a string.
@@ -2715,7 +2716,6 @@ class _ParserHelper:
         @return: a list of AmpBoxes encoded in the given string.
         """
         return cls.parse(BytesIO(data))
-    parseString = classmethod(parseString)
 
 
 

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -963,7 +963,7 @@ class BoxDispatcher:
 
         try:
             co = commandType(*a, **kw)
-        except:
+        except BaseException:
             return fail()
         return co._doCommand(self)
 
@@ -1164,16 +1164,18 @@ class CommandLocator:
         """
         def doit(box):
             kw = command.parseArguments(box, self)
+
             def checkKnownErrors(error):
                 key = error.trap(*command.allErrors)
                 code = command.allErrors[key]
                 desc = str(error.value)
                 return Failure(RemoteAmpError(
                         code, desc, key in command.fatalErrors, local=error))
+
             def makeResponseFor(objects):
                 try:
                     return command.makeResponse(objects, self)
-                except:
+                except BaseException:
                     # let's helpfully log this.
                     originalFailure = Failure()
                     raise BadLocalReturn(
@@ -1877,7 +1879,7 @@ class Command:
         """
         try:
             responseType = cls.responseType()
-        except:
+        except BaseException:
             return fail()
         return _objectsToStrings(objects, cls.response, responseType, proto)
 

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -73,6 +73,7 @@ class HandshakeCallbackContextFactory:
         self._method = method
 
 
+    @classmethod
     def factoryAndDeferred(cls):
         """
         Create a new L{HandshakeCallbackContextFactory} and return a two-tuple
@@ -81,7 +82,6 @@ class HandshakeCallbackContextFactory:
         """
         contextFactory = cls()
         return contextFactory, contextFactory._finished
-    factoryAndDeferred = classmethod(factoryAndDeferred)
 
 
     def _info(self, connection, where, ret):

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -511,6 +511,7 @@ class Failure(BaseException):
         return g.throw(self.type, self.value, self.tb)
 
 
+    @classmethod
     def _findFailure(cls):
         """
         Find the failure that represents the exception currently in context.
@@ -568,7 +569,6 @@ class Failure(BaseException):
         if frame and frame.f_code is cls.throwExceptionIntoGenerator.__code__:
             return frame.f_locals.get('self')
 
-    _findFailure = classmethod(_findFailure)
 
     def __repr__(self):
         return "<%s %s: %s>" % (reflect.qual(self.__class__),

--- a/src/twisted/python/logfile.py
+++ b/src/twisted/python/logfile.py
@@ -45,6 +45,7 @@ class BaseLogFile:
         self._openFile()
 
 
+    @classmethod
     def fromFullPath(cls, filename, *args, **kwargs):
         """
         Construct a log file from a full file path.
@@ -52,7 +53,6 @@ class BaseLogFile:
         logPath = os.path.abspath(filename)
         return cls(os.path.basename(logPath),
                    os.path.dirname(logPath), *args, **kwargs)
-    fromFullPath = classmethod(fromFullPath)
 
 
     def shouldRotate(self):

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -87,6 +87,8 @@ class _ErrorFormatter(object):
         self.formatMessage = FormatMessage
         self.errorTab = errorTab
 
+
+    @classmethod
     def fromEnvironment(cls):
         """
         Get as many of the platform-specific error translation objects as
@@ -105,7 +107,6 @@ class _ErrorFormatter(object):
         except ImportError:
             errorTab = None
         return cls(WinError, FormatMessage, errorTab)
-    fromEnvironment = classmethod(fromEnvironment)
 
 
     def formatError(self, errorcode):

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -2409,6 +2409,7 @@ class MagicSchemaCommand(amp.Command):
     A command which overrides L{parseResponse}, L{parseArguments}, and
     L{makeResponse}.
     """
+    @classmethod
     def parseResponse(self, strings, protocol):
         """
         Don't do any parsing, just jam the input strings and protocol
@@ -2417,9 +2418,9 @@ class MagicSchemaCommand(amp.Command):
         """
         protocol.parseResponseArguments = (strings, protocol)
         return strings
-    parseResponse = classmethod(parseResponse)
 
 
+    @classmethod
     def parseArguments(cls, strings, protocol):
         """
         Don't do any parsing, just jam the input strings and protocol
@@ -2428,9 +2429,9 @@ class MagicSchemaCommand(amp.Command):
         """
         protocol.parseArgumentsArguments = (strings, protocol)
         return strings
-    parseArguments = classmethod(parseArguments)
 
 
+    @classmethod
     def makeArguments(cls, objects, protocol):
         """
         Don't do any serializing, just jam the input strings and protocol
@@ -2439,7 +2440,6 @@ class MagicSchemaCommand(amp.Command):
         """
         protocol.makeArgumentsArguments = (objects, protocol)
         return objects
-    makeArguments = classmethod(makeArguments)
 
 
 

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -890,6 +890,7 @@ class _AnsiColorizer(object):
         self.stream = stream
 
 
+    @classmethod
     def supported(cls, stream=sys.stdout):
         """
         A class method that returns True if the current platform supports
@@ -908,10 +909,9 @@ class _AnsiColorizer(object):
                 except curses.error:
                     curses.setupterm()
                     return curses.tigetnum("colors") > 2
-            except:
+            except BaseException:
                 # guess false in case of error
                 return False
-    supported = classmethod(supported)
 
 
     def write(self, text, color):
@@ -951,6 +951,7 @@ class _Win32Colorizer(object):
             }
 
 
+    @classmethod
     def supported(cls, stream=sys.stdout):
         try:
             import win32console
@@ -968,7 +969,6 @@ class _Win32Colorizer(object):
             return False
         else:
             return True
-    supported = classmethod(supported)
 
 
     def write(self, text, color):
@@ -987,9 +987,9 @@ class _NullColorizer(object):
         self.stream = stream
 
 
+    @classmethod
     def supported(cls, stream=sys.stdout):
         return True
-    supported = classmethod(supported)
 
 
     def write(self, text, color):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9820

This eliminates a bunch of mypy errors such as:

```
src/twisted/protocols/amp.py:1924:21: error: Incompatible types in assignment (expression has type "classmethod", variable has type "Callable[[Command, Any, Any], Any]")
 [assignment]
        parseResponse = classmethod(parseResponse)
```