### PR TITLE
9887 - twisted.web.twcgi can now handle url parameters in python 3

### DIFF
--- a/src/twisted/web/newsfragments/9887.bugfix
+++ b/src/twisted/web/newsfragments/9887.bugfix
@@ -1,0 +1,1 @@
+twisted.web.twcgi can now handle url parameters in python 3

--- a/src/twisted/web/test/test_cgi.py
+++ b/src/twisted/web/test/test_cgi.py
@@ -94,6 +94,8 @@ print("")
 print(param)
 '''
 
+
+
 class PythonScript(twcgi.FilteredScript):
     filter = sys.executable
 
@@ -396,8 +398,7 @@ class CGIScriptTests(unittest.TestCase):
             cgiFile.write(URL_PARAMETER_CGI)
 
         portnum = self.startServer(cgiFilename)
-        url = "http://localhost:%d/cgi?param=1234" % (portnum, ) #cgiFilename,)
-        print(url)
+        url = "http://localhost:%d/cgi?param=1234" % (portnum, )
         url = url.encode("ascii")
         agent = client.Agent(reactor)
         d = agent.request(b"GET", url)

--- a/src/twisted/web/twcgi.py
+++ b/src/twisted/web/twcgi.py
@@ -109,10 +109,10 @@ class CGIScript(resource.Resource):
             qargs = []
         else:
             qs = env['QUERY_STRING'] = request.uri[qindex+1:]
-            if '=' in qs:
+            if b'=' in qs:
                 qargs = []
             else:
-                qargs = [urllib.unquote(x) for x in qs.split('+')]
+                qargs = [urllib.parse.unquote(x.decode()) for x in qs.split(b'+')]
 
         # Propagate HTTP headers
         for title, header in request.getAllHeaders().items():

--- a/src/twisted/web/twcgi.py
+++ b/src/twisted/web/twcgi.py
@@ -112,7 +112,8 @@ class CGIScript(resource.Resource):
             if b'=' in qs:
                 qargs = []
             else:
-                qargs = [urllib.parse.unquote(x.decode()) for x in qs.split(b'+')]
+                qargs = [urllib.parse.unquote(x.decode())
+                         for x in qs.split(b'+')]
 
         # Propagate HTTP headers
         for title, header in request.getAllHeaders().items():


### PR DESCRIPTION
##  Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9887<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
