### PR TITLE
Fix docstring syntax errors

### DIFF
--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -323,12 +323,12 @@ class CheckersMixin(object):
     and deny specified credentials.
 
     Subclasses must provide
-    - C{getCheckers} which returns a sequence of
-      L{checkers.ICredentialChecker}
-    - C{getGoodCredentials} which returns a list of 2-tuples of
-      credential to check and avaterId to expect.
-    - C{getBadCredentials} which returns a list of credentials
-      which are expected to be unauthorized.
+      - C{getCheckers} which returns a sequence of
+        L{checkers.ICredentialChecker}
+      - C{getGoodCredentials} which returns a list of 2-tuples of
+        credential to check and avaterId to expect.
+      - C{getBadCredentials} which returns a list of credentials
+        which are expected to be unauthorized.
     """
 
     @defer.inlineCallbacks

--- a/src/twisted/mail/test/test_pop3.py
+++ b/src/twisted/mail/test/test_pop3.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Test cases for Ltwisted.mail.pop3} module.
+Test cases for L{twisted.mail.pop3} module.
 """
 
 

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -4211,7 +4211,8 @@ class EDNSMessageSpecificsTests(ConstructorTestsMixin,
 
 
 
-class EDNSMessageEqualityTests(ComparisonTestsMixin, unittest.SynchronousTestCase):
+class EDNSMessageEqualityTests(ComparisonTestsMixin,
+                               unittest.SynchronousTestCase):
     """
     Tests for equality between L{dns._EDNSMessage} instances.
 
@@ -4926,7 +4927,9 @@ class CompactReprTests(unittest.SynchronousTestCase):
     """
     Tests for L{dns._compactRepr}.
     """
+
     messageFactory = Foo
+
     def test_defaults(self):
         """
         L{dns._compactRepr} omits field values and sections which have the

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -4213,7 +4213,7 @@ class EDNSMessageSpecificsTests(ConstructorTestsMixin,
 
 class EDNSMessageEqualityTests(ComparisonTestsMixin, unittest.SynchronousTestCase):
     """
-    Tests for equality between L(dns._EDNSMessage} instances.
+    Tests for equality between L{dns._EDNSMessage} instances.
 
     These tests will not work with L{dns.Message} because it does not use
     L{twisted.python.util.FancyEqMixin}.
@@ -4924,7 +4924,7 @@ class Foo(object):
 
 class CompactReprTests(unittest.SynchronousTestCase):
     """
-    Tests for L[dns._compactRepr}.
+    Tests for L{dns._compactRepr}.
     """
     messageFactory = Foo
     def test_defaults(self):

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -42,13 +42,13 @@ class ZshScriptTestMixin(object):
     Integration test helper to show that C{usage.Options} classes can have zsh
     completion functions generated for them without raising errors.
 
-    In your subclasses set a class variable like so:
+    In your subclasses set a class variable like so::
 
-    #            | cmd name | Fully Qualified Python Name of Options class |
-    #
-    generateFor = [('conch',  'twisted.conch.scripts.conch.ClientOptions'),
-                   ('twistd', 'twisted.scripts.twistd.ServerOptions'),
-                   ]
+      #            | cmd name | Fully Qualified Python Name of Options class |
+      #
+      generateFor = [('conch',  'twisted.conch.scripts.conch.ClientOptions'),
+                     ('twistd', 'twisted.scripts.twistd.ServerOptions'),
+                     ]
 
     Each package that contains Twisted scripts should contain one TestCase
     subclass which also inherits from this mixin, and contains a C{generateFor}

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -419,7 +419,7 @@ class InsensitiveDictTests(TestCase):
 
 class PasswordTestingProcessProtocol(ProcessProtocol):
     """
-    Write the string C{"secret\n"} to a subprocess and then collect all of
+    Write the string C{"secret\\n"} to a subprocess and then collect all of
     its output and fire a Deferred with it when the process ends.
     """
     def connectionMade(self):

--- a/src/twisted/web/test/test_xml.py
+++ b/src/twisted/web/test/test_xml.py
@@ -817,8 +817,9 @@ class BrokenHTMLTests(TestCase):
     """
     Tests for when microdom encounters very bad HTML and C{beExtremelyLenient}
     is enabled. These tests are inspired by some HTML generated in by a mailer,
-    which breaks up very long lines by splitting them with '!\n '. The expected
-    behaviour is loosely modelled on the way Firefox treats very bad HTML.
+    which breaks up very long lines by splitting them with '!\\n '.
+    The expected behaviour is loosely modelled on the way Firefox treats very
+    bad HTML.
     """
 
     def checkParsed(self, input, expected, beExtremelyLenient=1):


### PR DESCRIPTION
This removes some noise from the pydoctor logging, so actual problems will stand out more.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9868
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] ~~I have updated the automated tests.~~ Only docstrings are changed.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
