### PR TITLE
9874 mthuurne missing docstring field names

### DIFF
--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -26,7 +26,7 @@ class Logger(object):
     @type source: L{object}
     @ivar source: The object which is emitting events via this logger
 
-    @type: L{ILogObserver}
+    @type observer: L{ILogObserver}
     @ivar observer: The observer that this logger will send events to.
     """
 

--- a/src/twisted/names/secondary.py
+++ b/src/twisted/names/secondary.py
@@ -107,10 +107,10 @@ class SecondaryAuthority(FileAuthority):
 
     @ivar _port: The port number of the server from which zone transfers will
     be attempted.
-    @type: C{int}
+    @type _port: C{int}
 
     @ivar domain: The domain for which this is the secondary authority.
-    @type: C{bytes}
+    @type domain: C{bytes}
 
     @ivar _reactor: The reactor to use to perform the zone transfers, or
     L{None} to use the global reactor.

--- a/src/twisted/names/secondary.py
+++ b/src/twisted/names/secondary.py
@@ -103,14 +103,14 @@ class SecondaryAuthority(FileAuthority):
 
     @ivar primary: The IP address of the server from which zone transfers will
     be attempted.
-    @type primary: C{str}
+    @type primary: L{str}
 
     @ivar _port: The port number of the server from which zone transfers will
     be attempted.
-    @type _port: C{int}
+    @type _port: L{int}
 
     @ivar domain: The domain for which this is the secondary authority.
-    @type domain: C{bytes}
+    @type domain: L{bytes}
 
     @ivar _reactor: The reactor to use to perform the zone transfers, or
     L{None} to use the global reactor.

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -53,7 +53,7 @@ the modules outside the standard library's python-files directory::
                 modinfo.name, modinfo.filePath.path))
 
 @var theSystemPath: The very top of the Python object space.
-@type: L{PythonPath}
+@type theSystemPath: L{PythonPath}
 """
 
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9874
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] ~~I have updated the automated tests.~~ Only docstrings were changed.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
