### PR TITLE
[mypy] Implement some functions defined in zope interfaces

### DIFF
--- a/src/twisted/application/runner/test/test_pidfile.py
+++ b/src/twisted/application/runner/test/test_pidfile.py
@@ -474,3 +474,70 @@ class DummyFilePath(object):
 
     def exists(self):
         return self._exists
+
+
+    def sep(self):
+        # IFilePath.sep
+        raise NotImplementedError("Unimplemented: DummyFilePath.sep")
+
+
+    def child(self):
+        # IFilePath.child
+        raise NotImplementedError("Unimplemented: DummyFilePath.child")
+
+
+    def changed(self):
+        # IFilePath.changed
+        raise NotImplementedError("Unimplemented: DummyFilePath.changed")
+
+
+    def getsize(self):
+        # IFilePath.getsize
+        raise NotImplementedError("Unimplemented: DummyFilePath.getsize")
+
+
+    def getModificationTime(self):
+        # IFilePath.getModificationTime
+        raise NotImplementedError(
+            "Unimplemented: DummyFilePath.getModificationTime")
+
+
+    def getStatusChangeTime(self):
+        # IFilePath.getStatusChangeTime
+        raise NotImplementedError(
+            "Unimplemented: DummyFilePath.getStatusChangeTime")
+
+
+    def getAccessTime(self):
+        # IFilePath.getAccessTime
+        raise NotImplementedError("Unimplemented: DummyFilePath.getAccessTime")
+
+
+    def isdir(self):
+        # IFilePath.isdir
+        raise NotImplementedError("Unimplemented: DummyFilePath.isdir")
+
+
+    def isfile(self):
+        # IFilePath.isfile
+        raise NotImplementedError("Unimplemented: DummyFilePath.isfile")
+
+
+    def children(self):
+        # IFilePath.children
+        raise NotImplementedError("Unimplemented: DummyFilePath.children")
+
+
+    def basename(self):
+        # IFilePath.basename
+        raise NotImplementedError("Unimplemented: DummyFilePath.basename")
+
+
+    def parent(self):
+        # IFilePath.parent
+        raise NotImplementedError("Unimplemented: DummyFilePath.parent")
+
+
+    def sibling(self):
+        # IFilePath.sibling
+        raise NotImplementedError("Unimplemented: DummyFilePath.sibling")

--- a/src/twisted/application/test/test_internet.py
+++ b/src/twisted/application/test/test_internet.py
@@ -129,6 +129,18 @@ class FakePort(object):
         self.deferred = Deferred()
         return self.deferred
 
+
+    def getHost(self):
+        # IListeningPort.getHost
+        pass
+
+
+    def startListening(self):
+        # IListeningPort.startListening
+        pass
+
+
+
 verifyClass(IStreamServerEndpoint, FakeServer)
 
 

--- a/src/twisted/conch/avatar.py
+++ b/src/twisted/conch/avatar.py
@@ -17,6 +17,16 @@ class ConchUser:
         self.subsystemLookup = {}
 
 
+    @property
+    def conn(self):
+        return self._conn
+
+
+    @conn.setter
+    def conn(self, value):
+        self._conn = value
+
+
     def lookupChannel(self, channelType, windowSize, maxPacket, data):
         klass = self.channelLookup.get(channelType, None)
         if not klass:

--- a/src/twisted/conch/insults/helper.py
+++ b/src/twisted/conch/insults/helper.py
@@ -456,6 +456,64 @@ class TerminalBuffer(protocol.Protocol):
         return b'\n'.join(lines)
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError("Unimplemented: TerminalBuffer.getHost")
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError("Unimplemented: TerminalBuffer.getPeer")
+
+
+    def loseConnection(self):
+        # ITransport.loseConnection
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.loseConnection")
+
+
+    def writeSequence(self, data):
+        # ITransport.writeSequence
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.writeSequence")
+
+
+    def horizontalTabulationSet(self):
+        # ITerminalTransport.horizontalTabulationSet
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.horizontalTabulationSet")
+
+
+    def tabulationClear(self):
+        # TerminalTransport.tabulationClear
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.tabulationClear")
+
+
+    def tabulationClearAll(self):
+        # TerminalTransport.tabulationClearAll
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.tabulationClearAll")
+
+
+    def doubleHeightLine(self, top=True):
+        # ITerminalTransport.doubleHeightLine
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.doubleHeightLine")
+
+
+    def singleWidthLine(self):
+        # ITerminalTransport.singleWidthLine
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.singleWidthLine")
+
+
+    def doubleWidthLine(self):
+        # ITerminalTransport.doubleWidthLine
+        raise NotImplementedError(
+            "Unimplemented: TerminalBuffer.doubleWidthLine")
+
+
 
 class ExpectationTimeout(Exception):
     pass

--- a/src/twisted/conch/insults/insults.py
+++ b/src/twisted/conch/insults/insults.py
@@ -514,9 +514,20 @@ class ServerProtocol(protocol.Protocol):
         self._cursorReports = []
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError("Unimplemented: ServerProtocol.getHost")
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError("Unimplemented: ServerProtocol.getPeer")
+
+
     def connectionMade(self):
         if self.protocolFactory is not None:
-            self.terminalProtocol = self.protocolFactory(*self.protocolArgs, **self.protocolKwArgs)
+            self.terminalProtocol = self.protocolFactory(*self.protocolArgs,
+                                                         **self.protocolKwArgs)
 
             try:
                 factory = self.factory

--- a/src/twisted/conch/manhole_ssh.py
+++ b/src/twisted/conch/manhole_ssh.py
@@ -85,7 +85,20 @@ class TerminalSession(components.Adapter):
         raise econch.ConchError("Cannot execute commands")
 
 
+    def windowChanged(self, newWindowSize):
+        # ISession.windowChanged
+        raise NotImplementedError(
+            "Unimplemented: TerminalSession.windowChanged")
+
+
+    def eofReceived(self):
+        # ISession.eofReceived
+        raise NotImplementedError(
+            "Unimplemented: TerminalSession.eofReceived")
+
+
     def closed(self):
+        # ISession.closed
         pass
 
 

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -91,6 +91,275 @@ def %s(self, *a, **kw):
 """ % (method, method))
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError("Unimplemented: TransportSequence.getHost")
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.getPeer")
+
+
+    def loseConnection(self):
+        # ITransport.loseConnection
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.loseConnection")
+
+
+    def write(self, data):
+        # ITransport.write
+        raise NotImplementedError("Unimplemented: TransportSequence.write")
+
+
+    def writeSequence(self, data):
+        # ITransport.writeSequence
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.writeSequence")
+
+
+    def cursorUp(self, n=1):
+        # ITerminalTransport.cursorUp
+        raise NotImplementedError("Unimplemented: TransportSequence.cursorUp")
+
+
+    def cursorDown(self, n=1):
+        # ITerminalTransport.cursorDown
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.cursorDown")
+
+
+    def cursorForward(self, n=1):
+        # ITerminalTransport.cursorForward
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.cursorForward")
+
+
+    def cursorBackward(self, n=1):
+        # ITerminalTransport.cursorBackward
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.cursorBackward")
+
+
+    def cursorPosition(self, column, line):
+        # ITerminalTransport.cursorPosition
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.cursorPosition")
+
+
+    def cursorHome(self):
+        # ITerminalTransport.cursorHome
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.cursorHome")
+
+
+    def index(self):
+        # ITerminalTransport.index
+        raise NotImplementedError("Unimplemented: TransportSequence.index")
+
+
+    def reverseIndex(self):
+        # ITerminalTransport.reverseIndex
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.reverseIndex")
+
+
+    def nextLine(self):
+        # ITerminalTransport.nextLine
+        raise NotImplementedError("Unimplemented: TransportSequence.nextLine")
+
+
+    def saveCursor(self):
+        # ITerminalTransport.saveCursor
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.saveCursor")
+
+
+    def restoreCursor(self):
+        # ITerminalTransport.restoreCursor
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.restoreCursor")
+
+
+    def setModes(self, modes):
+        # ITerminalTransport.setModes
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.setModes")
+
+
+    def resetModes(self, mode):
+        # ITerminalTransport.resetModes
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.resetModes")
+
+
+    def setPrivateModes(self, modes):
+        # ITerminalTransport.setPrivateModes
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.setPrivateModes")
+
+
+    def resetPrivateModes(self, modes):
+        # ITerminalTransport.resetPrivateModes
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.resetPrivateModes")
+
+
+    def applicationKeypadMode(self):
+        # ITerminalTransport.applicationKeypadMode
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.applicationKeypadMode")
+
+
+    def numericKeypadMode(self):
+        # ITerminalTransport.numericKeypadMode
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.numericKeypadMode")
+
+
+    def selectCharacterSet(self, charSet, which):
+        # ITerminalTransport.selectCharacterSet
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.selectCharacterSet")
+
+
+    def shiftIn(self):
+        # ITerminalTransport.shiftIn
+        raise NotImplementedError("Unimplemented: TransportSequence.shiftIn")
+
+
+    def shiftOut(self):
+        # ITerminalTransport.shiftOut
+        raise NotImplementedError("Unimplemented: TransportSequence.shiftOut")
+
+
+    def singleShift2(self):
+        # ITerminalTransport.singleShift2
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.singleShift2")
+
+
+    def singleShift3(self):
+        # ITerminalTransport.singleShift3
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.singleShift3")
+
+
+    def selectGraphicRendition(self, *attributes):
+        # ITerminalTransport.selectGraphicRendition
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.selectGraphicRendition")
+
+
+    def horizontalTabulationSet(self):
+        # ITerminalTransport.horizontalTabulationSet
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.horizontalTabulationSet")
+
+
+    def tabulationClear(self):
+        # ITerminalTransport.tabulationClear
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.tabulationClear")
+
+
+    def tabulationClearAll(self):
+        # ITerminalTransport.tabulationClearAll
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.tabulationClearAll")
+
+
+    def doubleHeightLine(self, top=True):
+        # ITerminalTransport.doubleHeightLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.doubleHeightLine")
+
+
+    def singleWidthLine(self):
+        # ITerminalTransport.singleWidthLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.singleWidthLine")
+
+
+    def doubleWidthLine(self):
+        # ITerminalTransport.doubleWidthLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.doubleWidthLine")
+
+
+    def eraseToLineEnd(self):
+        # ITerminalTransport.eraseToLineEnd
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseToLineEnd")
+
+
+    def eraseToLineBeginning(self):
+        # ITerminalTransport.eraseToLineBeginning
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseToLineBeginning")
+
+
+    def eraseLine(self):
+        # ITerminalTransport.eraseLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseLine")
+
+
+    def eraseToDisplayEnd(self):
+        # ITerminalTransport.eraseToDisplayEnd
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseToDisplayEnd")
+
+
+    def eraseToDisplayBeginning(self):
+        # ITerminalTransport.eraseToDisplayBeginning
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseToDisplayBeginning")
+
+
+    def eraseDisplay(self):
+        # ITerminalTransport.eraseDisplay
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.eraseDisplay")
+
+
+    def deleteCharacter(self, n=1):
+        # ITerminalTransport.deleteCharacter
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.deleteCharacter")
+
+
+    def insertLine(self, n=1):
+        # ITerminalTransport.insertLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.insertLine")
+
+
+    def deleteLine(self, n=1):
+        # ITerminalTransport.deleteLine
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.deleteLine")
+
+
+    def reportCursorPosition(self):
+        # ITerminalTransport.reportCursorPosition
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.reportCursorPosition")
+
+
+    def reset(self):
+        # ITerminalTransport.reset
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.reset")
+
+
+    def unhandledControlSequence(self, seq):
+        # ITerminalTransport.unhandledControlSequence
+        raise NotImplementedError(
+            "Unimplemented: TransportSequence.unhandledControlSequence")
+
+
 
 class LocalTerminalBufferMixin(object):
     """

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -354,6 +354,21 @@ class InMemoryRemoteFile(BytesIO):
         self._closed = True
 
 
+    def getAttrs(self):
+        # ISFTPFile.getAttrs
+        pass
+
+
+    def readChunk(self, offset, length):
+        # ISFTPFile.readChunk
+        pass
+
+
+    def setAttrs(self, attrs):
+        # ISFTPFile.getAttrs
+        pass
+
+
     def getvalue(self):
         """
         Get current data of file.

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -532,6 +532,26 @@ class RekeyAvatar(ConchUser):
         """
 
 
+    def eofReceived(self):
+        # ISession.eofReceived
+        pass
+
+
+    def execCommand(self, proto, command):
+        # ISession.execCommand
+        pass
+
+
+    def getPty(self, term, windowSize, modes):
+        # ISession.getPty
+        pass
+
+
+    def windowChanged(self, newWindowSize):
+        # ISession.windowChanged
+        pass
+
+
 
 class RekeyRealm:
     """

--- a/src/twisted/conch/test/test_telnet.py
+++ b/src/twisted/conch/test/test_telnet.py
@@ -19,6 +19,7 @@ from twisted.test import proto_helpers
 from twisted.python.compat import iterbytes
 
 
+
 @implementer(telnet.ITelnetProtocol)
 class TestProtocol:
     localEnableable = ()
@@ -76,6 +77,21 @@ class TestProtocol:
 
     def disableRemote(self, option):
         self.disabledRemote.append(option)
+
+
+    def connectionMade(self):
+        # IProtocol.connectionMade
+        pass
+
+
+    def unhandledCommand(self):
+        # ITelnetProtocol.unhandledCommand
+        pass
+
+
+    def unhandledSubnegotiation(self):
+        # ITelnetProtocol.unhandledSubnegotiation
+        pass
 
 
 

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -243,6 +243,11 @@ class AnonymousChecker(object):
     credentialInterfaces = (IAnonymous,)
 
 
+    def requestAvatarId(credentials):
+        # ICredentialsChecker.requestAvatarId
+        pass
+
+
 
 class SSHUserAuthServerTests(unittest.TestCase):
     """

--- a/src/twisted/internet/_dumbwin32proc.py
+++ b/src/twisted/internet/_dumbwin32proc.py
@@ -407,6 +407,16 @@ class Process(_pollingfile._PollingTimer, BaseProcess):
         self.loseConnection()
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError("Unimplemented: Process.getHost")
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError("Unimplemented: Process.getPeer")
+
+
     def __repr__(self):
         """
         Return a string representation of the process.

--- a/src/twisted/internet/_posixstdio.py
+++ b/src/twisted/internet/_posixstdio.py
@@ -22,6 +22,7 @@ class PipeAddress(object):
     pass
 
 
+
 @implementer(interfaces.ITransport, interfaces.IProducer,
              interfaces.IConsumer, interfaces.IHalfCloseableDescriptor)
 class StandardIO(object):
@@ -48,13 +49,16 @@ class StandardIO(object):
         if self._writer is not None:
             self._writer.loseConnection()
 
+
     def write(self, data):
         if self._writer is not None:
             self._writer.write(data)
 
+
     def writeSequence(self, data):
         if self._writer is not None:
             self._writer.writeSequence(data)
+
 
     def loseConnection(self):
         self.disconnecting = True
@@ -65,8 +69,10 @@ class StandardIO(object):
             # Don't loseConnection, because we don't want to SIGPIPE it.
             self._reader.stopReading()
 
+
     def getPeer(self):
         return PipeAddress()
+
 
     def getHost(self):
         return PipeAddress()
@@ -75,6 +81,7 @@ class StandardIO(object):
     # Callbacks from process.ProcessReader/ProcessWriter
     def childDataReceived(self, fd, data):
         self.protocol.dataReceived(data)
+
 
     def childConnectionLost(self, fd, reason):
         if self.disconnected:
@@ -88,6 +95,7 @@ class StandardIO(object):
                 self._writeConnectionLost(reason)
         else:
             self.connectionLost(reason)
+
 
     def connectionLost(self, reason):
         self.disconnected = True
@@ -107,11 +115,12 @@ class StandardIO(object):
 
         try:
             protocol.connectionLost(reason)
-        except:
+        except BaseException:
             log.err()
 
+
     def _writeConnectionLost(self, reason):
-        self._writer=None
+        self._writer = None
         if self.disconnecting:
             self.connectionLost(reason)
             return
@@ -124,8 +133,9 @@ class StandardIO(object):
                 log.err()
                 self.connectionLost(failure.Failure())
 
+
     def _readConnectionLost(self, reason):
-        self._reader=None
+        self._reader = None
         p = interfaces.IHalfCloseableProtocol(self.protocol, None)
         if p:
             try:
@@ -136,6 +146,7 @@ class StandardIO(object):
         else:
             self.connectionLost(reason)
 
+
     # IConsumer
     def registerProducer(self, producer, streaming):
         if self._writer is None:
@@ -143,26 +154,42 @@ class StandardIO(object):
         else:
             self._writer.registerProducer(producer, streaming)
 
+
     def unregisterProducer(self):
         if self._writer is not None:
             self._writer.unregisterProducer()
+
 
     # IProducer
     def stopProducing(self):
         self.loseConnection()
 
+
     def pauseProducing(self):
         if self._reader is not None:
             self._reader.pauseProducing()
+
 
     def resumeProducing(self):
         if self._reader is not None:
             self._reader.resumeProducing()
 
+
     def stopReading(self):
         """Compatibility only, don't use. Call pauseProducing."""
         self.pauseProducing()
 
+
     def startReading(self):
         """Compatibility only, don't use. Call resumeProducing."""
         self.resumeProducing()
+
+
+    def readConnectionLost(self):
+        # L{IHalfCloseableDescriptor.readConnectionLost}
+        raise NotImplementedError()
+
+
+    def writeConnectionLost(self):
+        # L{IHalfCloseableDescriptor.writeConnectionLost}
+        raise NotImplementedError()

--- a/src/twisted/internet/_resolver.py
+++ b/src/twisted/internet/_resolver.py
@@ -40,6 +40,11 @@ class HostResolution(object):
         self.name = name
 
 
+    def cancel(self):
+        # IHostResolution.cancel
+        raise NotImplementedError()
+
+
 
 _any = frozenset([IPv4Address, IPv6Address])
 

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -304,6 +304,16 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.connectionLost(reason)
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError()
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError()
+
+
     def _isSendBufferFull(self):
         """
         Determine whether the user-space send buffer for this transport is full

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -775,6 +775,12 @@ class ReactorBase(PluggableResolverMixin):
         """
         self.running = True
 
+
+    def run(self):
+        # IReactorCore.run
+        raise NotImplementedError()
+
+
     # IReactorTime
 
     seconds = staticmethod(runtimeSeconds)

--- a/src/twisted/internet/iocpreactor/abstract.py
+++ b/src/twisted/internet/iocpreactor/abstract.py
@@ -396,4 +396,15 @@ class FileHandle(_ConsumerMixin, _LogOwner):
         self.loseConnection()
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError()
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError()
+
+
+
 __all__ = ['FileHandle']

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -241,6 +241,18 @@ class Connection(abstract.FileHandle, _SocketCloser, _AbortingMixin):
         else:
             abstract.FileHandle.unregisterProducer(self)
 
+
+    def getHost(self):
+        # ITCPTransport.getHost
+        pass
+
+
+    def getPeer(self):
+        # ITCPTransport.getPeer
+        pass
+
+
+
 if _startTLS is not None:
     classImplements(Connection, interfaces.ITLSTransport)
 

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -954,6 +954,16 @@ class Process(_BaseProcess):
         _BaseProcess.maybeCallProcessEnded(self)
 
 
+    def getHost(self):
+        # ITransport.getHost
+        raise NotImplementedError()
+
+
+    def getPeer(self):
+        # ITransport.getPeer
+        raise NotImplementedError()
+
+
 
 @implementer(IProcessTransport)
 class PTYProcess(abstract.FileDescriptor, _BaseProcess):
@@ -1118,3 +1128,13 @@ class PTYProcess(abstract.FileDescriptor, _BaseProcess):
         Write some data to the open process.
         """
         return fdesc.writeToFD(self.fd, data)
+
+
+    def closeChildFD(self, descriptor):
+        # IProcessTransport
+        raise NotImplementedError()
+
+
+    def writeToChild(self, childFD, data):
+        # IProcessTransport
+        raise NotImplementedError()

--- a/src/twisted/internet/ssl.py
+++ b/src/twisted/internet/ssl.py
@@ -189,6 +189,11 @@ class Server(tcp.Server):
         self.startTLS(self.server.ctxFactory)
 
 
+    def getPeerCertificate(self):
+        # ISSLTransport.getPeerCertificate
+        raise NotImplementedError("Server.getPeerCertificate")
+
+
 
 class Port(tcp.Port):
     """

--- a/src/twisted/internet/test/fakeendpoint.py
+++ b/src/twisted/internet/test/fakeendpoint.py
@@ -50,13 +50,19 @@ class EndpointBase(object):
 
 @implementer(IStreamClientEndpoint)
 class StreamClient(EndpointBase):
-    pass
+
+    def connect(self):
+        # IStreamClientEndpoint.connect
+        pass
 
 
 
 @implementer(IStreamServerEndpoint)
 class StreamServer(EndpointBase):
-    pass
+
+    def listen(self):
+        # IStreamClientEndpoint.listen
+        pass
 
 
 

--- a/src/twisted/internet/test/test_base.py
+++ b/src/twisted/internet/test/test_base.py
@@ -61,6 +61,26 @@ class FakeReactor(object):
         self._threadpool.stop()
 
 
+    def getDelayedCalls(self):
+        # IReactorTime.getDelayedCalls
+        pass
+
+
+    def seconds(self):
+        # IReactorTime.seconds
+        pass
+
+
+    def callInThread(self, callable, *args, **kwargs):
+        # IReactorInThreads.callInThread
+        pass
+
+
+    def suggestThreadPoolSize(self, size):
+        # IReactorThreads.suggestThreadPoolSize
+        pass
+
+
 
 class ThreadedResolverTests(TestCase):
     """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -861,6 +861,11 @@ class MemoryProcessTransport(StringTransportWithDisconnection, object):
         self.signals.append(signal)
 
 
+    def pid(self):
+        # IProcessTransport.pid
+        pass
+
+
 
 verifyClass(interfaces.IConsumer, MemoryProcessTransport)
 verifyClass(interfaces.IPushProducer, MemoryProcessTransport)

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -868,6 +868,22 @@ class RaisingMemoryReactor(object):
         raise self._connectException
 
 
+    def adoptDatagramPort(self):
+        """
+        Fake L{IReactorSocket.adoptDatagramPort}, that raises
+        L{_connectException}.
+        """
+        raise self._connectException
+
+
+    def adoptStreamConnection(self):
+        """
+        Fake L{IReactorSocket.adoptStreamConnection}, that raises
+        L{_connectException}.
+        """
+        raise self._connectException
+
+
 
 class NonStreamingProducer(object):
     """

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -5194,6 +5194,11 @@ class MemoryAccount(MemoryAccountWithoutNamespaces):
         return None
 
 
+    def getUserNamespaces(self):
+        # INamespacePresenter.getUserNamespaces
+        return None
+
+
 
 _statusRequestDict = {
     'MESSAGES': 'getMessageCount',

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -1363,6 +1363,11 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         raise cred.error.UnauthorizedLogin()
 
 
+    def stopProducing(self):
+        # IProducer.stopProducing
+        raise NotImplementedError()
+
+
 
 @implementer(IMailbox)
 class Mailbox:

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1704,6 +1704,21 @@ class SimpleMailbox:
         self.closed = True
 
 
+    def fetch(self, messages, uid):
+        # IMailboxIMAP.fetch
+        pass
+
+
+    def getUID(self, message):
+        # IMailboxIMAP.getUID
+        pass
+
+
+    def store(self):
+        # IMailboxIMAP.store
+        pass
+
+
 
 @implementer(imap4.IMailboxInfo, imap4.IMailbox)
 class UncloseableMailbox(object):
@@ -1854,6 +1869,21 @@ class UncloseableMailbox(object):
         for i in delete:
             self.messages.remove(i)
         return [i[3] for i in delete]
+
+
+    def fetch(self, messages, uid):
+        # IMailboxIMAP.fetch
+        pass
+
+
+    def getUID(self, message):
+        # IMailboxIMAP.getUID
+        pass
+
+
+    def store(self, messages, flags, mode, uid):
+        # IMailboxIMAP.store
+        pass
 
 
 

--- a/src/twisted/mail/test/test_mail.py
+++ b/src/twisted/mail/test/test_mail.py
@@ -792,7 +792,7 @@ class StubAliasableDomain(object):
     """
     Minimal testable implementation of IAliasableDomain.
     """
-    def exists(self, user):
+    def exists(self, user, memo=None):
         """
         No test coverage for invocations of this method on domain objects,
         so we just won't implement it.

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -2100,9 +2100,12 @@ class UnknownRecord(tputil.FancyEqMixin, tputil.FancyStrMixin, object):
 
     @since: 11.1
     """
+    TYPE = None
+
     fancybasename = 'UNKNOWN'
     compareAttributes = ('data', 'ttl')
     showAttributes = (('data', _nicebytes), 'ttl')
+
 
     def __init__(self, data=b'', ttl=None):
         self.data = data

--- a/src/twisted/pair/test/test_ethernet.py
+++ b/src/twisted/pair/test/test_ethernet.py
@@ -12,6 +12,13 @@ class MyProtocol:
     def __init__(self, expecting):
         self.expecting = list(expecting)
 
+
+    def addProto(self):
+        """
+        Not implemented
+        """
+
+
     def datagramReceived(self, data, **kw):
         assert self.expecting, 'Got a packet when not expecting anymore.'
         expect = self.expecting.pop(0)

--- a/src/twisted/pair/test/test_ip.py
+++ b/src/twisted/pair/test/test_ip.py
@@ -12,6 +12,7 @@ class MyProtocol:
     def __init__(self, expecting):
         self.expecting = list(expecting)
 
+
     def datagramReceived(self, data, **kw):
         assert self.expecting, 'Got a packet when not expecting anymore.'
         expectData, expectKw = self.expecting.pop(0)
@@ -26,6 +27,13 @@ class MyProtocol:
             assert expectKw[k] == kw[k], "Expected %s=%r, got %r" % (k, expectKw[k], kw[k])
         assert expectKw == kw, "Expected %r, got %r" % (expectKw, kw)
         assert expectData == data, "Expected %r, got %r" % (expectData, data)
+
+
+    def addProto(self):
+        # IRawDatagramProtocol.addProto
+        pass
+
+
 
 class IPTests(unittest.TestCase):
     def testPacketParsing(self):

--- a/src/twisted/pair/test/test_tuntap.py
+++ b/src/twisted/pair/test/test_tuntap.py
@@ -1335,6 +1335,11 @@ class IPRecordingProtocol(AbstractDatagramProtocol):
         self.received.append(datagram)
 
 
+    def addProto(self):
+        # IRawPacketProtocol.addProto
+        pass
+
+
 
 class TunTests(TunnelTestsMixin, SynchronousTestCase):
     """

--- a/src/twisted/plugins/twisted_trial.py
+++ b/src/twisted/plugins/twisted_trial.py
@@ -18,6 +18,133 @@ class _Reporter(object):
         self.klass = klass
 
 
+    @property
+    def stream(self):
+        # IReporter.stream
+        pass
+
+
+    @property
+    def tbformat(self):
+        # IReporter.tbformat
+        pass
+
+
+    @property
+    def args(self):
+        # IReporter.args
+        pass
+
+
+    @property
+    def shouldStop(self):
+        # IReporter.shouldStop
+        pass
+
+
+    @property
+    def separator(self):
+        # IReporter.separator
+        pass
+
+
+    @property
+    def testsRun(self):
+        # IReporter.testsRun
+        pass
+
+
+    def addError(self, test, error):
+        # IReporter.addError
+        pass
+
+
+    def addExpectedFailure(self, test, failure, todo=None):
+        # IReporter.addExpectedFailure
+        pass
+
+
+    def addFailure(self, test, failure):
+        # IReporter.addFailure
+        pass
+
+
+    def addSkip(self, test, reason):
+        # IReporter.addSkip
+        pass
+
+
+    def addSuccess(self, test):
+        # IReporter.addSuccess
+        pass
+
+
+    def addUnexpectedSuccess(self, test, todo=None):
+        # IReporter.addUnexpectedSuccess
+        pass
+
+
+    def cleanupErrors(self, errs):
+        # IReporter.cleanupErrors
+        pass
+
+
+    def done(self):
+        # IReporter.done
+        pass
+
+
+    def endSuite(self, name):
+        # IReporter.endSuite
+        pass
+
+
+    def printErrors(self):
+        # IReporter.printErrors
+        pass
+
+
+    def printSummary(self):
+        # IReporter.printSummary
+        pass
+
+
+    def startSuite(self, name):
+        # IReporter.startSuite
+        pass
+
+
+    def startTest(self, method):
+        # IReporter.startTest
+        pass
+
+
+    def stopTest(self, method):
+        # IReporter.stopTest
+        pass
+
+
+    def upDownError(self, userMeth, warn=True, printStatus=True):
+        # IReporter.upDownError
+        pass
+
+
+    def wasSuccessful(self):
+        # IReporter.wasSuccessful
+        pass
+
+
+    def write(self, string):
+        # IReporter.write
+        pass
+
+
+    def writeln(self, string):
+        # IReporter.writeln
+        pass
+
+
+
 Tree = _Reporter("Tree Reporter",
                  "twisted.trial.reporter",
                  description="verbose color output (default reporter)",

--- a/src/twisted/python/test/test_components.py
+++ b/src/twisted/python/test/test_components.py
@@ -587,8 +587,11 @@ class IProxiedSubInterface(IProxiedInterface):
         """
 
 
+
 @implementer(IProxiedInterface)
-class Yayable(object):
+class Yayable(object):  # type: ignore[misc]
+    # class does not implement Attribute ifaceAttribute
+    # so we need to turn off mypy warning
     """
     A provider of L{IProxiedInterface} which increments a counter for
     every call to C{yay}.
@@ -599,6 +602,7 @@ class Yayable(object):
     def __init__(self):
         self.yays = 0
         self.yayArgs = []
+
 
     def yay(self, *a, **kw):
         """
@@ -611,12 +615,17 @@ class Yayable(object):
 
 
 @implementer(IProxiedSubInterface)
-class Booable(object):
+class Booable(object):  # type: ignore[misc]
+    # class does not implement Attribute ifaceAttribute
+    # so we need to turn off mypy warning
     """
     An implementation of IProxiedSubInterface
     """
+
     yayed = False
     booed = False
+
+
     def yay(self):
         """
         Mark the fact that 'yay' has been called.

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -255,6 +255,31 @@ class FakeTransport:
             self.protocol.dataReceived(buf)
 
 
+    def getTcpKeepAlive(self):
+        # ITCPTransport.getTcpKeepAlive
+        pass
+
+
+    def getTcpNoDelay(self):
+        # ITCPTransport.getTcpNoDelay
+        pass
+
+
+    def loseWriteConnection(self):
+        # ITCPTransport.loseWriteConnection
+        pass
+
+
+    def setTcpKeepAlive(self, enabled):
+        # ITCPTransport.setTcpKeepAlive
+        pass
+
+
+    def setTcpNoDelay(self):
+        # ITCPTransport.setTcpNoDelay
+        pass
+
+
 
 def makeFakeClient(clientProtocol):
     """

--- a/src/twisted/test/stdio_test_halfclose.py
+++ b/src/twisted/test/stdio_test_halfclose.py
@@ -55,6 +55,11 @@ class HalfCloseProtocol(protocol.Protocol):
         reactor.stop()
 
 
+    def writeConnectionLost(self, reason):
+        # IHalfCloseableProtocol.writeConnectionLost
+        pass
+
+
 
 if __name__ == '__main__':
     reflect.namedAny(sys.argv[1]).install()

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -2083,6 +2083,13 @@ class SignalCapturingMemoryReactor(MemoryReactor):
     MemoryReactor that implements the _ISupportsExitSignalCapturing interface,
     all other operations identical to MemoryReactor.
     """
+    @property
+    def _exitSignal(self):
+        return self._val
+
+    @_exitSignal.setter
+    def _exitSignal(self, val):
+        self._val = val
 
 
 

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -505,7 +505,7 @@ class Reporter(TestResult):
         self._write('\n')
 
 
-    def upDownError(self, method, error, warn, printStatus):
+    def upDownError(self, method, error, warn=True, printStatus=True):
         super(Reporter, self).upDownError(method, error, warn, printStatus)
         if warn:
             tbStr = self._formatFailureTraceback(error)

--- a/src/twisted/web/_auth/wrapper.py
+++ b/src/twisted/web/_auth/wrapper.py
@@ -73,6 +73,11 @@ class UnauthorizedResource(object):
         return self
 
 
+    def putChild(self, child):
+        # IResource.putChild
+        raise NotImplementedError()
+
+
 
 @implementer(IResource)
 class HTTPAuthSessionWrapper(object):
@@ -233,3 +238,8 @@ class HTTPAuthSessionWrapper(object):
             if fact.scheme == scheme:
                 return (fact, b' '.join(elements[1:]))
         return (None, None)
+
+
+    def putChild(self, child):
+        # IResource.putChild
+        raise NotImplementedError()

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1917,7 +1917,6 @@ class _NoPushProducer(object):
         Tells a producer that it has produced too much data to process for
         the time being, and to stop until resumeProducing() is called.
         """
-        pass
 
 
     def resumeProducing(self):
@@ -1927,7 +1926,6 @@ class _NoPushProducer(object):
         This tells a producer to re-add itself to the main loop and produce
         more data for its consumer.
         """
-        pass
 
 
     def registerProducer(self, producer, streaming):
@@ -1937,14 +1935,18 @@ class _NoPushProducer(object):
         @param producer: The producer to register.
         @param streaming: Whether this is a streaming producer or not.
         """
-        pass
 
 
     def unregisterProducer(self):
         """
         Stop consuming data from a producer, without disconnecting.
         """
-        pass
+
+
+    def stopProducing(self):
+        """
+        IProducer.stopProducing
+        """
 
 
 

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -89,7 +89,40 @@ class DummyChannel:
 
     @implementer(ISSLTransport)
     class SSL(TCP):
-        pass
+        def abortConnection(self):
+            # ITCPTransport.abortConnection
+            pass
+
+
+        def getTcpKeepAlive(self):
+            # ITCPTransport.getTcpKeepAlive
+            pass
+
+
+        def getTcpNoDelay(self):
+            # ITCPTransport.getTcpNoDelay
+            pass
+
+
+        def loseWriteConnection(self):
+            # ITCPTransport.loseWriteConnection
+            pass
+
+
+        def setTcpKeepAlive(self):
+            # ITCPTransport.setTcpKeepAlive
+            pass
+
+
+        def setTcpNoDelay(self):
+            # ITCPTransport.setTcpNoDelay
+            pass
+
+
+        def getPeerCertificate(self):
+            # ISSLTransport.getPeerCertificate
+            pass
+
 
     site = Site(Resource())
 
@@ -145,6 +178,41 @@ class DummyChannel:
 
     def isSecure(self):
         return isinstance(self.transport, self.SSL)
+
+
+    def abortConnection(self):
+        # ITCPTransport.abortConnection
+        pass
+
+
+    def getTcpKeepAlive(self):
+        # ITCPTransport.getTcpKeepAlive
+        pass
+
+
+    def getTcpNoDelay(self):
+        # ITCPTransport.getTcpNoDelay
+        pass
+
+
+    def loseWriteConnection(self):
+        # ITCPTransport.loseWriteConnection
+        pass
+
+
+    def setTcpKeepAlive(self):
+        # ITCPTransport.setTcpKeepAlive
+        pass
+
+
+    def setTcpNoDelay(self):
+        # ITCPTransport.setTcpNoDelay
+        pass
+
+
+    def getPeerCertificate(self):
+        # ISSLTransport.getPeerCertificate
+        pass
 
 
 

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -1984,6 +1984,16 @@ class StringProducer:
         self.stopped = True
 
 
+    def pauseProducing(self):
+        # IBodyProducer.pauseProducing
+        pass
+
+
+    def resumeProducing(self):
+        # IBodyProducer.resumeProducing
+        pass
+
+
 
 class RequestTests(TestCase):
     """

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1249,6 +1249,27 @@ class HeadlessResource(object):
         return server.NOT_DONE_YET
 
 
+    def isLeaf(self):
+        """
+        # IResource.isLeaf
+        """
+        raise NotImplementedError()
+
+
+    def getChildWithDefault(self):
+        """
+        # IResource.getChildWithDefault
+        """
+        raise NotImplementedError()
+
+
+    def putChild(self, child):
+        """
+        # IResource.putChild
+        """
+        raise NotImplementedError()
+
+
 
 class NewRenderTests(unittest.TestCase):
     """

--- a/src/twisted/words/im/ircsupport.py
+++ b/src/twisted/words/im/ircsupport.py
@@ -291,3 +291,8 @@ class IRCAccount(basesupport.AbstractAccount):
         d = cc.connectTCP(self.host, self.port)
         d.addErrback(logonDeferred.errback)
         return logonDeferred
+
+
+    def logOff(self):
+        # IAccount.logOff
+        pass

--- a/src/twisted/words/im/pbsupport.py
+++ b/src/twisted/words/im/pbsupport.py
@@ -227,6 +227,11 @@ class PBAccount(basesupport.AbstractAccount):
             raise error.ConnectionError("Connection in progress")
 
 
+    def logOff(self):
+        # IAccount.logOff
+        pass
+
+
     def _startLogOn(self, chatui):
         print('Connecting...', end=' ')
         d = pb.getObjectAt(self.host, self.port)

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -56,6 +56,11 @@ class Anonymous(object):
         return None
 
 
+    def getResponse(self, challenge):
+        # ISASLMechanism.getResponse
+        pass
+
+
 
 @implementer(ISASLMechanism)
 class Plain(object):
@@ -87,6 +92,11 @@ class Plain(object):
         return (self.authzid.encode('utf-8') + b"\x00" +
                 self.authcid.encode('utf-8') + b"\x00" +
                 self.password.encode('utf-8'))
+
+
+    def getResponse(self, challenge):
+        # ISASLMechanism.getResponse
+        pass
 
 
 

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -937,27 +937,36 @@ class PBMind(pb.Referenceable):
     def __init__(self):
         pass
 
+
     def jellyFor(self, jellier):
         qual = reflect.qual(PBMind)
         if isinstance(qual, unicode):
             qual = qual.encode("utf-8")
         return qual, jellier.invoker.registerReference(self)
 
+
     def remote_userJoined(self, user, group):
         pass
+
 
     def remote_userLeft(self, user, group, reason):
         pass
 
+
     def remote_receive(self, sender, recipient, message):
         pass
+
 
     def remote_groupMetaUpdate(self, group, meta):
         pass
 
 
+
 @implementer(iwords.IChatClient)
 class PBMindReference(pb.RemoteReference):
+
+    name = ""
+
     def receive(self, sender, recipient, message):
         if iwords.IGroup.providedBy(recipient):
             rec = PBGroup(self.realm, self.avatar, recipient)
@@ -969,11 +978,13 @@ class PBMindReference(pb.RemoteReference):
             rec,
             message)
 
+
     def groupMetaUpdate(self, group, meta):
         return self.callRemote(
             'groupMetaUpdate',
             PBGroup(self.realm, self.avatar, group),
             meta)
+
 
     def userJoined(self, group, user):
         return self.callRemote(
@@ -981,13 +992,18 @@ class PBMindReference(pb.RemoteReference):
             PBGroup(self.realm, self.avatar, group),
             PBUser(self.realm, self.avatar, user))
 
+
     def userLeft(self, group, user, reason=None):
         return self.callRemote(
             'userLeft',
             PBGroup(self.realm, self.avatar, group),
             PBUser(self.realm, self.avatar, user),
             reason)
+
+
+
 pb.setUnjellyableForClass(PBMind, PBMindReference)
+
 
 
 class PBGroup(pb.Referenceable):
@@ -1028,12 +1044,49 @@ class PBGroupReference(pb.RemoteReference):
             self.name = self.name.decode('utf-8')
         return pb.RemoteReference.unjellyFor(self, unjellier, [clsName, ref])
 
+
     def leave(self, reason=None):
         return self.callRemote("leave", reason)
 
+
     def send(self, message):
         return self.callRemote("send", message)
+
+
+    def add(self, user):
+        # IGroup.add
+        pass
+
+
+    def iterusers(self):
+        # IGroup.iterusers
+        pass
+
+
+    def receive(self, sender, recipient, message):
+        # IGroup.receive
+        pass
+
+
+    def remove(self, user, reason=None):
+        # IGroup.remove
+        pass
+
+
+    def setMetadata(self, meta):
+        # IGroup.setMetadata
+        pass
+
+
+    def size(self):
+        # IGroup.size
+        pass
+
+
+
 pb.setUnjellyableForClass(PBGroup, PBGroupReference)
+
+
 
 class PBUser(pb.Referenceable):
     def __init__(self, realm, avatar, user):
@@ -1068,7 +1121,44 @@ class ChatAvatar(pb.Referenceable):
         d = self.avatar.realm.getGroup(groupName)
         d.addCallback(cbGroup)
         return d
+
+
+    @property
+    def name(self):
+        # IChatClient.name
+        pass
+
+
+    @name.setter
+    def name(self, value):
+        # IChatClient.name
+        pass
+
+
+    def groupMetaUpdate(self, group, meta):
+        # IChatClient.groupMetaUpdate
+        pass
+
+
+    def receive(self, sender, recipient, message):
+        # IChatClient.receive
+        pass
+
+
+    def userJoined(self, group, user):
+        # IChatClient.userJoined
+        pass
+
+
+    def userLeft(self, group, user, reason=None):
+        # IChatClient.userLeft
+        pass
+
+
+
 registerAdapter(ChatAvatar, iwords.IUser, pb.IPerspective)
+
+
 
 class AvatarReference(pb.RemoteReference):
     def join(self, groupName):
@@ -1125,6 +1215,11 @@ class WordsRealm(object):
             raise NotImplementedError(self, interfaces)
 
         return self.getUser(avatarId).addCallback(gotAvatar)
+
+
+    def itergroups(self):
+        # IChatServer.itergroups
+        pass
 
 
     # IChatService, mostly.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9852

When running mypy over the twisted codebase with:

```
tox -e mypy
```

There are many errors that look like this:

```
src/twisted/words/protocols/jabber/sasl_mechanisms.py:47:1: error: 'Anonymous' is missing following 'ISASLMechanism' interface members: getResponse.  [misc]
src/twisted/words/protocols/jabber/sasl_mechanisms.py:61:1: error: 'Plain' is missing following 'ISASLMechanism' interface members: getResponse.  [misc]
src/twisted/internet/_dumbwin32proc.py:110:1: error: 'Process' is missing following 'twisted.internet.interfaces.ITransport' interface members: getHost, getPeer.
src/twisted/internet/abstract.py:151:1: error: 'FileDescriptor' is missing following 'ITransport' interface members: getHost, getPeer.  [misc]
src/twisted/internet/process.py:623:1: error: 'Process' is missing following 'twisted.internet.interfaces.ITransport' interface members: getHost, getPeer.  [misc]
src/twisted/internet/process.py:959:1: error: 'PTYProcess' is missing following 'twisted.internet.interfaces.ITransport' interface members: getHost, getPeer.  [misc]
src/twisted/internet/process.py:959:1: error: 'PTYProcess' is missing following 'IProcessTransport' interface members: closeChildFD, writeToChild.  [misc]
src/twisted/internet/_resolver.py:31:1: error: 'HostResolution' is missing following 'IHostResolution' interface members: cancel.  [misc]
src/twisted/internet/base.py:504:1: error: 'ReactorBase' is missing following 'IReactorCore' interface members: run.  [misc]
src/twisted/internet/_newtls.py:162:1: error: 'ConnectionMixin' is missing following 'twisted.internet.interfaces.ITCPTransport' interface members: getHost, getPeer,
```

In an effort to quieten these errors, this
PR adds comments to turn off these mypy warnings in a few places.

In a few other places, I implemented no-op methods in some classes, to appease mypy.
add comments