### PR TITLE
[mypy] Change delimiter to bytes in irc.py

### DIFF
--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -2917,7 +2917,7 @@ class DccChat(basic.LineReceiver, styles.Ephemeral):
     """
 
     queryData = None
-    delimiter = CR + NL
+    delimiter = CR.encode('ascii') + NL.encode('ascii')
     client = None
     remoteParty = None
     buffer = b""


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9866

This PR cleans up this error:

```
src/twisted/words/protocols/irc.py:2920:17: error: Incompatible types in assignment (expression has type "str", base class "LineReceiver" defined the type as "bytes")  [assignment]
```