### PR TITLE
[mypy] [9895] Define Server and Client classes explicitly

### DIFF
--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -97,7 +97,7 @@ class _AbstractServer(_VolatileDataService):
     """
 
     volatile = ['_port']
-    method = None
+    method = ""  # type: str
     reactor = None
 
     _port = None
@@ -138,8 +138,8 @@ class _AbstractServer(_VolatileDataService):
         @rtype: an object providing
             L{twisted.internet.interfaces.IListeningPort}.
         """
-        return getattr(_maybeGlobalReactor(self.reactor),
-                       'listen%s' % (self.method,))(*self.args, **self.kwargs)
+        return getattr(_maybeGlobalReactor(self.reactor), 'listen{}'.format(
+                       self.method,))(*self.args, **self.kwargs)
 
 
 
@@ -161,7 +161,7 @@ class _AbstractClient(_VolatileDataService):
     """
 
     volatile = ['_connection']
-    method = None
+    method = ""  # type: str
     reactor = None
 
     _connection = None
@@ -197,34 +197,79 @@ class _AbstractClient(_VolatileDataService):
 
 
 
-_doc={
-'Client':
-"""Connect to %(tran)s
+_clientDoc = """Connect to {tran}
 
-Call reactor.connect%(tran)s when the service starts, with the
+Call reactor.connect{tran} when the service starts, with the
 arguments given to the constructor.
-""",
-'Server':
-"""Serve %(tran)s clients
+"""
 
-Call reactor.listen%(tran)s when the service starts, with the
+_serverDoc = """Serve {tran} clients
+
+Call reactor.listen{tran} when the service starts, with the
 arguments given to the constructor. When the service stops,
 stop listening. See twisted.internet.interfaces for documentation
 on arguments to the reactor method.
-""",
-}
+"""
 
-for tran in 'TCP UNIX SSL UDP UNIXDatagram Multicast'.split():
-    for side in 'Server Client'.split():
-        if tran == "Multicast" and side == "Client":
-            continue
-        if tran == "UDP" and side == "Client":
-            continue
-        base = globals()['_Abstract'+side]
-        doc = _doc[side] % vars()
 
-        klass = type(tran+side, (base,), {'method': tran, '__doc__': doc})
-        globals()[tran+side] = klass
+
+class TCPServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='TCP')
+    method = 'TCP'
+
+
+
+class TCPClient(_AbstractClient):
+    __doc__ = _clientDoc.format(tran='TCP')
+    method = 'TCP'
+
+
+
+class UNIXServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='UNIX')
+    method = 'UNIX'
+
+
+
+class UNIXClient(_AbstractClient):
+    __doc__ = _clientDoc.format(tran='UNIX')
+    method = 'UNIX'
+
+
+
+class SSLServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='SSL')
+    method = 'SSL'
+
+
+
+class SSLClient(_AbstractClient):
+    __doc__ = _clientDoc.format(tran='SSL')
+    method = 'SSL'
+
+
+
+class UDPServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='UDP')
+    method = 'UDP'
+
+
+
+class UNIXDatagramServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='UNIXDatagram')
+    method = 'UNIXDatagram'
+
+
+
+class UNIXDatagramClient(_AbstractClient):
+    __doc__ = _clientDoc.format(tran='UNIXDatagram')
+    method = 'UNIXDatagram'
+
+
+
+class MulticastServer(_AbstractServer):
+    __doc__ = _serverDoc.format(tran='Multicast')
+    method = 'Multicast'
 
 
 
@@ -1149,9 +1194,9 @@ class ClientService(service.Service, object):
         return self._machine.stop()
 
 
-__all__ = (['TimerService', 'CooperatorService', 'MulticastServer',
-            'StreamServerEndpointService', 'UDPServer',
-            'ClientService'] +
-           [tran + side
-            for tran in 'TCP UNIX SSL UNIXDatagram'.split()
-            for side in 'Server Client'.split()])
+
+__all__ = ['TimerService', 'CooperatorService', 'MulticastServer',
+           'StreamServerEndpointService', 'UDPServer',
+           'ClientService', 'TCPServer', 'TCPClient',
+           'UNIXServer', 'UNIXClient', 'SSLServer', 'SSLClient',
+           'UNIXDatagramServer', 'UNIXDatagramClient']

--- a/src/twisted/test/test_application.py
+++ b/src/twisted/test/test_application.py
@@ -526,12 +526,12 @@ class InternetTests(TestCase):
         L{service.Service} subclasses that in general have corresponding
         reactor.listenXXX or reactor.connectXXX calls.
         """
-        trans = 'TCP UNIX SSL UDP UNIXDatagram Multicast'.split()
+        trans = ['TCP', 'UNIX', 'SSL', 'UDP', 'UNIXDatagram', 'Multicast']
         for tran in trans[:]:
             if not getattr(interfaces, "IReactor" + tran)(reactor, None):
                 trans.remove(tran)
         for tran in trans:
-            for side in 'Server Client'.split():
+            for side in ['Server', 'Client']:
                 if tran == "Multicast" and side == "Client":
                     continue
                 if tran == "UDP" and side == "Client":


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9895

d562a59
Instead, just define these classes explicitly:

- TCPServer
- TCPClient
- UNIXServer
- UNIXClient
- SSLServer
- SSLClient
- UNIXDatagramServer
- UNIXDatagramClient
- UDPServer
- MulticastServer

This eliminates mypy errors such as:

```
src/twisted/words/test/test_jabberjstrports.py:12:1: error: Module 'twisted.application.internet' has no attribute 'TCPClient'  [attr-defined]
    from twisted.application.internet import TCPClient
```