### PR TITLE
[mypy] [9900] Fix mypy error on src/twisted/mail/relaymanager.py

### DIFF
--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -41,6 +41,16 @@ class ManagedRelayerMixin:
         self.manager = manager
 
 
+    @property
+    def factory(self):
+        return self._factory
+
+
+    @factory.setter
+    def factory(self, value):
+        self._factory = value
+
+
     def sentMail(self, code, resp, numOk, addresses, log):
         """
         called when e-mail has been sent


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9900

This fixes this mypy error:

```
src/twisted/mail/relaymanager.py:65:33: error: "ManagedRelayerMixin" has no attribute "factory"  [attr-defined]
            self.manager.notifyDone(self.factory)
```

The `SMTPManagedRelayerFactory.buildProtocol()` method sets the `factory` attribute on the  `SMTPManagedRelayer`.

https://github.com/twisted/twisted/blob/0a08045aa70db5bfe098a3bd5a4f25f96e99645d/src/twisted/mail/relaymanager.py#L188 , this method sets the `factory` attribute:

```
