### PR TITLE
[mypy] cannot infer type of lambda

### DIFF
--- a/src/twisted/test/test_policies.py
+++ b/src/twisted/test/test_policies.py
@@ -357,7 +357,8 @@ class WrapperTests(unittest.TestCase):
 
 
 class WrappingFactory(policies.WrappingFactory):
-    protocol = lambda s, f, p: p
+    def protocol(self, f, p):
+        return p
 
     def startFactory(self):
         policies.WrappingFactory.startFactory(self)


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9865

This cleans up this mypy error:

```
src/twisted/test/test_policies.py:360:16: error: Cannot infer type of lambda  [misc]
```