### PR TITLE
[mypy] suppress errors after ImportError

### DIFF
--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -42,8 +42,8 @@ try:
     from twisted.internet.stdio import StandardIO, PipeAddress
 except ImportError:
     # fallback if pywin32 is not installed
-    StandardIO = None
-    PipeAddress = None
+    StandardIO = None  # type: ignore[assignment]
+    PipeAddress = None  # type: ignore[assignment]
 
 from twisted.internet.task import LoopingCall
 from twisted.internet._resolver import HostResolution

--- a/src/twisted/internet/test/test_serialport.py
+++ b/src/twisted/internet/test/test_serialport.py
@@ -12,7 +12,7 @@ from twisted.internet.error import ConnectionDone
 try:
     from twisted.internet import serialport
 except ImportError:
-    serialport = None
+    serialport = None  # type: ignore[assignment]
 
 
 

--- a/src/twisted/internet/test/test_win32serialport.py
+++ b/src/twisted/internet/test/test_win32serialport.py
@@ -26,7 +26,7 @@ except ImportError:
     if testingForced:
         raise
 
-    serialport = None
+    serialport = None  # type: ignore[assignment]
     serial = None
 
 

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -23,11 +23,10 @@ from twisted.internet import (
 from twisted.test import iosim
 from twisted.test.proto_helpers import StringTransport
 
-ssl = None
 try:
     from twisted.internet import ssl
 except ImportError:
-    pass
+    ssl = None  # type: ignore[assignment]
 
 if ssl and not ssl.supported:
     ssl = None


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9862

In cases where an import can fail, such as:

```
try:
    from twisted.internet.stdio import StandardIO, PipeAddress
except ImportError:
    # fallback if pywin32 is not installed
    StandardIO = None
    PipeAddress = None
```

mypy will fail with:

```
src/twisted/internet/endpoints.py:45:5: error: Cannot assign multiple types to name "StandardIO" without an explicit "Type[...]" annotation  [misc]
src/twisted/internet/endpoints.py:45:18: error: Incompatible types in assignment (expression has type "None", variable has type "Type[StandardIO]")  [assignment]
```

This PR cleans up those errors.
