### PR TITLE
[mypy] [9896] Reduce mypy errors: explicitly define global variables in context module

### DIFF
--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -124,6 +124,13 @@ class ThreadedContextTracker(object):
         return self.currentContext().getContext(key, default)
 
 
+
+theContextTracker = ThreadedContextTracker()
+call = theContextTracker.callWithContext
+get = theContextTracker.getContext
+
+
+
 def installContextTracker(ctr):
     global theContextTracker
     global call
@@ -132,5 +139,3 @@ def installContextTracker(ctr):
     theContextTracker = ctr
     call = theContextTracker.callWithContext
     get = theContextTracker.getContext
-
-installContextTracker(ThreadedContextTracker())


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9896

Explicitly define global variables to eliminate mypy errors:
* theContextTracker
* call
* get

This eliminates mypy errors:

```
src/twisted/_threads/test/test_team.py:11:1: error: Module 'twisted.python.context' has no attribute 'call'  [attr-defined]
    from twisted.python.context import call, get
    ^
src/twisted/_threads/test/test_team.py:11:1: error: Module 'twisted.python.context' has no attribute 'get'  [attr-defined]
    from twisted.python.context import call, get
```