### PR TITLE
[mypy] Remove duplicate definition of workers in src/twisted/python/threadpool.py

### DIFF
--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -41,7 +41,6 @@ class ThreadPool:
     max = 20
     joined = False
     started = False
-    workers = 0
     name = None
 
     threadFactory = threading.Thread


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9854

This removes this mypy error:

```
src/twisted/python/threadpool.py:84:6: error: Name 'workers' already defined on line 44  [no-redef]
```