### PR TITLE
[mypy] [9886] Reduce mypy errors in styles.py

### DIFF
--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -14,6 +14,7 @@ import types
 from typing import Dict
 from twisted.python.compat import _PYPY
 from twisted.python import log, reflect
+from io import StringIO as _cStringIO
 
 
 
@@ -84,7 +85,9 @@ def unpickleMethod(im_name, im_self, im_class):
 
 
 
-copy_reg.pickle(types.MethodType, pickleMethod, unpickleMethod)
+copy_reg.pickle(types.MethodType, pickleMethod)
+
+
 
 def _pickleFunction(f):
     """
@@ -125,11 +128,15 @@ def _unpickleFunction(fullyQualifiedName):
 
 
 
-copy_reg.pickle(types.FunctionType, _pickleFunction, _unpickleFunction)
+copy_reg.pickle(types.FunctionType, _pickleFunction)
+
+
 
 def pickleModule(module):
     'support function for copy_reg to pickle module refs'
     return unpickleModule, (module.__name__,)
+
+
 
 def unpickleModule(name):
     'support function for copy_reg to unpickle module refs'
@@ -137,12 +144,11 @@ def unpickleModule(name):
         log.msg("Module has moved: %s" % name)
         name = oldModules[name]
         log.msg(name)
-    return __import__(name,{},{},'x')
+    return __import__(name, {}, {}, 'x')
 
 
-copy_reg.pickle(types.ModuleType,
-                pickleModule,
-                unpickleModule)
+
+copy_reg.pickle(types.ModuleType, pickleModule)
 
 
 
@@ -223,13 +229,6 @@ def unpickleStringI(val, sek):
 
 
 
-try:
-    from cStringIO import InputType, OutputType, StringIO as _cStringIO
-except ImportError:
-    from io import StringIO as _cStringIO
-else:
-    copy_reg.pickle(OutputType, pickleStringO, unpickleStringO)
-    copy_reg.pickle(InputType, pickleStringI, unpickleStringI)
 
 
 
@@ -273,6 +272,8 @@ def doUpgrade():
     versionedsToUpgrade = {}
     upgraded = {}
 
+
+
 def requireUpgrade(obj):
     """Require that a Versioned instance be upgraded completely first.
     """
@@ -281,6 +282,8 @@ def requireUpgrade(obj):
         upgraded[objID] = 1
         obj.versionUpgrade()
         return obj
+
+
 
 def _aybabtu(c):
     """
@@ -298,6 +301,8 @@ def _aybabtu(c):
             l.append(b)
     # return all except the unwanted classes
     return l[2:]
+
+
 
 class Versioned:
     """
@@ -326,6 +331,7 @@ class Versioned:
         versionedsToUpgrade[id(self)] = self
         self.__dict__ = state
 
+
     def __getstate__(self, dict=None):
         """Get state, adding a version number to it on its way out.
         """
@@ -339,8 +345,10 @@ class Versioned:
                     if slot in dct:
                         del dct[slot]
             if 'persistenceVersion' in base.__dict__:
-                dct['%s.persistenceVersion' % reflect.qual(base)] = base.persistenceVersion
+                dct['{}.persistenceVersion'.format(
+                    reflect.qual(base))] = base.persistenceVersion
         return dct
+
 
     def versionUpgrade(self):
         """(internal) Do a version upgrade.

--- a/src/twisted/persisted/test/test_styles.py
+++ b/src/twisted/persisted/test/test_styles.py
@@ -5,6 +5,7 @@
 Tests for L{twisted.persisted.styles}.
 """
 
+import copy
 import pickle
 
 from twisted.trial import unittest
@@ -15,10 +16,15 @@ class Foo:
     """
     Helper class.
     """
+    def __init__(self):
+        self.instance_member = 'test-value'
+
+
     def method(self):
         """
         Helper method.
         """
+        return self.instance_member
 
 
 
@@ -78,6 +84,20 @@ class UnpickleMethodTests(unittest.TestCase):
         self.assertIsNot(m, foo.method)
 
 
+    def test_instanceCopyMethod(self):
+        """
+        Copying an instance method returns a new method with the same
+        behavior.
+        """
+        foo = Foo()
+        m = copy.copy(foo.method)
+        self.assertEqual(m, foo.method)
+        self.assertIsNot(m, foo.method)
+        self.assertEqual('test-value', m())
+        foo.instance_member = 'new-value'
+        self.assertEqual('new-value', m())
+
+
     def test_instanceBuildingNameNotPresent(self):
         """
         If the named method is not present in the class,
@@ -88,6 +108,15 @@ class UnpickleMethodTests(unittest.TestCase):
         m = unpickleMethod('method', foo, Bar)
         self.assertEqual(m, foo.method)
         self.assertIsNot(m, foo.method)
+
+
+    def test_copyFunction(self):
+        """
+        Copying a function returns the same reference, without creating
+        an actual copy.
+        """
+        f = copy.copy(sampleFunction)
+        self.assertEqual(f, sampleFunction)
 
 
     def test_primeDirective(self):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9886

Eliminate mypy errors:

```
src/twisted/persisted/styles.py:87:49: error: Argument 3 to "pickle" has incompatible type "Callable[[Any, Any, Any], Any]"; expected
"Optional[Callable[[Union[Tuple[Callable[..., Type[MethodType]], Tuple[Any, ...]], Tuple[Callable[..., Type[MethodType]], Tuple[Any, ...], Optional[Any]]]], Type[MethodType]]]"  [arg-type]
    copy_reg.pickle(types.MethodType, pickleMethod, unpickleMethod)
                                                    ^
src/twisted/persisted/styles.py:231:48: error: Argument 3 to "pickle" has incompatible type "Callable[[Any, Any], Any]"; expected
"Optional[Callable[[Union[Tuple[Callable[..., Any], Tuple[Any, ...]], Tuple[Callable[..., Any], Tuple[Any, ...], Optional[Any]]]], Any]]"  [arg-type]
        copy_reg.pickle(OutputType, pickleStringO, unpickleStringO)
                                                   ^
src/twisted/persisted/styles.py:232:47: error: Argument 3 to "pickle" has incompatible type "Callable[[Any, Any], Any]"; expected
"Optional[Callable[[Union[Tuple[Callable[..., Any], Tuple[Any, ...]], Tuple[Callable[..., Any], Tuple[Any, ...], Optional[Any]]]], Any]]"  [arg-type]
        copy_reg.pickle(InputType, pickleStringI, unpickleStringI)
```
