### PR TITLE
xmlrpc: verify HTTPS certificates against the system bundle

### DIFF
--- a/src/twisted/web/newsfragments/9836.bugfix
+++ b/src/twisted/web/newsfragments/9836.bugfix
@@ -1,0 +1,1 @@
+xmlrpc's Proxy class now verifies HTTPS certificates against the system bundle.


### PR DESCRIPTION
Use `ssl.optionsForClientTLS()` when opening the HTTPS connection with `connectSSL()`. With this change, Twisted will use `ssl.platformTrust()` to verify the TLS connection.

Raise `ssl.SSL.Error` in `QueryProtocol` instead of silently skipping it.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9836
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.