### PR TITLE
Add more type annotations

### DIFF
--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -39,6 +39,7 @@ reactor.listen/connect* methods for more information.
 
 
 from random import random as _goodEnoughRandom
+from typing import List
 
 from twisted.python import log
 from twisted.logger import Logger
@@ -67,7 +68,7 @@ def _maybeGlobalReactor(maybeReactor):
 
 class _VolatileDataService(service.Service):
 
-    volatile = []
+    volatile = []  # type: List[str]
 
     def __getstate__(self):
         d = service.Service.__getstate__(self)

--- a/src/twisted/conch/manhole_ssh.py
+++ b/src/twisted/conch/manhole_ssh.py
@@ -8,6 +8,7 @@ insults/SSH integration support.
 @author: Jp Calderone
 """
 
+from typing import Dict
 from zope.interface import implementer
 
 from twisted.conch import avatar, interfaces as iconch, error as econch
@@ -134,8 +135,8 @@ class TerminalRealm:
 
 
 class ConchFactory(factory.SSHFactory):
-    publicKeys = {}
-    privateKeys = {}
+    publicKeys = {}  # type: Dict[bytes, bytes]
+    privateKeys = {}  # type: Dict[bytes, bytes]
 
     def __init__(self, portal):
         self.portal = portal

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -9,6 +9,7 @@ Basic line editing support.
 """
 
 import string
+from typing import Dict
 
 from zope.interface import implementer
 
@@ -17,7 +18,10 @@ from twisted.conch.insults import insults, helper
 from twisted.python import log, reflect
 from twisted.python.compat import iterbytes
 
-_counters = {}
+_counters = {}  # type: Dict[str, int]
+
+
+
 class Logging(object):
     """
     Wrapper which logs attribute lookups.

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -24,6 +24,7 @@ import struct
 import tty
 import fcntl
 import signal
+from typing import List, Tuple
 
 
 
@@ -57,8 +58,8 @@ class ClientOptions(options.ConchOptions):
                       usage.Completer(descr="argument", repeat=True)]
         )
 
-    localForwards = []
-    remoteForwards = []
+    localForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
+    remoteForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
 
     def opt_escape(self, esc):
         """

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -14,16 +14,20 @@ from twisted.conch.ssh import session, forwarding, channel
 from twisted.conch.client.default import isInKnownHosts
 from twisted.internet import reactor, defer, protocol, tksupport
 from twisted.python import usage, log
-from twisted.python.compat import _PY3
 
-import os, sys, getpass, struct, base64, signal
+import base64
+import getpass
+import os
+import signal
+import struct
+import sys
+from typing import List, Tuple
 
-if _PY3:
-    import tkinter as Tkinter
-    import tkinter.filedialog as tkFileDialog
-    import tkinter.messagebox as tkMessageBox
-else:
-    import Tkinter, tkFileDialog, tkMessageBox
+import tkinter as Tkinter
+import tkinter.filedialog as tkFileDialog
+import tkinter.messagebox as tkMessageBox
+
+
 
 class TkConchMenu(Tkinter.Frame):
     def __init__(self, *args, **params):
@@ -222,9 +226,9 @@ class GeneralOptions(usage.Options):
                       usage.Completer(descr="argument", repeat=True)]
         )
 
-    identitys = []
-    localForwards = []
-    remoteForwards = []
+    identitys = []  # type: List[str]
+    localForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
+    remoteForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
 
     def opt_identity(self, i):
         self.identitys.append(i)
@@ -421,13 +425,15 @@ class SSHClientTransport(transport.SSHClientTransport):
             user = getpass.getuser()
         self.requestService(SSHUserAuthClient(user, SSHConnection()))
 
-class SSHUserAuthClient(userauth.SSHUserAuthClient):
-    usedFiles = []
 
-    def getPassword(self, prompt = None):
+
+class SSHUserAuthClient(userauth.SSHUserAuthClient):
+    usedFiles = []  # type: List[str]
+
+    def getPassword(self, prompt=None):
         if not prompt:
             prompt = "%s@%s's password: " % (self.user, options['host'])
-        return deferredAskFrame(prompt,0)
+        return deferredAskFrame(prompt, 0)
 
     def getPublicKey(self):
         files = [x for x in options.identitys if x not in self.usedFiles]
@@ -552,8 +558,7 @@ class SSHSession(channel.SSHChannel):
             self.write(char)
 
     def dataReceived(self, data):
-        if _PY3 and isinstance(data, bytes):
-            data = data.decode("utf-8")
+        data = data.decode("utf-8")
         if options['ansilog']:
             print(repr(data))
         frame.write(data)

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -52,11 +52,11 @@ class SSHChannel(log.Logger):
     @type remoteClosed: L{bool}
     """
 
-    name = None # only needed for client channels
+    name = None  # type: bytes  # only needed for client channels
 
-    def __init__(self, localWindow = 0, localMaxPacket = 0,
-                       remoteWindow = 0, remoteMaxPacket = 0,
-                       conn = None, data=None, avatar = None):
+    def __init__(self, localWindow=0, localMaxPacket=0,
+                 remoteWindow=0, remoteMaxPacket=0,
+                 conn=None, data=None, avatar=None):
         self.localWindowSize = localWindow or 131072
         self.localWindowLeft = self.localWindowSize
         self.localMaxPacket = localMaxPacket or 32768

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -8,6 +8,7 @@ import errno
 import struct
 import warnings
 
+from typing import Dict
 from zope.interface import implementer
 
 from twisted.conch.interfaces import ISFTPServer, ISFTPFile
@@ -23,7 +24,7 @@ class FileTransferBase(protocol.Protocol):
 
     versions = (3, )
 
-    packetTypes = {}
+    packetTypes = {}  # type: Dict[int, str]
 
     def __init__(self):
         self.buf = b''

--- a/src/twisted/conch/ssh/service.py
+++ b/src/twisted/conch/ssh/service.py
@@ -9,12 +9,15 @@ Maintainer: Paul Swartz
 """
 
 
+from typing import Dict
 from twisted.python import log
 
+
+
 class SSHService(log.Logger):
-    name = None # this is the ssh name for the service
-    protocolMessages = {} # these map #'s -> protocol names
-    transport = None # gets set later
+    name = None  # type: bytes  # this is the ssh name for the service
+    protocolMessages = {}  # type: Dict[int, str]  # map #'s -> protocol names
+    transport = None  # gets set later
 
     def serviceStarted(self):
         """

--- a/src/twisted/conch/ui/tkvt100.py
+++ b/src/twisted/conch/ui/tkvt100.py
@@ -8,11 +8,8 @@
 Maintainer: Paul Swartz
 """
 
-try:
-    import tkinter as Tkinter
-    import tkinter.font as tkFont
-except ImportError:
-    import Tkinter, tkFont
+import tkinter as Tkinter
+import tkinter.font as tkFont
 import string
 from . import ansi
 

--- a/src/twisted/cred/strcred.py
+++ b/src/twisted/cred/strcred.py
@@ -16,6 +16,7 @@ Examples:
 
 
 import sys
+from typing import Optional, Sequence, Type
 
 from zope.interface import Interface, Attribute
 
@@ -154,7 +155,7 @@ class AuthOptionMixin:
         will send all help-related output. Default: L{sys.stdout}
     """
 
-    supportedInterfaces = None
+    supportedInterfaces = None  # type: Optional[Sequence[Type[Interface]]]
     authOutput = sys.stdout
 
 

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -7,6 +7,8 @@ L{twisted.cred.strcred}.
 
 
 import os
+from typing import List, Sequence, Type
+from zope.interface import Interface
 
 from twisted import plugin
 from twisted.trial import unittest
@@ -280,7 +282,7 @@ class UnixCheckerTests(unittest.TestCase):
 
 
     if None in (pwd, spwd, crypt):
-        availability = []
+        availability = []  # type: List[str]
         for module, name in ((pwd, "pwd"), (spwd, "spwd"), (crypt, "crypt")):
             if module is None:
                 availability += [name]
@@ -595,7 +597,7 @@ class OptionsSupportsAllInterfaces(usage.Options, strcred.AuthOptionMixin):
 
 
 class OptionsSupportsNoInterfaces(usage.Options, strcred.AuthOptionMixin):
-    supportedInterfaces = []
+    supportedInterfaces = []  # type: Sequence[Type[Interface]]
 
 
 

--- a/src/twisted/internet/_baseprocess.py
+++ b/src/twisted/internet/_baseprocess.py
@@ -18,7 +18,7 @@ _missingProcessExited = ("Since Twisted 8.2, IProcessProtocol.processExited "
 
 
 class BaseProcess(object):
-    pid = None
+    pid = None  # type: int
     status = None
     lostProcess = 0
     proto = None

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -6,6 +6,7 @@
 Helpers for working with producers.
 """
 
+from typing import List
 from zope.interface import implementer
 
 from twisted.internet.interfaces import IPushProducer
@@ -15,7 +16,8 @@ from twisted.python.reflect import safe_str
 
 
 # This module exports nothing public, it's for internal Twisted use only.
-__all__ = []
+__all__ = []  # type: List[str]
+
 
 
 @implementer(IPushProducer)

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -8,6 +8,7 @@ Very basic functionality for a Reactor implementation.
 
 
 import socket  # needed only for sync-dns
+from typing import List
 from zope.interface import implementer, classImplements
 
 import sys
@@ -1189,8 +1190,8 @@ class BasePort(abstract.FileDescriptor):
     Note: This does not actually implement IListeningPort.
     """
 
-    addressFamily = None
-    socketType = None
+    addressFamily = None  # type: socket.AddressFamily
+    socketType = None  # type: socket.SocketKind
 
     def createInternetSocket(self):
         s = socket.socket(self.addressFamily, self.socketType)
@@ -1298,4 +1299,4 @@ class _SignalReactorMixin(object):
 
 
 
-__all__ = []
+__all__ = []  # type: List[str]

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -61,7 +61,8 @@ from twisted.python.systemd import ListenFDs
 from ._idna import _idnaBytes, _idnaText
 
 try:
-    from twisted.protocols.tls import TLSMemoryBIOFactory
+    from twisted.protocols.tls import (
+        TLSMemoryBIOFactory as _TLSMemoryBIOFactory)
     from twisted.internet.ssl import (
         optionsForClientTLS, PrivateCertificate, Certificate, KeyPair,
         CertificateOptions, trustRootFromCertificates
@@ -69,6 +70,8 @@ try:
     from OpenSSL.SSL import Error as SSLError
 except ImportError:
     TLSMemoryBIOFactory = None
+else:
+    TLSMemoryBIOFactory = _TLSMemoryBIOFactory
 
 __all__ = ["clientFromString", "serverFromString",
            "TCP4ServerEndpoint", "TCP6ServerEndpoint",

--- a/src/twisted/internet/fdesc.py
+++ b/src/twisted/internet/fdesc.py
@@ -10,9 +10,11 @@ Utility functions for dealing with POSIX file descriptors.
 import os
 import errno
 try:
-    import fcntl
+    import fcntl as _fcntl
 except ImportError:
     fcntl = None
+else:
+    fcntl = _fcntl
 
 # twisted imports
 from twisted.internet.main import CONNECTION_LOST, CONNECTION_DONE

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -12,6 +12,8 @@ import errno
 import os
 import sys
 
+from typing import Union, Sequence, Type
+
 from zope.interface import implementer, classImplements
 
 from twisted.internet import error, udp, tcp
@@ -31,13 +33,18 @@ _NO_FILEDESC = error.ConnectionFdescWentAway('File descriptor lost')
 
 
 try:
-    from twisted.protocols import tls
+    from twisted.protocols import tls as _tls
 except ImportError:
     tls = None
-    try:
-        from twisted.internet import ssl
-    except ImportError:
-        ssl = None
+else:
+    tls = _tls
+
+try:
+    from twisted.internet import ssl as _ssl
+except ImportError:
+    ssl = None
+else:
+    ssl = _ssl
 
 unixEnabled = (platformType == 'posix')
 
@@ -182,7 +189,7 @@ class _UnixWaker(_FDWaker):
 
 
 if platformType == 'posix':
-    _Waker = _UnixWaker
+    _Waker = _UnixWaker  # type: Union[Type[_FDWaker], Type[_SocketWaker]]
 else:
     # Primarily Windows and Jython.
     _Waker = _SocketWaker
@@ -431,7 +438,7 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin,
     if unixEnabled:
         _supportedAddressFamilies = (
             socket.AF_INET, socket.AF_INET6, socket.AF_UNIX,
-        )
+        )  # type: Sequence[socket.AddressFamily]
     else:
         _supportedAddressFamilies = (
             socket.AF_INET, socket.AF_INET6,

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -11,6 +11,7 @@ Twisted.  The Protocol class contains some introductory material.
 
 
 import random
+from typing import Optional, Type
 from zope.interface import implementer
 
 from twisted.python import log, failure, components
@@ -29,7 +30,7 @@ class Factory:
     """
 
     # Put a subclass of Protocol here:
-    protocol = None
+    protocol = None  # type: Optional[Type['Protocol']]
 
     numPorts = 0
     noisy = True

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -13,6 +13,8 @@ import socket
 import sys
 from errno import EINTR, EBADF
 
+from typing import Type
+
 from zope.interface import implementer
 
 from twisted.internet.interfaces import IReactorFDSet
@@ -47,13 +49,14 @@ else:
 try:
     from twisted.internet.win32eventreactor import _ThreadedWin32EventsMixin
 except ImportError:
-    _extraBase = object
+    _extraBase = object  # type: Type[object]
 else:
     _extraBase = _ThreadedWin32EventsMixin
 
 
+
 @implementer(IReactorFDSet)
-class SelectReactor(posixbase.PosixReactorBase, _extraBase):
+class SelectReactor(posixbase.PosixReactorBase, _extraBase):  # type: ignore[misc,valid-type]  # noqa
     """
     A select() based reactor - runs on all POSIX platforms and on Win32.
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -46,15 +46,18 @@ except ImportError:
 
 
 if platformType == 'win32':
-    # no such thing as WSAEPERM or error code 10001 according to winsock.h or MSDN
+    # no such thing as WSAEPERM or error code 10001
+    # according to winsock.h or MSDN
     EPERM = object()
-    from errno import WSAEINVAL as EINVAL
-    from errno import WSAEWOULDBLOCK as EWOULDBLOCK
-    from errno import WSAEINPROGRESS as EINPROGRESS
-    from errno import WSAEALREADY as EALREADY
-    from errno import WSAEISCONN as EISCONN
-    from errno import WSAENOBUFS as ENOBUFS
-    from errno import WSAEMFILE as EMFILE
+    from errno import WSAEINVAL as EINVAL  # type: ignore[attr-defined]
+    from errno import (  # type: ignore[attr-defined]
+        WSAEWOULDBLOCK as EWOULDBLOCK)
+    from errno import (  # type: ignore[attr-defined]
+        WSAEINPROGRESS as EINPROGRESS)
+    from errno import WSAEALREADY as EALREADY  # type: ignore[attr-defined]
+    from errno import WSAEISCONN as EISCONN  # type: ignore[attr-defined]
+    from errno import WSAENOBUFS as ENOBUFS  # type: ignore[attr-defined]
+    from errno import WSAEMFILE as EMFILE  # type: ignore[attr-defined]
     # No such thing as WSAENFILE, either.
     ENFILE = object()
     # Nor ENOMEM

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -14,6 +14,7 @@ from ctypes import (
     CDLL, POINTER, Structure, c_char_p, c_ushort, c_int,
     c_uint32, c_uint8, c_void_p, c_ubyte, pointer, cast)
 from ctypes.util import find_library
+from typing import Any, List, Tuple
 
 from twisted.python.compat import _PY3, nativeString
 
@@ -34,7 +35,7 @@ if sys.platform.startswith('freebsd') or sys.platform == 'darwin':
     _sockaddrCommon = [
         ("sin_len", c_uint8),
         ("sin_family", c_uint8),
-        ]
+        ]  # type: List[Tuple[str, Any]]
 else:
     _sockaddrCommon = [
         ("sin_family", c_ushort),

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -10,6 +10,7 @@ Various helpers for tests for connection-oriented transports.
 import socket
 
 from gc import collect
+from typing import Optional
 from weakref import ref
 
 from zope.interface.verify import verifyObject
@@ -291,8 +292,7 @@ class ConnectionTestsMixin(object):
     implementations.
     """
 
-    # This should be a reactormixins.EndpointCreator instance.
-    endpoints = None
+    endpoints = None  # type: Optional[EndpointCreator]
 
 
     def test_logPrefix(self):

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -20,7 +20,9 @@ __all__ = ['TestTimeoutError', 'ReactorBuilder', 'needsRunningReactor']
 import os
 import signal
 import time
-from typing import Dict, Type, Union
+from typing import Dict, Sequence, Optional, Type, Union
+
+from zope.interface import Interface
 
 from twisted.trial.unittest import SynchronousTestCase, SkipTest
 from twisted.trial.util import DEFAULT_TIMEOUT_DURATION, acquireAttribute
@@ -171,7 +173,7 @@ class ReactorBuilder:
 
     reactorFactory = None
     originalHandler = None
-    requiredInterfaces = None
+    requiredInterfaces = None  # type: Optional[Sequence[Type[Interface]]]
     skippedReactors = {}  # type: Dict[str, str]
 
     def setUp(self):

--- a/src/twisted/internet/test/test_newtls.py
+++ b/src/twisted/internet/test/test_newtls.py
@@ -17,9 +17,11 @@ from twisted.internet.test.test_tls import ContextGeneratingMixin
 from twisted.internet.test.test_tcp import TCPCreator
 try:
     from twisted.protocols import tls
-    from twisted.internet import _newtls
+    from twisted.internet import _newtls as __newtls
 except ImportError:
     _newtls = None
+else:
+    _newtls = __newtls
 from zope.interface import implementer
 
 

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -16,6 +16,7 @@ import os
 import socket
 
 from functools import wraps
+from typing import Optional, Sequence, Type
 
 import attr
 
@@ -1526,7 +1527,7 @@ class TCPPortTestsMixin(object):
     """
     Tests for L{IReactorTCP.listenTCP}
     """
-    requiredInterfaces = (IReactorTCP,)
+    requiredInterfaces = (IReactorTCP,)  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """
@@ -2125,7 +2126,7 @@ class WriteSequenceTestsMixin(object):
     """
     Test for L{twisted.internet.abstract.FileDescriptor.writeSequence}.
     """
-    requiredInterfaces = (IReactorTCP,)
+    requiredInterfaces = (IReactorTCP,)  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     def setWriteBufferSize(self, transport, value):
         """
@@ -2832,7 +2833,7 @@ class AbortConnectionMixin(object):
     Unit tests for L{ITransport.abortConnection}.
     """
     # Override in subclasses, should be an EndpointCreator instance:
-    endpoints = None
+    endpoints = None  # type: Optional[EndpointCreator]
 
     def runAbortTest(self, clientClass, serverClass,
                      clientConnectionLostReason=None):

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -8,7 +8,8 @@ Tests for implementations of L{ITLSTransport}.
 
 __metaclass__ = type
 
-from zope.interface import implementer
+from typing import Optional, Sequence, Type
+from zope.interface import implementer, Interface
 
 from twisted.python.compat import networkString
 from twisted.python.filepath import FilePath
@@ -40,8 +41,9 @@ else:
     from twisted.internet.ssl import ClientContextFactory
 
 
+
 class TLSMixin:
-    requiredInterfaces = [IReactorSSL]
+    requiredInterfaces = [IReactorSSL]  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     if platform.isWindows():
         msg = (

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -13,13 +13,14 @@ from socket import AF_INET, SOCK_STREAM, SOL_SOCKET, socket, error
 from pprint import pformat
 from hashlib import md5
 from struct import pack
+from typing import Optional, Sequence, Type
 
 try:
     from socket import AF_UNIX
 except ImportError:
     AF_UNIX = None
 
-from zope.interface import implementer
+from zope.interface import Interface, implementer
 
 from twisted.internet import interfaces, base
 from twisted.internet.address import UNIXAddress
@@ -84,7 +85,8 @@ class UNIXCreator(EndpointCreator):
     """
     Create UNIX socket end points.
     """
-    requiredInterfaces = (interfaces.IReactorUNIX,)
+    requiredInterfaces = (
+        interfaces.IReactorUNIX,)  # type: Optional[Sequence[Type[Interface]]]
 
     def server(self, reactor):
         """
@@ -717,7 +719,8 @@ class SocketUNIXMixin(object):
     Mixin which uses L{IReactorSocket.adoptStreamPort} to hand out listening
     UNIX ports.
     """
-    requiredInterfaces = (IReactorUNIX, IReactorSocket,)
+    requiredInterfaces = (IReactorUNIX,
+                          IReactorSocket,)  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     def getListeningPort(self, reactor, factory):
         """
@@ -790,7 +793,7 @@ class ListenUNIXMixin(object):
 
 
 class UNIXPortTestsMixin(object):
-    requiredInterfaces = (IReactorUNIX,)
+    requiredInterfaces = (IReactorUNIX,)  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -26,14 +26,18 @@ from zope.interface import implementer
 
 from twisted.python.runtime import platformType
 if platformType == 'win32':
-    from errno import WSAEWOULDBLOCK
-    from errno import WSAEINTR, WSAEMSGSIZE, WSAETIMEDOUT
-    from errno import WSAECONNREFUSED, WSAECONNRESET, WSAENETRESET
-    from errno import WSAEINPROGRESS
-    from errno import WSAENOPROTOOPT as ENOPROTOOPT
+    from errno import WSAEWOULDBLOCK  # type: ignore[attr-defined]
+    from errno import (  # type: ignore[attr-defined]
+        WSAEINTR, WSAEMSGSIZE, WSAETIMEDOUT)
+    from errno import (  # type: ignore[attr-defined]
+      WSAECONNREFUSED, WSAECONNRESET, WSAENETRESET)
+    from errno import WSAEINPROGRESS  # type: ignore[attr-defined]
+    from errno import (  # type: ignore[attr-defined]
+        WSAENOPROTOOPT as ENOPROTOOPT)
 
     # Classify read and write errors
-    _sockErrReadIgnore = [WSAEINTR, WSAEWOULDBLOCK, WSAEMSGSIZE, WSAEINPROGRESS]
+    _sockErrReadIgnore = [WSAEINTR, WSAEWOULDBLOCK, WSAEMSGSIZE,
+                          WSAEINPROGRESS]
     _sockErrReadRefuse = [WSAECONNREFUSED, WSAECONNRESET, WSAENETRESET,
                           WSAETIMEDOUT]
 

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -16,14 +16,12 @@ import stat
 import socket
 import struct
 from errno import EINTR, EMSGSIZE, EAGAIN, EWOULDBLOCK, ECONNREFUSED, ENOBUFS
-
+from typing import Optional, Type
 from zope.interface import implementer, implementer_only, implementedBy
-
-if not hasattr(socket, 'AF_UNIX'):
-    raise ImportError("UNIX sockets not supported on this platform")
 
 from twisted.internet import main, base, tcp, udp, error, interfaces
 from twisted.internet import protocol, address
+from twisted.internet.abstract import FileDescriptor
 from twisted.python import lockfile, log, reflect, failure
 from twisted.python.filepath import _coerceToFilesystemEncoding
 from twisted.python.util import untilConcludes
@@ -31,9 +29,15 @@ from twisted.python.compat import lazyByteSlice
 
 
 try:
-    from twisted.python import sendmsg
+    from twisted.python import sendmsg as _sendmsg
 except ImportError:
     sendmsg = None
+else:
+    sendmsg = _sendmsg
+
+if not hasattr(socket, 'AF_UNIX'):
+    raise ImportError("UNIX sockets not supported on this platform")
+
 
 
 
@@ -67,7 +71,7 @@ class _SendmsgMixin(object):
         registered producer, if there is one.
     """
 
-    _writeSomeDataBase = None
+    _writeSomeDataBase = None  # type: Optional[Type[FileDescriptor]]
     _fileDescriptorBufferSize = 64
 
     def __init__(self):

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -29,6 +29,7 @@ import email.utils
 
 from itertools import chain
 from io import BytesIO
+from typing import Any, List
 
 from zope.interface import implementer
 
@@ -171,7 +172,7 @@ class MessageSet(object):
         is being used that maintains its own state, it is guaranteed
         that it will not be called out-of-order).
     """
-    _empty = []
+    _empty = []  # type: List[Any]
     _infinity = float('inf')
 
     def __init__(self, start=_empty, end=_empty):

--- a/src/twisted/mail/pop3client.py
+++ b/src/twisted/mail/pop3client.py
@@ -13,6 +13,7 @@ Don't use this module directly.  Use twisted.mail.pop3 instead.
 
 import re
 from hashlib import md5
+from typing import List
 
 from twisted.python import log
 from twisted.python.compat import intToBytes
@@ -1261,4 +1262,6 @@ class POP3Client(basic.LineOnlyReceiver, policies.TimeoutMixin):
         """
         return self.sendShort(b'QUIT', None)
 
-__all__ = []
+
+
+__all__ = []  # type: List[str]

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -13,6 +13,7 @@ import functools
 import locale
 import os
 from io import BytesIO
+from typing import List, Optional, Tuple, Type
 import uuid
 
 from itertools import chain
@@ -49,7 +50,8 @@ from twisted.test.proto_helpers import StringTransport, StringTransportWithDisco
 try:
     from twisted.test.ssl_helpers import ClientTLSContext, ServerTLSContext
 except ImportError:
-    ClientTLSContext = ServerTLSContext = None
+    ClientTLSContext = None  # type: ignore[assignment,misc]
+    ServerTLSContext = None  # type: ignore[assignment,misc]
 
 
 
@@ -1619,7 +1621,7 @@ class IMAP4HelperTests(unittest.TestCase):
 @implementer(imap4.IMailboxInfo, imap4.IMailbox, imap4.ICloseableMailbox)
 class SimpleMailbox:
     flags = ('\\Flag1', 'Flag2', '\\AnotherSysFlag', 'LastFlag')
-    messages = []
+    messages = []  # type: List[Tuple[bytes, list, bytes, int]]
     mUID = 0
     rw = 1
     closed = False
@@ -1708,7 +1710,7 @@ class UncloseableMailbox(object):
     A mailbox that cannot be closed.
     """
     flags = ('\\Flag1', 'Flag2', '\\AnotherSysFlag', 'LastFlag')
-    messages = []
+    messages = []  # type:List[Tuple[bytes, list, bytes, int]]
     mUID = 0
     rw = 1
     closed = False
@@ -1930,8 +1932,8 @@ class SimpleClient(imap4.IMAP4Client):
 
 class IMAP4HelperMixin:
 
-    serverCTX = None
-    clientCTX = None
+    serverCTX = None  # type: Optional[ServerTLSContext]
+    clientCTX = None  # type: Optional[ClientTLSContext]
 
     def setUp(self):
         d = defer.Deferred()
@@ -4635,7 +4637,7 @@ class PreauthIMAP4ClientMixin(object):
     @ivar client: An L{IMAP4Client} which is connected to
         C{transport}.
     """
-    clientProtocol = imap4.IMAP4Client
+    clientProtocol = imap4.IMAP4Client  # type: Type[imap4.IMAP4Client]
 
     def setUp(self):
         """
@@ -7036,8 +7038,12 @@ class CopyWorkerTests(unittest.TestCase):
 
 
 class TLSTests(IMAP4HelperMixin, unittest.TestCase):
-    serverCTX = ServerTLSContext and ServerTLSContext()
-    clientCTX = ClientTLSContext and ClientTLSContext()
+    serverCTX = None
+    clientCTX = None
+    if ServerTLSContext:
+        serverCTX = ServerTLSContext()
+    if ClientTLSContext:
+        clientCTX = ClientTLSContext()
 
     def loopback(self):
         return loopback.loopbackTCP(self.server, self.client, noisy=False)

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -5,6 +5,7 @@
 import sys
 import inspect
 
+from typing import List
 from zope.interface import directlyProvides
 
 from twisted.internet import reactor, defer, error, protocol, interfaces
@@ -529,7 +530,8 @@ class POP3HelperMixin:
 class TLSServerFactory(protocol.ServerFactory):
     class protocol(basic.LineReceiver):
         context = None
-        output = []
+        output = []  # type: List[bytes]
+
         def connectionMade(self):
             self.factory.input = []
             self.output = self.output[:]
@@ -679,8 +681,14 @@ class POP3ClientModuleStructureTests(unittest.TestCase):
                          if not c[0][0] == '_']
 
         for pc in publicClasses:
+            if sys.version_info < (3, 7) and pc == 'List':
+                # typing.List shows up in publicClasses on
+                # Python < 3.7, so skip it.
+                continue
             if not pc == 'POP3Client':
-                self.assertTrue(hasattr(twisted.mail.pop3, pc))
+                self.assertTrue(
+                    hasattr(twisted.mail.pop3, pc),
+                    "{} not in {}".format(pc, twisted.mail.pop3))
             else:
-                self.assertTrue(hasattr(twisted.mail.pop3,
-                    'AdvancedPOP3Client'))
+                self.assertTrue(
+                    hasattr(twisted.mail.pop3, 'AdvancedPOP3Client'))

--- a/src/twisted/persisted/dirdbm.py
+++ b/src/twisted/persisted/dirdbm.py
@@ -24,16 +24,12 @@ Maintainer: Itamar Shtull-Trauring
 import os
 import base64
 import glob
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from twisted.python.filepath import FilePath
 
 try:
-    _open
+    _open  # type: ignore[has-type]
 except NameError:
     _open = open
 

--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -17,13 +17,14 @@ except ImportError:
 import copy
 import inspect
 
+from typing import Dict
 from twisted.python.compat import _PY3, _PYPY
 
 # Twisted Imports
 from twisted.python import log
 from twisted.python import reflect
 
-oldModules = {}
+oldModules = {}  # type: Dict[str, types.ModuleType]
 
 
 try:
@@ -291,8 +292,11 @@ class Ephemeral:
         self.__class__ = Ephemeral
 
 
-versionedsToUpgrade = {}
+
+versionedsToUpgrade = {}  # type: Dict[int, 'Versioned']
 upgraded = {}
+
+
 
 def doUpgrade():
     global versionedsToUpgrade, upgraded

--- a/src/twisted/plugins/__init__.py
+++ b/src/twisted/plugins/__init__.py
@@ -15,5 +15,7 @@ the __path__ variable.
 """
 
 from twisted.plugin import pluginPackagePaths
-__path__.extend(pluginPackagePaths(__name__))
-__all__ = []                    # nothing to see here, move along, move along
+from typing import List
+
+__path__.extend(pluginPackagePaths(__name__))  # type: ignore[name-defined]
+__all__ = []  # type: List[str] # nothing to see here, move along, move along

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -3,6 +3,7 @@
 """
 Generic sentence handling tools: hopefully reusable.
 """
+from typing import Set
 
 
 
@@ -34,7 +35,7 @@ class _BaseSentence(object):
         sentence.
     @type ALLOWED_ATTRIBUTES: C{set} of C{str}
     """
-    ALLOWED_ATTRIBUTES = set()
+    ALLOWED_ATTRIBUTES = set()  # type: Set[str]
 
 
     def __init__(self, sentenceData):

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -12,6 +12,7 @@ from functools import partial
 from operator import attrgetter
 from zope.interface import implementer
 from constantly import Names, NamedConstant
+from typing import Sequence
 
 from twisted.python.util import FancyEqMixin
 from twisted.positioning import ipositioning
@@ -159,7 +160,7 @@ class Angle(FancyEqMixin, object):
     }
 
 
-    compareAttributes = 'angleType', 'inDecimalDegrees'
+    compareAttributes = 'angleType', 'inDecimalDegrees'  # type: Sequence[str]
 
 
     def __init__(self, angle=None, angleType=None):

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -200,7 +200,9 @@ import types, warnings
 
 from io import BytesIO
 from struct import pack
-import decimal, datetime
+from typing import Any, Callable, Dict, List, Tuple, Type
+import datetime
+import decimal
 from functools import partial
 from itertools import count
 
@@ -225,9 +227,11 @@ from twisted.python.compat import (
 )
 
 try:
-    from twisted.internet import ssl
+    from twisted.internet import ssl as _ssl
 except ImportError:
     ssl = None
+else:
+    ssl = _ssl
 
 if ssl and not ssl.supported:
     ssl = None
@@ -626,14 +630,19 @@ class IncompatibleVersions(AmpError):
     """
 
 
+
 PROTOCOL_ERRORS = {UNHANDLED_ERROR_CODE: UnhandledCommand}
+
+
 
 class AmpBox(dict):
     """
-    I am a packet in the AMP protocol, much like a regular bytes:bytes dictionary.
+    I am a packet in the AMP protocol, much like a
+    regular bytes:bytes dictionary.
     """
-    __slots__ = []              # be like a regular dictionary, don't magically
-                                # acquire a __dict__...
+    # be like a regular dictionary don't magically
+    # acquire a __dict__...
+    __slots__ = []  # type: List[str]
 
 
     def __init__(self, *args, **kw):
@@ -732,7 +741,7 @@ class QuitBox(AmpBox):
     """
     I am an AmpBox that, upon being sent, terminates the connection.
     """
-    __slots__ = []
+    __slots__ = []  # type: List[str]
 
 
     def __repr__(self):
@@ -1123,7 +1132,8 @@ class CommandLocator:
         metaclass.
         """
 
-        _currentClassCommands = []
+        _currentClassCommands = []  # type: List[Tuple[Command, Callable]]
+
         def __new__(cls, name, bases, attrs):
             commands = cls._currentClassCommands[:]
             cls._currentClassCommands[:] = []
@@ -1791,7 +1801,7 @@ class Command:
                         % (name, ))
 
             errors = {}
-            fatalErrors = {}
+            fatalErrors = {}  # type: Dict[Exception, bytes]
             accumulateClassDict(newtype, 'errors', errors)
             accumulateClassDict(newtype, 'fatalErrors', fatalErrors)
 
@@ -1820,14 +1830,14 @@ class Command:
 
             return newtype
 
-    arguments = []
-    response = []
-    extra = []
-    errors = {}
-    fatalErrors = {}
+    arguments = []  # type: List[Tuple[bytes, _LocalArgument]]
+    response = []  # type: List[Tuple[bytes, Argument]]
+    extra = []  # type: List[Any]
+    errors = {}  # type: Dict[Exception, bytes]
+    fatalErrors = {}  # type: Dict[Exception, bytes]
 
-    commandType = Box
-    responseType = Box
+    commandType = Box  # type: Type[Command]
+    responseType = Box  # type: Type[AmpBox]
 
     requiresAnswer = True
 
@@ -2074,7 +2084,7 @@ class _TLSBox(AmpBox):
     """
     I am an AmpBox that, upon being sent, initiates a TLS connection.
     """
-    __slots__ = []
+    __slots__ = []  # type: List[str]
 
     def __init__(self):
         if ssl is None:

--- a/src/twisted/protocols/htb.py
+++ b/src/twisted/protocols/htb.py
@@ -20,6 +20,7 @@ shaper for the Linux kernel<http://luxik.cdi.cz/~devik/qos/htb/>}.
 # time.time.  time.time, it has been pointed out, can go backwards.  Is
 # the same true of os.times?
 from time import time
+from typing import Optional
 from zope.interface import implementer, Interface
 
 from twisted.protocols import pcp
@@ -41,8 +42,8 @@ class Bucket:
     @type rate: C{int}
     """
 
-    maxburst = None
-    rate = None
+    maxburst = None  # type: Optional[int]
+    rate = None  # type: Optional[int]
 
     _refcount = 0
 
@@ -128,7 +129,7 @@ class HierarchicalBucketFilter:
     @type sweepInterval: C{int}
     """
     bucketFactory = Bucket
-    sweepInterval = None
+    sweepInterval = None  # type: Optional[int]
 
     def __init__(self, parentFilter=None):
         self.buckets = {}

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -13,6 +13,7 @@ import socket
 import time
 import warnings
 
+from typing import Dict
 from zope.interface import implementer, Interface
 from collections import OrderedDict
 
@@ -1081,9 +1082,9 @@ class RegisterProxy(Proxy):
 
     portal = None
 
-    registry = None # Should implement IRegistry
+    registry = None  # Should implement IRegistry
 
-    authorizers = {}
+    authorizers = {}  # type: Dict[str, IAuthorizer]
 
     def __init__(self, *args, **kw):
         Proxy.__init__(self, *args, **kw)

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -10,6 +10,7 @@ import sys
 import struct
 from io import BytesIO
 
+from typing import List
 from zope.interface.verify import verifyObject
 
 from twisted.python.compat import _PY3, iterbytes
@@ -573,7 +574,7 @@ class TestNetstring(TestMixin, basic.NetstringReceiver):
 
 class LPTestCaseMixin:
 
-    illegalStrings = []
+    illegalStrings = []  # type: List[bytes]
     protocol = None
 
 

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -373,7 +373,7 @@ class build_ext_twisted(build_ext.build_ext, object):
 
 
 
-def _checkCPython(sys=sys, platform=platform):
+def _checkCPython(sys=sys, platform=platform) -> bool:
     """
     Checks if this implementation is CPython.
 
@@ -389,7 +389,8 @@ def _checkCPython(sys=sys, platform=platform):
     return platform.python_implementation() == "CPython"
 
 
-_isCPython = _checkCPython()
+
+_isCPython = _checkCPython()  # type: bool
 
 notPortedModules = [
     "twisted.mail.alias",

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -21,6 +21,7 @@ Serializing a formatting structure is done with L{flatten}.
 """
 
 
+from typing import Sequence
 from twisted.python.util import FancyEqMixin
 
 
@@ -36,7 +37,7 @@ class _Attribute(FancyEqMixin, object):
     @type children: C{list}
     @ivar children: Child attributes.
     """
-    compareAttributes = ('children',)
+    compareAttributes = ('children',)  # type: Sequence[str]
 
 
     def __init__(self):

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -14,10 +14,10 @@ This is thread-safe.
 
 
 from threading import local
+from typing import Dict, Type
 
 
-
-defaultContextDict = {}
+defaultContextDict = {}  # type: Dict[Type[object], Dict[str, str]]
 
 setDefault = defaultContextDict.__setitem__
 

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -21,7 +21,7 @@ import opcode
 from inspect import getmro
 
 from twisted.python import reflect
-from twisted.python.compat import _PY3, NativeStringIO as StringIO
+from io import StringIO
 
 count = 0
 traceupLength = 4
@@ -228,10 +228,7 @@ class Failure(BaseException):
     # on PY3, b'a'[0] == 97 while in py2 b'a'[0] == b'a' opcodes
     # are stored in bytes so we need to properly account for this
     # difference.
-    if _PY3:
-        _yieldOpcode = opcode.opmap["YIELD_VALUE"]
-    else:
-        _yieldOpcode = chr(opcode.opmap["YIELD_VALUE"])
+    _yieldOpcode = opcode.opmap["YIELD_VALUE"]
 
 
     def __init__(self, exc_value=None, exc_type=None, exc_tb=None,
@@ -455,10 +452,7 @@ class Failure(BaseException):
         """
         error = self.check(*errorTypes)
         if not error:
-            if _PY3:
-                self.raiseException()
-            else:
-                raise self
+            self.raiseException()
         return error
 
 

--- a/src/twisted/python/formmethod.py
+++ b/src/twisted/python/formmethod.py
@@ -11,6 +11,8 @@ to format methods.
 """
 
 import calendar
+from typing import Any, Optional, Tuple
+
 
 
 class FormException(Exception):
@@ -19,6 +21,7 @@ class FormException(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args)
         self.descriptions = kwargs
+
 
 
 class InputError(FormException):
@@ -32,7 +35,7 @@ class Argument:
     """Base class for form arguments."""
 
     # default value for argument, if no other default is given
-    defaultDefault = None
+    defaultDefault = None  # type: Any
 
     def __init__(self, name, default=None, shortDesc=None,
                  longDesc=None, hints=None, allowNone=1):
@@ -64,10 +67,11 @@ class Argument:
         raise NotImplementedError("implement in subclass")
 
 
+
 class String(Argument):
     """A single string.
     """
-    defaultDefault = ''
+    defaultDefault = ''  # type: str
     min = 0
     max = None
 
@@ -87,14 +91,17 @@ class String(Argument):
         return str(val)
 
 
+
 class Text(String):
     """A long string.
     """
 
 
+
 class Password(String):
     """A string which should be obscured when input.
     """
+
 
 
 class VerifiedPassword(String):
@@ -111,6 +118,7 @@ class VerifiedPassword(String):
         return s
 
 
+
 class Hidden(String):
     """A string which is not displayed.
 
@@ -118,10 +126,11 @@ class Hidden(String):
     """
 
 
+
 class Integer(Argument):
     """A single integer.
     """
-    defaultDefault = None
+    defaultDefault = None  # type: Optional[int]
 
     def __init__(self, name, allowNone=1, default=None, shortDesc=None,
                  longDesc=None, hints=None):
@@ -139,7 +148,10 @@ class Integer(Argument):
         try:
             return int(val)
         except ValueError:
-            raise InputError("%s is not valid, please enter a whole number, e.g. 10" % val)
+            raise InputError(
+                "{} is not valid, please enter "
+                "a whole number, e.g. 10".format(val))
+
 
 
 class IntegerRange(Integer):
@@ -162,9 +174,10 @@ class IntegerRange(Integer):
         return result
 
 
+
 class Float(Argument):
 
-    defaultDefault = None
+    defaultDefault = None  # type: Optional[float]
 
     def __init__(self, name, allowNone=1, default=None, shortDesc=None,
                  longDesc=None, hints=None):
@@ -184,6 +197,7 @@ class Float(Argument):
             return float(val)
         except ValueError:
             raise InputError("Invalid float: %s" % val)
+
 
 
 class Choice(Argument):
@@ -209,6 +223,7 @@ class Choice(Argument):
                 return val
         else:
             raise InputError("Invalid Choice: %s" % inIdent)
+
 
 
 class Flags(Argument):
@@ -240,12 +255,15 @@ class Flags(Argument):
         return outFlags
 
 
+
 class CheckGroup(Flags):
     pass
 
 
+
 class RadioGroup(Choice):
     pass
+
 
 
 class Boolean(Argument):
@@ -256,6 +274,8 @@ class Boolean(Argument):
         if lInVal in ('no', 'n', 'f', 'false', '0'):
             return 0
         return 1
+
+
 
 class File(Argument):
     def __init__(self, name, allowNone=1, shortDesc=None, longDesc=None,
@@ -271,15 +291,20 @@ class File(Argument):
         else:
             raise InputError("Invalid File")
 
+
+
 def positiveInt(x):
     x = int(x)
-    if x <= 0: raise ValueError
+    if x <= 0:
+        raise ValueError
     return x
+
+
 
 class Date(Argument):
     """A date -- (year, month, day) tuple."""
 
-    defaultDefault = None
+    defaultDefault = None  # type: Optional[Tuple[int, int, int]]
 
     def __init__(self, name, allowNone=1, default=None, shortDesc=None,
                  longDesc=None, hints=None):

--- a/src/twisted/python/htmlizer.py
+++ b/src/twisted/python/htmlizer.py
@@ -8,8 +8,10 @@ HTML rendering of Python source.
 
 from twisted.python.compat import _tokenize, escape
 
-import tokenize, keyword
+import keyword
+import tokenize
 from . import reflect
+from typing import List
 
 
 
@@ -73,7 +75,7 @@ class HTMLWriter:
     tokens as HTML spans.
     """
 
-    noSpan = []
+    noSpan = []  # type: List[str]
 
     def __init__(self, writer):
         self.writer = writer

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -15,16 +15,11 @@ import linecache
 
 from imp import reload
 
-try:
-    # Python 2
-    from types import InstanceType
-except ImportError:
-    # Python 3
-    pass
+from types import ModuleType
+from typing import Dict
 
 # Sibling Imports
 from twisted.python import log, reflect
-from twisted.python.compat import _PY3
 
 lastRebuild = time.time()
 
@@ -82,17 +77,17 @@ class Sensitive(object):
                 return getattr(anObject.im_class, anObject.__name__)
             else:
                 return getattr(anObject.__self__, anObject.__name__)
-        elif not _PY3 and t == InstanceType:
-            # Kick it, if it's out of date.
-            getattr(anObject, 'nothing', None)
-            return anObject
         elif _isClassType(t):
             return latestClass(anObject)
         else:
             log.msg('warning returning anObject!')
             return anObject
 
-_modDictIDMap = {}
+
+
+_modDictIDMap = {}  # type:Dict[int, ModuleType]
+
+
 
 def latestFunction(oldFunc):
     """

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -14,9 +14,14 @@ import sys
 import warnings
 
 try:
-    import pwd, grp
+    import pwd as _pwd
+    import grp as _grp
 except ImportError:
-    pwd = grp = None
+    pwd = None
+    grp = None
+else:
+    pwd = _pwd
+    grp = _grp
 
 from twisted.trial import unittest
 from twisted.trial.util import suppress as SUPPRESS

--- a/src/twisted/python/threadable.py
+++ b/src/twisted/python/threadable.py
@@ -25,7 +25,10 @@ def unpickle_lock():
         return XLock()
     else:
         return DummyLock()
-unpickle_lock.__safe_for_unpickling__ = True
+
+
+
+unpickle_lock.__safe_for_unpickling__ = True  # type: ignore[attr-defined]
 
 
 
@@ -129,10 +132,11 @@ XLock = None
 
 
 try:
-    import threading as threadingmodule
+    import threading as _threadingmodule
 except ImportError:
     threadingmodule = None
 else:
+    threadingmodule = _threadingmodule
     init(True)
 
 

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -20,6 +20,7 @@ import sys
 import getopt
 from os import path
 import textwrap
+from typing import Callable, Optional
 
 # Sibling Imports
 from twisted.python import reflect, util
@@ -186,7 +187,7 @@ class Options(dict):
             self._dispatch.update(dispatch)
 
 
-    __hash__ = object.__hash__
+    __hash__ = object.__hash__  # type: Callable[[object], int]
 
 
     def opt_help(self):
@@ -559,7 +560,8 @@ class Completer(object):
     This class produces no completion matches itself - see the various
     subclasses for specific completion functionality.
     """
-    _descr = None
+    _descr = None  # type: Optional[str]
+
     def __init__(self, descr=None, repeat=False):
         """
         @type descr: C{str}

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -8,14 +8,25 @@ import os
 import sys
 import warnings
 try:
-    import grp
-    import pwd
+    import grp as _grp
+    import pwd as _pwd
 except ImportError:
-    pwd = grp = None
+    pwd = None
+    grp = None
+else:
+    grp = _grp
+    pwd = _pwd
+
 try:
-    from os import setgroups, getgroups
+    from os import setgroups as _setgroups, getgroups as _getgroups
 except ImportError:
-    setgroups = getgroups = None
+    setgroups = None
+    getgroups = None
+else:
+    setgroups = _setgroups
+    getgroups = _getgroups
+
+from typing import Sequence
 
 from twisted.python.compat import _PY3, unicode
 from incremental import Version
@@ -596,7 +607,7 @@ class FancyStrMixin:
     might be used for a float.
     """
     # Override in subclasses:
-    showAttributes = ()
+    showAttributes = ()  # type: Sequence[str]
 
 
     def __str__(self):
@@ -623,7 +634,7 @@ class FancyEqMixin:
     Comparison is done using the list of attributes defined in
     C{compareAttributes}.
     """
-    compareAttributes = ()
+    compareAttributes = ()  # type: Sequence[str]
 
     def __eq__(self, other):
         if not self.compareAttributes:
@@ -645,9 +656,11 @@ class FancyEqMixin:
 
 try:
     # initgroups is available in Python 2.7+ on UNIX-likes
-    from os import initgroups as _initgroups
+    from os import initgroups as __initgroups
 except ImportError:
     _initgroups = None
+else:
+    _initgroups = __initgroups
 
 
 

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -30,10 +30,12 @@ class FakeWindowsError(OSError):
     is missing.
     """
 
+
+
 try:
-    WindowsError = WindowsError
+    WindowsError = WindowsError  # type: OSError
 except NameError:
-    WindowsError = FakeWindowsError
+    WindowsError = FakeWindowsError  # type: ignore[misc,assignment]
 
 
 _cmdLineQuoteRe = re.compile(r'(\\*)"')

--- a/src/twisted/runner/inetdconf.py
+++ b/src/twisted/runner/inetdconf.py
@@ -6,6 +6,10 @@
 Parser for inetd.conf files
 """
 
+from typing import Optional
+
+
+
 # Various exceptions
 class InvalidConfError(Exception):
     """
@@ -46,7 +50,7 @@ class SimpleConfFile:
     """
 
     commentChar = '#'
-    defaultFilename = None
+    defaultFilename = None  # type: Optional[str]
 
     def parseFile(self, file=None):
         """

--- a/src/twisted/runner/procmontap.py
+++ b/src/twisted/runner/procmontap.py
@@ -6,6 +6,8 @@
 Support for creating a service which runs a process monitor.
 """
 
+from typing import List, Sequence
+
 from twisted.python import usage
 from twisted.runner.procmon import ProcessMonitor
 
@@ -31,7 +33,7 @@ class Options(usage.Options):
                       "seconds) to wait before attempting to restart a "
                       "process", float]]
 
-    optFlags = []
+    optFlags = []  # type: List[Sequence[str]]
 
 
     longdesc = """\

--- a/src/twisted/spread/test/test_pb.py
+++ b/src/twisted/spread/test/test_pb.py
@@ -20,6 +20,7 @@ import weakref
 from collections import deque
 
 from io import BytesIO as StringIO
+from typing import Dict
 from zope.interface import implementer, Interface
 
 from twisted.trial import unittest
@@ -288,7 +289,8 @@ class SimpleFactoryCopy(pb.Copyable):
     @cvar allIDs: hold every created instances of this class.
     @type allIDs: C{dict}
     """
-    allIDs = {}
+    allIDs = {}  # type: Dict[int, 'SimpleFactoryCopy']
+
     def __init__(self, id):
         self.id = id
         SimpleFactoryCopy.allIDs[id] = self

--- a/src/twisted/test/test_adbapi.py
+++ b/src/twisted/test/test_adbapi.py
@@ -9,6 +9,7 @@ from twisted.trial import unittest
 
 import os
 import stat
+from typing import Dict
 
 from twisted.enterprise.adbapi import ConnectionPool, ConnectionLost
 from twisted.enterprise.adbapi import Connection, Transaction
@@ -28,7 +29,7 @@ class ADBAPITestBase(object):
     """
     Test the asynchronous DB-API code.
     """
-    openfun_called = {}
+    openfun_called = {}  # type: Dict[object, bool]
 
     if interfaces.IReactorThreads(reactor, None) is None:
         skip = "ADB-API requires threads, no way to test without them"

--- a/src/twisted/test/test_postfix.py
+++ b/src/twisted/test/test_postfix.py
@@ -5,6 +5,7 @@
 Test cases for twisted.protocols.postfix module.
 """
 
+from typing import List, Dict, Tuple
 from twisted.trial import unittest
 from twisted.protocols import postfix
 from twisted.test.proto_helpers import StringTransport
@@ -37,11 +38,11 @@ class PostfixTCPMapQuoteTests(unittest.TestCase):
 class PostfixTCPMapServerTestCase(object):
     data = {
         # 'key': 'value',
-        }
+        }  # type: Dict[bytes, bytes]
 
     chat = [
         # (input, expected_output),
-        ]
+        ]  # type: List[Tuple[bytes, bytes]]
 
 
     def test_chat(self):

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -12,6 +12,8 @@ import errno
 import hamcrest
 from functools import wraps
 
+from typing import Type
+
 from zope.interface import implementer
 
 from twisted.trial import unittest
@@ -118,7 +120,7 @@ class MyProtocolFactoryMixin(object):
 
     protocolConnectionMade = None
     protocolConnectionLost = None
-    protocol = None
+    protocol = None  # type: Type[AccumulatingProtocol]
     called = 0
 
     def __init__(self):

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -8,20 +8,20 @@ Tests for L{twisted.application.app} and L{twisted.scripts.twistd}.
 
 import errno
 import inspect
+import pickle
 import signal
 import os
 import sys
 
 try:
-    import pwd
-    import grp
+    import pwd as _pwd
+    import grp as _grp
 except ImportError:
-    pwd = grp = None
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+    pwd = None
+    grp = None
+else:
+    pwd = _pwd
+    grp = _grp
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -12,6 +12,8 @@ Maintainer: Jonathan Lange
 import inspect
 import warnings
 
+from typing import List
+
 from zope.interface import implementer
 
 # We can't import reactor at module-level because this code runs before trial
@@ -24,7 +26,9 @@ from twisted.trial import itrial, util
 from twisted.trial._synctest import (
     FailTest, SkipTest, SynchronousTestCase)
 
-_wait_is_running = []
+_wait_is_running = []  # type: List[None]
+
+
 
 @implementer(itrial.ITestCase)
 class TestCase(SynchronousTestCase):

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -388,7 +388,9 @@ class _Assertions(pyunit.TestCase, object):
         """
         super(_Assertions, self).assertFalse(condition, msg)
         return condition
-    assertNot = failUnlessFalse = failIf = assertFalse
+    assertNot = assertFalse
+    failUnlessFalse = assertFalse
+    failIf = assertFalse
 
 
     def assertTrue(self, condition, msg=None):
@@ -399,7 +401,9 @@ class _Assertions(pyunit.TestCase, object):
         """
         super(_Assertions, self).assertTrue(condition, msg)
         return condition
-    assert_ = failUnlessTrue = failUnless = assertTrue
+    assert_ = assertTrue
+    failUnlessTrue = assertTrue
+    failUnless = assertTrue
 
 
     def assertRaises(self, exception, f=None, *args, **kwargs):
@@ -436,7 +440,9 @@ class _Assertions(pyunit.TestCase, object):
         """
         super(_Assertions, self).assertEqual(first, second, msg)
         return first
-    failUnlessEqual = failUnlessEquals = assertEquals = assertEqual
+    failUnlessEqual = assertEqual
+    failUnlessEquals = assertEqual
+    assertEquals = assertEqual
 
 
     def assertIs(self, first, second, msg=None):
@@ -449,9 +455,11 @@ class _Assertions(pyunit.TestCase, object):
         '%r is not %r' % (first, second)
         """
         if first is not second:
-            raise self.failureException(msg or '%r is not %r' % (first, second))
+            raise self.failureException(
+                msg or '%r is not %r' % (first, second))
         return first
-    failUnlessIdentical = assertIdentical = assertIs
+    failUnlessIdentical = assertIs
+    assertIdentical = assertIs
 
 
     def assertIsNot(self, first, second, msg=None):
@@ -466,7 +474,8 @@ class _Assertions(pyunit.TestCase, object):
         if first is second:
             raise self.failureException(msg or '%r is %r' % (first, second))
         return first
-    failIfIdentical = assertNotIdentical = assertIsNot
+    failIfIdentical = assertIsNot
+    assertNotIdentical = assertIsNot
 
 
     def assertNotEqual(self, first, second, msg=None):
@@ -479,7 +488,9 @@ class _Assertions(pyunit.TestCase, object):
         if not first != second:
             raise self.failureException(msg or '%r == %r' % (first, second))
         return first
-    assertNotEquals = failIfEquals = failIfEqual = assertNotEqual
+    assertNotEquals = assertNotEqual
+    failIfEquals = assertNotEqual
+    failIfEqual = assertNotEqual
 
 
     def assertIn(self, containee, container, msg=None):
@@ -532,7 +543,8 @@ class _Assertions(pyunit.TestCase, object):
             raise self.failureException(msg or '%r == %r within %r places'
                                         % (first, second, places))
         return first
-    assertNotAlmostEquals = failIfAlmostEqual = assertNotAlmostEqual
+    assertNotAlmostEquals = assertNotAlmostEqual
+    failIfAlmostEqual = assertNotAlmostEqual
     failIfAlmostEquals = assertNotAlmostEqual
 
 
@@ -552,8 +564,8 @@ class _Assertions(pyunit.TestCase, object):
             raise self.failureException(msg or '%r != %r within %r places'
                                         % (first, second, places))
         return first
-    assertAlmostEquals = failUnlessAlmostEqual = assertAlmostEqual
-    failUnlessAlmostEquals = assertAlmostEqual
+    assertAlmostEquals = assertAlmostEqual
+    failUnlessAlmostEqual = assertAlmostEqual
 
 
     def assertApproximates(self, first, second, tolerance, msg=None):

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -8,6 +8,9 @@
 import os
 import pdb
 import sys
+import unittest as pyunit
+
+from typing import List
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -24,8 +27,6 @@ from twisted.plugins import twisted_trial
 from twisted import plugin
 from twisted.internet import defer
 
-
-pyunit = __import__('unittest')
 
 
 class CapturingDebugger(object):
@@ -594,7 +595,8 @@ class UntilFailureTests(unittest.SynchronousTestCase):
         """
         A test case that fails when run 3 times in a row.
         """
-        count = []
+        count = []  # type: List[None]
+
         def test_foo(self):
             self.count.append(None)
             if len(self.count) == 3:
@@ -897,8 +899,10 @@ class MalformedMethodTests(unittest.SynchronousTestCase):
         """
         def test_foo(self, blah):
             pass
-        def test_bar():
+
+        def test_bar():  # type: ignore[misc]
             pass
+
         test_spam = defer.inlineCallbacks(test_bar)
 
     def _test(self, method):

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -20,6 +20,7 @@ import warnings
 import sys
 
 from collections import deque
+from typing import List
 
 from zope.interface import implementer
 
@@ -44,7 +45,7 @@ from twisted.web.error import ExcessiveBufferingError
 
 
 # This API is currently considered private.
-__all__ = []
+__all__ = []  # type: List[str]
 
 
 _END_STREAM_SENTINEL = object()

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -14,6 +14,7 @@ import os
 import time
 import warnings
 
+from typing import Any, Dict, Callable
 from zope.interface import implementer
 
 from twisted.web import server
@@ -212,7 +213,7 @@ class File(resource.Resource, filepath.FilePath):
         ".bz2": "bzip2"
         }
 
-    processors = {}
+    processors = {}  # type: Dict[str, Callable[[str, Any], Data]]
 
     indexNames = ["index", "index.html", "index.htm", "index.rpy"]
 

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -59,12 +59,13 @@ from twisted.web.error import SchemeNotSupported
 from twisted.logger import globalLogPublisher
 
 try:
-    from twisted.internet import ssl
+    from twisted.internet import ssl as _ssl
 except ImportError:
     ssl = None
     skipWhenNoSSL = "SSL not present, cannot run SSL tests."
     skipWhenSSLPresent = None
 else:
+    ssl = _ssl
     skipWhenSSLPresent = "SSL present."
     skipWhenNoSSL = None
     from twisted.internet._sslverify import ClientTLSOptions, IOpenSSLTrustRoot

--- a/src/twisted/web/test/test_distrib.py
+++ b/src/twisted/web/test/test_distrib.py
@@ -8,9 +8,11 @@ Tests for L{twisted.web.distrib}.
 from os.path import abspath
 from xml.dom.minidom import parseString
 try:
-    import pwd
+    import pwd as _pwd
 except ImportError:
     pwd = None
+else:
+    pwd = _pwd
 
 from zope.interface.verify import verifyObject
 

--- a/src/twisted/words/im/locals.py
+++ b/src/twisted/words/im/locals.py
@@ -2,8 +2,9 @@
 # See LICENSE for details.
 
 
+
 class Enum:
-    group = None
+    group = None  # type: str
 
     def __init__(self, label):
         self.label = label
@@ -15,12 +16,17 @@ class Enum:
         return self.label
 
 
+
 class StatusEnum(Enum):
     group = 'Status'
+
+
 
 OFFLINE = Enum('Offline')
 ONLINE = Enum('Online')
 AWAY = Enum('Away')
+
+
 
 class OfflineError(Exception):
     """The requested action can't happen while offline."""

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -8,16 +8,23 @@ Jabber Identifier support.
 
 This module provides an object to represent Jabber Identifiers (JIDs) and
 parse string representations into them with proper checking for illegal
-characters, case folding and canonicalisation through L{stringprep<twisted.words.protocols.jabber.xmpp_stringprep>}.
+characters, case folding and canonicalisation through
+L{stringprep<twisted.words.protocols.jabber.xmpp_stringprep>}.
 """
 
+from typing import Dict
 from twisted.python.compat import _PY3, unicode
-from twisted.words.protocols.jabber.xmpp_stringprep import nodeprep, resourceprep, nameprep
+from twisted.words.protocols.jabber.xmpp_stringprep import (
+    nodeprep, resourceprep, nameprep)
+
+
 
 class InvalidFormat(Exception):
     """
     The given string could not be parsed into a valid Jabber Identifier (JID).
     """
+
+
 
 def parse(jidstring):
     """
@@ -105,7 +112,11 @@ def prep(user, host, resource):
 
     return (user, host, resource)
 
-__internJIDs = {}
+
+
+__internJIDs = {}  # type: Dict[str, 'JID']
+
+
 
 def internJID(jidstring):
     """
@@ -120,6 +131,8 @@ def internJID(jidstring):
         j = JID(jidstring)
         __internJIDs[jidstring] = j
         return j
+
+
 
 class JID(object):
     """


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9827

Add some type annotations which eliminate mypy errors such as:

```
src/twisted/words/protocols/jabber/jid.py:108:1: error: Need type annotation for '__internJIDs' (hint: "__internJIDs: Dict[<type>, <type>] = ...")  [var-annotated]
    __internJIDs = {}
```