### PR TITLE
[mypy] [9890] Reduce mypy errors

### DIFF
--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -768,11 +768,11 @@ class AbstractDatagramProtocol:
         self.doStart()
 
 
-    def datagramReceived(self, datagram: str, addr):
+    def datagramReceived(self, datagram: bytes, addr):
         """
         Called when a datagram is received.
 
-        @param datagram: the string received from the transport.
+        @param datagram: the bytes received from the transport.
         @param addr: tuple of source of datagram.
         """
 

--- a/src/twisted/pair/ip.py
+++ b/src/twisted/pair/ip.py
@@ -36,6 +36,7 @@ class IPProtocol(protocol.AbstractDatagramProtocol):
     def __init__(self):
         self.ipProtos = {}
 
+
     def addProto(self, num, proto):
         proto = raw.IRawDatagramProtocol(proto)
         if num < 0:
@@ -45,6 +46,7 @@ class IPProtocol(protocol.AbstractDatagramProtocol):
         if num not in self.ipProtos:
             self.ipProtos[num] = []
         self.ipProtos[num].append(proto)
+
 
     def datagramReceived(self,
                          data,

--- a/src/twisted/pair/raw.py
+++ b/src/twisted/pair/raw.py
@@ -17,7 +17,9 @@ class IRawDatagramProtocol(Interface):
         Add a protocol on top of this one.
         """
 
-    def datagramReceived():
+    def datagramReceived(data, partial, source, dest, protocol, version, ihl,
+                         tos, tot_len, fragment_id, fragment_offset,
+                         dont_fragment, more_fragments, ttl):
         """
         An IP datagram has been received. Parse and process it.
         """
@@ -34,7 +36,7 @@ class IRawPacketProtocol(Interface):
         Add a protocol on top of this one.
         """
 
-    def datagramReceived():
+    def datagramReceived(data, partial, dest, source, protocol):
         """
         An IP datagram has been received. Parse and process it.
         """

--- a/src/twisted/pair/test/test_ethernet.py
+++ b/src/twisted/pair/test/test_ethernet.py
@@ -19,13 +19,16 @@ class MyProtocol:
         """
 
 
-    def datagramReceived(self, data, **kw):
+    def datagramReceived(self, data, partial, dest, source, protocol):
         assert self.expecting, 'Got a packet when not expecting anymore.'
         expect = self.expecting.pop(0)
-        assert expect == (data, kw), \
-               "Expected %r, got %r" % (
-            expect, (data, kw),
-            )
+        localVariables = locals()
+        params = {'partial': partial, 'dest': dest, 'source': source,
+                  'protocol': protocol}
+        assert expect == (data, params), "Expected {!r}, got {!r}".format(
+            expect, (data, params))
+
+
 
 class EthernetTests(unittest.TestCase):
     def testPacketParsing(self):
@@ -109,10 +112,13 @@ class EthernetTests(unittest.TestCase):
         proto.datagramReceived(b"123456987654\x08\x00foobar",
                                partial=0)
 
-        assert not p1.expecting, \
-               'Should not expect any more packets, but still want %r' % p1.expecting
-        assert not p2.expecting, \
-               'Should not expect any more packets, but still want %r' % p2.expecting
+        assert not p1.expecting, (
+            'Should not expect any more packets, '
+            'but still want {!r}'.format(p1.expecting))
+        assert not p2.expecting, (
+            'Should not expect any more packets,'
+            ' but still want {!r}'.format(p2.expecting))
+
 
     def testWrongProtoNotSeen(self):
         proto = ethernet.EthernetProtocol()
@@ -123,6 +129,7 @@ class EthernetTests(unittest.TestCase):
                                partial=0)
         proto.datagramReceived(b"012345abcdef\x08\x00quux",
                                partial=1)
+
 
     def testDemuxing(self):
         proto = ethernet.EthernetProtocol()

--- a/src/twisted/pair/test/test_ip.py
+++ b/src/twisted/pair/test/test_ip.py
@@ -13,20 +13,22 @@ class MyProtocol:
         self.expecting = list(expecting)
 
 
-    def datagramReceived(self, data, **kw):
+    def datagramReceived(self, data, partial, source, dest, protocol, version,
+                         ihl, tos, tot_len, fragment_id, fragment_offset,
+                         dont_fragment, more_fragments, ttl):
         assert self.expecting, 'Got a packet when not expecting anymore.'
         expectData, expectKw = self.expecting.pop(0)
 
         expectKwKeys = expectKw.keys()
         expectKwKeys = list(sorted(expectKwKeys))
-        kwKeys = kw.keys()
-        kwKeys = list(sorted(kwKeys))
-        assert expectKwKeys == kwKeys, "Expected %r, got %r" % (expectKwKeys, kwKeys)
+        localVariables = locals()
 
         for k in expectKwKeys:
-            assert expectKw[k] == kw[k], "Expected %s=%r, got %r" % (k, expectKw[k], kw[k])
-        assert expectKw == kw, "Expected %r, got %r" % (expectKw, kw)
-        assert expectData == data, "Expected %r, got %r" % (expectData, data)
+            assert expectKw[k] == localVariables[k], \
+                "Expected {}={!r}, got {!r}".format(
+                 k, expectKw[k], localVariables[k])
+        assert expectData == data, "Expected {!r}, got {!r}".format(
+            expectData, data)
 
 
     def addProto(self, num, proto):

--- a/src/twisted/pair/test/test_tuntap.py
+++ b/src/twisted/pair/test/test_tuntap.py
@@ -1340,7 +1340,8 @@ class IPRecordingProtocol(AbstractDatagramProtocol):
         self.received = []
 
 
-    def datagramReceived(self, datagram, partial=False):
+    def datagramReceived(self, datagram, partial=False, dest=None, source=None,
+                         protocol=None):
         self.received.append(datagram)
 
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9890

Eliminate mypy errors such as:

```
src/twisted/pair/rawudp.py:41:5: error: Signature of "RawUDPProtocol" incompatible with "datagramReceived" of supertype "IRawDatagramProtocol"  [override]
        def datagramReceived(self,
        ^
src/twisted/pair/ip.py:49:5: error: Signature of "IPProtocol" incompatible with "datagramReceived" of supertype "IRawPacketProtocol"  [override]
        def datagramReceived(self,
        ^
src/twisted/pair/test/test_tuntap.py:1343:5: error: Signature of "IPRecordingProtocol" incompatible with "datagramReceived" of supertype "IRawPacketProtocol"  [override]
        def datagramReceived(self, datagram, partial=False):
        ^
src/twisted/pair/test/test_tuntap.py:1358:24: error: Incompatible types in assignment (expression has type "Type[IPRecordingProtocol]", variable has type
src/twisted/pair/test/test_tuntap.py:1381:24: error: Incompatible types in assignment (expression has type "Type[EthernetRecordingProtocol]", variable has type
src/twisted/pair/test/test_ip.py:16:5: error: Signature of "MyProtocol" incompatible with "datagramReceived" of supertype "IRawDatagramProtocol"  [override]
        def datagramReceived(self, data, **kw):
        ^
src/twisted/pair/test/test_ethernet.py:22:5: error: Signature of "MyProtocol" incompatible with "datagramReceived" of supertype "IRawPacketProtocol"  [override]
        def datagramReceived(self, data, **kw):
        ^
```