### PR TITLE
Use xml.etree.ElementTree instead of deprecated cElementTree

### DIFF
--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -36,6 +36,7 @@ steps:
    python -c "import sys; print(sys.prefix)"
    python -c "import sys; print(sys.exec_prefix)"
    python -c "import sys; print(sys.executable)"
+   python -c "import os; print(os.environ)"
    python -c "import struct; print(struct.calcsize('P') * 8)"
   displayName: 'Get Python Information'
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 from unittest import skipIf
 
-from xml.etree.cElementTree import XML
+from xml.etree.ElementTree import XML
 
 from collections import OrderedDict
 


### PR DESCRIPTION
This is a resubmission of https://github.com/twisted/twisted/pull/1278
using my name, to work around Unicode issues when submitted by Michał Górny (mgorny), who has non-ASCII characters in his name. (!!)