### PR TITLE
[mypy] [9884] Introduce an _IWaker interface, reduce mypy errors

### DIFF
--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -12,9 +12,9 @@ import errno
 import os
 import sys
 
-from typing import Union, Sequence, Type
+from typing import Sequence
 
-from zope.interface import implementer, classImplements
+from zope.interface import Attribute, Interface, implementer, classImplements
 
 from twisted.internet import error, udp, tcp
 from twisted.internet.base import ReactorBase, _SignalReactorMixin
@@ -63,6 +63,37 @@ if platform.isWindows():
         win32process = None
 
 
+
+class _IWaker(Interface):
+    """
+    Interface to wake up the event loop based on the self-pipe trick.
+
+    The U{I{self-pipe trick}<http://cr.yp.to/docs/selfpipe.html>}, used to wake
+    up the main loop from another thread or a signal handler.
+    This is why we have wakeUp together with doRead
+
+    This is used by threads or signals to wake up the event loop.
+    """
+    disconnected = Attribute('')
+
+    def wakeUp():
+        """
+        Called when the event should be wake up.
+        """
+
+    def doRead():
+        """
+        Read some data from my connection and discard it.
+        """
+
+    def connectionLost(reason: failure.Failure):
+        """
+        Called when connection was closed and the pipes.
+        """
+
+
+
+@implementer(_IWaker)
 class _SocketWaker(log.Logger):
     """
     The I{self-pipe trick<http://cr.yp.to/docs/selfpipe.html>}, implemented
@@ -99,13 +130,16 @@ class _SocketWaker(log.Logger):
             if e.args[0] != errno.WSAEWOULDBLOCK:
                 raise
 
+
     def doRead(self):
-        """Read some data from my connection.
+        """
+        Read some data from my connection.
         """
         try:
             self.r.recv(8192)
         except socket.error:
             pass
+
 
     def connectionLost(self, reason):
         self.r.close()
@@ -165,6 +199,7 @@ class _FDWaker(log.Logger, object):
 
 
 
+@implementer(_IWaker)
 class _UnixWaker(_FDWaker):
     """
     This class provides a simple interface to wake up the event loop.
@@ -189,10 +224,11 @@ class _UnixWaker(_FDWaker):
 
 
 if platformType == 'posix':
-    _Waker = _UnixWaker  # type: Union[Type[_FDWaker], Type[_SocketWaker]]
+    _Waker = _UnixWaker
 else:
     # Primarily Windows and Jython.
-    _Waker = _SocketWaker
+    _Waker = _SocketWaker  # type: ignore[misc,assignment]
+
 
 
 class _SIGCHLDWaker(_FDWaker):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9884

This cleans up these mypy errors:

```
src/twisted/internet/posixbase.py:195:5: error: Cannot assign multiple types to name "_Waker" without an explicit "Type[...]" annotation  [misc]
src/twisted/internet/posixbase.py:195:14: error: Incompatible types in assignment (expression has type "Type[_SocketWaker]", variable has type "Type[_UnixWaker]")  [assignment]

src/twisted/internet/cfreactor.py:47:18: error: Variable "twisted.internet.posixbase._Waker" is not valid as a type  [valid-type]
src/twisted/internet/cfreactor.py:47:18: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
src/twisted/internet/cfreactor.py:47:18: error: Invalid base class "_Waker"  [misc]
```