### PR TITLE
[mypy] [9881] Remove twisted.python.filepath.FilePath.statinfo

### DIFF
--- a/src/twisted/newsfragments/9881.removal
+++ b/src/twisted/newsfragments/9881.removal
@@ -1,0 +1,1 @@
+twisted.python.filepath.FilePath.statinfo was deprecated in Twisted 15.0.0 and has now been removed.

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -29,15 +29,13 @@ from zope.interface import Interface, Attribute, implementer
 # modified for inclusion in the standard library.  --glyph
 
 from twisted.python.compat import comparable, cmp, unicode
-from twisted.python.deprecate import deprecated
 from twisted.python.runtime import platform
-from incremental import Version
-
+from twisted.python.util import FancyEqMixin
 from twisted.python.win32 import ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND
 from twisted.python.win32 import ERROR_INVALID_NAME, ERROR_DIRECTORY, O_BINARY
 from twisted.python.win32 import WindowsError
 
-from twisted.python.util import FancyEqMixin
+
 
 _CREATE_FLAGS = (os.O_EXCL |
                  os.O_CREAT |
@@ -597,15 +595,6 @@ class Permissions(FancyEqMixin, object):
             [x.shorthand() for x in (self.user, self.group, self.other)])
 
 
-class _SpecialNoValue(object):
-    """
-    An object that represents 'no value', to be used in deprecating statinfo.
-
-    Please remove once statinfo is removed.
-    """
-    pass
-
-
 
 def _asFilesystemBytes(path: Union[bytes, str], encoding: str = "") -> bytes:
     """
@@ -707,22 +696,6 @@ class FilePath(AbstractFilePath):
 
     @type path: L{bytes} or L{unicode}
     @ivar path: The path from which 'downward' traversal is permitted.
-
-    @ivar statinfo: (WARNING: statinfo is deprecated as of Twisted 15.0.0 and
-        will become a private attribute)
-        The currently cached status information about the file on
-        the filesystem that this L{FilePath} points to.  This attribute is
-        L{None} if the file is in an indeterminate state (either this
-        L{FilePath} has not yet had cause to call C{stat()} yet or
-        L{FilePath.changed} indicated that new information is required), 0 if
-        C{stat()} was called and returned an error (i.e. the path did not exist
-        when C{stat()} was called), or a C{stat_result} object that describes
-        the last known status of the underlying file (or directory, as the case
-        may be).  Trust me when I tell you that you do not want to use this
-        attribute.  Instead, use the methods on L{FilePath} which give you
-        information about it, like C{getsize()}, C{isdir()},
-        C{getModificationTime()}, and so on.
-    @type statinfo: L{int} or L{None} or L{os.stat_result}
     """
     _statinfo = None
     path = None
@@ -1732,56 +1705,6 @@ class FilePath(AbstractFilePath):
         else:
             self.changed()
             destination.changed()
-
-
-    @property
-    @deprecated(Version('Twisted', 15, 0, 0),
-                "other FilePath methods such as getsize(), "
-                "isdir(), getModificationTime(), etc.")
-    def statinfo(self, value=_SpecialNoValue):
-        """
-        FilePath.statinfo is deprecated.
-
-        @param value: value to set statinfo to, if setting a value
-        @return: C{_statinfo} if getting, L{None} if setting
-        """
-        # This is a pretty awful hack to use the deprecated decorator to
-        # deprecate a class attribute.  Ideally, there would just be a
-        # statinfo property and a statinfo property setter, but the
-        # 'deprecated' decorator does not produce the correct FQDN on class
-        # methods.  So the property stuff needs to be set outside the class
-        # definition - but the getter and setter both need the same function
-        # in order for the 'deprecated' decorator to produce the right
-        # deprecation string.
-        if value is _SpecialNoValue:
-            return self._statinfo
-        else:
-            self._statinfo = value
-
-
-    @statinfo.setter
-    @deprecated(Version('Twisted', 15, 0, 0),
-                "other FilePath methods such as getsize(), "
-                "isdir(), getModificationTime(), etc.")
-    def statinfo(self, value=_SpecialNoValue):
-        """
-        FilePath.statinfo is deprecated.
-
-        @param value: value to set statinfo to, if setting a value
-        @return: C{_statinfo} if getting, L{None} if setting
-        """
-        # This is a pretty awful hack to use the deprecated decorator to
-        # deprecate a class attribute.  Ideally, there would just be a
-        # statinfo property and a statinfo property setter, but the
-        # 'deprecated' decorator does not produce the correct FQDN on class
-        # methods.  So the property stuff needs to be set outside the class
-        # definition - but the getter and setter both need the same function
-        # in order for the 'deprecated' decorator to produce the right
-        # deprecation string.
-        if value is _SpecialNoValue:
-            return self._statinfo
-        else:
-            self._statinfo = value
 
 
 

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -1444,9 +1444,8 @@ class FilePathTests(AbstractFilePathTests):
         self.assertEqual(fp.getsize(), 5)
         fp.changed()
 
-        # This path should look like we don't know what status it's in, not that
-        # we know that it didn't exist when last we checked.
-        self.assertIsNone(fp.statinfo)
+        # This path should look like we don't know what status it's in, not
+        # that we know that it didn't exist when last we checked.
         self.assertEqual(fp.getsize(), 8)
 
 
@@ -1465,48 +1464,6 @@ class FilePathTests(AbstractFilePathTests):
         self.assertEqual(
             self.path.child(b"sub1").getPermissions().shorthand(),
             "rwxrw-r--")
-
-
-    def test_deprecateStatinfoGetter(self):
-        """
-        Getting L{twisted.python.filepath.FilePath.statinfo} is deprecated.
-        """
-        fp = filepath.FilePath(self.mktemp())
-        fp.statinfo
-        warningInfo = self.flushWarnings([self.test_deprecateStatinfoGetter])
-        self.assertEqual(len(warningInfo), 1)
-        self.assertEqual(warningInfo[0]['category'], DeprecationWarning)
-        self.assertEqual(
-            warningInfo[0]['message'],
-            "twisted.python.filepath.FilePath.statinfo was deprecated in "
-            "Twisted 15.0.0; please use other FilePath methods such as "
-            "getsize(), isdir(), getModificationTime(), etc. instead")
-
-
-    def test_deprecateStatinfoSetter(self):
-        """
-        Setting L{twisted.python.filepath.FilePath.statinfo} is deprecated.
-        """
-        fp = filepath.FilePath(self.mktemp())
-        fp.statinfo = None
-        warningInfo = self.flushWarnings([self.test_deprecateStatinfoSetter])
-        self.assertEqual(len(warningInfo), 1)
-        self.assertEqual(warningInfo[0]['category'], DeprecationWarning)
-        self.assertEqual(
-            warningInfo[0]['message'],
-            "twisted.python.filepath.FilePath.statinfo was deprecated in "
-            "Twisted 15.0.0; please use other FilePath methods such as "
-            "getsize(), isdir(), getModificationTime(), etc. instead")
-
-
-    def test_deprecateStatinfoSetterSets(self):
-        """
-        Setting L{twisted.python.filepath.FilePath.statinfo} changes the value
-        of _statinfo such that getting statinfo again returns the new value.
-        """
-        fp = filepath.FilePath(self.mktemp())
-        fp.statinfo = None
-        self.assertIsNone(fp.statinfo)
 
 
     def test_filePathNotDeprecated(self):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9881

Remove `twisted.python.filepath.FilePath.statinfo` which has been deprecated since Twisted 15.0.0

This eliminates some mypy errors as well.