### PR TITLE
[mypy] [9898] Change type of  twisted.internet.protocol.Factory.factory to allow AbstractDatagramProtocol.

### DIFF
--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -11,7 +11,7 @@ Twisted.  The Protocol class contains some introductory material.
 
 
 import random
-from typing import Optional, Type
+from typing import Optional, Type, Union
 from zope.interface import implementer
 
 from twisted.python import log, failure, components
@@ -30,7 +30,7 @@ class Factory:
     """
 
     # Put a subclass of Protocol here:
-    protocol = None  # type: Optional[Type['Protocol']]
+    protocol = None  # type: Optional[Union[Type['Protocol'], Type['AbstractDatagramProtocol']]]  # noqa
 
     numPorts = 0
     noisy = True

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -11,7 +11,7 @@ import random
 import errno
 import hamcrest
 from functools import wraps
-from typing import Optional, Type
+from typing import Optional, Type, Union
 from unittest import skipIf
 
 from zope.interface import implementer
@@ -119,7 +119,7 @@ class MyProtocolFactoryMixin(object):
 
     protocolConnectionMade = None
     protocolConnectionLost = None
-    protocol = None  # type: Optional[Type[protocol.Protocol]]
+    protocol = None  # type: Optional[Union[Type[protocol.Protocol],Type[protocol.AbstractDatagramProtocol]]]  # noqa
     called = 0
 
     def __init__(self):


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9898

This fixes these mypy errors:

```
src/twisted/pair/test/test_tuntap.py:1359:24: error: Incompatible types in assignment (expression has type "Type[IPRecordingProtocol]", variable has type
"Optional[Type[Protocol]]")  [assignment]
        factory.protocol = IPRecordingProtocol
                           ^
src/twisted/pair/test/test_tuntap.py:1382:24: error: Incompatible types in assignment (expression has type "Type[EthernetRecordingProtocol]", variable has type
"Optional[Type[Protocol]]")  [assignment]
        factory.protocol = EthernetRecordingProtocol
```
