### PR TITLE
 Add type annotations to __eq__() et al

### DIFF
--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -946,7 +946,7 @@ class Key(object):
         """
         Return True if other represents an object with the same key.
         """
-        if type(self) == type(other):
+        if isinstance(other, Key):
             return self.type() == other.type() and self.data() == other.data()
         else:
             return NotImplemented

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -942,7 +942,7 @@ class Key(object):
         """
         self._keyObject = keyObject
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Return True if other represents an object with the same key.
         """
@@ -951,7 +951,7 @@ class Key(object):
         else:
             return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """
         Return True if other represents anything other than this key.
         """

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -951,15 +951,6 @@ class Key(object):
         else:
             return NotImplemented
 
-    def __ne__(self, other: object) -> bool:
-        """
-        Return True if other represents anything other than this key.
-        """
-        result = self.__eq__(other)
-        if result == NotImplemented:
-            return result
-        return not result
-
     def __repr__(self):
         """
         Return a pretty representation of this object.

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -458,7 +458,7 @@ class Certificate(CertBase):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Certificate):
             return self.dump() == other.dump()
-        return False
+        return NotImplemented
 
 
     @classmethod

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -455,13 +455,13 @@ class Certificate(CertBase):
                                               self.getIssuer().commonName)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Certificate):
             return self.dump() == other.dump()
         return False
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
 

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -461,10 +461,6 @@ class Certificate(CertBase):
         return False
 
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
-
-
     @classmethod
     def load(Class, requestData, format=crypto.FILETYPE_ASN1, args=()):
         """

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -138,12 +138,6 @@ class UNIXAddress(object):
             return False
 
 
-    def __ne__(self, other: object) -> bool:
-        if isinstance(other, self.__class__):
-            return not self.__eq__(other)
-        return True
-
-
     def __repr__(self):
         name = self.name
         if name:

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -170,7 +170,8 @@ class _ServerFactoryIPv4Address(IPv4Address):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, tuple):
-            warnings.warn("IPv4Address.__getitem__ is deprecated.  Use attributes instead.",
+            warnings.warn("IPv4Address.__getitem__ is deprecated.  "
+                          "Use attributes instead.",
                           category=DeprecationWarning, stacklevel=2)
             return (self.host, self.port) == other
         elif isinstance(other, IPv4Address):

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -116,10 +116,9 @@ class UNIXAddress(object):
             Overriding C{attrs} to ensure the os level samefile
             check is done if the name attributes do not match.
             """
-            if isinstance(other, self.__class__):
-                res = self.name == other.name
-            else:
-                return False
+            if not isinstance(other, self.__class__):
+                return NotImplemented
+            res = self.name == other.name
             if not res and self.name and other.name:
                 try:
                     return os.path.samefile(self.name, other.name)
@@ -135,7 +134,7 @@ class UNIXAddress(object):
         def __eq__(self, other: object) -> bool:
             if isinstance(other, self.__class__):
                 return self.name == other.name
-            return False
+            return NotImplemented
 
 
     def __repr__(self):
@@ -172,4 +171,4 @@ class _ServerFactoryIPv4Address(IPv4Address):
             a = (self.type, self.host, self.port)
             b = (other.type, other.host, other.port)
             return a == b
-        return False
+        return NotImplemented

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -111,7 +111,7 @@ class UNIXAddress(object):
     name = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))
 
     if getattr(os.path, 'samefile', None) is not None:
-        def __eq__(self, other):
+        def __eq__(self, other: object) -> bool:
             """
             Overriding C{attrs} to ensure the os level samefile
             check is done if the name attributes do not match.
@@ -132,13 +132,13 @@ class UNIXAddress(object):
                         raise e
             return res
     else:
-        def __eq__(self, other):
+        def __eq__(self, other: object) -> bool:
             if isinstance(other, self.__class__):
                 return self.name == other.name
             return False
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return not self.__eq__(other)
         return True
@@ -168,7 +168,7 @@ class UNIXAddress(object):
 class _ServerFactoryIPv4Address(IPv4Address):
     """Backwards compatibility hack. Just like IPv4Address in practice."""
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, tuple):
             warnings.warn("IPv4Address.__getitem__ is deprecated.  Use attributes instead.",
                           category=DeprecationWarning, stacklevel=2)

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -161,7 +161,7 @@ class DelayedCall:
         return not (self.cancelled or self.called)
 
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
         """
         Implement C{<=} operator between two L{DelayedCall} instances.
 
@@ -171,7 +171,7 @@ class DelayedCall:
         return self.time <= other.time
 
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         """
         Implement C{<} operator between two L{DelayedCall} instances.
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -168,7 +168,10 @@ class DelayedCall:
         Comparison is based on the C{time} attribute (unadjusted by the
         delayed time).
         """
-        return self.time <= other.time
+        if isinstance(other, DelayedCall):
+            return self.time <= other.time
+        else:
+            return NotImplemented
 
 
     def __lt__(self, other: object) -> bool:
@@ -178,7 +181,10 @@ class DelayedCall:
         Comparison is based on the C{time} attribute (unadjusted by the
         delayed time).
         """
-        return self.time < other.time
+        if isinstance(other, DelayedCall):
+            return self.time < other.time
+        else:
+            return NotImplemented
 
 
     def __repr__(self):

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -421,7 +421,8 @@ class MessageSet(object):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, MessageSet):
             return self.ranges == other.ranges
-        return False
+        return NotImplemented
+
 
 
 class LiteralString:

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -418,12 +418,12 @@ class MessageSet(object):
         return '<MessageSet %s>' % (str(self),)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, MessageSet):
             return self.ranges == other.ranges
         return False
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
 

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -423,9 +423,6 @@ class MessageSet(object):
             return self.ranges == other.ranges
         return False
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
-
 
 class LiteralString:
     def __init__(self, size, defered):

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -75,7 +75,7 @@ class SerialNumber(FancyStrMixin, object):
         self._number = int(number) % self._modulo
 
 
-    def _convertOther(self, other):
+    def _convertOther(self, other: object) -> 'SerialNumber':
         """
         Check that a foreign object is suitable for use in the comparison or
         arithmetic magic methods of this L{SerialNumber} instance. Raise
@@ -117,20 +117,22 @@ class SerialNumber(FancyStrMixin, object):
     def __eq__(self, other: object) -> bool:
         """
         Allow rich equality comparison with another L{SerialNumber} instance.
-
-        @type other: L{SerialNumber}
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         return other._number == self._number
 
 
     def __lt__(self, other: object) -> bool:
         """
         Allow I{less than} comparison with another L{SerialNumber} instance.
-
-        @type other: L{SerialNumber}
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         return (
             (self._number < other._number
              and (other._number - self._number) < self._halfRing)
@@ -143,11 +145,11 @@ class SerialNumber(FancyStrMixin, object):
     def __gt__(self, other: object) -> bool:
         """
         Allow I{greater than} comparison with another L{SerialNumber} instance.
-
-        @type other: L{SerialNumber}
-        @rtype: L{bool}
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         return (
             (self._number < other._number
              and (other._number - self._number) > self._halfRing)
@@ -161,11 +163,11 @@ class SerialNumber(FancyStrMixin, object):
         """
         Allow I{less than or equal} comparison with another L{SerialNumber}
         instance.
-
-        @type other: L{SerialNumber}
-        @rtype: L{bool}
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         return self == other or self < other
 
 
@@ -173,15 +175,15 @@ class SerialNumber(FancyStrMixin, object):
         """
         Allow I{greater than or equal} comparison with another L{SerialNumber}
         instance.
-
-        @type other: L{SerialNumber}
-        @rtype: L{bool}
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         return self == other or self > other
 
 
-    def __add__(self, other):
+    def __add__(self, other: object) -> 'SerialNumber':
         """
         Allow I{addition} with another L{SerialNumber} instance.
 
@@ -201,12 +203,13 @@ class SerialNumber(FancyStrMixin, object):
 
         @see: U{http://tools.ietf.org/html/rfc1982#section-3.1}
 
-        @type other: L{SerialNumber}
-        @rtype: L{SerialNumber}
         @raises: L{ArithmeticError} if C{other} is more than C{_maxAdd}
             ie more than half the maximum value of this serial number.
         """
-        other = self._convertOther(other)
+        try:
+            other = self._convertOther(other)
+        except TypeError:
+            return NotImplemented
         if other._number <= self._maxAdd:
             return SerialNumber(
                 (self._number + other._number) % self._modulo,

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -114,7 +114,7 @@ class SerialNumber(FancyStrMixin, object):
         return self._number
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Allow rich equality comparison with another L{SerialNumber} instance.
 
@@ -124,7 +124,7 @@ class SerialNumber(FancyStrMixin, object):
         return other._number == self._number
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """
         Allow rich equality comparison with another L{SerialNumber} instance.
 
@@ -133,7 +133,7 @@ class SerialNumber(FancyStrMixin, object):
         return not self.__eq__(other)
 
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         """
         Allow I{less than} comparison with another L{SerialNumber} instance.
 
@@ -149,7 +149,7 @@ class SerialNumber(FancyStrMixin, object):
         )
 
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
         """
         Allow I{greater than} comparison with another L{SerialNumber} instance.
 
@@ -166,7 +166,7 @@ class SerialNumber(FancyStrMixin, object):
         )
 
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
         """
         Allow I{less than or equal} comparison with another L{SerialNumber}
         instance.
@@ -178,7 +178,7 @@ class SerialNumber(FancyStrMixin, object):
         return self == other or self < other
 
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> bool:
         """
         Allow I{greater than or equal} comparison with another L{SerialNumber}
         instance.

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -124,15 +124,6 @@ class SerialNumber(FancyStrMixin, object):
         return other._number == self._number
 
 
-    def __ne__(self, other: object) -> bool:
-        """
-        Allow rich equality comparison with another L{SerialNumber} instance.
-
-        @type other: L{SerialNumber}
-        """
-        return not self.__eq__(other)
-
-
     def __lt__(self, other: object) -> bool:
         """
         Allow I{less than} comparison with another L{SerialNumber} instance.

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -446,12 +446,6 @@ class Charstr(object):
         return NotImplemented
 
 
-    def __ne__(self, other: object) -> bool:
-        if isinstance(other, Charstr):
-            return self.string != other.string
-        return NotImplemented
-
-
     def __hash__(self):
         return hash(self.string)
 
@@ -558,12 +552,6 @@ class Name:
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Name):
             return self.name.lower() == other.name.lower()
-        return NotImplemented
-
-
-    def __ne__(self, other: object) -> bool:
-        if isinstance(other, Name):
-            return self.name.lower() != other.name.lower()
         return NotImplemented
 
 

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -440,13 +440,13 @@ class Charstr(object):
         self.string = readPrecisely(strio, l)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Charstr):
             return self.string == other.string
         return NotImplemented
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, Charstr):
             return self.string != other.string
         return NotImplemented
@@ -555,13 +555,13 @@ class Name:
             else:
                 self.name = self.name + b'.' + label
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Name):
             return self.name.lower() == other.name.lower()
         return NotImplemented
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, Name):
             return self.name.lower() != other.name.lower()
         return NotImplemented
@@ -1512,7 +1512,7 @@ class Record_A6(tputil.FancyStrMixin, tputil.FancyEqMixin):
             self.prefix.decode(strio)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Record_A6):
             return (self.prefixLen == other.prefixLen and
                     self.suffix[-self.bytes:] == other.suffix[-self.bytes:] and
@@ -1850,7 +1850,7 @@ class Record_HINFO(tputil.FancyStrMixin, tputil.FancyEqMixin):
         self.os = readPrecisely(strio, os)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Record_HINFO):
             return (self.os.lower() == other.os.lower() and
                     self.cpu.lower() == other.cpu.lower() and

--- a/src/twisted/names/test/test_rfc1982.py
+++ b/src/twisted/names/test/test_rfc1982.py
@@ -96,9 +96,10 @@ class SerialNumberTests(unittest.TestCase):
     def test_eqForeignType(self):
         """
         == comparison of L{SerialNumber} with a non-L{SerialNumber} instance
-        raises L{TypeError}.
+        returns L{NotImplemented}.
         """
-        self.assertRaises(TypeError, lambda: SerialNumber(1) == object())
+        self.assertFalse(SerialNumber(1) == object())
+        self.assertIs(SerialNumber(1).__eq__(object()), NotImplemented)
 
 
     def test_ne(self):
@@ -112,9 +113,10 @@ class SerialNumberTests(unittest.TestCase):
     def test_neForeignType(self):
         """
         != comparison of L{SerialNumber} with a non-L{SerialNumber} instance
-        raises L{TypeError}.
+        returns L{NotImplemented}.
         """
-        self.assertRaises(TypeError, lambda: SerialNumber(1) != object())
+        self.assertTrue(SerialNumber(1) != object())
+        self.assertIs(SerialNumber(1).__ne__(object()), NotImplemented)
 
 
     def test_le(self):

--- a/src/twisted/newsfragments/9919.bugfix
+++ b/src/twisted/newsfragments/9919.bugfix
@@ -1,0 +1,1 @@
+Comparator methods such as __eq__() now always return NotImplemented for uncomparable types.

--- a/src/twisted/newsfragments/9919.feature
+++ b/src/twisted/newsfragments/9919.feature
@@ -1,0 +1,1 @@
+twisted.python.util.InsensitiveDict now fully implements MutableMapping.

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -12,7 +12,7 @@ from functools import partial
 from operator import attrgetter
 from zope.interface import implementer
 from constantly import Names, NamedConstant
-from typing import Sequence
+from typing import ClassVar, Sequence
 
 from twisted.python.util import FancyEqMixin
 from twisted.positioning import ipositioning
@@ -160,7 +160,9 @@ class Angle(FancyEqMixin, object):
     }
 
 
-    compareAttributes = 'angleType', 'inDecimalDegrees'  # type: Sequence[str]
+    compareAttributes = (
+        'angleType', 'inDecimalDegrees'
+        )  # type: ClassVar[Sequence[str]]
 
 
     def __init__(self, angle=None, angleType=None):

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -21,7 +21,7 @@ Serializing a formatting structure is done with L{flatten}.
 """
 
 
-from typing import Sequence
+from typing import ClassVar, Sequence
 from twisted.python.util import FancyEqMixin
 
 
@@ -37,7 +37,7 @@ class _Attribute(FancyEqMixin, object):
     @type children: C{list}
     @ivar children: Child attributes.
     """
-    compareAttributes = ('children',)  # type: Sequence[str]
+    compareAttributes = ('children',)  # type: ClassVar[Sequence[str]]
 
 
     def __init__(self):
@@ -216,7 +216,7 @@ class DefaultFormattingState(FancyEqMixin, object):
     A character attribute that does nothing, thus applying no attributes to
     text.
     """
-    compareAttributes = ('_dummy',)  # type: Sequence[str]
+    compareAttributes = ('_dummy',)  # type: ClassVar[Sequence[str]]
 
     _dummy = 0
 

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -173,42 +173,42 @@ def comparable(klass):
     C{__eq__}, C{__lt__}, etc. methods are added to the class, relying on
     C{__cmp__} to implement their comparisons.
     """
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c
         return c == 0
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c
         return c != 0
 
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c
         return c < 0
 
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c
         return c <= 0
 
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c
         return c > 0
 
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> bool:
         c = self.__cmp__(other)
         if c is NotImplemented:
             return c

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -394,7 +394,7 @@ class PythonModule(_ModuleIteratorHelper):
                 return default
             raise
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         PythonModules with the same name are equal.
         """
@@ -402,7 +402,7 @@ class PythonModule(_ModuleIteratorHelper):
             return False
         return other.name == self.name
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """
         PythonModules with different names are not equal.
         """

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -402,14 +402,6 @@ class PythonModule(_ModuleIteratorHelper):
             return False
         return other.name == self.name
 
-    def __ne__(self, other: object) -> bool:
-        """
-        PythonModules with different names are not equal.
-        """
-        if not isinstance(other, PythonModule):
-            return True
-        return other.name != self.name
-
     def walkModules(self, importPackages=False):
         if importPackages and self.isPackage():
             self.load()

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -398,9 +398,9 @@ class PythonModule(_ModuleIteratorHelper):
         """
         PythonModules with the same name are equal.
         """
-        if not isinstance(other, PythonModule):
-            return False
-        return other.name == self.name
+        if isinstance(other, PythonModule):
+            return other.name == self.name
+        return NotImplemented
 
     def walkModules(self, importPackages=False):
         if importPackages and self.isPackage():

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -602,11 +602,11 @@ class EqualToEverything(object):
     """
     A class the instances of which consider themselves equal to everything.
     """
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return True
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return False
 
 
@@ -615,11 +615,11 @@ class EqualToNothing(object):
     """
     A class the instances of which consider themselves equal to nothing.
     """
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return False
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return True
 
 

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -618,10 +618,6 @@ class EqualToEverything(object):
         return True
 
 
-    def __ne__(self, other: object) -> bool:
-        return False
-
-
 
 class EqualToNothing(object):
     """
@@ -629,10 +625,6 @@ class EqualToNothing(object):
     """
     def __eq__(self, other: object) -> bool:
         return False
-
-
-    def __ne__(self, other: object) -> bool:
-        return True
 
 
 

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import warnings
 
+from typing import Iterable, Mapping, MutableMapping, Sequence
 from unittest import skipIf
 
 try:
@@ -350,6 +351,17 @@ class InsensitiveDictTests(TestCase):
     """
     Tests for L{util.InsensitiveDict}.
     """
+
+    def test_abc(self):
+        """
+        L{util.InsensitiveDict} implements L{typing.MutableMapping}.
+        """
+        dct = util.InsensitiveDict()
+        self.assertTrue(isinstance(dct, Iterable))
+        self.assertTrue(isinstance(dct, Mapping))
+        self.assertTrue(isinstance(dct, MutableMapping))
+        self.assertFalse(isinstance(dct, Sequence))  # not Reversible
+
 
     def test_preserve(self):
         """

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -26,7 +26,7 @@ else:
     setgroups = _setgroups
     getgroups = _getgroups
 
-from typing import Callable, Sequence, Union, Tuple
+from typing import Callable, Mapping, MutableMapping, Sequence, Union, Tuple
 
 from twisted.python.compat import unicode
 from incremental import Version
@@ -43,7 +43,7 @@ deprecatedModuleAttribute(
 
 
 
-class InsensitiveDict:
+class InsensitiveDict(MutableMapping):
     """
     Dictionary, that has case-insensitive keys.
 
@@ -52,8 +52,7 @@ class InsensitiveDict:
     looked up in lowercase and returned in lowercase by .keys() and .items().
     """
     """
-    Modified recipe at
-    http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/66315 originally
+    Modified recipe at http://code.activestate.com/recipes/66315/ originally
     contributed by Sami Hangaslammi.
     """
 
@@ -61,8 +60,9 @@ class InsensitiveDict:
         """
         Create an empty dictionary, or update from 'dict'.
         """
+        super().__init__()
         self.data = {}
-        self.preserve=preserve
+        self.preserve = preserve
         if dict:
             self.update(dict)
 
@@ -176,6 +176,8 @@ class InsensitiveDict:
         for v in self.data.values():
             yield self._doPreserve(v[0])
 
+    __iter__ = iterkeys
+
 
     def itervalues(self):
         for v in self.data.values():
@@ -187,8 +189,23 @@ class InsensitiveDict:
             yield self._doPreserve(k), v
 
 
+    _notFound = object()
+
+    def pop(self, key, default=_notFound):
+        """
+        @see: L{dict.pop}
+        @since: Twisted NEXT
+        """
+        try:
+            return self.data.pop(self._lowerOrReturn(key))[1]
+        except KeyError:
+            if default is self._notFound:
+                raise
+            return default
+
+
     def popitem(self):
-        i=self.items()[0]
+        i = self.items()[0]
         del self[i[0]]
         return i
 
@@ -207,10 +224,13 @@ class InsensitiveDict:
 
 
     def __eq__(self, other: object) -> bool:
-        for k, v in self.items():
-            if not (k in other) or not (other[k] == v):
-                return 0
-        return len(self) == len(other)
+        if isinstance(other, Mapping):
+            for k, v in self.items():
+                if k not in other or other[k] != v:
+                    return False
+            return len(self) == len(other)
+        else:
+            return NotImplemented
 
 
 

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -26,7 +26,8 @@ else:
     setgroups = _setgroups
     getgroups = _getgroups
 
-from typing import Callable, Mapping, MutableMapping, Sequence, Union, Tuple
+from typing import (Callable, ClassVar, Mapping, MutableMapping, Sequence,
+                    Union, Tuple)
 
 from twisted.python.compat import unicode
 from incremental import Version
@@ -650,7 +651,7 @@ class FancyEqMixin:
     Comparison is done using the list of attributes defined in
     C{compareAttributes}.
     """
-    compareAttributes = ()  # type: Sequence[Union[str, Sequence[str], Tuple[str, Callable]]]  # noqa
+    compareAttributes = ()  # type: ClassVar[Sequence[str]]
 
     def __eq__(self, other: object) -> bool:
         if not self.compareAttributes:

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -206,7 +206,7 @@ class InsensitiveDict:
         return len(self.data)
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         for k,v in self.items():
             if not (k in other) or not (other[k]==v):
                 return 0
@@ -632,7 +632,7 @@ class FancyEqMixin:
     """
     compareAttributes = ()  # type: Sequence[Union[str, Sequence[str], Tuple[str, Callable]]]  # noqa
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not self.compareAttributes:
             return self is other
         if isinstance(self, other.__class__):
@@ -642,7 +642,7 @@ class FancyEqMixin:
         return NotImplemented
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         result = self.__eq__(other)
         if result is NotImplemented:
             return result

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -657,9 +657,8 @@ class FancyEqMixin:
         if not self.compareAttributes:
             return self is other
         if isinstance(self, other.__class__):
-            return (
-                [getattr(self, name) for name in self.compareAttributes] ==
-                [getattr(other, name) for name in self.compareAttributes])
+            return all(getattr(self, name) == getattr(other, name)
+                       for name in self.compareAttributes)
         return NotImplemented
 
 

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -207,10 +207,10 @@ class InsensitiveDict:
 
 
     def __eq__(self, other: object) -> bool:
-        for k,v in self.items():
-            if not (k in other) or not (other[k]==v):
+        for k, v in self.items():
+            if not (k in other) or not (other[k] == v):
                 return 0
-        return len(self)==len(other)
+        return len(self) == len(other)
 
 
 

--- a/src/twisted/test/testutils.py
+++ b/src/twisted/test/testutils.py
@@ -107,10 +107,6 @@ class _Equal(object):
         return True
 
 
-    def __ne__(self, other: object) -> bool:
-        return False
-
-
 
 class _NotEqual(object):
     """
@@ -118,10 +114,6 @@ class _NotEqual(object):
     """
     def __eq__(self, other: object) -> bool:
         return False
-
-
-    def __ne__(self, other: object) -> bool:
-        return True
 
 
 

--- a/src/twisted/test/testutils.py
+++ b/src/twisted/test/testutils.py
@@ -103,11 +103,11 @@ class _Equal(object):
     """
     A class the instances of which are equal to anything and everything.
     """
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return True
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return False
 
 
@@ -116,11 +116,11 @@ class _NotEqual(object):
     """
     A class the instances of which are equal to nothing.
     """
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return False
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return True
 
 

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1014,10 +1014,6 @@ class SynchronousTestCase(_Assertions):
         return self is other
 
 
-    def __ne__(self, other: object) -> bool:
-        return self is not other
-
-
     def __hash__(self):
         return hash((self.__class__, self._testMethodName))
 

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1011,7 +1011,10 @@ class SynchronousTestCase(_Assertions):
         method twice.  Most likely, trial should stop using a set to hold
         tests, but until it does, this is necessary on Python 2.6. -exarkun
         """
-        return self is other
+        if isinstance(other, SynchronousTestCase):
+            return self is other
+        else:
+            return NotImplemented
 
 
     def __hash__(self):

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1002,7 +1002,7 @@ class SynchronousTestCase(_Assertions):
             testMethod, self, sys.modules.get(self.__class__.__module__)]
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Override the comparison defined by the base TestCase which considers
         instances of the same class with the same _testMethodName to be
@@ -1014,7 +1014,7 @@ class SynchronousTestCase(_Assertions):
         return self is other
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return self is not other
 
 

--- a/src/twisted/trial/test/mockdoctest.py
+++ b/src/twisted/trial/test/mockdoctest.py
@@ -44,7 +44,7 @@ class Counter(object):
             self._count += other
         return self
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """equality operator, compare other to my value()
 
            >>> c = Counter()
@@ -58,7 +58,7 @@ class Counter(object):
         """
         return self._count == other
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """inequality operator
 
              >>> c = Counter()

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1609,7 +1609,7 @@ class Request:
             self.channel.loseConnection()
 
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Determines if two requests are the same object.
 
@@ -1630,7 +1630,7 @@ class Request:
         return NotImplemented
 
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """
         Determines if two requests are not the same object.
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1628,27 +1628,6 @@ class Request:
         return NotImplemented
 
 
-    def __ne__(self, other: object) -> bool:
-        """
-        Determines if two requests are not the same object.
-
-        @param other: Another object whose identity will be compared
-            to this instance's.
-
-        @return: L{True} when the two are not the same object and
-            L{False} when they are.
-        @rtype: L{bool}
-        """
-        # When other is not an instance of request, return
-        # NotImplemented so that Python uses other.__ne__ to perform
-        # the comparison.  This ensures that a Request proxy generated
-        # by proxyForInterface can compare equal to an actual Request
-        # instance by turning request != proxy into proxy != request.
-        if isinstance(other, Request):
-            return self is not other
-        return NotImplemented
-
-
     def __hash__(self):
         """
         A C{Request} is hashable so that it can be used as a mapping key.

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -446,7 +446,7 @@ class _IDeprecatedHTTPChannelToRequestInterface(Interface):
         """
 
 
-    def __eq__(other):
+    def __eq__(other: object) -> bool:
         """
         Determines if two requests are the same object.
 
@@ -455,11 +455,10 @@ class _IDeprecatedHTTPChannelToRequestInterface(Interface):
 
         @return: L{True} when the two are the same object and L{False}
             when not.
-        @rtype: L{bool}
         """
 
 
-    def __ne__(other):
+    def __ne__(other: object) -> bool:
         """
         Determines if two requests are not the same object.
 
@@ -468,7 +467,6 @@ class _IDeprecatedHTTPChannelToRequestInterface(Interface):
 
         @return: L{True} when the two are not the same object and
             L{False} when they are.
-        @rtype: L{bool}
         """
 
 

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -3482,7 +3482,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
 
         class _NotARequest(object):
 
-            def __eq__(self, other):
+            def __eq__(self, other: object) -> bool:
                 eqCalls.append(other)
                 return True
 
@@ -3502,7 +3502,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
 
         class _NotARequest(object):
 
-            def __ne__(self, other):
+            def __ne__(self, other: object) -> bool:
                 eqCalls.append(other)
                 return True
 

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -219,19 +219,6 @@ class JID(object):
         else:
             return NotImplemented
 
-    def __ne__(self, other: object) -> bool:
-        """
-        Inequality comparison.
-
-        This negates L{__eq__} for comparison with JIDs and uses the default
-        comparison for other types.
-        """
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        else:
-            return not result
-
 
     def __hash__(self):
         """

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -204,7 +204,7 @@ class JID(object):
             else:
                 return self.host
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Equality comparison.
 
@@ -219,7 +219,7 @@ class JID(object):
         else:
             return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """
         Inequality comparison.
 


### PR DESCRIPTION
Some of the existing code was incorrect or outdated when passed an uncomparable value: they would return `False` or raise `TypeError`. I updated those to return `NotImplemented` instead.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9919
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
