### PR TITLE
Fix docstring cross-references

### DIFF
--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -33,7 +33,7 @@ class ICredentials(Interface):
     I check credentials.
 
     Implementors I{must} specify the sub-interfaces of ICredentials
-    to which it conforms, using L{zope.interface.declarations.implementer}.
+    to which it conforms, using L{zope.interface.implementer}.
     """
 
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1538,7 +1538,7 @@ def _cancellableInlineCallbacks(g):
 
         @param result: An L{_InternalInlineCallbacksCancelledError} from
             C{cancel()}.
-        @return: A new L{Deferred} that the C{@}L{inlineCallback} generator
+        @return: A new L{Deferred} that the C{@}L{inlineCallbacks} generator
             can callback or errback through.
         """
         result.trap(_InternalInlineCallbacksCancelledError)

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -75,7 +75,7 @@ class FileAuthority(common.ResolverBase):
         L{dns.Record_SOA}.
 
     @ivar records: A mapping of domains (as lowercased L{bytes}) to records.
-    @type records: L{dict} with L{byte} keys
+    @type records: L{dict} with L{bytes} keys
     """
     # See https://twistedmatrix.com/trac/ticket/6650
     _ADDITIONAL_PROCESSING_TYPES = (dns.CNAME, dns.MX, dns.NS)

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -32,7 +32,7 @@ class Expose(object):
         Add one or more functions to the set of exposed functions.
 
         This is a way to declare something about a class definition, similar to
-        L{zope.interface.declarations.implementer}.  Use it like this::
+        L{zope.interface.implementer}.  Use it like this::
 
             magic = Expose('perform extra magic')
             class Foo(Bar):

--- a/src/twisted/words/xish/domish.py
+++ b/src/twisted/words/xish/domish.py
@@ -272,7 +272,7 @@ class IElement(Interface):
             contains the local name, or a tuple of (uri, local_name) for a
             fully qualified name. In the former case, the namespace URI is
             inherited from this element.
-        @type name: L{str} or L{tuple} of (L{stre}, L{str})
+        @type name: L{str} or L{tuple} of (L{str}, L{str})
 
         @param defaultUri: default namespace URI for child elements. If
             L{None}, this is inherited from this element.


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9873
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] ~~I have updated the automated tests.~~ Only docstrings were changed.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
