### PR TITLE
Remove _connDone parameter from FileDescriptor.loseConnection()

### DIFF
--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -377,7 +377,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.startWriting()
 
 
-    def loseConnection(self, _connDone=failure.Failure(main.CONNECTION_DONE)):
+    def loseConnection(self):
         """Close the connection at the next available opportunity.
 
         Call this to cause this FileDescriptor to lose its connection.  It will
@@ -396,7 +396,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
                 # doWrite won't trigger the connection close anymore
                 self.stopReading()
                 self.stopWriting()
-                self.connectionLost(_connDone)
+                self.connectionLost(failure.Failure(main.CONNECTION_DONE))
             else:
                 self.stopReading()
                 self.startWriting()

--- a/src/twisted/newsfragments/9849.bugfix
+++ b/src/twisted/newsfragments/9849.bugfix
@@ -1,0 +1,1 @@
+The _connDone parameter has been removed from twisted.internet.abstract.FileDescriptor.loseConnection()'s signature in order to match the signature in the base class twisted.internet._newtls.ConnectionMixin loseConnection().


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9849



The signature of FileDescriptor.loseConnection() was modified here:
https://github.com/twisted/twisted/commit/081d393ab03da92d744d8fb2b5d77705662a0caa

I think extending that signature was wrong, since it doesn't match the base class signature of that method.