### PR TITLE
Always use sys.stdout.buffer which is always available on Python 3+

### DIFF
--- a/src/twisted/internet/test/process_cli.py
+++ b/src/twisted/internet/test/process_cli.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 
@@ -7,7 +6,7 @@ try:
     # so newline characters are munged on writing, interfering with
     # the tests.
     import msvcrt
-    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)  # type:ignore[attr-defined]  # noqa
 except ImportError:
     pass
 
@@ -16,11 +15,7 @@ except ImportError:
 for arg in sys.argv[1:]:
     res = arg + chr(0)
 
-    if sys.version_info < (3, 0):
-        stdout = sys.stdout
-    else:
-        stdout = sys.stdout.buffer
-        res = res.encode(sys.getfilesystemencoding(), "surrogateescape")
-
-    stdout.write(res)
-    stdout.flush()
+    sys.stdout.buffer.write(
+        res.encode(sys.getfilesystemencoding(), "surrogateescape")
+    )
+    sys.stdout.flush()

--- a/src/twisted/test/process_stdinreader.py
+++ b/src/twisted/test/process_stdinreader.py
@@ -9,29 +9,23 @@ Script used by twisted.test.test_process on win32.
 import msvcrt
 import os
 import sys
-msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-msvcrt.setmode(sys.stderr.fileno(), os.O_BINARY)
+msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)  # type:ignore[attr-defined]
+msvcrt.setmode(sys.stderr.fileno(), os.O_BINARY)  # type:ignore[attr-defined]
 
 # We want to write bytes directly to the output, not text, because otherwise
-# newlines get mangled. Get the buffer if it is available.
-if hasattr(sys.stdout, "buffer"):
-    stdout = sys.stdout.buffer
-else:
-    stdout = sys.stdout
-
-if hasattr(sys.stderr, "buffer"):
-    stderr = sys.stderr.buffer
-else:
-    stderr = sys.stderr
+# newlines get mangled. Get the underlying buffer.
+stdout = sys.stdout.buffer
+stderr = sys.stderr.buffer
+stdin = sys.stdin.buffer
 
 stdout.write(b"out\n")
 stdout.flush()
 stderr.write(b"err\n")
 stderr.flush()
 
-data = sys.stdin.read()
+data = stdin.read()
 
-stdout.write(data.encode('ascii'))
+stdout.write(data)
 stdout.write(b"\nout\n")
 stderr.write(b"err\n")
 

--- a/src/twisted/test/process_tester.py
+++ b/src/twisted/test/process_tester.py
@@ -1,27 +1,19 @@
 """Test program for processes."""
 
-import sys, os
-
-# Twisted is unimportable from this file, so just do the PY3 check manually
-if sys.version_info < (3, 0):
-    _PY3 = False
-else:
-    _PY3 = True
+import os
+import sys
 
 test_file_match = "process_test.log.*"
 test_file = "process_test.log.%d" % os.getpid()
 
+
+
 def main():
     f = open(test_file, 'wb')
 
-    if _PY3:
-        stdin = sys.stdin.buffer
-        stderr = sys.stderr.buffer
-        stdout = sys.stdout.buffer
-    else:
-        stdin = sys.stdin
-        stdout = sys.stdout
-        stderr = sys.stderr
+    stdin = sys.stdin.buffer
+    stderr = sys.stderr.buffer
+    stdout = sys.stdout.buffer
 
     # stage 1
     b = stdin.read(4)

--- a/src/twisted/test/test_iutils.py
+++ b/src/twisted/test/test_iutils.py
@@ -52,13 +52,8 @@ class ProcessUtilsTests(unittest.TestCase):
         scriptFile = self.makeSourceFile([
                 "import sys",
                 "for s in b'hello world\\n':",
-                "    if hasattr(sys.stdout, 'buffer'):",
-                "        # Python 3",
-                "        s = bytes([s])",
-                "        sys.stdout.buffer.write(s)",
-                "    else:",
-                "        # Python 2",
-                "        sys.stdout.write(s)",
+                "    s = bytes([s])",
+                "    sys.stdout.buffer.write(s)",
                 "    sys.stdout.flush()"])
         d = utils.getProcessOutput(self.exe, ['-u', scriptFile])
         return d.addCallback(self.assertEqual, b"hello world\n")
@@ -122,14 +117,8 @@ class ProcessUtilsTests(unittest.TestCase):
         """
         scriptFile = self.makeSourceFile([
             "import sys",
-            "if hasattr(sys.stdout, 'buffer'):",
-            "    # Python 3",
-            "    sys.stdout.buffer.write(b'hello world!\\n')",
-            "    sys.stderr.buffer.write(b'goodbye world!\\n')",
-            "else:",
-            "    # Python 2",
-            "    sys.stdout.write(b'hello world!\\n')",
-            "    sys.stderr.write(b'goodbye world!\\n')",
+            "sys.stdout.buffer.write(b'hello world!\\n')",
+            "sys.stderr.buffer.write(b'goodbye world!\\n')",
             "sys.exit(1)"
             ])
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9823

Fix mypy errors like:

```
src/twisted/test/process_stdinreader.py:20:14: error: Incompatible types in assignment (expression has type "TextIO", variable has type "BinaryIO")  [assignment]
        stdout = sys.stdout
```