### PR TITLE
Use xml.etree.ElementTree instead of deprecated cElementTree

### DIFF
--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -2390,18 +2390,18 @@ class Win32UnicodeEnvironmentTests(unittest.TestCase):
     def test_encodableUnicodeEnvironment(self):
         """
         Test C{os.environ} (inherited by every subprocess on Windows) that
-        contains an ascii-encodable Unicode string. This is different from
-        passing Unicode environment explicitly to spawnProcess (which is not
-        supported on Python 2).
+        contains an ascii-encodable Unicode string.
         """
         os.environ[self.goodKey] = self.goodValue
         self.addCleanup(operator.delitem, os.environ, self.goodKey)
 
-        p = GetEnvironmentDictionary.run(reactor, [], properEnv)
+        p = GetEnvironmentDictionary.run(reactor, [], os.environ)
+
         def gotEnvironment(environ):
             self.assertEqual(
                 environ[self.goodKey.encode('ascii')],
                 self.goodValue.encode('ascii'))
+
         return p.getResult().addCallback(gotEnvironment)
 
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 from unittest import skipIf
 
-from xml.etree.cElementTree import XML
+from xml.etree.ElementTree import XML
 
 from collections import OrderedDict
 


### PR DESCRIPTION
The xml.etree.cElementTree is deprecated, and has been removed in Python
3.9.  At the same time, xml.etree.ElementTree has already been using
cElementTree implicitly since Python 3.3.  Update test_flatten to use
the latter to provide compatibility with newer Python versions.

Fixes: ticket:9834

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9834
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
