### PR TITLE
[mypy] [9891] Reduce mypy errors

### DIFF
--- a/src/twisted/conch/client/options.py
+++ b/src/twisted/conch/client/options.py
@@ -7,6 +7,9 @@ from twisted.python import usage
 from twisted.python.compat import unicode
 
 import sys
+from typing import List, Optional, Union
+
+
 
 class ConchOptions(usage.Options):
 
@@ -18,9 +21,10 @@ class ConchOptions(usage.Options):
                      ['option', 'o', None, 'Ignored OpenSSH options'],
                      ['host-key-algorithms', '', None],
                      ['known-hosts', '', None, 'File to check for host keys'],
-                     ['user-authentications', '', None, 'Types of user authentications to use.'],
+                     ['user-authentications', '', None,
+                      'Types of user authentications to use.'],
                      ['logfile', '', None, 'File to log to, or - for stdout'],
-                   ]
+                     ]  # type: List[List[Optional[Union[str, int]]]]
 
     optFlags = [['version', 'V', 'Display version number only.'],
                 ['compress', 'C', 'Enable compression.'],

--- a/src/twisted/conch/scripts/cftp.py
+++ b/src/twisted/conch/scripts/cftp.py
@@ -15,7 +15,7 @@ import stat
 import struct
 import sys
 import tty
-from typing import List, Union
+from typing import List, Optional, Union
 
 from twisted.conch.client import connect, default, options
 from twisted.conch.ssh import connection, common
@@ -45,7 +45,7 @@ class ClientOptions(options.ConchOptions):
                     ['requests', 'R', 5,
                      'Number of requests to make before waiting for a reply.'],
                     ['subsystem', 's', 'sftp',
-                     'Subsystem/server program to connect to.']]  # type: List[List[Union[str, int, None]]]  # noqa
+                     'Subsystem/server program to connect to.']]  # type: List[List[Optional[Union[str, int]]]]  # noqa
 
     compData = usage.Completions(
         descriptions={

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -243,7 +243,7 @@ class AnonymousChecker(object):
     credentialInterfaces = (IAnonymous,)
 
 
-    def requestAvatarId(credentials):
+    def requestAvatarId(self, credentials):
         # ICredentialsChecker.requestAvatarId
         pass
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -56,7 +56,7 @@ class IConnector(Interface):
 
 
 class IResolverSimple(Interface):
-    def getHostByName(name, timeout = (1, 3, 11, 45)):
+    def getHostByName(name, timeout):
         """
         Resolve the domain name C{name} into an IP address.
 
@@ -1097,7 +1097,7 @@ class IReactorSocket(Interface):
 
 
     def adoptDatagramPort(fileDescriptor, addressFamily, protocol,
-                          maxPacketSize=8192):
+                          maxPacketSize):
         """
         Add an existing listening I{SOCK_DGRAM} socket to the reactor to
         monitor for read and write readiness.

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1024,7 +1024,7 @@ class _FileDescriptorReservation(object):
         self._fileDescriptor = None
 
 
-    def __exit__(self, excValue, excType, traceback):
+    def __exit__(self, excType, excValue, traceback):
         """
         See L{_IFileDescriptorReservation.__exit__}.
         """
@@ -1066,7 +1066,7 @@ class _NullFileDescriptorReservation(object):
         """
 
 
-    def __exit__(self, excValue, excType, traceback):
+    def __exit__(self, excType, excValue, traceback):
         """
         Do nothing.  See L{_IFileDescriptorReservation.__exit__}.
 

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -877,7 +877,7 @@ class RaisingMemoryReactor(object):
         raise self._connectException
 
 
-    def adoptStreamConnection(self):
+    def adoptStreamConnection(self, fileDescriptor, addressFamily, factory):
         """
         Fake L{IReactorSocket.adoptStreamConnection}, that raises
         L{_connectException}.

--- a/src/twisted/mail/test/test_smtp.py
+++ b/src/twisted/mail/test/test_smtp.py
@@ -12,7 +12,7 @@ import re
 
 from io import BytesIO
 from unittest import skipIf
-from typing import Optional, Type
+from typing import Any, List, Optional, Type, Tuple
 
 from zope.interface import implementer, directlyProvides
 
@@ -423,7 +423,7 @@ To: foo
         (b'', b'220.*\r\n$', None, None),
         (b'HELO foo.com\r\n', b'250.*\r\n$', None, None),
         (b'RSET\r\n', b'250.*\r\n$', None, None),
-        ]
+        ]  # type: List[Tuple[bytes, bytes, Any, Any]]
     for helo_, from_, to_, realfrom, realto, msg in messages:
         data.append((b'MAIL FROM:<' + from_ + b'>\r\n', b'250.*\r\n',
                      None, None))

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -8,6 +8,7 @@ Test cases for twisted.python._shellcomp
 
 import sys
 from io import BytesIO
+from typing import List, Optional
 
 from twisted.trial import unittest
 from twisted.python import _shellcomp, usage, reflect
@@ -447,13 +448,13 @@ class FighterAceOptions(usage.Options):
                  'Enable a small chance that your machine guns will jam!'],
                 ['verbose', 'v',
                  'Verbose logging (may be specified more than once)'],
-                ]
+                ]  # type: List[List[Optional[str]]]
 
     optParameters = [['pilot-name', None, "What's your name, Ace?",
                       'Manfred von Richthofen'],
                      ['detail', 'd',
                       'Select the level of rendering detail (1-5)', '3'],
-            ]
+                     ]  # type: List[List[Optional[str]]]
 
     subCommands = [['server', None, FighterAceServerOptions,
                     'Start FighterAce game-server.'],

--- a/src/twisted/test/stdio_test_halfclose.py
+++ b/src/twisted/test/stdio_test_halfclose.py
@@ -55,7 +55,7 @@ class HalfCloseProtocol(protocol.Protocol):
         reactor.stop()
 
 
-    def writeConnectionLost(self, reason):
+    def writeConnectionLost(self):
         # IHalfCloseableProtocol.writeConnectionLost
         pass
 

--- a/src/twisted/web/_auth/wrapper.py
+++ b/src/twisted/web/_auth/wrapper.py
@@ -240,6 +240,6 @@ class HTTPAuthSessionWrapper(object):
         return (None, None)
 
 
-    def putChild(self, child):
+    def putChild(self, path, child):
         # IResource.putChild
         raise NotImplementedError()


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9891

Clean up mypy errors such as:

```
+src/twisted/internet/tcp.py:1027:5: error: Signature of "_FileDescriptorReservation" incompatible with "__exit__" of supertype "_IFileDescriptorReservation"  [override]
+        def __exit__(self, excValue, excType, traceback):
+        ^
+src/twisted/internet/tcp.py:1069:5: error: Signature of "_NullFileDescriptorReservation" incompatible with "__exit__" of supertype "_IFileDescriptorReservation"
+[override]
+        def __exit__(self, excValue, excType, traceback):
+        ^
+src/twisted/internet/testing.py:871:5: error: Signature of "RaisingMemoryReactor" incompatible with "adoptDatagramPort" of supertype "IReactorSocket"  [override]
+        def adoptDatagramPort(self, fileDescriptor, addressFamily, protocol,
+        ^
+src/twisted/internet/testing.py:880:5: error: Signature of "RaisingMemoryReactor" incompatible with "adoptStreamConnection" of supertype "IReactorSocket"  [override]
+        def adoptStreamConnection(self):
+        ^
+src/twisted/test/stdio_test_halfclose.py:58:5: error: Signature of "HalfCloseProtocol" incompatible with "writeConnectionLost" of supertype "IHalfCloseableProtocol"
+[override]
+        def writeConnectionLost(self, reason):
+        ^
+src/twisted/conch/scripts/cftp.py:40:21: error: Incompatible types in assignment (expression has type "List[List[Union[str, int, None]]]", base class "ConchOptions"
+defined the type as "List[List[Optional[str]]]")  [assignment]
+        optParameters = [
+                        ^
+src/twisted/web/_auth/wrapper.py:243:5: error: Signature of "HTTPAuthSessionWrapper" incompatible with "putChild" of supertype "IResource"  [override]
+        def putChild(self, child):
+        ^
+src/twisted/python/test/test_shellcomp.py:485:31: error: List item 1 has incompatible type "None"; expected "str"  [list-item]
+        optFlags = [['no-stalls', None,
+                                  ^
+src/twisted/mail/test/test_smtp.py:434:22: error: Argument 1 to "append" of "list" has incompatible type
+"Tuple[bytes, bytes, bytes, Tuple[bytes, Tuple[bytes, bytes, List[bytes], bytes]]]"; expected "Tuple[bytes, bytes, None, None]"  [arg-type]
+            data.append((b'DATA\r\n', b'354.*\r\n',
+                         ^
+src/twisted/conch/test/test_userauth.py:246:5: error: Signature of "AnonymousChecker" incompatible with "requestAvatarId" of supertype "ICredentialsChecker"  [override]
+        def requestAvatarId(credentials):
+        ^
+src/twisted/internet/test/test_tcp.py:462:5: error: Signature of "FakeResolver" incompatible with "getHostByName" of supertype "IResolverSimple"  [override]
+        def getHostByName(self, name, timeout):
+        ^
```