### PR TITLE
[9835] Fix ParentRedirect for header sanitization

### DIFF
--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -39,7 +39,7 @@ class IRequest(Interface):
 
     prepath = Attribute(
         "The URL path segments which have been processed during resource "
-        "traversal, as a list of {bytes}.")
+        "traversal, as a list of L{bytes}.")
 
     postpath = Attribute(
         "The URL path segments which have not (yet) been processed "

--- a/src/twisted/web/newsfragments/9835.bugfix
+++ b/src/twisted/web/newsfragments/9835.bugfix
@@ -1,0 +1,1 @@
+twisted.web.util.ParentRedirect has been fixed (it was broken a security fix in Twisted 19.2.0) and more thoroughly documented.

--- a/src/twisted/web/newsfragments/9835.bugfix
+++ b/src/twisted/web/newsfragments/9835.bugfix
@@ -1,1 +1,1 @@
-twisted.web.util.ParentRedirect has been fixed (it was broken a security fix in Twisted 19.2.0) and more thoroughly documented.
+twisted.web.util.ParentRedirect has been fixed and documented. It was broken by a security fix in Twisted 19.2.0.

--- a/src/twisted/web/test/test_util.py
+++ b/src/twisted/web/test/test_util.py
@@ -67,7 +67,9 @@ class ParentRedirectTests(SynchronousTestCase):
         """
         Render a response to a request with path *requestPath*
 
-        @param requestPath: A slash-separated path like L{b'/foo/bar'}.
+        @param requestPath: A slash-separated path like C{b'/foo/bar'}.
+
+        @returns: The value of the I{Location} header.
         """
         request = Request(DummyChannel(), True)
         request.method = b'GET'
@@ -76,31 +78,33 @@ class ParentRedirectTests(SynchronousTestCase):
         resource = ParentRedirect()
         resource.render(request)
 
-        [location] = request.responseHeaders.getRawHeader(b'Location')
+        [location] = request.responseHeaders.getRawHeaders(b'Location')
         return location
 
     def test_locationRoot(self):
         """
-        At the URL root issue a redirect to the current URL.
+        At the URL root issue a redirect to the current URL, removing any query
+        string.
         """
-        self.assertEqual(b'/', self.doLocationTest(b'/'))
+        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/'))
+        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/?biff=baff'))
 
     def test_locationToRoot(self):
-        self.assertEqual(b'/', self.doLocationTest(b'/foo'))
-        self.assertEqual(b'/', self.doLocationTest(b'/foo/'))
+        """
+        A request for a resource one level down from the URL root produces
+        a redirect to the root.
+        """
+        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/foo'))
+        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/foo?bar=sproiiing'))
 
     def test_locationUpOne(self):
-        self.assertEqual(b'/foo/', self.doLocationTest(b'/foo/bar'))
-        self.assertEqual(b'/foo/', self.doLocationTest(b'/foo/bar/'))
-
-    def test_getChild(self):
         """
-        L{ParentRedirector} returns itself as its own child.
+        Requests for resources directly under the path C{/foo/} produce
+        redirects to C{/foo/}.
         """
-        resource = ParentRedirect()
-
-        self.assertTrue(resource.isLeaf)
-        self.assertIs(resource, resource.getChild(b'foo'))
+        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/'))
+        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/bar'))
+        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/bar?biz=baz'))
 
 
 

--- a/src/twisted/web/test/test_util.py
+++ b/src/twisted/web/test/test_util.py
@@ -8,21 +8,19 @@ Tests for L{twisted.web.util}.
 
 import gc
 
-from twisted.python.failure import Failure
-from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.internet import defer
 from twisted.python.compat import _PY3, intToBytes, networkString
+from twisted.python.failure import Failure
+from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.web import resource, util
 from twisted.web.error import FlattenerError
 from twisted.web.http import FOUND
 from twisted.web.server import Request
 from twisted.web.template import TagLoader, flattenString, tags
 from twisted.web.test.requesthelper import DummyChannel, DummyRequest
-from twisted.web.util import DeferredResource
-from twisted.web.util import _SourceFragmentElement, _FrameElement
-from twisted.web.util import _StackElement, FailureElement, formatFailure
-from twisted.web.util import redirectTo, _SourceLineElement
-
+from twisted.web.util import (DeferredResource, FailureElement, _FrameElement,
+                              _SourceFragmentElement, _SourceLineElement,
+                              _StackElement, formatFailure, redirectTo)
 
 
 class RedirectToTests(TestCase):

--- a/src/twisted/web/test/test_util.py
+++ b/src/twisted/web/test/test_util.py
@@ -24,10 +24,12 @@ from twisted.web.util import (DeferredResource, FailureElement, ParentRedirect,
                               redirectTo)
 
 
+
 class RedirectToTests(TestCase):
     """
     Tests for L{redirectTo}.
     """
+
 
     def test_headersAndCode(self):
         """
@@ -62,7 +64,6 @@ class ParentRedirectTests(SynchronousTestCase):
     """
     Test L{ParentRedirect}.
     """
-
     def doLocationTest(self, requestPath: bytes):
         """
         Render a response to a request with path *requestPath*
@@ -81,13 +82,16 @@ class ParentRedirectTests(SynchronousTestCase):
         [location] = request.responseHeaders.getRawHeaders(b'Location')
         return location
 
+
     def test_locationRoot(self):
         """
         At the URL root issue a redirect to the current URL, removing any query
         string.
         """
         self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/'))
-        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/?biff=baff'))
+        self.assertEqual(b'http://10.0.0.1/',
+                         self.doLocationTest(b'/?biff=baff'))
+
 
     def test_locationToRoot(self):
         """
@@ -95,17 +99,21 @@ class ParentRedirectTests(SynchronousTestCase):
         a redirect to the root.
         """
         self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/foo'))
-        self.assertEqual(b'http://10.0.0.1/', self.doLocationTest(b'/foo?bar=sproiiing'))
+        self.assertEqual(b'http://10.0.0.1/',
+                         self.doLocationTest(b'/foo?bar=sproiiing'))
+
 
     def test_locationUpOne(self):
         """
         Requests for resources directly under the path C{/foo/} produce
         redirects to C{/foo/}.
         """
-        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/'))
-        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/bar'))
-        self.assertEqual(b'http://10.0.0.1/foo/', self.doLocationTest(b'/foo/bar?biz=baz'))
-
+        self.assertEqual(b'http://10.0.0.1/foo/',
+                         self.doLocationTest(b'/foo/'))
+        self.assertEqual(b'http://10.0.0.1/foo/',
+                         self.doLocationTest(b'/foo/bar'))
+        self.assertEqual(b'http://10.0.0.1/foo/',
+                         self.doLocationTest(b'/foo/bar?biz=baz'))
 
 
 

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -104,16 +104,35 @@ class ChildRedirector(Redirect):
         return ChildRedirector(newUrl)
 
 
+
 class ParentRedirect(resource.Resource):
     """
-    I redirect to URLPath.here().
+    Redirect to the nearest directory and strip any query string.
+
+    This generates redirects like::
+
+        /              \u2192  /
+        /foo           \u2192  /
+        /foo?bar       \u2192  /
+        /foo/          \u2192  /foo/
+        /foo/bar       \u2192  /foo/
+        /foo/bar?baz   \u2192  /foo/
+
+    However, the generated I{Location} header contains an absolute URL rather
+    than a path.
+
+    The response is the same regardless of HTTP method.
     """
     isLeaf = 1
-    def render(self, request):
-        return redirectTo(urlpath.URLPath.fromRequest(request).here(), request)
 
-    def getChild(self, request):
-        return self
+
+    def render(self, request) -> bytes:
+        """
+        Respond to all requests by redirecting to nearest directory.
+        """
+        here = str(urlpath.URLPath.fromRequest(request).here()).encode('ascii')
+        return redirectTo(here, request)
+
 
 
 class DeferredResource(resource.Resource):

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -104,8 +104,8 @@ class ChildRedirector(Redirect):
     def __init__(self, url):
         # XXX is this enough?
         if ((url.find('://') == -1)
-            and (not url.startswith('..'))
-            and (not url.startswith('/'))):
+                and (not url.startswith('..'))
+                and (not url.startswith('/'))):
             raise ValueError((
                 "It seems you've given me a redirect (%s) that is a child of"
                 " myself! That's not good, it'll cause an infinite redirect."

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -10,7 +10,7 @@ An assortment of web server-related utilities.
 import linecache
 
 from twisted.python import urlpath
-from twisted.python.compat import _PY3, escape, nativeString, unicode
+from twisted.python.compat import escape
 from twisted.python.reflect import fullyQualifiedName
 from twisted.web import resource
 from twisted.web.template import (Element, TagLoader, XMLString, flattenString,
@@ -42,7 +42,7 @@ def redirectTo(URL: bytes, request) -> bytes:
     @param request: The request object to use to generate the redirect.
     @type request: L{IRequest<twisted.web.iweb.IRequest>} provider
 
-    @raise TypeError: If the type of C{URL} a L{unicode} instead of L{bytes}.
+    @raise TypeError: If the type of C{URL} a L{str} instead of L{bytes}.
 
     @return: A C{bytes} containing HTML which tries to convince the client agent
         to visit the new location even if it doesn't respect the I{FOUND}
@@ -52,7 +52,7 @@ def redirectTo(URL: bytes, request) -> bytes:
             def render_GET(self, request):
                 return redirectTo(b"http://example.com/", request)
     """
-    if isinstance(URL, unicode) :
+    if isinstance(URL, str) :
         raise TypeError("Unicode object not allowed as URL")
     request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
     request.redirect(URL)
@@ -415,7 +415,7 @@ class FailureElement(Element):
         """
         Render the exception value as a child of C{tag}.
         """
-        return tag(unicode(self.failure.value).encode('utf8'))
+        return tag(str(self.failure.value).encode('utf8'))
 
 
     @renderer

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -33,12 +33,11 @@ def _PRE(text):
 
 
 
-def redirectTo(URL, request):
+def redirectTo(URL: bytes, request) -> bytes:
     """
     Generate a redirect to the given location.
 
     @param URL: A L{bytes} giving the location to which to redirect.
-    @type URL: L{bytes}
 
     @param request: The request object to use to generate the redirect.
     @type request: L{IRequest<twisted.web.iweb.IRequest>} provider
@@ -57,7 +56,7 @@ def redirectTo(URL, request):
         raise TypeError("Unicode object not allowed as URL")
     request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
     request.redirect(URL)
-    content =  """
+    content = b"""
 <html>
     <head>
         <meta http-equiv=\"refresh\" content=\"0;URL=%(url)s\">
@@ -66,9 +65,7 @@ def redirectTo(URL, request):
     <a href=\"%(url)s\">click here</a>
     </body>
 </html>
-""" % {'url': nativeString(URL)}
-    if _PY3:
-        content = content.encode("utf8")
+""" % {b'url': URL}
     return content
 
 

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -45,7 +45,7 @@ def redirectTo(URL: bytes, request) -> bytes:
 
     @raise TypeError: If the type of C{URL} a L{str} instead of L{bytes}.
 
-    @return: A C{bytes} containing HTML which tries to convince the client
+    @return: A L{bytes} containing HTML which tries to convince the client
         agent
         to visit the new location even if it doesn't respect the I{FOUND}
         response code.  This is intended to be returned from a render method,
@@ -58,6 +58,8 @@ def redirectTo(URL: bytes, request) -> bytes:
         raise TypeError("Unicode object not allowed as URL")
     request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
     request.redirect(URL)
+    # FIXME: The URL should be HTML-escaped.
+    # https://twistedmatrix.com/trac/ticket/9839
     content = b"""
 <html>
     <head>
@@ -457,7 +459,7 @@ def formatFailure(myFailure):
 
     @type myFailure: L{Failure<twisted.python.failure.Failure>}
 
-    @rtype: C{bytes}
+    @rtype: L{bytes}
     @return: A string containing the HTML representation of the given failure.
     """
     result = []

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -10,14 +10,11 @@ An assortment of web server-related utilities.
 import linecache
 
 from twisted.python import urlpath
-from twisted.python.compat import _PY3, unicode, nativeString, escape
+from twisted.python.compat import _PY3, escape, nativeString, unicode
 from twisted.python.reflect import fullyQualifiedName
-
 from twisted.web import resource
-
-from twisted.web.template import TagLoader, XMLString, Element, renderer
-from twisted.web.template import flattenString
-
+from twisted.web.template import (Element, TagLoader, XMLString, flattenString,
+                                  renderer)
 
 
 def _PRE(text):


### PR DESCRIPTION
I fixed this to coerce the Location header to a bytestring as used to happen implicitly.

I also removed the broken `getChild` method. This was never called because `isLeaf = 1` and had the wrong signature anyway.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9835#comment:2
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.