### PR TITLE
[mypy] [9899] Eliminate mypy error in src/twisted/python/test/test_components.py

### DIFF
--- a/src/twisted/python/test/test_components.py
+++ b/src/twisted/python/test/test_components.py
@@ -626,7 +626,7 @@ class Booable(object):  # type: ignore[misc]
     booed = False
 
 
-    def yay(self):
+    def yay(self, *a, **kw):
         """
         Mark the fact that 'yay' has been called.
         """


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9899

Eliminate this mypy error:

```
src/twisted/python/test/test_components.py:629:5: error: Signature of "Booable" incompatible with "yay" of supertype
"twisted.python.test.test_components.IProxiedInterface"  [override]
        def yay(self):
        ^
```