### PR TITLE
[mypy] [9892] Reduce mypy errors

### DIFF
--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -19,7 +19,6 @@ from typing import Any, List, Tuple
 from twisted.python.compat import nativeString, _bytesChr as chr
 
 
-
 libc = CDLL(find_library("c"))  # type: ignore[arg-type]
 
 if sys.platform.startswith('freebsd') or sys.platform == 'darwin':
@@ -30,7 +29,7 @@ if sys.platform.startswith('freebsd') or sys.platform == 'darwin':
 else:
     _sockaddrCommon = [
         ("sin_family", c_ushort),
-        ]
+        ]   # type: List[Tuple[str, Any]]
 
 
 

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -19,7 +19,7 @@ from typing import Any, List, Tuple
 from twisted.python.compat import nativeString, _bytesChr as chr
 
 
-libc = CDLL(find_library("c"))  # type: ignore[arg-type]
+libc = CDLL(find_library("c") or "")
 
 if sys.platform.startswith('freebsd') or sys.platform == 'darwin':
     _sockaddrCommon = [

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -390,6 +390,7 @@ class TuntapPort(abstract.FileDescriptor):
             return defer.succeed(None)
 
 
+    @deprecated(Version("Twisted", 14, 0, 0), stopListening)
     def loseConnection(self):
         """
         Close this tunnel.  Use L{TuntapPort.stopListening} instead.
@@ -427,7 +428,3 @@ class TuntapPort(abstract.FileDescriptor):
         @rtype: L{TunnelAddress}
         """
         return TunnelAddress(self._mode, self.interface)
-
-TuntapPort.loseConnection = deprecated(
-    Version("Twisted", 14, 0, 0),
-    TuntapPort.stopListening)(TuntapPort.loseConnection)

--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -783,7 +783,7 @@ class FTP(basic.LineReceiver, policies.TimeoutMixin, object):
 
     passivePortRange = range(0, 1)
 
-    listenFactory = reactor.listenTCP
+    listenFactory = reactor.listenTCP  # type: ignore[attr-defined]
     _encoding = 'latin-1'
 
     def reply(self, key, *args):
@@ -2801,7 +2801,7 @@ class FTPClient(FTPClientBasic):
 
     @ivar passive: See description in __init__.
     """
-    connectFactory = reactor.connectTCP
+    connectFactory = reactor.connectTCP  # type: ignore[attr-defined]
 
     def __init__(self, username='anonymous',
                  password='twisted@twistedmatrix.com',

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -118,7 +118,6 @@ try:
     from twisted.web._http2 import H2Connection
     H2_ENABLED = True
 except ImportError:
-    H2Connection = None
     H2_ENABLED = False
 
 
@@ -804,6 +803,7 @@ class Request:
 
     # methods for channel - end users should not use these
 
+    @deprecated(Version("Twisted", 16, 3, 0))
     def noLongerQueued(self):
         """
         Notify the object that it is no longer queued.
@@ -1479,6 +1479,7 @@ class Request:
         self.host = address.IPv4Address("TCP", host, port)
 
 
+    @deprecated(Version('Twisted', 18, 4, 0), replacement="getClientAddress")
     def getClientIP(self):
         """
         Return the IP address of the client who submitted this request.
@@ -1658,15 +1659,6 @@ class Request:
         """
         return id(self)
 
-
-
-Request.getClientIP = deprecated(
-    Version('Twisted', 18, 4, 0),
-    replacement="getClientAddress",
-)(Request.getClientIP)
-
-Request.noLongerQueued = deprecated(
-    Version("Twisted", 16, 3, 0))(Request.noLongerQueued)
 
 
 class _DataLoss(Exception):
@@ -3057,7 +3049,11 @@ class HTTPFactory(protocol.ServerFactory):
         timestamps.
     """
 
-    protocol = _genericHTTPChannelProtocolFactory
+    # We need to ignore the mypy error here, because
+    # _genericHTTPChannelProtocolFactory is a callable which returns a proxy
+    # to a Protocol, instead of a concrete Protocol object, as expected in
+    # the protocol.Factory interface
+    protocol = _genericHTTPChannelProtocolFactory  # type: ignore[assignment]
 
     logPath = None
 


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9892

This eliminates mypy errors such as:

```
src/twisted/protocols/ftp.py:786:21: error: Module has no attribute "listenTCP"  [attr-defined]
        listenFactory = reactor.listenTCP
                        ^
src/twisted/protocols/ftp.py:2804:22: error: Module has no attribute "connectTCP"  [attr-defined]
        connectFactory = reactor.connectTCP
                         ^
src/twisted/pair/tuntap.py:431:1: error: Cannot assign to a method  [assignment]
    TuntapPort.loseConnection = deprecated(
    ^
src/twisted/web/http.py:121:5: error: Cannot assign to a type  [misc]
        H2Connection = None
        ^
src/twisted/web/http.py:121:20: error: Incompatible types in assignment (expression has type "None", variable has type "Type[H2Connection]")  [assignment]
        H2Connection = None
                       ^
src/twisted/web/http.py:1663:1: error: Cannot assign to a method  [assignment]
    Request.getClientIP = deprecated(
    ^
src/twisted/web/http.py:1668:1: error: Cannot assign to a method  [assignment]
    Request.noLongerQueued = deprecated(
    ^
src/twisted/web/http.py:3060:16: error: Incompatible types in assignment (expression has type "Callable[[Any], Any]", base class "Factory" defined the type as
"Optional[Type[Protocol]]")  [assignment]
        protocol = _genericHTTPChannelProtocolFactory
                   ^
```