### PR TITLE
[mypy] Fix error: "All conditional function variants must have identical signatures"

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -42,8 +42,9 @@ except ImportError:
         def run(f, *args, **kwargs):
             return f(*args, **kwargs)
 
-
-    def _copy_context():
+    # typing ignored due to:
+    # https://github.com/python/typeshed/issues/4249
+    def _copy_context():  # type: ignore[misc]
         return _NoContext
 
 log = Logger()

--- a/src/twisted/persisted/sob.py
+++ b/src/twisted/persisted/sob.py
@@ -76,7 +76,7 @@ class Persistent:
             from twisted.persisted.aot import jellyToSource as dumpFunc
             ext = "tas"
         else:
-            def dumpFunc(obj, file):
+            def dumpFunc(obj, file=None):
                 pickle.dump(obj, file, 2)
             ext = "tap"
         return ext, dumpFunc

--- a/src/twisted/protocols/ident.py
+++ b/src/twisted/protocols/ident.py
@@ -157,7 +157,7 @@ class ProcServerMixin:
             return getpwuid(uid)[0]
         del getpwuid
     except ImportError:
-        def getUsername(self, uid):
+        def getUsername(self, uid, getpwuid=None):
             raise IdentError()
 
 

--- a/src/twisted/python/lockfile.py
+++ b/src/twisted/python/lockfile.py
@@ -50,7 +50,9 @@ else:
         ERROR_ACCESS_DENIED = 5
         ERROR_INVALID_PARAMETER = 87
 
-        def kill(pid, signal):
+        # typing ignored due to:
+        # https://github.com/python/typeshed/issues/4249
+        def kill(pid, signal):  # type: ignore[misc]
             try:
                 OpenProcess(0, 0, pid)
             except pywintypes.error as e:
@@ -66,7 +68,9 @@ else:
     _open = open
 
 
-    def symlink(value, filename):
+    # typing ignored due to:
+    # https://github.com/python/typeshed/issues/4249
+    def symlink(value, filename):  # type: ignore[misc]
         """
         Write a file at C{filename} with the contents of C{value}. See the
         above comment block as to why this is needed.
@@ -92,7 +96,9 @@ else:
             raise
 
 
-    def readlink(filename):
+    # typing ignored due to:
+    # https://github.com/python/typeshed/issues/4249
+    def readlink(filename):  # type: ignore[misc]
         """
         Read the contents of C{filename}. See the above comment block as to why
         this is needed.
@@ -109,7 +115,9 @@ else:
             return result
 
 
-    def rmlink(filename):
+    # typing ignored due to:
+    # https://github.com/python/typeshed/issues/4249
+    def rmlink(filename):  # type: ignore[misc]
         os.remove(os.path.join(filename, 'symlink'))
         os.rmdir(filename)
 

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -13,12 +13,7 @@ from io import BytesIO
 from sys import exc_info
 from types import GeneratorType
 from traceback import extract_tb
-
-try:
-    from inspect import iscoroutine
-except ImportError:
-    def iscoroutine(*args, **kwargs):
-        return False
+from inspect import iscoroutine
 
 from twisted.python.compat import unicode, nativeString, iteritems
 from twisted.internet.defer import Deferred, ensureDeferred


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9855

Eliminate these mypy errors:

```
src/twisted/python/lockfile.py:53:9: error: All conditional function variants must have identical signatures  [misc]
src/twisted/python/lockfile.py:69:5: error: All conditional function variants must have identical signatures  [misc]
src/twisted/python/lockfile.py:95:5: error: All conditional function variants must have identical signatures  [misc]
src/twisted/python/lockfile.py:112:5: error: All conditional function variants must have identical signatures  [misc]
src/twisted/internet/defer.py:46:5: error: All conditional function variants must have identical signatures  [misc]
src/twisted/protocols/ident.py:160:9: error: All conditional function variants must have identical signatures  [misc]
src/twisted/persisted/sob.py:79:13: error: All conditional function variants must have identical signatures  [misc]
src/twisted/web/_flatten.py:20:5: error: All conditional function variants must have identical signatures  [misc]
```