### PR TITLE
[mypy] [9861] Tell mypy to ignore classes which derive from dynamic base classes

### DIFF
--- a/src/twisted/_threads/test/test_team.py
+++ b/src/twisted/_threads/test/test_team.py
@@ -14,7 +14,9 @@ from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from .. import IWorker, Team, createMemoryWorker, AlreadyQuit
 
-class ContextualWorker(proxyForInterface(IWorker, "_realWorker")):
+
+
+class ContextualWorker(proxyForInterface(IWorker, "_realWorker")):  # type: ignore[misc]  # noqa
     """
     A worker implementation that supplies a context.
     """

--- a/src/twisted/internet/cfreactor.py
+++ b/src/twisted/internet/cfreactor.py
@@ -44,6 +44,7 @@ _WRITE = 1
 _preserveSOError = 1 << 6
 
 
+
 class _WakerPlus(_Waker):
     """
     The normal Twisted waker will simply wake up the main loop, which causes an

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -315,7 +315,7 @@ class _IProcessTransportWithConsumerAndProducer(interfaces.IProcessTransport,
 
 
 class _ProcessEndpointTransport(
-        proxyForInterface(_IProcessTransportWithConsumerAndProducer,
+        proxyForInterface(_IProcessTransportWithConsumerAndProducer,  # type: ignore[misc]  # noqa
                           '_process')):
     """
     An L{ITransport}, L{IProcessTransport}, L{IConsumer}, and L{IPushProducer}

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1959,7 +1959,7 @@ class CookieAgent(object):
 
 
 
-class GzipDecoder(proxyForInterface(IResponse)):
+class GzipDecoder(proxyForInterface(IResponse)):  # type: ignore[misc]
     """
     A wrapper for a L{Response} instance which handles gzip'ed body.
 
@@ -1982,7 +1982,7 @@ class GzipDecoder(proxyForInterface(IResponse)):
 
 
 
-class _GzipProtocol(proxyForInterface(IProtocol)):
+class _GzipProtocol(proxyForInterface(IProtocol)):  # type: ignore[misc]
     """
     A L{Protocol} implementation which wraps another one, transparently
     decompressing received data.

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2767,7 +2767,7 @@ class _XForwardedForAddress(object):
 
 
 
-class _XForwardedForRequest(proxyForInterface(IRequest, "_request")):
+class _XForwardedForRequest(proxyForInterface(IRequest, "_request")):  # type: ignore[misc]  # noqa
     """
     Add a layer on top of another request that only uses the value of an
     X-Forwarded-For header as the result of C{getClientAddress}.
@@ -2825,7 +2825,7 @@ def proxiedLogFormatter(timestamp, request):
 
 
 
-class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):
+class _GenericHTTPChannelProtocol(proxyForInterface(IProtocol, "_channel")):  # type: ignore[misc]  # noqa
     """
     A proxy object that wraps one of the HTTP protocol objects, and switches
     between them depending on TLS negotiated protocol.

--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -387,7 +387,7 @@ class _IEncodingResource(Interface):
 
 
 @implementer(_IEncodingResource)
-class EncodingResourceWrapper(proxyForInterface(IResource)):
+class EncodingResourceWrapper(proxyForInterface(IResource)):  # type: ignore[misc] # noqa
     """
     Wrap a L{IResource}, potentially applying an encoding to the response body
     generated.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -56,7 +56,7 @@ from ._util import (
 
 
 
-class _IDeprecatedHTTPChannelToRequestInterfaceProxy(proxyForInterface(
+class _IDeprecatedHTTPChannelToRequestInterfaceProxy(proxyForInterface(  # type: ignore[misc]  # noqa
         http._IDeprecatedHTTPChannelToRequestInterface)):
     """
     Proxy L{_IDeprecatedHTTPChannelToRequestInterface}.  Used to


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9861

mypy complains if it cannot figure what a base class is.  For example:

```
src/twisted/_threads/test/test_team.py:17:24: error: Unsupported dynamic base class "proxyForInterface"  [misc]
```

This PR quietens those errors.
