### PR TITLE
Add type annotations to __repr__() and __str__()

### DIFF
--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -487,7 +487,7 @@ class _ReconnectingProtocolProxy(object):
         return getattr(self._protocol, item)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s wrapping %r>' % (
             self.__class__.__name__, self._protocol)
 
@@ -524,7 +524,7 @@ class _DisconnectFactory(object):
         return getattr(self._protocolFactory, item)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s wrapping %r>' % (
             self.__class__.__name__, self._protocolFactory)
 

--- a/src/twisted/conch/insults/insults.py
+++ b/src/twisted/conch/insults/insults.py
@@ -462,7 +462,7 @@ class _const(object):
         self.name = name
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '[' + self.name + ']'
 
 

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -38,7 +38,7 @@ class Logging(object):
         self._logFile = open(key + '-' + str(count), 'w')
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(super(Logging, self).__getattribute__('original'))
 
 
@@ -380,7 +380,7 @@ class LocalTerminalBufferMixin(object):
             TransportSequence(transport, self.terminalCopy))
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.terminalCopy)
 
 

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -42,7 +42,7 @@ class Logging(object):
         return str(super(Logging, self).__getattribute__('original'))
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(super(Logging, self).__getattribute__('original'))
 
 

--- a/src/twisted/conch/ssh/address.py
+++ b/src/twisted/conch/ssh/address.py
@@ -38,7 +38,7 @@ class SSHTransportAddress(util.FancyEqMixin, object):
         self.address = address
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'SSHTransportAddress(%r)' % (self.address,)
 
 

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -72,7 +72,7 @@ class SSHChannel(log.Logger):
         self.closing = 0
         self.localClosed = 0
         self.remoteClosed = 0
-        self.id = None # gets set later by SSHConnection
+        self.id = None  # gets set later by SSHConnection
 
 
     def __str__(self) -> str:

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -75,7 +75,7 @@ class SSHChannel(log.Logger):
         self.id = None # gets set later by SSHConnection
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return nativeString(self.__bytes__())
 
 

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -1021,7 +1021,7 @@ class SFTPError(Exception):
         return self._message
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'SFTPError {}: {}'.format(self.code, self.message)
 
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -951,7 +951,7 @@ class Key(object):
         else:
             return NotImplemented
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a pretty representation of this object.
         """

--- a/src/twisted/conch/telnet.py
+++ b/src/twisted/conch/telnet.py
@@ -291,7 +291,7 @@ class TelnetError(Exception):
 
 
 class NegotiationError(TelnetError):
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__module__ + '.' + self.__class__.__name__ + ':' + repr(self.args[0])
 
 
@@ -426,7 +426,7 @@ class Telnet(protocol.Protocol):
             negotiating = False
             onResult = None
 
-            def __str__(self):
+            def __str__(self) -> str:
                 return self.state + ('*' * self.negotiating)
 
 

--- a/src/twisted/conch/telnet.py
+++ b/src/twisted/conch/telnet.py
@@ -435,7 +435,7 @@ class Telnet(protocol.Protocol):
             self.him = self._Perspective()
 
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return '<_OptionState us=%s him=%s>' % (self.us, self.him)
 
 

--- a/src/twisted/conch/telnet.py
+++ b/src/twisted/conch/telnet.py
@@ -292,7 +292,8 @@ class TelnetError(Exception):
 
 class NegotiationError(TelnetError):
     def __str__(self) -> str:
-        return self.__class__.__module__ + '.' + self.__class__.__name__ + ':' + repr(self.args[0])
+        return (self.__class__.__module__ + '.' + self.__class__.__name__ + ':'
+                + repr(self.args[0]))
 
 
 

--- a/src/twisted/internet/_dumbwin32proc.py
+++ b/src/twisted/internet/_dumbwin32proc.py
@@ -417,7 +417,7 @@ class Process(_pollingfile._PollingTimer, BaseProcess):
         raise NotImplementedError("Unimplemented: Process.getPeer")
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string representation of the process.
         """

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -335,7 +335,7 @@ class DistinguishedName(dict):
             setattr(x509name, k, nativeString(v))
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<DN %s>' % (dict.__repr__(self)[1:-1])
 
 
@@ -449,7 +449,7 @@ class Certificate(CertBase):
     """
     An x509 certificate.
     """
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s Subject=%s Issuer=%s>' % (self.__class__.__name__,
                                               self.getSubject().commonName,
                                               self.getIssuer().commonName)
@@ -619,7 +619,7 @@ class PrivateCertificate(Certificate):
     """
     An x509 certificate and private key.
     """
-    def __repr__(self):
+    def __repr__(self) -> str:
         return Certificate.__repr__(self) + ' with ' + repr(self.privateKey)
 
 
@@ -761,7 +761,7 @@ class PublicKey:
         return self.keyHash() == otherKey.keyHash()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s %s>' % (self.__class__.__name__, self.keyHash())
 
 
@@ -1762,7 +1762,7 @@ class OpenSSLCipher(FancyEqMixin, object):
         self.fullName = fullName
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A runnable representation of the cipher.
         """

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -137,7 +137,7 @@ class UNIXAddress(object):
             return NotImplemented
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = self.name
         if name:
             name = _coerceToFilesystemEncoding('', self.name)

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -187,7 +187,7 @@ class DelayedCall:
             return NotImplemented
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Implement C{repr()} for L{DelayedCall} instances.
 
@@ -1195,7 +1195,7 @@ class BaseConnector:
             reflect.qual(self.__class__) + " did not implement "
             "getDestination")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s instance at 0x%x %s %s>" % (
             reflect.qual(self.__class__), id(self), self.state,
             self.getDestination())

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -726,7 +726,7 @@ class Deferred:
                 chain.pop()
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return a string representation of this C{Deferred}.
         """
@@ -1004,7 +1004,7 @@ class FirstError(Exception):
         return 'FirstError[#%d, %r]' % (self.index, self.subFailure.value)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         The I{str} of L{FirstError} instances includes the I{str} of the
         entire wrapped failure (including its traceback and exception) and

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -996,7 +996,7 @@ class FirstError(Exception):
         self.index = index
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         The I{repr} of L{FirstError} instances includes the repr of the
         wrapped failure's exception and the index of the L{FirstError}.

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -805,7 +805,7 @@ class HostnameEndpoint(object):
         self._attemptDelay = attemptDelay
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Produce a string representation of the L{HostnameEndpoint}.
 

--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -16,7 +16,7 @@ from incremental import Version
 class BindError(Exception):
     """An error occurred binding to an interface"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -41,7 +41,7 @@ class CannotListenError(BindError):
         self.port = port
         self.socketError = socketError
 
-    def __str__(self):
+    def __str__(self) -> str:
         iface = self.interface or 'any'
         return "Couldn't listen on %s:%s: %s." % (iface, self.port,
                                                  self.socketError)
@@ -58,7 +58,7 @@ class MulticastJoinError(Exception):
 class MessageLengthError(Exception):
     """Message is too long to send"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -70,7 +70,7 @@ class MessageLengthError(Exception):
 class DNSLookupError(IOError):
     """DNS lookup failed"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -92,7 +92,7 @@ class ConnectError(Exception):
         self.osError = osError
         Exception.__init__(self, string)
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__ or self.__class__.__name__
         if self.osError:
             s = '%s: %s' % (s, self.osError)
@@ -218,7 +218,7 @@ class ConnectionClosed(Exception):
 class ConnectionLost(ConnectionClosed):
     """Connection to the other side was lost in a non-clean fashion"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__.strip().splitlines()[0]
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -235,7 +235,7 @@ class ConnectionAborted(ConnectionLost):
     @since: 11.1
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = [(
             "Connection was aborted locally using"
             " ITCPTransport.abortConnection"
@@ -251,7 +251,7 @@ class ConnectionAborted(ConnectionLost):
 class ConnectionDone(ConnectionClosed):
     """Connection was closed cleanly"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -281,7 +281,7 @@ class ConnectionFdescWentAway(ConnectionLost):
 class AlreadyCalled(ValueError):
     """Tried to cancel an already-called event"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -293,7 +293,7 @@ class AlreadyCalled(ValueError):
 class AlreadyCancelled(ValueError):
     """Tried to cancel an already-cancelled event"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -381,7 +381,7 @@ class ProcessExitedAlready(Exception):
 class NotConnectingError(RuntimeError):
     """The Connector was not connecting when it was asked to stop connecting"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
@@ -393,7 +393,7 @@ class NotConnectingError(RuntimeError):
 class NotListeningError(RuntimeError):
     """The Port was not listening when it was asked to stop listening"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = self.__doc__
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))

--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -14,10 +14,10 @@ from incremental import Version
 
 
 class BindError(Exception):
-    """An error occurred binding to an interface"""
+    __doc__ = MESSAGE = "An error occurred binding to an interface"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -56,10 +56,10 @@ class MulticastJoinError(Exception):
 
 
 class MessageLengthError(Exception):
-    """Message is too long to send"""
+    __doc__ = MESSAGE = "Message is too long to send"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -68,10 +68,10 @@ class MessageLengthError(Exception):
 
 
 class DNSLookupError(IOError):
-    """DNS lookup failed"""
+    __doc__ = MESSAGE = "DNS lookup failed"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -83,17 +83,18 @@ class ConnectInProgressError(Exception):
     """A connect operation was started and isn't done yet."""
 
 
+
 # connection errors
 
 class ConnectError(Exception):
-    """An error occurred while connecting"""
+    __doc__ = MESSAGE = "An error occurred while connecting"
 
     def __init__(self, osError=None, string=""):
         self.osError = osError
         Exception.__init__(self, string)
 
     def __str__(self) -> str:
-        s = self.__doc__ or self.__class__.__name__
+        s = self.MESSAGE
         if self.osError:
             s = '%s: %s' % (s, self.osError)
         if self.args[0]:
@@ -104,71 +105,69 @@ class ConnectError(Exception):
 
 
 class ConnectBindError(ConnectError):
-    """Couldn't bind"""
+    __doc__ = MESSAGE = "Couldn't bind"
 
 
 
 class UnknownHostError(ConnectError):
-    """Hostname couldn't be looked up"""
+    __doc__ = MESSAGE = "Hostname couldn't be looked up"
 
 
 
 class NoRouteError(ConnectError):
-    """No route to host"""
+    __doc__ = MESSAGE = "No route to host"
 
 
 
 class ConnectionRefusedError(ConnectError):
-    """Connection was refused by other side"""
+    __doc__ = MESSAGE = "Connection was refused by other side"
 
 
 
 class TCPTimedOutError(ConnectError):
-    """TCP connection timed out"""
+    __doc__ = MESSAGE = "TCP connection timed out"
 
 
 
 class BadFileError(ConnectError):
-    """File used for UNIX socket is no good"""
+    __doc__ = MESSAGE = "File used for UNIX socket is no good"
 
 
 
 class ServiceNameUnknownError(ConnectError):
-    """Service name given as port is unknown"""
+    __doc__ = MESSAGE = "Service name given as port is unknown"
 
 
 
 class UserError(ConnectError):
-    """User aborted connection"""
+    __doc__ = MESSAGE = "User aborted connection"
 
 
 
 class TimeoutError(UserError):
-    """User timeout caused connection failure"""
+    __doc__ = MESSAGE = "User timeout caused connection failure"
 
 
 
 class SSLError(ConnectError):
-    """An SSL error occurred"""
+    __doc__ = MESSAGE = "An SSL error occurred"
 
 
 
 class VerifyError(Exception):
-    """Could not verify something that was supposed to be signed.
-    """
+    __doc__ = MESSAGE = \
+        "Could not verify something that was supposed to be signed."
 
 
 
 class PeerVerifyError(VerifyError):
-    """The peer rejected our verify error.
-    """
+    __doc__ = MESSAGE = "The peer rejected our verify error."
 
 
 
 class CertificateError(Exception):
-    """
-    We did not find a certificate where we expected to find one.
-    """
+    __doc__ = MESSAGE = \
+        "We did not find a certificate where we expected to find one."
 
 
 
@@ -216,14 +215,17 @@ class ConnectionClosed(Exception):
 
 
 class ConnectionLost(ConnectionClosed):
-    """Connection to the other side was lost in a non-clean fashion"""
+    __doc__ = MESSAGE = """
+    Connection to the other side was lost in a non-clean fashion
+    """
 
     def __str__(self) -> str:
-        s = self.__doc__.strip().splitlines()[0]
+        s = self.MESSAGE.strip().splitlines()[:1]
         if self.args:
-            s = '%s: %s' % (s, ' '.join(self.args))
-        s = '%s.' % s
-        return s
+            s.append(': ')
+            s.append(' '.join(self.args))
+        s.append('.')
+        return ''.join(s)
 
 
 
@@ -234,25 +236,16 @@ class ConnectionAborted(ConnectionLost):
 
     @since: 11.1
     """
-
-    def __str__(self) -> str:
-        s = [(
-            "Connection was aborted locally using"
-            " ITCPTransport.abortConnection"
-        )]
-        if self.args:
-            s.append(': ')
-            s.append(' '.join(self.args))
-        s.append('.')
-        return ''.join(s)
+    MESSAGE = "Connection was aborted locally using " \
+              "ITCPTransport.abortConnection"
 
 
 
 class ConnectionDone(ConnectionClosed):
-    """Connection was closed cleanly"""
+    __doc__ = MESSAGE = "Connection was closed cleanly"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -270,19 +263,21 @@ class FileDescriptorOverrun(ConnectionLost):
     fewer bytes have been written than file descriptors have been sent, the
     connection is closed with this exception.
     """
+    MESSAGE = "A mis-use of IUNIXTransport.sendFileDescriptor caused " \
+              "the connection to be closed."
 
 
 
 class ConnectionFdescWentAway(ConnectionLost):
-    """Uh""" #TODO
+    __doc__ = MESSAGE = "Uh"  # TODO
 
 
 
 class AlreadyCalled(ValueError):
-    """Tried to cancel an already-called event"""
+    __doc__ = MESSAGE = "Tried to cancel an already-called event"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -291,10 +286,10 @@ class AlreadyCalled(ValueError):
 
 
 class AlreadyCancelled(ValueError):
-    """Tried to cancel an already-cancelled event"""
+    __doc__ = MESSAGE = "Tried to cancel an already-cancelled event"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -326,7 +321,7 @@ deprecate.deprecatedModuleAttribute(
 
 
 class ProcessDone(ConnectionDone):
-    """A process has ended without apparent errors"""
+    __doc__ = MESSAGE = "A process has ended without apparent errors"
 
     def __init__(self, status):
         Exception.__init__(self, "process finished with exit code 0")
@@ -337,7 +332,7 @@ class ProcessDone(ConnectionDone):
 
 
 class ProcessTerminated(ConnectionLost):
-    """
+    __doc__ = MESSAGE = """
     A process has ended with a probable error condition
 
     @ivar exitCode: See L{__init__}
@@ -379,10 +374,11 @@ class ProcessExitedAlready(Exception):
 
 
 class NotConnectingError(RuntimeError):
-    """The Connector was not connecting when it was asked to stop connecting"""
+    __doc__ = MESSAGE = \
+        "The Connector was not connecting when it was asked to stop connecting"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s
@@ -391,10 +387,11 @@ class NotConnectingError(RuntimeError):
 
 
 class NotListeningError(RuntimeError):
-    """The Port was not listening when it was asked to stop listening"""
+    __doc__ = MESSAGE = \
+        "The Port was not listening when it was asked to stop listening"
 
     def __str__(self) -> str:
-        s = self.__doc__
+        s = self.MESSAGE
         if self.args:
             s = '%s: %s' % (s, ' '.join(self.args))
         s = '%s.' % s

--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -44,7 +44,7 @@ class CannotListenError(BindError):
     def __str__(self) -> str:
         iface = self.interface or 'any'
         return "Couldn't listen on %s:%s: %s." % (iface, self.port,
-                                                 self.socketError)
+                                                  self.socketError)
 
 
 

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -385,7 +385,7 @@ class Server(Connection):
         self.startReading()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A string representation of this connection.
         """
@@ -450,7 +450,7 @@ class Port(_SocketCloser, _LogOwner):
             self._addressType = address.IPv6Address
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._realPortNumber is not None:
             return "<%s of %s on %s>" % (self.__class__,
                                          self.factory.__class__,

--- a/src/twisted/internet/iocpreactor/udp.py
+++ b/src/twisted/internet/iocpreactor/udp.py
@@ -74,7 +74,7 @@ class Port(abstract.FileHandle):
                 self.interface, 'not an IPv4 or IPv6 address')
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._realPortNumber is not None:
             return ("<%s on %s>" %
                     (self.protocol.__class__, self._realPortNumber))

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -490,7 +490,7 @@ class _BaseProcess(BaseProcess, object):
         os.execvpe(executable, args, environment)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         String representation of a process.
         """

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -201,7 +201,7 @@ class _InstanceFactory(ClientFactory):
         self.deferred = deferred
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ClientCreator factory: %r>" % (self.instance, )
 
 

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -276,7 +276,7 @@ class LoopingCall:
         self.call = self.clock.callLater(howLong(), self)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if hasattr(self.f, '__qualname__'):
             func = self.f.__qualname__
         elif hasattr(self.f, '__name__'):

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -776,7 +776,7 @@ class _BaseTCPClient(object):
         return self._addressType('TCP', *self.realAddress)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = '<%s to %s at %x>' % (self.__class__, self.addr, id(self))
         return s
 
@@ -836,7 +836,7 @@ class Server(_TLSServerMixin, Connection):
         self.startReading()
         self.connected = 1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A string representation of this connection.
         """
@@ -1337,7 +1337,7 @@ class Port(base.BasePort, _SocketCloser):
         return self
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._realPortNumber is not None:
             return "<%s of %s on %s>" % (self.__class__,
                 self.factory.__class__, self._realPortNumber)

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1340,9 +1340,11 @@ class Port(base.BasePort, _SocketCloser):
     def __repr__(self) -> str:
         if self._realPortNumber is not None:
             return "<%s of %s on %s>" % (self.__class__,
-                self.factory.__class__, self._realPortNumber)
+                                         self.factory.__class__,
+                                         self._realPortNumber)
         else:
-            return "<%s of %s (not listening)>" % (self.__class__, self.factory.__class__)
+            return "<%s of %s (not listening)>" % (self.__class__,
+                                                   self.factory.__class__)
 
     def createInternetSocket(self):
         s = base.BasePort.createInternetSocket(self)

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -158,7 +158,7 @@ class Port(base.BasePort):
         return self
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._realPortNumber is not None:
             return "<%s on %s>" % (self.protocol.__class__, self._realPortNumber)
         else:

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -160,7 +160,8 @@ class Port(base.BasePort):
 
     def __repr__(self) -> str:
         if self._realPortNumber is not None:
-            return "<%s on %s>" % (self.protocol.__class__, self._realPortNumber)
+            return "<%s on %s>" % (self.protocol.__class__,
+                                   self._realPortNumber)
         else:
             return "<%s not connected>" % (self.protocol.__class__,)
 

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -348,7 +348,7 @@ class Port(_UNIXPort, tcp.Port):
         self._preexistingSocket = port
         return self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         factoryName = reflect.qual(self.factory.__class__)
         if hasattr(self, 'socket'):
             return '<%s on %r>' % (
@@ -481,7 +481,7 @@ class DatagramPort(_UNIXPort, udp.Port):
         self.mode = mode
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         protocolName = reflect.qual(self.protocol.__class__,)
         if hasattr(self, 'socket'):
             return '<%s on %r>' % (protocolName, self.port)

--- a/src/twisted/logger/_legacy.py
+++ b/src/twisted/logger/_legacy.py
@@ -34,7 +34,7 @@ class LegacyLogObserverWrapper(object):
         self.legacyObserver = legacyObserver
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "{self.__class__.__name__}({self.legacyObserver})"
             .format(self=self)

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -104,7 +104,7 @@ class Logger(object):
         )
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s %r>" % (self.__class__.__name__, self.namespace)
 
 

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -108,7 +108,7 @@ class FlatFormattingTests(unittest.TestCase):
                 """
                 self.destructed = True
 
-            def __repr__(self):
+            def __repr__(self) -> str:
                 if self.destructed:
                     return "post-serialization garbage"
                 else:
@@ -241,7 +241,7 @@ class FlatFormattingTests(unittest.TestCase):
         @param flattenFirst: callable to flatten an event
         """
         class ObjectWithRepr(object):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "repr"
 
         class Something(object):

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -188,7 +188,7 @@ class FlatFormattingTests(unittest.TestCase):
                 """
                 Hack
                 """
-                def __str__(self):
+                def __str__(self) -> str:
                     return str(next(counter))
 
             event = dict(

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -424,7 +424,7 @@ class Unformattable(object):
     An object that raises an exception from C{__repr__}.
     """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(1 / 0)
 
 

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -138,7 +138,7 @@ class SaveLoadTests(TestCase):
             def __init__(self, value):
                 self.value = value
 
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return("reprable")
 
         inputEvent = {

--- a/src/twisted/logger/test/test_legacy.py
+++ b/src/twisted/logger/test/test_legacy.py
@@ -47,7 +47,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         L{LegacyLogObserverWrapper} returns the expected string.
         """
         class LegacyObserver(object):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "<Legacy Observer>"
 
             def __call__(self):

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -49,7 +49,7 @@ class LogComposedObject(object):
         self.state = state
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "<LogComposedObject {state}>".format(state=self.state)
 
 

--- a/src/twisted/mail/_except.py
+++ b/src/twisted/mail/_except.py
@@ -71,8 +71,8 @@ class NoSupportedAuthentication(IMAP4Exception):
 
     def __str__(self) -> str:
         return (IMAP4Exception.__str__(self)
-            + ': Server supports %r, client supports %r'
-            % (self.serverSupports, self.clientSupports))
+                + ': Server supports %r, client supports %r'
+                % (self.serverSupports, self.clientSupports))
 
 
 

--- a/src/twisted/mail/_except.py
+++ b/src/twisted/mail/_except.py
@@ -36,19 +36,19 @@ class MailboxException(IMAP4Exception):
 
 
 class MailboxCollision(MailboxException):
-    def __str__(self):
+    def __str__(self) -> str:
         return 'Mailbox named %s already exists' % self.args
 
 
 
 class NoSuchMailbox(MailboxException):
-    def __str__(self):
+    def __str__(self) -> str:
         return 'No mailbox named %s exists' % self.args
 
 
 
 class ReadOnlyMailbox(MailboxException):
-    def __str__(self):
+    def __str__(self) -> str:
         return 'Mailbox open in read-only state'
 
 
@@ -69,7 +69,7 @@ class NoSupportedAuthentication(IMAP4Exception):
         self.serverSupports = serverSupports
         self.clientSupports = clientSupports
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (IMAP4Exception.__str__(self)
             + ': Server supports %r, client supports %r'
             % (self.serverSupports, self.clientSupports))
@@ -137,7 +137,7 @@ class SMTPClientError(SMTPError):
         self.retry = retry
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__bytes__().decode("utf-8")
 
 
@@ -277,7 +277,7 @@ class SMTPServerError(SMTPError):
         self.resp = resp
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%.3d %s" % (self.code, self.resp)
 
 
@@ -290,7 +290,7 @@ class SMTPAddressError(SMTPServerError):
         self.addr = Address(addr)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%.3d <%s>... %s" % (self.code, self.addr, self.resp)
 
 

--- a/src/twisted/mail/alias.py
+++ b/src/twisted/mail/alias.py
@@ -202,7 +202,7 @@ class AddressAlias(AliasBase):
         self.alias = smtp.Address(alias)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{AddressAlias} instance.
 
@@ -317,7 +317,7 @@ class FileWrapper:
         self.fp = None
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{FileWrapper} instance.
 
@@ -348,7 +348,7 @@ class FileAlias(AliasBase):
         self.filename = filename
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{FileAlias} instance.
 
@@ -508,7 +508,7 @@ class MessageWrapper:
         """
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{MessageWrapper} instance.
 
@@ -577,7 +577,7 @@ class ProcessAlias(AliasBase):
         self.program = self.path[0]
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{ProcessAlias} instance.
 
@@ -679,7 +679,7 @@ class MultiWrapper:
             o.connectionLost()
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{MultiWrapper} instance.
 
@@ -753,7 +753,7 @@ class AliasGroup(AliasBase):
         return len(self.aliases)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build a string representation of this L{AliasGroup} instance.
 

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -414,7 +414,7 @@ class MessageSet(object):
         return ','.join(p)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<MessageSet %s>' % (str(self),)
 
 
@@ -533,7 +533,7 @@ class Command:
         self.lines = []
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<imap4.Command {!r} {!r} {!r} {!r} {!r}>".format(
             self.command, self.args, self.wantResponse, self.continuation,
             self.lines

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -399,7 +399,7 @@ class MessageSet(object):
         return res
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         p = []
         for low, high in self.ranges:
             if low == high:
@@ -4950,7 +4950,7 @@ class DontQuoteMe:
         self.value = value
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
 
@@ -5879,7 +5879,7 @@ class _FetchParser:
         partialBegin = None
         partialLength = None
 
-        def __str__(self):
+        def __str__(self) -> str:
             return nativeString(self.__bytes__())
 
         def __bytes__(self):
@@ -5917,7 +5917,7 @@ class _FetchParser:
         fields = None
         part = None
 
-        def __str__(self):
+        def __str__(self) -> str:
             return nativeString(self.__bytes__())
 
 

--- a/src/twisted/mail/mail.py
+++ b/src/twisted/mail/mail.py
@@ -172,7 +172,7 @@ class DomainWithDefaultDict:
         return len(self.domains)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Build an informal string representation of this dictionary.
 

--- a/src/twisted/mail/mail.py
+++ b/src/twisted/mail/mail.py
@@ -183,7 +183,7 @@ class DomainWithDefaultDict:
         return '<DomainWithDefaultDict %s>' % (self.domains,)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Build an "official" string representation of this dictionary.
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -300,7 +300,7 @@ class Address:
             return b''
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s.%s(%s)" % (self.__module__, self.__class__.__name__,
                               repr(str(self)))
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -332,10 +332,10 @@ class User:
         protocol isn't picklabe, but we want User to be, so skip it in
         the pickle.
         """
-        return { 'dest' : self.dest,
-                 'helo' : self.helo,
-                 'protocol' : None,
-                 'orig' : self.orig }
+        return {'dest': self.dest,
+                'helo': self.helo,
+                'protocol': None,
+                'orig': self.orig}
 
 
     def __str__(self) -> str:

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -289,7 +289,7 @@ class Address:
 
         return b''.join(res)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return nativeString(bytes(self))
 
 
@@ -338,7 +338,7 @@ class User:
                  'orig' : self.orig }
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return nativeString(bytes(self.dest))
 
 

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -97,7 +97,7 @@ class SerialNumber(FancyStrMixin, object):
         return other
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return a string representation of this L{SerialNumber} instance.
 

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -459,7 +459,7 @@ class Charstr(object):
         return hash(self.string)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Represent this L{Charstr} instance by its string value.
         """
@@ -568,7 +568,7 @@ class Name:
         return hash(self.name)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Represent this L{Name} instance by its string name.
         """
@@ -632,7 +632,7 @@ class Query:
         return NotImplemented
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         t = QUERY_TYPES.get(self.type, EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
         c = QUERY_CLASSES.get(self.cls, 'UNKNOWN (%d)' % self.cls)
         return '<Query %s %s %s>' % (self.name, t, c)
@@ -985,7 +985,7 @@ class RRHeader(tputil.FancyEqMixin):
         return self.auth
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         t = QUERY_TYPES.get(self.type, EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
         c = QUERY_CLASSES.get(self.cls, 'UNKNOWN (%d)' % self.cls)
         return '<RR name=%s type=%s class=%s ttl=%ds auth=%s>' % (self.name, t, c, self.ttl, self.auth and 'True' or 'False')
@@ -1182,7 +1182,7 @@ class Record_A(tputil.FancyEqMixin):
         return hash(self.address)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '<A address=%s ttl=%s>' % (self.dottedQuad(), self.ttl)
     __repr__ = __str__
 
@@ -1524,7 +1524,7 @@ class Record_A6(tputil.FancyStrMixin, tputil.FancyEqMixin):
         return hash((self.prefixLen, self.suffix[-self.bytes:], self.prefix))
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '<A6 %s %s (%d) ttl=%s>' % (
             self.prefix,
             socket.inet_ntop(AF_INET6, self.suffix),

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -633,7 +633,9 @@ class Query:
 
 
     def __str__(self) -> str:
-        t = QUERY_TYPES.get(self.type, EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
+        t = QUERY_TYPES.get(
+                self.type,
+                EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
         c = QUERY_CLASSES.get(self.cls, 'UNKNOWN (%d)' % self.cls)
         return '<Query %s %s %s>' % (self.name, t, c)
 
@@ -986,9 +988,12 @@ class RRHeader(tputil.FancyEqMixin):
 
 
     def __str__(self) -> str:
-        t = QUERY_TYPES.get(self.type, EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
+        t = QUERY_TYPES.get(
+                self.type,
+                EXT_QUERIES.get(self.type, 'UNKNOWN (%d)' % self.type))
         c = QUERY_CLASSES.get(self.cls, 'UNKNOWN (%d)' % self.cls)
-        return '<RR name=%s type=%s class=%s ttl=%ds auth=%s>' % (self.name, t, c, self.ttl, self.auth and 'True' or 'False')
+        return '<RR name=%s type=%s class=%s ttl=%ds auth=%s>' % (
+                self.name, t, c, self.ttl, self.auth and 'True' or 'False')
 
 
     __repr__ = __str__

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -638,7 +638,7 @@ class Query:
         return '<Query %s %s %s>' % (self.name, t, c)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Query(%r, %r, %r)' % (self.name.name, self.type, self.cls)
 
 
@@ -2475,7 +2475,7 @@ class Message(tputil.FancyEqMixin):
         self.additional = []
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Generate a repr of this L{Message}.
 
@@ -2818,7 +2818,7 @@ class _EDNSMessage(tputil.FancyEqMixin, object):
         self.additional = additional
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return _compactRepr(
             self,
             flagNames=('answer', 'auth', 'trunc', 'recDes', 'recAv',

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -4920,7 +4920,7 @@ class Foo(object):
         self.section1 = section1
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Call L{dns._compactRepr} to generate a string representation.
         """

--- a/src/twisted/newsfragments/9918.bugfix
+++ b/src/twisted/newsfragments/9918.bugfix
@@ -1,0 +1,1 @@
+Descriptive error messages from twisted.internet.error are now present when running with 'python -OO'.

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -250,7 +250,7 @@ class TuntapPort(abstract.FileDescriptor):
         self.logstr = "%s (%s)" % (logPrefix, self._mode.name)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = (fullyQualifiedName(self.protocol.__class__),)
         if self.connected:
             args = args + ("",)

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -13,6 +13,7 @@ import fcntl
 import errno
 import struct
 import warnings
+from typing import Tuple
 
 from collections import namedtuple
 from constantly import Flags, FlagConstant
@@ -251,7 +252,7 @@ class TuntapPort(abstract.FileDescriptor):
 
 
     def __repr__(self) -> str:
-        args = (fullyQualifiedName(self.protocol.__class__),)
+        args = (fullyQualifiedName(self.protocol.__class__),)  # type: Tuple[str, ...]  # noqa
         if self.connected:
             args = args + ("",)
         else:

--- a/src/twisted/plugin.py
+++ b/src/twisted/plugin.py
@@ -45,7 +45,7 @@ class CachedPlugin(object):
         self.provided = provided
         self.dropin.plugins.append(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<CachedPlugin %r/%r (provides %r)>' % (
             self.name, self.dropin.moduleName,
             ', '.join([i.__name__ for i in self.provided]))

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -72,7 +72,7 @@ class _BaseSentence(object):
             raise AttributeError(msg)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a textual representation of this sentence.
 

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -256,7 +256,7 @@ class Angle(FancyEqMixin, object):
         return self._angle
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this angle.
 
@@ -373,7 +373,7 @@ class Heading(Angle):
     compareAttributes = list(Angle.compareAttributes) + ["variation"]
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this angle.
 
@@ -499,7 +499,7 @@ class Altitude(FancyEqMixin, object):
         return self._altitude
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this altitude.
 
@@ -569,7 +569,7 @@ class _BaseSpeed(FancyEqMixin, object):
         return self._speed
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this speed object.
 
@@ -786,7 +786,7 @@ class PositionError(FancyEqMixin, object):
     _REPR_TEMPLATE = "<PositionError (pdop: %s, hdop: %s, vdop: %s)>"
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of positioning information object.
 
@@ -822,7 +822,7 @@ class BeaconInformation(object):
         self.usedBeacons = set()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this beacon information object.
 
@@ -878,7 +878,7 @@ class PositioningBeacon(object):
         return hash(self.identifier)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this beacon.
 
@@ -928,7 +928,7 @@ class Satellite(PositioningBeacon):
         self.signalToNoiseRatio = signalToNoiseRatio
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns a string representation of this Satellite.
 

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -516,7 +516,7 @@ class TooLong(AmpError):
         self.keyName = keyName
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         hdr = self.isKey and "key" or "value"
         if not self.isKey:
             hdr += ' ' + repr(self.keyName)
@@ -535,7 +535,7 @@ class BadLocalReturn(AmpError):
         self.enclosed = enclosed
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.message + " " + self.enclosed.getBriefTraceback()
 
     __str__ = __repr__
@@ -720,7 +720,7 @@ class AmpBox(dict):
         """
         proto.sendBox(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'AmpBox(%s)' % (dict.__repr__(self),)
 
 # amp.Box => AmpBox
@@ -734,7 +734,7 @@ class QuitBox(AmpBox):
     __slots__ = []  # type: List[str]
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'QuitBox(**%s)' % (super(QuitBox, self).__repr__(),)
 
 
@@ -766,7 +766,7 @@ class _SwitchBox(AmpBox):
         self.innerProto = innerProto
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '_SwitchBox(%r, **%s)' % (self.innerProto,
                                          dict.__repr__(self),)
 
@@ -2612,7 +2612,7 @@ class AMP(BinaryBoxProtocol, BoxDispatcher,
         return secondResponder
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A verbose string representation which gives us information about this
         AMP connection.

--- a/src/twisted/protocols/ident.py
+++ b/src/twisted/protocols/ident.py
@@ -22,7 +22,7 @@ class IdentError(Exception):
 
     identDescription = 'UNKNOWN-ERROR'
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.identDescription
 
 

--- a/src/twisted/protocols/pcp.py
+++ b/src/twisted/protocols/pcp.py
@@ -90,7 +90,7 @@ class BasicProducerConsumerProxy:
         if self.consumer:
             self.consumer.unregisterProducer()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s@%x around %s>' % (self.__class__, id(self), self.consumer)
 
 

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -358,7 +358,8 @@ class URL:
 
 
     def __repr__(self) -> str:
-        return '<URL %s:%s@%s:%r/%s>' % (self.username, self.password, self.host, self.port, self.transport)
+        return '<URL %s:%s@%s:%r/%s>' % (self.username, self.password,
+                                         self.host, self.port, self.transport)
 
 
 
@@ -544,7 +545,8 @@ class Request(Message):
 
 
     def __repr__(self) -> str:
-        return "<SIP Request %d:%s %s>" % (id(self), self.method, self.uri.toString())
+        return "<SIP Request %d:%s %s>" % (id(self), self.method,
+                                           self.uri.toString())
 
 
     def _getHeaderLine(self):

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -357,7 +357,7 @@ class URL:
         return self.toString()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<URL %s:%s@%s:%r/%s>' % (self.username, self.password, self.host, self.port, self.transport)
 
 
@@ -543,7 +543,7 @@ class Request(Message):
             cleanRequestURL(self.uri)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<SIP Request %d:%s %s>" % (id(self), self.method, self.uri.toString())
 
 
@@ -565,7 +565,7 @@ class Response(Message):
         self.phrase = phrase
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<SIP Response %d:%s>" % (id(self), self.code)
 
 

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -353,7 +353,7 @@ class URL:
         return "".join(l)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.toString()
 
 

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -211,7 +211,7 @@ class Project(object):
         self.directory = directory
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '%s(%r)' % (
             self.__class__.__name__, self.directory)
 

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -44,7 +44,7 @@ class _Attribute(FancyEqMixin, object):
         self.children = []
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s %r>' % (type(self).__name__, vars(self))
 
 

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -292,7 +292,7 @@ class ReprableComponentized(Componentized):
     def __init__(self):
         Componentized.__init__(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         from pprint import pprint
         sio = NativeStringIO()
         pprint(self._adapterCache, sio)

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -465,7 +465,7 @@ class _ModuleProxy(object):
         state._lastWasPath = False
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Get a string containing the type of the module proxy and a
         representation of the wrapped module object.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -564,7 +564,7 @@ class Failure(BaseException):
             return frame.f_locals.get('self')
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s %s: %s>" % (reflect.qual(self.__class__),
                                 reflect.qual(self.type),
                                 self.getErrorMessage())

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -570,7 +570,7 @@ class Failure(BaseException):
                                 self.getErrorMessage())
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "[Failure instance: %s]" % self.getBriefTraceback()
 
 

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -525,7 +525,7 @@ class RWX(FancyEqMixin, object):
         self.execute = executable
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "RWX(read=%s, write=%s, execute=%s)" % (
             self.read, self.write, self.execute)
 
@@ -577,7 +577,7 @@ class Permissions(FancyEqMixin, object):
         )
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "[%s | %s | %s]" % (
             str(self.user), str(self.group), str(self.other))
 
@@ -1351,7 +1351,7 @@ class FilePath(AbstractFilePath):
         return splitext(self.path)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'FilePath(%r)' % (self.path,)
 
 

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -269,7 +269,7 @@ class PythonAttribute:
         self._loaded = loaded
         self.pythonValue = pythonValue
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'PythonAttribute<%r>'%(self.name,)
 
     def isLoaded(self):
@@ -327,7 +327,7 @@ class PythonModule(_ModuleIteratorHelper):
     def _getEntry(self):
         return self.pathEntry
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string representation including the module name.
         """
@@ -454,7 +454,7 @@ class PathEntry(_ModuleIteratorHelper):
     def _getEntry(self):
         return self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'PathEntry<%r>' % (self.filePath,)
 
     def _packagePaths(self):
@@ -731,7 +731,7 @@ class PythonPath:
             return False
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Display my sysPath and moduleDict in a string representation.
         """

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -270,7 +270,7 @@ class PythonAttribute:
         self.pythonValue = pythonValue
 
     def __repr__(self) -> str:
-        return 'PythonAttribute<%r>'%(self.name,)
+        return 'PythonAttribute<%r>' % (self.name,)
 
     def isLoaded(self):
         """

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -104,7 +104,7 @@ class ExitedWithStderr(Exception):
     A process exited with some stderr.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Dump the errors in a pretty way in the event of a subprocess traceback.
         """

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -718,9 +718,11 @@ class TestURL(SynchronousTestCase):
         class Unexpected(object):
             def __str__(self) -> str:
                 return "wrong"
+
             def __repr__(self) -> str:
                 return "<unexpected>"
         defaultExpectation = "unicode" if bytes is str else "str"
+
         def assertRaised(raised, expectation, name):
             self.assertEqual(str(raised.exception),
                              "expected {} for {}, got {}".format(

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -716,7 +716,7 @@ class TestURL(SynchronousTestCase):
         constructor is off the stack.
         """
         class Unexpected(object):
-            def __str__(self):
+            def __str__(self) -> str:
                 return "wrong"
             def __repr__(self) -> str:
                 return "<unexpected>"

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -718,7 +718,7 @@ class TestURL(SynchronousTestCase):
         class Unexpected(object):
             def __str__(self):
                 return "wrong"
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "<unexpected>"
         defaultExpectation = "unicode" if bytes is str else "str"
         def assertRaised(raised, expectation, name):

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -276,7 +276,7 @@ class URLPath(object):
         return self._fromURL(self._url.click(st.decode("ascii")))
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         The L{str} of a L{URLPath} is its URL text.
         """

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -283,7 +283,7 @@ class URLPath(object):
         return nativeString(self._url.asURI().asText())
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         The L{repr} of a L{URLPath} is an eval-able expression which will
         construct a similar L{URLPath}.

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -547,7 +547,7 @@ class Options(dict):
 
         return s + longdesc + commands
 
-    #def __repr__(self):
+    #def __repr__(self) -> str:
     #    XXX: It'd be cool if we could return a succinct representation
     #        of which flags and options are set here.
 

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -547,9 +547,6 @@ class Options(dict):
 
         return s + longdesc + commands
 
-    #def __repr__(self) -> str:
-    #    XXX: It'd be cool if we could return a succinct representation
-    #        of which flags and options are set here.
 
 
 _ZSH = 'zsh'

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -446,7 +446,7 @@ class Options(dict):
         return longOpt, shortOpt, docs, settings, synonyms, dispatch
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.getSynopsis() + '\n' + self.getUsage(width=None)
 
     def getSynopsis(self):

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -27,7 +27,7 @@ else:
     getgroups = _getgroups
 
 from typing import (Callable, ClassVar, Mapping, MutableMapping, Sequence,
-                    Union, Tuple)
+                    Union, Tuple, cast)
 
 from twisted.python.compat import unicode
 from incremental import Version
@@ -629,13 +629,20 @@ class FancyStrMixin:
 
     def __str__(self) -> str:
         r = ['<', getattr(self, 'fancybasename', self.__class__.__name__)]
+        # The casts help mypy understand which type from the Union applies
+        # in each 'if' case.
+        #   https://github.com/python/mypy/issues/9171
         for attr in self.showAttributes:
             if isinstance(attr, str):
                 r.append(' %s=%r' % (attr, getattr(self, attr)))
             elif len(attr) == 2:
-                r.append((' %s=' % (attr[0],)) + attr[1](getattr(self, attr[0])))
+                attr = cast(Tuple[str, Callable], attr)
+                r.append((' %s=' % (attr[0],))
+                         + attr[1](getattr(self, attr[0])))
             else:
-                r.append((' %s=' + attr[2]) % (attr[1], getattr(self, attr[0])))
+                attr = cast(Tuple[str, str, str], attr)
+                r.append((' %s=' + attr[2])
+                         % (attr[1], getattr(self, attr[0])))
         r.append('>')
         return ''.join(r)
 

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -165,7 +165,7 @@ class InsensitiveDict(MutableMapping):
             self[k] = v
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         String representation of the dictionary.
         """

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -628,8 +628,7 @@ class FancyStrMixin:
 
 
     def __str__(self) -> str:
-        r = ['<', (hasattr(self, 'fancybasename') and self.fancybasename)
-             or self.__class__.__name__]
+        r = ['<', getattr(self, 'fancybasename', self.__class__.__name__)]
         for attr in self.showAttributes:
             if isinstance(attr, str):
                 r.append(' %s=%r' % (attr, getattr(self, attr)))

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -627,7 +627,7 @@ class FancyStrMixin:
     showAttributes = ()  # type: Sequence[Union[str, Tuple[str, str, str], Tuple[str, Callable]]]  # noqa
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         r = ['<', (hasattr(self, 'fancybasename') and self.fancybasename)
              or self.__class__.__name__]
         for attr in self.showAttributes:

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -60,7 +60,7 @@ class ZipPath(AbstractFilePath):
                    (other.archive, other.pathInArchive))
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         parts = [_coerceToFilesystemEncoding(
             self.sep, os.path.abspath(self.archive.path))]
         parts.extend(self.pathInArchive.split(self.sep))
@@ -290,7 +290,7 @@ class ZipArchive(ZipPath):
         return FilePath(self.zipfile.filename).getStatusChangeTime()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'ZipArchive(%r)' % (os.path.abspath(self.path),)
 
 

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -409,7 +409,7 @@ class ProcessMonitor(service.Service):
             self.stopProcess(name)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         l = []
         for name, proc in self._processes.items():
             uidgid = ''

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -410,7 +410,7 @@ class ProcessMonitor(service.Service):
 
 
     def __repr__(self) -> str:
-        l = []
+        lst = []
         for name, proc in self._processes.items():
             uidgid = ''
             if proc.uid is not None:
@@ -420,7 +420,7 @@ class ProcessMonitor(service.Service):
 
             if uidgid:
                 uidgid = '(' + uidgid + ')'
-            l.append('%r%s: %r' % (name, uidgid, proc.args))
+            lst.append('%r%s: %r' % (name, uidgid, proc.args))
         return ('<' + self.__class__.__name__ + ' '
-                + ' '.join(l)
+                + ' '.join(lst)
                 + '>')

--- a/src/twisted/spread/flavors.py
+++ b/src/twisted/spread/flavors.py
@@ -603,7 +603,7 @@ class RemoteCacheObserver:
         self.cached = cached
         self.perspective = perspective
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<RemoteCacheObserver(%s, %s, %s) at %s>" % (
             self.broker, self.cached, self.perspective, id(self))
 

--- a/src/twisted/spread/jelly.py
+++ b/src/twisted/spread/jelly.py
@@ -320,7 +320,7 @@ class Unpersistable:
         self.reason = reason
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Unpersistable(%s)" % repr(self.reason)
 
 

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -415,7 +415,7 @@ class Local:
         self.refcount = 1
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<pb.Local %r ref:%s>" % (self.object, self.refcount)
 
 

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -34,7 +34,7 @@ class TLSNegotiation:
         self.readyToSend = connectState
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'TLSNegotiation(%r)' % (self.obj,)
 
 
@@ -105,7 +105,7 @@ class FakeTransport:
         self.peerAddress = peerAddress
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'FakeTransport<%s,%s,%s>' % (
             self.isServer and 'S' or 'C', self.serial,
             self.protocol.__class__.__name__)

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -79,7 +79,7 @@ class TestProto(protocol.Protocol):
         self.onConnLost.callback(self.data)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Custom repr for testing to avoid coupling amp tests with repr from
         L{Protocol}

--- a/src/twisted/test/test_cooperator.py
+++ b/src/twisted/test/test_cooperator.py
@@ -224,7 +224,7 @@ class CooperatorTests(unittest.TestCase):
             def __init__(self, func):
                 self.func = func
 
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return '<FakeCall %r>' % (self.func,)
 
         def sched(f):

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -536,7 +536,7 @@ class FailureTests(SynchronousTestCase):
 class BrokenStr(Exception):
     """
     An exception class the instances of which cannot be presented as strings
-    via C{str}.
+    via L{str}.
     """
     def __str__(self) -> str:
         # Could raise something else, but there's no point as yet.
@@ -547,7 +547,7 @@ class BrokenStr(Exception):
 class BrokenExceptionMetaclass(type):
     """
     A metaclass for an exception type which cannot be presented as a string via
-    C{str}.
+    L{str}.
     """
     def __str__(self) -> str:
         raise ValueError("You cannot make a string out of me.")
@@ -557,7 +557,7 @@ class BrokenExceptionMetaclass(type):
 class BrokenExceptionType(Exception, object):
     """
     The aforementioned exception type which cnanot be presented as a string via
-    C{str}.
+    L{str}.
     """
     __metaclass__ = BrokenExceptionMetaclass
 

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -535,8 +535,8 @@ class FailureTests(SynchronousTestCase):
 
 class BrokenStr(Exception):
     """
-    An exception class the instances of which cannot be presented as strings via
-    C{str}.
+    An exception class the instances of which cannot be presented as strings
+    via C{str}.
     """
     def __str__(self) -> str:
         # Could raise something else, but there's no point as yet.

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -538,7 +538,7 @@ class BrokenStr(Exception):
     An exception class the instances of which cannot be presented as strings via
     C{str}.
     """
-    def __str__(self):
+    def __str__(self) -> str:
         # Could raise something else, but there's no point as yet.
         raise self
 
@@ -549,7 +549,7 @@ class BrokenExceptionMetaclass(type):
     A metaclass for an exception type which cannot be presented as a string via
     C{str}.
     """
-    def __str__(self):
+    def __str__(self) -> str:
         raise ValueError("You cannot make a string out of me.")
 
 

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -308,13 +308,13 @@ IOBase.register(FakeFile)  # type: ignore[attr-defined]
 
 
 class EvilStr:
-    def __str__(self):
+    def __str__(self) -> str:
         1 // 0
 
 
 
 class EvilRepr:
-    def __str__(self):
+    def __str__(self) -> str:
         return "Happy Evil Repr"
 
 

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -318,7 +318,7 @@ class EvilRepr:
         return "Happy Evil Repr"
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         1 // 0
 
 
@@ -970,7 +970,7 @@ class DefaultObserverTests(unittest.SynchronousTestCase):
         with a message that causes L{repr} to raise.
         """
         class Ouch(object):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return str(1 / 0)
 
         message = ("foo", Ouch())

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -309,7 +309,7 @@ IOBase.register(FakeFile)  # type: ignore[attr-defined]
 
 class EvilStr:
     def __str__(self) -> str:
-        1 // 0
+        return str(1 // 0)
 
 
 
@@ -319,7 +319,7 @@ class EvilRepr:
 
 
     def __repr__(self) -> str:
-        1 // 0
+        return str(1 // 0)
 
 
 

--- a/src/twisted/test/test_reflect.py
+++ b/src/twisted/test/test_reflect.py
@@ -390,7 +390,7 @@ class Breakable(object):
             return '<Breakable>'
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.breakRepr:
             raise RuntimeError("repr!")
         else:

--- a/src/twisted/test/test_reflect.py
+++ b/src/twisted/test/test_reflect.py
@@ -383,7 +383,7 @@ class Breakable(object):
     breakRepr = False
     breakStr = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.breakStr:
             raise RuntimeError("str!")
         else:

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -64,7 +64,7 @@ class Todo(object):
         self.errors = errors
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Todo reason=%r errors=%r>" % (self.reason, self.errors)
 
 

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -97,7 +97,7 @@ class TestResult(pyunit.TestResult, object):
         self._timings = []
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ('<%s run=%d errors=%d failures=%d todos=%d dones=%d skips=%d>'
                 % (reflect.qual(self.__class__), self.testsRun,
                    len(self.errors), len(self.failures),

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -340,7 +340,7 @@ class ErrorHolder(TestHolder):
         self.error = util.excInfoOrFailureToExcInfo(error)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ErrorHolder description=%r error=%r>" % (
             self.description, self.error[1])
 

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -32,7 +32,7 @@ class MockEquality(FancyEqMixin, object):
         self.name = name
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "MockEquality(%s)" % (self.name,)
 
 

--- a/src/twisted/trial/test/test_util.py
+++ b/src/twisted/trial/test/test_util.py
@@ -414,7 +414,7 @@ class JanitorTests(SynchronousTestCase):
             A stub Selectable which only has an interesting string
             representation.
             """
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "(SELECTABLE!)"
 
         reactor = StubReactor([], [Selectable()])

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -51,7 +51,7 @@ class DirtyReactorAggregateError(Exception):
         self.selectables = selectables
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return a multi-line message describing all of the unclean state.
         """

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -67,7 +67,7 @@ class slot(object):
         self.columnNumber = columnNumber
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "slot(%r)" % (self.name,)
 
 
@@ -258,7 +258,7 @@ class Tag(object):
         return self
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         rstr = ''
         if self.attributes:
             rstr += ', attributes=%r' % self.attributes
@@ -286,7 +286,7 @@ class CDATA(object):
         self.data = data
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'CDATA(%r)' % (self.data,)
 
 
@@ -305,7 +305,7 @@ class Comment(object):
         self.data = data
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Comment(%r)' % (self.data,)
 
 
@@ -325,5 +325,5 @@ class CharRef(object):
         self.ordinal = ordinal
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "CharRef(%d)" % (self.ordinal,)

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -389,7 +389,7 @@ class HTTPClientFactory(protocol.ClientFactory):
         return self._disconnectedDeferred
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s: %s>" % (self.__class__.__name__, self.url)
 
     def setURL(self, url):
@@ -1239,7 +1239,7 @@ class _HTTP11ClientFactory(protocol.Factory):
         self._metadata = metadata
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '_HTTP11ClientFactory({}, {})'.format(
             self._quiescentCallback,
             self._metadata)

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -254,7 +254,7 @@ class MissingRenderMethod(RenderError):
         self.renderName = renderName
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '%r: %r had no render method named %r' % (
             self.__class__.__name__, self.element, self.renderName)
 
@@ -272,7 +272,7 @@ class MissingTemplateLoader(RenderError):
         self.element = element
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '%r: %r had no loader' % (self.__class__.__name__,
                                          self.element)
 
@@ -365,7 +365,7 @@ class FlattenerError(Exception):
             return ascii(obj)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Present a string representation which includes a template traceback, so
         we can tell where this error occurred in the template, as well as in

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -85,7 +85,7 @@ class Error(Exception):
         self.response = response
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return nativeString(self.status + b" " + self.message)
 
 
@@ -221,7 +221,7 @@ class UnsupportedMethod(Exception):
                 "but my first argument is not a sequence.")
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Expected one of %r" % (self.allowedMethods,)
 
 
@@ -394,7 +394,7 @@ class FlattenerError(Exception):
             str(self._exception) + '\n')
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self)
 
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -946,7 +946,7 @@ class Request:
         self.process()
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string description of the request including such information
         as the request method and request URI.

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -78,7 +78,7 @@ class Headers(object):
                 self.setRawHeaders(name, values)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string fully describing the headers set on this object.
         """

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -124,9 +124,10 @@ class MismatchedTags(Exception):
 
 
     def __str__(self) -> str:
-        return ("expected </%s>, got </%s> line: %s col: %s, began line: %s col: %s"
-                % (self.expect, self.got, self.endLine, self.endCol, self.begLine,
-                   self.begCol))
+        return ("expected </%s>, got </%s> line: %s col: %s, "
+                "began line: %s col: %s"
+                % (self.expect, self.got, self.endLine, self.endCol,
+                   self.begLine, self.begCol))
 
 
 

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -468,7 +468,7 @@ class Text(CharacterData):
         w(val)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Text(%s" % repr(self.nodeValue) + ')'
 
 
@@ -741,7 +741,7 @@ class Element(Node):
             w(" />")
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         rep = "Element(%s" % repr(self.nodeName)
         if self.attributes:
             rep += ", attributes=%r" % (self.attributes,)

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -123,7 +123,7 @@ class MismatchedTags(Exception):
          self.endCol) = filename, expect, got, begLine, begCol, endLine, endCol
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ("expected </%s>, got </%s> line: %s col: %s, began line: %s col: %s"
                 % (self.expect, self.got, self.endLine, self.endCol, self.begLine,
                    self.begCol))
@@ -752,7 +752,7 @@ class Element(Node):
         return rep + ')'
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         rep = "<" + self.nodeName
         if self._filename or self._markpos:
             rep += " ("

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -1080,7 +1080,7 @@ h1 {padding: 0.1em; background-color: #777; color: white; border-bottom: thin wh
         return done
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<DirectoryLister of %r>' % self.path
 
     __str__ = __repr__

--- a/src/twisted/web/sux.py
+++ b/src/twisted/web/sux.py
@@ -72,8 +72,10 @@ class ParseError(Exception):
         self.message = message
 
     def __str__(self) -> str:
-       return "%s:%s:%s: %s" % (self.filename, self.line, self.col,
-                                self.message)
+        return "%s:%s:%s: %s" % (self.filename, self.line, self.col,
+                                 self.message)
+
+
 
 class XMLParser(Protocol):
 

--- a/src/twisted/web/sux.py
+++ b/src/twisted/web/sux.py
@@ -71,7 +71,7 @@ class ParseError(Exception):
         self.col = col
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
        return "%s:%s:%s: %s" % (self.filename, self.line, self.col,
                                 self.message)
 

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -454,7 +454,7 @@ class XMLFile(object):
                 return _flatsaxParse(f)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<XMLFile of %r>' % (self._path,)
 
 

--- a/src/twisted/web/test/test_client.py
+++ b/src/twisted/web/test/test_client.py
@@ -19,7 +19,7 @@ class DummyEndPoint(object):
     def __init__(self, someString):
         self.someString = someString
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DummyEndPoint({})'.format(self.someString)
 
     def connect(self, factory):

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -457,7 +457,7 @@ class FlattenerErrorTests(TestCase):
         """
         @implementer(IRenderable)
         class Renderable(object):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "renderable repr"
 
         self.assertEqual(

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -102,7 +102,7 @@ class ElementTests(TestCase):
         A L{MissingTemplateLoader} instance can be repr()'d without error.
         """
         class PrettyReprElement(Element):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return 'Pretty Repr Element'
         self.assertIn('Pretty Repr Element',
                       repr(MissingTemplateLoader(PrettyReprElement())))
@@ -125,7 +125,7 @@ class ElementTests(TestCase):
         A L{MissingRenderMethod} instance can be repr()'d without error.
         """
         class PrettyReprElement(Element):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return 'Pretty Repr Element'
         s = repr(MissingRenderMethod(PrettyReprElement(),
                                      'expectedMethod'))

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1387,7 +1387,7 @@ class NewRenderTests(unittest.TestCase):
         server error is returned.
         """
         class RiggedRepr(object):
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return 'my>repr'
 
         result = RiggedRepr()

--- a/src/twisted/words/ewords.py
+++ b/src/twisted/words/ewords.py
@@ -5,9 +5,13 @@
 """Exception definitions for Words
 """
 
+
+
 class WordsError(Exception):
     def __str__(self) -> str:
         return self.__class__.__name__ + ': ' + Exception.__str__(self)
+
+
 
 class NoSuchUser(WordsError):
     pass

--- a/src/twisted/words/ewords.py
+++ b/src/twisted/words/ewords.py
@@ -6,7 +6,7 @@
 """
 
 class WordsError(Exception):
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__ + ': ' + Exception.__str__(self)
 
 class NoSuchUser(WordsError):

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -65,7 +65,7 @@ class AbstractGroup:
         return '<%s %r>' % (self.__class__, self.name)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '%s@%s' % (self.name, self.account.accountName)
 
 
@@ -97,7 +97,7 @@ class AbstractPerson:
         return '<%s %r/%s>' % (self.__class__, self.name, self.status)
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '%s@%s' % (self.name, self.account.accountName)
 
 

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -61,7 +61,7 @@ class AbstractGroup:
         self.account.client.leaveGroup(self.name)
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s %r>' % (self.__class__, self.name)
 
 
@@ -93,7 +93,7 @@ class AbstractPerson:
         return '--'
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s %r/%s>' % (self.__class__, self.name, self.status)
 
 
@@ -294,7 +294,7 @@ class AbstractAccount(styles.Versioned):
         return reason
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s: %s (%s@%s:%s)>" % (self.__class__,
                                         self.accountName,
                                         self.username,

--- a/src/twisted/words/im/locals.py
+++ b/src/twisted/words/im/locals.py
@@ -9,7 +9,7 @@ class Enum:
     def __init__(self, label):
         self.label = label
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s: %s>' % (self.group, self.label)
 
     def __str__(self):

--- a/src/twisted/words/im/locals.py
+++ b/src/twisted/words/im/locals.py
@@ -12,7 +12,7 @@ class Enum:
     def __repr__(self) -> str:
         return '<%s: %s>' % (self.group, self.label)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.label
 
 

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -3201,7 +3201,7 @@ class DccFileReceive(DccFileReceiveBasic):
 
         # self.transport.log(logmsg)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self.connected:
             return "<Unconnected DccFileReceive object at %x>" % (id(self),)
         from_ = self.transport.getPeer()

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -3204,7 +3204,9 @@ class DccFileReceive(DccFileReceiveBasic):
     def __str__(self) -> str:
         if not self.connected:
             return "<Unconnected DccFileReceive object at %x>" % (id(self),)
-        from_ = self.transport.getPeer()
+        transport = self.transport
+        assert transport is not None
+        from_ = transport.getPeer()
         if self.fromUser:
             from_ = "%s (%s)" % (self.fromUser, from_)
 

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -3211,7 +3211,7 @@ class DccFileReceive(DccFileReceiveBasic):
         s = ("DCC transfer of '%s' from %s" % (self.filename, from_))
         return s
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = ("<%s at %x: GET %s>"
              % (self.__class__, id(self), self.filename))
         return s

--- a/src/twisted/words/protocols/jabber/error.py
+++ b/src/twisted/words/protocols/jabber/error.py
@@ -94,7 +94,7 @@ class BaseError(Exception):
         self.appCondition = appCondition
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         message = "%s with condition %r" % (self.__class__.__name__,
                                             self.condition)
 

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -244,7 +244,7 @@ class JID(object):
     __str__ = __unicode__
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Get object representation.
 

--- a/src/twisted/words/protocols/jabber/sasl.py
+++ b/src/twisted/words/protocols/jabber/sasl.py
@@ -47,7 +47,7 @@ class SASLAuthError(SASLError):
         self.condition = condition
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "SASLAuthError with condition %r" % self.condition
 
 


### PR DESCRIPTION
The first two commits are scripted replacements that annotate all `__repr__()` and `__str__()` methods in the source tree. Since an annotated method has its body checked by mypy, this triggers a few error messages for those bodies that need to be fixed manually, which is what the remainder of the commits are for. Please read the individual commit comments for details.

There are two significant behavioral changes:
- `twisted.names.dns.RRHeader` now raises `ValueError` instead of `AssertionError` if the payload type does not match
- descriptive error messages from `twisted.internet.error` are now present when running with `python -OO`

I added a news fragment for each of them.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9918
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
