### PR TITLE
[mypy] Rename some variables which collide with other variables

### DIFF
--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -9,7 +9,8 @@
 # Implementation module for the `conch` command.
 #
 
-from twisted.conch.client import connect, default, options
+from twisted.conch.client import connect, default
+from twisted.conch.client.options import ConchOptions
 from twisted.conch.error import ConchError
 from twisted.conch.ssh import connection, common
 from twisted.conch.ssh import session, forwarding, channel
@@ -28,7 +29,7 @@ from typing import List, Tuple
 
 
 
-class ClientOptions(options.ConchOptions):
+class ClientOptions(ConchOptions):
 
     synopsis = """Usage:   conch [options] host [command]
 """

--- a/src/twisted/test/stdio_test_halfclose.py
+++ b/src/twisted/test/stdio_test_halfclose.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     reflect.namedAny(sys.argv[1]).install()
     log.startLogging(open(sys.argv[2], 'wb'))
     from twisted.internet import reactor
-    protocol = HalfCloseProtocol()
-    stdio.StandardIO(protocol)
+    halfCloseProtocol = HalfCloseProtocol()
+    stdio.StandardIO(halfCloseProtocol)
     reactor.run()
-    sys.exit(protocol.exitCode)
+    sys.exit(halfCloseProtocol.exitCode)

--- a/src/twisted/test/stdio_test_loseconn.py
+++ b/src/twisted/test/stdio_test_loseconn.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     reflect.namedAny(sys.argv[1]).install()
     log.startLogging(open(sys.argv[2], 'wb'))
     from twisted.internet import reactor
-    protocol = LoseConnChild()
-    stdio.StandardIO(protocol)
+    protocolLoseConnChild = LoseConnChild()
+    stdio.StandardIO(protocolLoseConnChild)
     reactor.run()
-    sys.exit(protocol.exitCode)
+    sys.exit(protocolLoseConnChild.exitCode)


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9863

In src/twisted/conch/scripts/conch.py , this line:

```
# Rest of code in "run"
options = None
```

causes mypy to complain with:

```
src/twisted/conch/scripts/conch.py:105:11: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
```

This PR cleans up a few errors similar to that.