### PR TITLE
Fix verifyCryptedPassword() for crypt.crypt() throwing in py3.9

### DIFF
--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -16,8 +16,6 @@ try:
     import pwd
 except ImportError:
     pwd = None  # type: ignore[assignment]
-else:
-    import crypt
 
 try:
     import spwd

--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -35,30 +35,13 @@ from twisted.cred.credentials import IUsernamePassword, ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
 from twisted.python import failure, reflect
+from twisted.plugins.cred_unix import verifyCryptedPassword
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.util import runAsEffectiveUser
 from twisted.python.filepath import FilePath
 from twisted.logger import Logger
 
 _log = Logger()
-
-
-
-def verifyCryptedPassword(crypted, pw):
-    """
-    Check that the password, when crypted, matches the stored crypted password.
-
-    @param crypted: The stored crypted password.
-    @type crypted: L{str}
-    @param pw: The password the user has given.
-    @type pw: L{str}
-
-    @rtype: L{bool}
-    """
-    try:
-        return crypt.crypt(pw, crypted) == crypted
-    except OSError:
-        return False
 
 
 

--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -55,7 +55,10 @@ def verifyCryptedPassword(crypted, pw):
 
     @rtype: L{bool}
     """
-    return crypt.crypt(pw, crypted) == crypted
+    try:
+        return crypt.crypt(pw, crypted) == crypted
+    except OSError:
+        return False
 
 
 

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -328,6 +328,18 @@ class CryptTests(TestCase):
                                                      password.encode("utf-8"))
             self.assertFalse(result)
 
+    def test_verifyCryptedPasswordOSError(self):
+        """
+        L{cred_unix.verifyCryptedPassword} when OSError is raised
+        """
+        def mockCrypt(password, salt):
+            raise OSError("")
+
+        password = "sample password ^%$"
+        cryptedCorrect = crypt.crypt(password, "ab")
+        self.patch(crypt, "crypt", mockCrypt)
+        self.assertFalse(cred_unix.verifyCryptedPassword(cryptedCorrect,
+                                                         password))
 
 
 class FileDBCheckerTests(TestCase):

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -108,7 +108,7 @@ class UNIXAddress:
     @type name: C{bytes}
     """
 
-    name = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))
+    name = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))  # type: bytes
 
     if getattr(os.path, 'samefile', None) is not None:
         def __eq__(self, other: object) -> bool:

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -43,7 +43,10 @@ def verifyCryptedPassword(crypted, pw):
         pw = pw.decode('utf-8')
     if not isinstance(crypted, StringType):
         crypted = crypted.decode('utf-8')
-    return crypt.crypt(pw, crypted) == crypted
+    try:
+        return crypt.crypt(pw, crypted) == crypted
+    except OSError:
+        return False
 
 
 

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -16,7 +16,6 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import IUsernamePassword
 from twisted.cred.error import UnauthorizedLogin
 from twisted.internet import defer
-from twisted.python.compat import StringType
 
 
 
@@ -39,9 +38,9 @@ def verifyCryptedPassword(crypted, pw):
 
     if crypt is None:
         raise NotImplementedError("cred_unix not supported on this platform")
-    if not isinstance(pw, StringType):
+    if isinstance(pw, bytes):
         pw = pw.decode('utf-8')
-    if not isinstance(crypted, StringType):
+    if isinstance(crypted, bytes):
         crypted = crypted.decode('utf-8')
     try:
         return crypt.crypt(pw, crypted) == crypted
@@ -79,7 +78,7 @@ class UNIXChecker:
         @type username: L{unicode}/L{str} or L{bytes}
         """
         try:
-            if not isinstance(username, StringType):
+            if isinstance(username, bytes):
                 username = username.decode('utf-8')
             cryptedPass = pwd.getpwnam(username).pw_passwd
         except KeyError:
@@ -107,7 +106,7 @@ class UNIXChecker:
         @type username: L{unicode}/L{str} or L{bytes}
         """
         try:
-            if not isinstance(username, StringType):
+            if isinstance(username, bytes):
                 username = username.decode('utf-8')
             if getattr(spwd.struct_spwd, "sp_pwdp", None):
                 # Python 3


### PR DESCRIPTION
In Python 3.9, the crypt.crypt() function may throw an exception
if the underlying crypt() function fails.  Update
verifyCryptedPassword() to account for that, and preserve the existing
behavior of returning False in that case.

Fixes: ticket:9833

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9833
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
