### PR TITLE
Interface methods should not have 'self' argument

### DIFF
--- a/src/twisted/protocols/haproxy/_interfaces.py
+++ b/src/twisted/protocols/haproxy/_interfaces.py
@@ -33,7 +33,7 @@ class IProxyParser(zope.interface.Interface):
     Streaming parser that handles PROXY protocol headers.
     """
 
-    def feed(self, data):
+    def feed(data):
         """
         Consume a chunk of data and attempt to parse it.
 
@@ -49,7 +49,7 @@ class IProxyParser(zope.interface.Interface):
         """
 
 
-    def parse(self, line):
+    def parse(line):
         """
         Parse a bytestring as a full PROXY protocol header line.
 

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -473,7 +473,7 @@ class IPathImportMapper(Interface):
     This is an internal interface, used to map importers to factories for
     FilePath-like objects.
     """
-    def mapPath(self, pathLikeString):
+    def mapPath(pathLikeString):
         """
         Return a FilePath-like object.
 

--- a/src/twisted/python/test/test_components.py
+++ b/src/twisted/python/test/test_components.py
@@ -581,7 +581,7 @@ class IProxiedSubInterface(IProxiedInterface):
     An interface that derives from another for use with L{proxyForInterface}.
     """
 
-    def boo(self):
+    def boo():
         """
         A different sample method which should be proxied.
         """


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9837

This fixes several warnings that I found by running:

```
tox -e mypy
```

such as:

```
src/twisted/protocols/haproxy/_interfaces.py:36:5: error: Interface methods should not have 'self' argument  [misc]
        def feed(self, data):
        ^
src/twisted/protocols/haproxy/_interfaces.py:52:5: error: Interface methods should not have 'self' argument  [misc]
        def parse(self, line):
        ^
```