### PR TITLE
imapserver: fix copy operation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,5 +113,5 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 .. |circleci| image:: https://circleci.com/gh/twisted/twisted.svg?style=svg
 .. _circleci: https://circleci.com/gh/twisted/twisted
 
-.. |mypy| image:: https://github.com/twisted/twisted/workflows/mypy.yaml/badge.svg
+.. |mypy| image:: https://github.com/twisted/twisted/workflows/mypy/badge.svg
 .. _mypy: https://github.com/twisted/twisted

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -2399,11 +2399,12 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
 
 
     def do_COPY(self, tag, messages, mailbox, uid=0):
-        mailbox = self._parseMbox(mailbox)
+        mailbox = _parseMbox(mailbox)
         maybeDeferred(self.account.select, mailbox
-            ).addCallback(self._cbCopySelectedMailbox, tag, messages, mailbox, uid
-            ).addErrback(self._ebCopySelectedMailbox, tag
-            )
+                      ).addCallback(self._cbCopySelectedMailbox, tag, messages,
+                                    mailbox, uid
+                                    ).addErrback(self._ebCopySelectedMailbox,
+                                                 tag)
     select_COPY = (do_COPY, arg_seqset, arg_finalastring)
 
 


### PR DESCRIPTION
## Contributor Checklist:

 * [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9910
 * [X] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
 * [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
 * [ ] I have updated the automated tests.
 * [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.


_parseMbox is not an attribute. This fixes the copy operation.