### PR TITLE
 Drop obsolete private definitions from twisted.python.compat

### DIFF
--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -33,7 +33,7 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import IUsernamePassword, ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
-from twisted.python.compat import _keys, _b64decodebytes
+from twisted.python.compat import _b64decodebytes
 from twisted.python import failure, reflect, log
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.util import runAsEffectiveUser
@@ -263,7 +263,7 @@ class SSHProtocolChecker:
 
     @property
     def credentialInterfaces(self):
-        return _keys(self.checkers)
+        return list(self.checkers.keys())
 
 
     def registerChecker(self, checker, *credentialInterfaces):

--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -10,6 +10,7 @@ Provide L{ICredentialsChecker} implementations to be used in Conch protocols.
 import sys
 import binascii
 import errno
+from base64 import decodebytes
 
 try:
     import pwd
@@ -33,7 +34,6 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import IUsernamePassword, ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
-from twisted.python.compat import _b64decodebytes
 from twisted.python import failure, reflect, log
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.util import runAsEffectiveUser
@@ -228,7 +228,7 @@ class SSHPublicKeyDatabase:
                     if len(l2) < 2:
                         continue
                     try:
-                        if _b64decodebytes(l2[1]) == credentials.blob:
+                        if decodebytes(l2[1]) == credentials.blob:
                             return True
                     except binascii.Error:
                         continue

--- a/src/twisted/conch/client/default.py
+++ b/src/twisted/conch/client/default.py
@@ -13,8 +13,7 @@ interact with a known_hosts database, use L{twisted.conch.client.knownhosts}.
 
 
 from twisted.python import log
-from twisted.python.compat import (
-    nativeString, raw_input, _b64decodebytes as decodebytes)
+from twisted.python.compat import nativeString, raw_input
 from twisted.python.filepath import FilePath
 
 from twisted.conch.error import ConchError
@@ -30,6 +29,7 @@ import getpass
 import io
 import os
 import sys
+from base64 import decodebytes
 
 # The default location of the known hosts file (probably should be parsed out
 # of an ssh config file someday).

--- a/src/twisted/conch/insults/window.py
+++ b/src/twisted/conch/insults/window.py
@@ -10,7 +10,6 @@ import array
 
 from twisted.conch.insults import insults, helper
 from twisted.python import text as tptext
-from twisted.python.compat import _bytesChr as chr
 
 
 
@@ -472,7 +471,7 @@ class Canvas(Widget):
 def horizontalLine(terminal, y, left, right):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
     terminal.cursorPosition(left, y)
-    terminal.write(chr(0o161) * (right - left))
+    terminal.write(b'\161' * (right - left))
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 
 
@@ -481,7 +480,7 @@ def verticalLine(terminal, x, top, bottom):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
     for n in range(top, bottom):
         terminal.cursorPosition(x, n)
-        terminal.write(chr(0o170))
+        terminal.write(b'\170')
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 
 
@@ -499,18 +498,18 @@ def rectangle(terminal, position, dimension):
     terminal.selectCharacterSet(insults.CS_DRAWING, insults.G0)
 
     terminal.cursorPosition(top, left)
-    terminal.write(chr(0o154))
-    terminal.write(chr(0o161) * (width - 2))
-    terminal.write(chr(0o153))
+    terminal.write(b'\154')
+    terminal.write(b'\161' * (width - 2))
+    terminal.write(b'\153')
     for n in range(height - 2):
         terminal.cursorPosition(left, top + n + 1)
-        terminal.write(chr(0o170))
+        terminal.write(b'\170')
         terminal.cursorForward(width - 2)
-        terminal.write(chr(0o170))
+        terminal.write(b'\170')
     terminal.cursorPosition(0, top + height - 1)
-    terminal.write(chr(0o155))
-    terminal.write(chr(0o161) * (width - 2))
-    terminal.write(chr(0o152))
+    terminal.write(b'\155')
+    terminal.write(b'\161' * (width - 2))
+    terminal.write(b'\152')
 
     terminal.selectCharacterSet(insults.CS_US, insults.G0)
 

--- a/src/twisted/conch/manhole.py
+++ b/src/twisted/conch/manhole.py
@@ -19,7 +19,7 @@ from io import BytesIO
 from twisted.conch import recvline
 
 from twisted.internet import defer
-from twisted.python.compat import _tokenize, _get_async_param
+from twisted.python.compat import _get_async_param
 from twisted.python.htmlizer import TokenPrinter
 
 
@@ -337,7 +337,7 @@ def lastColorizedLine(source):
     p = TokenPrinter(w.write).printtoken
     s = BytesIO(source)
 
-    for token in _tokenize(s.readline):
+    for token in tokenize.tokenize(s.readline):
         (tokenType, string, start, end, line) = token
         p(tokenType, string, start, end, line)
 

--- a/src/twisted/conch/ssh/connection.py
+++ b/src/twisted/conch/ssh/connection.py
@@ -17,8 +17,7 @@ from twisted.conch.ssh import service, common
 from twisted.conch import error
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.compat import (
-    nativeString, networkString, long, _bytesChr as chr)
+from twisted.python.compat import nativeString, networkString, long
 
 
 
@@ -444,10 +443,12 @@ class SSHConnection(service.SSHService):
         if channel.localClosed:
             return
         log.msg('sending request %r' % (requestType))
-        self.transport.sendPacket(MSG_CHANNEL_REQUEST, struct.pack('>L',
-                                    self.channelsToRemoteChannel[channel])
-                                  + common.NS(requestType)+chr(wantReply)
-                                  + data)
+        self.transport.sendPacket(
+                MSG_CHANNEL_REQUEST,
+                struct.pack('>L', self.channelsToRemoteChannel[channel])
+                + common.NS(requestType)
+                + bytes([wantReply])
+                + data)
         if wantReply:
             d = defer.Deferred()
             self.deferreds.setdefault(channel.id, []).append(d)
@@ -647,6 +648,5 @@ for name, value in locals().copy().items():
         messages[value] = name  # Doesn't handle doubles
 
 alphanums = networkString(string.ascii_letters + string.digits)
-TRANSLATE_TABLE = b''.join([chr(i) in alphanums and chr(i) or b'_'
-                            for i in range(256)])
+TRANSLATE_TABLE = bytes(i if i in alphanums else ord('_') for i in range(256))
 SSHConnection.protocolMessages = messages

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -7,12 +7,12 @@ Handling of RSA, DSA, ECDSA, and Ed25519 keys.
 """
 
 
-import base64
 import binascii
 import itertools
 import struct
 import unicodedata
 import warnings
+from base64 import b64encode, decodebytes, encodebytes
 from hashlib import md5, sha256
 
 import bcrypt
@@ -32,9 +32,7 @@ from pyasn1.type import univ
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_from_bytes, int_to_bytes
 from twisted.python import randbytes
-from twisted.python.compat import (
-    iterbytes, long, izip, nativeString, unicode,
-    _b64decodebytes as decodebytes, _b64encodebytes as encodebytes)
+from twisted.python.compat import iterbytes, long, izip, nativeString, unicode
 from twisted.python.constants import NamedConstant, Names
 from twisted.python.deprecate import _mutuallyExclusiveArguments
 
@@ -1046,8 +1044,7 @@ class Key(object):
         @rtype: L{str}
         """
         if format is FingerprintFormats.SHA256_BASE64:
-            return nativeString(base64.b64encode(
-                sha256(self.blob()).digest()))
+            return nativeString(b64encode(sha256(self.blob()).digest()))
         elif format is FingerprintFormats.MD5_HEX:
             return nativeString(
                 b':'.join([binascii.hexlify(x)

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -34,8 +34,7 @@ from twisted.conch.ssh.common import int_from_bytes, int_to_bytes
 from twisted.python import randbytes
 from twisted.python.compat import (
     iterbytes, long, izip, nativeString, unicode,
-    _b64decodebytes as decodebytes, _b64encodebytes as encodebytes,
-    _bytesChr as chr)
+    _b64decodebytes as decodebytes, _b64encodebytes as encodebytes)
 from twisted.python.constants import NamedConstant, Names
 from twisted.python.deprecate import _mutuallyExclusiveArguments
 
@@ -1439,7 +1438,7 @@ class Key(object):
         padByte = 0
         while len(privKeyList) % blockSize:
             padByte += 1
-            privKeyList += chr(padByte & 0xFF)
+            privKeyList += bytes([padByte & 0xFF])
         if passphrase:
             encKey = bcrypt.kdf(passphrase, salt, keySize + ivSize, 100)
             encryptor = Cipher(
@@ -1519,7 +1518,7 @@ class Key(object):
             bb = md5(ba + passphrase + iv).digest()
             encKey = (ba + bb)[:24]
             padLen = 8 - (len(asn1Data) % 8)
-            asn1Data += chr(padLen) * padLen
+            asn1Data += bytes([padLen]) * padLen
 
             encryptor = Cipher(
                 algorithms.TripleDES(encKey),

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -19,7 +19,7 @@ from zope.interface import implementer
 
 from twisted.internet import interfaces, protocol
 from twisted.logger import Logger
-from twisted.python.compat import _bytesChr as chr, networkString
+from twisted.python.compat import networkString
 from twisted.conch.interfaces import (
     EnvironmentVariableNotPermitted, ISession, ISessionSetEnv)
 from twisted.conch.ssh import common, channel, connection
@@ -331,7 +331,8 @@ class SSHSessionProcessProtocol(protocol.ProcessProtocol):
                     coreDumped = 0
                 self.session.conn.sendRequest(
                     self.session, b'exit-signal',
-                    common.NS(networkString(signame[3:])) + chr(coreDumped) +
+                    common.NS(networkString(signame[3:])) +
+                    bytes([coreDumped]) +
                     common.NS(b'') + common.NS(b''))
             elif err.exitCode is not None:
                 log.info('exitCode: {exitCode!r}', exitCode=err.exitCode)

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -27,7 +27,7 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from twisted import __version__ as twisted_version
 from twisted.internet import protocol, defer
 from twisted.python import log, randbytes
-from twisted.python.compat import iterbytes, _bytesChr as chr, networkString
+from twisted.python.compat import iterbytes, networkString
 
 # This import is needed if SHA256 hashing is used.
 # from twisted.python.compat import nativeString
@@ -529,7 +529,7 @@ class SSHTransportBase(protocol.Protocol):
                     self._keyExchangeState,))
 
         self.ourKexInitPayload = b''.join([
-            chr(MSG_KEXINIT),
+            bytes([MSG_KEXINIT]),
             randbytes.secureRandom(16),
             NS(b','.join(self.supportedKeyExchanges)),
             NS(b','.join(self.supportedPublicKeys)),
@@ -587,7 +587,7 @@ class SSHTransportBase(protocol.Protocol):
                 self._blockedByKeyExchange.append((messageType, payload))
                 return
 
-        payload = chr(messageType) + payload
+        payload = bytes([messageType]) + payload
         if self.outgoingCompression:
             payload = (self.outgoingCompression.compress(payload)
                        + self.outgoingCompression.flush(2))
@@ -829,7 +829,7 @@ class SSHTransportBase(protocol.Protocol):
         @return: A L{tuple} of negotiated key exchange algorithms, key
         algorithms, and unhandled data, or L{None} if something went wrong.
         """
-        self.otherKexInitPayload = chr(MSG_KEXINIT) + packet
+        self.otherKexInitPayload = bytes([MSG_KEXINIT]) + packet
         # This is useless to us:
         # cookie = packet[: 16]
         k = getNS(packet[16:], 10)
@@ -970,7 +970,7 @@ class SSHTransportBase(protocol.Protocol):
         @param language: optionally, the language the message is in.
         @type language: L{str}
         """
-        self.sendPacket(MSG_DEBUG, chr(alwaysDisplay) + NS(message) +
+        self.sendPacket(MSG_DEBUG, bytes([alwaysDisplay]) + NS(message) +
                         NS(language))
 
 

--- a/src/twisted/conch/telnet.py
+++ b/src/twisted/conch/telnet.py
@@ -15,7 +15,14 @@ from zope.interface import implementer
 
 from twisted.internet import protocol, interfaces as iinternet, defer
 from twisted.python import log
-from twisted.python.compat import _bytesChr as chr, iterbytes
+from twisted.python.compat import iterbytes
+
+
+
+def chr(i):
+    return bytes([i])
+
+
 
 MODE = chr(1)
 EDIT = 1

--- a/src/twisted/conch/test/keydata.py
+++ b/src/twisted/conch/test/keydata.py
@@ -9,7 +9,11 @@ Data used by test_keys as well as others.
 """
 
 
-from twisted.python.compat import long, _b64decodebytes as decodebytes
+from base64 import decodebytes
+
+from twisted.python.compat import long
+
+
 
 RSAData = {
     'n': long('269413617238113438198661010376758399219880277968382122687862697'

--- a/src/twisted/conch/test/test_checkers.py
+++ b/src/twisted/conch/test/test_checkers.py
@@ -15,13 +15,13 @@ else:
 
 import os
 
+from base64 import encodebytes
 from collections import namedtuple
 from io import BytesIO
 
 from zope.interface.verify import verifyObject
 
 from twisted.python import util
-from twisted.python.compat import _b64encodebytes
 from twisted.python.failure import Failure
 from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
@@ -163,8 +163,8 @@ class SSHPublicKeyDatabaseTests(TestCase):
 
     def setUp(self):
         self.checker = checkers.SSHPublicKeyDatabase()
-        self.key1 = _b64encodebytes(b"foobar")
-        self.key2 = _b64encodebytes(b"eggspam")
+        self.key1 = encodebytes(b"foobar")
+        self.key2 = encodebytes(b"eggspam")
         self.content = (b"t1 " + self.key1 + b" foo\nt2 " + self.key2 +
                         b" egg\n")
 

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -20,7 +20,6 @@ from twisted.internet import defer, task
 from twisted.protocols import loopback
 from twisted.python.reflect import requireModule
 from twisted.trial import unittest
-from twisted.python.compat import _bytesChr as chr
 
 if requireModule('cryptography') and requireModule('pyasn1'):
     from twisted.conch.ssh.common import NS
@@ -304,9 +303,10 @@ class SSHUserAuthServerTests(unittest.TestCase):
 
         See RFC 4252, Section 5.1.
         """
-        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), chr(0),
+        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), b'\0',
                            NS(b'foo')])
         d = self.authServer.ssh_USERAUTH_REQUEST(packet)
+
         def check(ignored):
             self.assertEqual(
                 self.authServer.transport.packets,
@@ -324,7 +324,7 @@ class SSHUserAuthServerTests(unittest.TestCase):
         See RFC 4252, Section 5.1.
         """
         # packet = username, next_service, authentication type, FALSE, password
-        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), chr(0),
+        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), b'\0',
                            NS(b'bar')])
         self.authServer.clock = task.Clock()
         d = self.authServer.ssh_USERAUTH_REQUEST(packet)
@@ -339,16 +339,18 @@ class SSHUserAuthServerTests(unittest.TestCase):
         """
         blob = keys.Key.fromString(keydata.publicRSA_openssh).blob()
         obj = keys.Key.fromString(keydata.privateRSA_openssh)
-        packet = (NS(b'foo') + NS(b'none') + NS(b'publickey') + b'\xff'
-                + NS(obj.sshType()) + NS(blob))
+        packet = (NS(b'foo') + NS(b'none') + NS(b'publickey') + b'\xff' +
+                  NS(obj.sshType()) + NS(blob))
         self.authServer.transport.sessionID = b'test'
-        signature = obj.sign(NS(b'test') + chr(userauth.MSG_USERAUTH_REQUEST)
-                + packet)
+        signature = obj.sign(NS(b'test')
+                             + bytes([userauth.MSG_USERAUTH_REQUEST])
+                             + packet)
         packet += NS(signature)
         d = self.authServer.ssh_USERAUTH_REQUEST(packet)
+
         def check(ignored):
             self.assertEqual(self.authServer.transport.packets,
-                    [(userauth.MSG_USERAUTH_SUCCESS, b'')])
+                             [(userauth.MSG_USERAUTH_SUCCESS, b'')])
         return d.addCallback(check)
 
 
@@ -516,11 +518,12 @@ class SSHUserAuthServerTests(unittest.TestCase):
         timeoutAuthServer.serviceStarted()
         timeoutAuthServer.clock.advance(11 * 60 * 60)
         timeoutAuthServer.serviceStopped()
-        self.assertEqual(timeoutAuthServer.transport.packets,
-                [(transport.MSG_DISCONNECT,
-                b'\x00' * 3 +
-                chr(transport.DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE) +
-                NS(b"you took too long") + NS(b''))])
+        self.assertEqual(
+            timeoutAuthServer.transport.packets,
+            [(transport.MSG_DISCONNECT,
+              b'\x00' * 3 +
+              bytes([transport.DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE]) +
+              NS(b"you took too long") + NS(b''))])
         self.assertTrue(timeoutAuthServer.transport.lostConnection)
 
 
@@ -543,18 +546,20 @@ class SSHUserAuthServerTests(unittest.TestCase):
         Test that the server disconnects if the client fails authentication
         too many times.
         """
-        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), chr(0),
+        packet = b''.join([NS(b'foo'), NS(b'none'), NS(b'password'), b'\0',
                            NS(b'bar')])
         self.authServer.clock = task.Clock()
         for i in range(21):
             d = self.authServer.ssh_USERAUTH_REQUEST(packet)
             self.authServer.clock.advance(2)
+
         def check(ignored):
-            self.assertEqual(self.authServer.transport.packets[-1],
+            self.assertEqual(
+                self.authServer.transport.packets[-1],
                 (transport.MSG_DISCONNECT,
-                b'\x00' * 3 +
-                chr(transport.DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE) +
-                NS(b"too many bad auths") + NS(b'')))
+                 b'\x00' * 3 +
+                 bytes([transport.DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE]) +
+                 NS(b"too many bad auths") + NS(b'')))
         return d.addCallback(check)
 
 
@@ -563,7 +568,7 @@ class SSHUserAuthServerTests(unittest.TestCase):
         If the user requests a service that we don't support, the
         authentication should fail.
         """
-        packet = NS(b'foo') + NS(b'') + NS(b'password') + chr(0) + NS(b'foo')
+        packet = NS(b'foo') + NS(b'') + NS(b'password') + b'\0' + NS(b'foo')
         self.authServer.clock = task.Clock()
         d = self.authServer.ssh_USERAUTH_REQUEST(packet)
         return d.addCallback(self._checkFailed)
@@ -644,25 +649,30 @@ class SSHUserAuthClientTests(unittest.TestCase):
         Test that the client can authenticate with a public key.
         """
         self.authClient.ssh_USERAUTH_FAILURE(NS(b'publickey') + b'\x00')
-        self.assertEqual(self.authClient.transport.packets[-1],
+        self.assertEqual(
+                self.authClient.transport.packets[-1],
                 (userauth.MSG_USERAUTH_REQUEST, NS(b'foo') + NS(b'nancy')
                     + NS(b'publickey') + b'\x00' + NS(b'ssh-dss')
                     + NS(keys.Key.fromString(
                         keydata.publicDSA_openssh).blob())))
-       # that key isn't good
+        # that key isn't good
         self.authClient.ssh_USERAUTH_FAILURE(NS(b'publickey') + b'\x00')
         blob = NS(keys.Key.fromString(keydata.publicRSA_openssh).blob())
-        self.assertEqual(self.authClient.transport.packets[-1],
-                (userauth.MSG_USERAUTH_REQUEST, (NS(b'foo') + NS(b'nancy')
-                    + NS(b'publickey') + b'\x00' + NS(b'ssh-rsa') + blob)))
-        self.authClient.ssh_USERAUTH_PK_OK(NS(b'ssh-rsa')
-            + NS(keys.Key.fromString(keydata.publicRSA_openssh).blob()))
-        sigData = (NS(self.authClient.transport.sessionID)
-                + chr(userauth.MSG_USERAUTH_REQUEST) + NS(b'foo')
-                + NS(b'nancy') + NS(b'publickey') + b'\x01' + NS(b'ssh-rsa')
-                + blob)
+        self.assertEqual(
+                self.authClient.transport.packets[-1],
+                (userauth.MSG_USERAUTH_REQUEST,
+                 (NS(b'foo') + NS(b'nancy') + NS(b'publickey') + b'\x00' +
+                  NS(b'ssh-rsa') + blob)))
+        self.authClient.ssh_USERAUTH_PK_OK(
+                NS(b'ssh-rsa')
+                + NS(keys.Key.fromString(keydata.publicRSA_openssh).blob()))
+        sigData = (NS(self.authClient.transport.sessionID) +
+                   bytes([userauth.MSG_USERAUTH_REQUEST]) + NS(b'foo') +
+                   NS(b'nancy') + NS(b'publickey') + b'\x01' + NS(b'ssh-rsa') +
+                   blob)
         obj = keys.Key.fromString(keydata.privateRSA_openssh)
-        self.assertEqual(self.authClient.transport.packets[-1],
+        self.assertEqual(
+                self.authClient.transport.packets[-1],
                 (userauth.MSG_USERAUTH_REQUEST, NS(b'foo') + NS(b'nancy')
                     + NS(b'publickey') + b'\x01' + NS(b'ssh-rsa') + blob
                     + NS(obj.sign(sigData))))

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -29,7 +29,7 @@ from twisted.conch.interfaces import ISession, ISFTPServer, ISFTPFile
 from twisted.cred import portal
 from twisted.internet.error import ProcessExitedAlready
 from twisted.python import components, log
-from twisted.python.compat import _bytesChr as chr, nativeString
+from twisted.python.compat import nativeString
 
 try:
     import utmp
@@ -297,7 +297,7 @@ class SSHSessionForUnixConchUser:
                 if not hasattr(tty, ttyMode):
                     continue
                 ttyval = getattr(tty, ttyMode)
-                attr[tty.CC][ttyval] = chr(modeValue)
+                attr[tty.CC][ttyval] = bytes([modeValue])
         tty.tcsetattr(pty.fileno(), tty.TCSANOW, attr)
 
 

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -16,7 +16,7 @@ from ctypes import (
 from ctypes.util import find_library
 from typing import Any, List, Tuple
 
-from twisted.python.compat import nativeString, _bytesChr as chr
+from twisted.python.compat import nativeString
 
 
 libc = CDLL(find_library("c") or "")
@@ -140,7 +140,7 @@ def _interfaces():
                     addr = None
 
                 if addr:
-                    packed = b''.join(map(chr, addr[0].sin_addr.in_addr[:]))
+                    packed = bytes(addr[0].sin_addr.in_addr[:])
                     packed = _maybeCleanupScopeIndex(family, packed)
                     results.append((
                             ifaddrs[0].ifa_name,

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -40,7 +40,7 @@ from twisted.internet import error
 from twisted.internet.defer import maybeDeferred
 from twisted.python import log, text
 from twisted.python.compat import (
-    _bytesChr, unichr as chr, _b64decodebytes as decodebytes,
+    unichr as chr, _b64decodebytes as decodebytes,
     _b64encodebytes as encodebytes,
     intToBytes, iterbytes, long, nativeString, networkString, unicode,
     _matchingString, _get_async_param,
@@ -571,7 +571,7 @@ class Command:
 # Some definitions (SP, CTL, DQUOTE) are also from the ABNF RFC -
 # <https://tools.ietf.org/html/rfc2234>.
 _SP = b' '
-_CTL = b''.join(_bytesChr(ch) for ch in chain(range(0x21), range(0x80, 0x100)))
+_CTL = bytes(chain(range(0x21), range(0x80, 0x100)))
 
 # It is easier to define ATOM-CHAR in terms of what it does not match than in
 # terms of what it does match.
@@ -582,7 +582,9 @@ _nativeNonAtomChars = _nonAtomChars.decode('charmap')
 _nonAtomRE = re.compile('[' + _nativeNonAtomChars + ']')
 
 # This is all the bytes that match the ATOM-CHAR from the grammar in the RFC.
-_atomChars = b''.join(_bytesChr(ch) for ch in list(range(0x100)) if _bytesChr(ch) not in _nonAtomChars)
+_atomChars = bytes(ch for ch in range(0x100) if ch not in _nonAtomChars)
+
+
 
 @implementer(IMailboxListener)
 class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -27,6 +27,7 @@ import uuid
 
 import email.utils
 
+from base64 import decodebytes, encodebytes
 from itertools import chain
 from io import BytesIO
 from typing import Any, List
@@ -40,10 +41,8 @@ from twisted.internet import error
 from twisted.internet.defer import maybeDeferred
 from twisted.python import log, text
 from twisted.python.compat import (
-    unichr as chr, _b64decodebytes as decodebytes,
-    _b64encodebytes as encodebytes,
-    intToBytes, iterbytes, long, nativeString, networkString, unicode,
-    _matchingString, _get_async_param,
+    unichr as chr, intToBytes, iterbytes, long, nativeString, networkString,
+    unicode, _matchingString, _get_async_param,
 )
 from twisted.internet import interfaces
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -36,8 +36,7 @@ from twisted.internet._idna import _idnaText
 from twisted.python import log
 from twisted.python import util
 from twisted.python.compat import (long, unicode, networkString,
-                                   nativeString, iteritems, _bytesChr,
-                                   iterbytes)
+                                   nativeString, iteritems, iterbytes)
 from twisted.python.runtime import platform
 
 from twisted.mail.interfaces import (IClientAuthentication,
@@ -2212,7 +2211,7 @@ def xtext_encode(s, errors=None):
         if ch == '+' or ch == '=' or o < 33 or o > 126:
             r.append(networkString('+%02X' % (o,)))
         else:
-            r.append(_bytesChr(o))
+            r.append(bytes([o]))
     return (b''.join(r), len(s))
 
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -36,7 +36,7 @@ from twisted.internet._idna import _idnaText
 from twisted.python import log
 from twisted.python import util
 from twisted.python.compat import (long, unicode, networkString,
-                                   nativeString, iteritems, _keys, _bytesChr,
+                                   nativeString, iteritems, _bytesChr,
                                    iterbytes)
 from twisted.python.runtime import platform
 
@@ -1618,7 +1618,7 @@ class ESMTP(SMTP):
         @rtype: L{dict} with L{bytes} keys and a value of either L{None} or a
             L{list} of L{bytes}.
         """
-        ext = {b'AUTH': _keys(self.challengers)}
+        ext = {b'AUTH': list(self.challengers.keys())}
         if self.canStartTLS and not self.startedTLS:
             ext[b'STARTTLS'] = None
         return ext

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -47,7 +47,6 @@ from urllib.parse import unquote as urlunquote
 
 
 _PY3 = True
-_PY35PLUS = True
 
 if sys.version_info >= (3, 7, 0):
     _PY37PLUS = True

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -46,8 +46,6 @@ from urllib.parse import quote as urlquote
 from urllib.parse import unquote as urlunquote
 
 
-_PY3 = True
-
 if sys.version_info >= (3, 7, 0):
     _PY37PLUS = True
 else:
@@ -488,10 +486,7 @@ def _coercedUnicode(s):
     @raise TypeError: The input is L{bytes} on Python 3.
     """
     if isinstance(s, bytes):
-        if _PY3:
-            raise TypeError("Expected str not %r (bytes)" % (s,))
-        else:
-            return s.decode('ascii')
+        raise TypeError("Expected str not %r (bytes)" % (s,))
     else:
         return s
 

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -28,7 +28,6 @@ import platform
 import socket
 import struct
 import sys
-import tokenize
 import urllib.parse as urllib_parse
 import warnings
 from base64 import decodebytes as _b64decodebytes
@@ -56,7 +55,6 @@ if platform.python_implementation() == 'PyPy':
 else:
     _PYPY = False
 
-_tokenize = tokenize.tokenize
 FileType = IOBase
 frozenset = frozenset
 InstanceType = object
@@ -610,7 +608,6 @@ __all__ = [
     "intern",
     "unichr",
     "raw_input",
-    "_tokenize",
     "_get_async_param",
     "Sequence",
 ]

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -406,17 +406,6 @@ def networkString(s):
 
 
 
-def _keys(d):
-    """
-    Return a list of the keys of C{d}.
-
-    @type d: L{dict}
-    @rtype: L{list}
-    """
-    return list(d.keys())
-
-
-
 def bytesEnviron():
     """
     Return a L{dict} of L{os.environ} where all text-strings are encoded into
@@ -599,7 +588,6 @@ __all__ = [
     "urlquote",
     "urlunquote",
     "cookielib",
-    "_keys",
     "_b64encodebytes",
     "_b64decodebytes",
     "_bytesChr",

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -443,29 +443,6 @@ def _constructMethod(cls, name, self):
 
 
 
-def _coercedUnicode(s):
-    """
-    Coerce ASCII-only byte strings into unicode for Python 2.
-
-    In Python 2 C{unicode(b'bytes')} returns a unicode string C{'bytes'}. In
-    Python 3, the equivalent C{str(b'bytes')} will return C{"b'bytes'"}
-    instead. This function mimics the behavior for Python 2. It will decode the
-    byte string as ASCII. In Python 3 it simply raises a L{TypeError} when
-    passing a byte string. Unicode strings are returned as-is.
-
-    @param s: The string to coerce.
-    @type s: L{bytes} or L{unicode}
-
-    @raise UnicodeError: The input L{bytes} is not ASCII decodable.
-    @raise TypeError: The input is L{bytes} on Python 3.
-    """
-    if isinstance(s, bytes):
-        raise TypeError("Expected str not %r (bytes)" % (s,))
-    else:
-        return s
-
-
-
 def _bytesRepr(bytestring):
     """
     Provide a repr for a byte string that begins with 'b' on both
@@ -577,7 +554,6 @@ __all__ = [
     "cookielib",
     "_b64encodebytes",
     "_b64decodebytes",
-    "_coercedUnicode",
     "_bytesRepr",
     "intern",
     "unichr",

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -59,9 +59,6 @@ if platform.python_implementation() == 'PyPy':
 else:
     _PYPY = False
 
-_shouldEnableNewStyle = lambda: False
-_EXPECT_NEWSTYLE = True
-
 _tokenize = tokenize.tokenize
 FileType = IOBase
 frozenset = frozenset

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -30,8 +30,6 @@ import struct
 import sys
 import urllib.parse as urllib_parse
 import warnings
-from base64 import decodebytes as _b64decodebytes
-from base64 import encodebytes as _b64encodebytes
 from collections.abc import Sequence
 from functools import reduce
 from html import escape
@@ -532,8 +530,6 @@ __all__ = [
     "urlquote",
     "urlunquote",
     "cookielib",
-    "_b64encodebytes",
-    "_b64decodebytes",
     "intern",
     "unichr",
     "raw_input",

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -443,26 +443,6 @@ def _constructMethod(cls, name, self):
 
 
 
-def _bytesRepr(bytestring):
-    """
-    Provide a repr for a byte string that begins with 'b' on both
-    Python 2 and 3.
-
-    @param bytestring: The string to repr.
-    @type bytestring: L{bytes}
-
-    @raise TypeError: The input is not L{bytes}.
-
-    @return: The repr with a leading 'b'.
-    @rtype: L{bytes}
-    """
-    if not isinstance(bytestring, bytes):
-        raise TypeError("Expected bytes not %r" % (bytestring,))
-
-    return repr(bytestring)
-
-
-
 def _get_async_param(isAsync=None, **kwargs):
     """
     Provide a backwards-compatible way to get async param value that does not
@@ -554,7 +534,6 @@ __all__ = [
     "cookielib",
     "_b64encodebytes",
     "_b64decodebytes",
-    "_bytesRepr",
     "intern",
     "unichr",
     "raw_input",

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -443,19 +443,6 @@ def _constructMethod(cls, name, self):
 
 
 
-def _bytesChr(i):
-    """
-    Like L{chr} but always works on ASCII, returning L{bytes}.
-
-    @param i: The ASCII code point to return.
-    @type i: L{int}
-
-    @rtype: L{bytes}
-    """
-    return bytes([i])
-
-
-
 def _coercedUnicode(s):
     """
     Coerce ASCII-only byte strings into unicode for Python 2.
@@ -590,7 +577,6 @@ __all__ = [
     "cookielib",
     "_b64encodebytes",
     "_b64decodebytes",
-    "_bytesChr",
     "_coercedUnicode",
     "_bytesRepr",
     "intern",

--- a/src/twisted/python/htmlizer.py
+++ b/src/twisted/python/htmlizer.py
@@ -6,7 +6,7 @@
 HTML rendering of Python source.
 """
 
-from twisted.python.compat import _tokenize, escape
+from twisted.python.compat import escape
 
 import keyword
 import tokenize
@@ -112,7 +112,7 @@ def filter(inp, out, writer=HTMLWriter):
     out.write(b'<pre>')
     printer = TokenPrinter(writer(out.write).write).printtoken
     try:
-        for token in _tokenize(inp.readline):
+        for token in tokenize.tokenize(inp.readline):
             (tokenType, string, start, end, line) = token
             printer(tokenType, string, start, end, line)
     except tokenize.TokenError:

--- a/src/twisted/scripts/_twistd_unix.py
+++ b/src/twisted/scripts/_twistd_unix.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 
 from twisted.python import log, logfile, usage
-from twisted.python.compat import (intToBytes, _bytesRepr)
+from twisted.python.compat import intToBytes
 from twisted.python.util import (
     switchUID, uidFromString, gidFromString, untilConcludes)
 from twisted.application import app, service
@@ -373,7 +373,7 @@ class UnixApplicationRunner(app.ApplicationRunner):
         return w
 
 
-    def _waitForStart(self, readPipe):
+    def _waitForStart(self, readPipe: int) -> int:
         """
         Wait for the daemonization success.
 
@@ -384,7 +384,7 @@ class UnixApplicationRunner(app.ApplicationRunner):
         @rtype: C{int}
         """
         data = untilConcludes(os.read, readPipe, 100)
-        dataRepr = _bytesRepr(data[2:])
+        dataRepr = repr(data[2:])
         if data != b"0":
             msg = ("An error has occurred: {}\nPlease look at log "
                    "file for more information.\n".format(dataRepr))

--- a/src/twisted/spread/banana.py
+++ b/src/twisted/spread/banana.py
@@ -20,20 +20,25 @@ from io import BytesIO
 from twisted.internet import protocol
 from twisted.persisted import styles
 from twisted.python import log
-from twisted.python.compat import iterbytes, long, _bytesChr as chr
+from twisted.python.compat import iterbytes, long
 from twisted.python.reflect import fullyQualifiedName
+
+
 
 class BananaError(Exception):
     pass
 
+
+
 def int2b128(integer, stream):
     if integer == 0:
-        stream(chr(0))
+        stream(b'\0')
         return
     assert integer > 0, "can only encode positive integers"
     while integer:
-        stream(chr(integer & 0x7f))
+        stream(bytes([integer & 0x7f]))
         integer = integer >> 7
+
 
 
 def b1282int(st):
@@ -56,19 +61,22 @@ def b1282int(st):
     return i
 
 
-# delimiter characters.
-LIST     = chr(0x80)
-INT      = chr(0x81)
-STRING   = chr(0x82)
-NEG      = chr(0x83)
-FLOAT    = chr(0x84)
-# "optional" -- these might be refused by a low-level implementation.
-LONGINT  = chr(0x85)
-LONGNEG  = chr(0x86)
-# really optional; this is part of the 'pb' vocabulary
-VOCAB    = chr(0x87)
 
-HIGH_BIT_SET = chr(0x80)
+# delimiter characters.
+LIST = b'\x80'
+INT = b'\x81'
+STRING = b'\x82'
+NEG = b'\x83'
+FLOAT = b'\x84'
+# "optional" -- these might be refused by a low-level implementation.
+LONGINT = b'\x85'
+LONGNEG = b'\x86'
+# really optional; this is part of the 'pb' vocabulary
+VOCAB = b'\x87'
+
+HIGH_BIT_SET = b'\x80'
+
+
 
 def setPrefixLimit(limit):
     """

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -35,8 +35,7 @@ from zope.interface import implementer, Interface
 
 # Twisted Imports
 from twisted.python import log, failure, reflect
-from twisted.python.compat import (unicode, _bytesChr as chr, range,
-                                   comparable, cmp)
+from twisted.python.compat import unicode, range, comparable, cmp
 from twisted.internet import defer, protocol
 from twisted.cred.portal import Portal
 from twisted.cred.credentials import IAnonymous, ICredentials
@@ -1268,9 +1267,8 @@ def challenge():
 
     @return: Some random data.
     """
-    crap = b''
-    for x in range(random.randrange(15,25)):
-        crap = crap + chr(random.randint(65,90))
+    crap = bytes(random.randint(65, 90)
+                 for x in range(random.randrange(15, 25)))
     crap = md5(crap).digest()
     return crap
 

--- a/src/twisted/spread/test/test_banana.py
+++ b/src/twisted/spread/test/test_banana.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from twisted.trial.unittest import TestCase
 from twisted.spread import banana
 from twisted.python import failure
-from twisted.python.compat import long, iterbytes, _bytesChr as chr
+from twisted.python.compat import long, iterbytes
 from twisted.internet import protocol, main
 from twisted.test.proto_helpers import StringTransport
 
@@ -367,8 +367,9 @@ class DialectTests(BananaTestBase):
     Tests for Banana's handling of dialects.
     """
     vocab = b'remote'
-    legalPbItem = chr(banana.Banana.outgoingVocabulary[vocab]) + banana.VOCAB
-    illegalPbItem = chr(122) + banana.VOCAB
+    legalPbItem = bytes([banana.Banana.outgoingVocabulary[vocab]]) \
+        + banana.VOCAB
+    illegalPbItem = bytes([122]) + banana.VOCAB
 
     def test_dialectNotSet(self):
         """

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -20,7 +20,7 @@ from twisted.python.compat import (
     reduce, execfile, _PYPY, comparable, cmp, nativeString,
     networkString, unicode as unicodeCompat, lazyByteSlice, reraise,
     NativeStringIO, iterbytes, intToBytes, ioType, bytesEnviron, iteritems,
-    unichr, raw_input, _bytesRepr, _get_async_param,
+    unichr, raw_input, _get_async_param,
 )
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
@@ -652,30 +652,6 @@ class RawInputTests(TestCase):
         self.patch(sys, "stdout", stdout)
         self.assertEqual(raw_input("Prompt"), "User input")
         self.assertEqual(stdout.data, "Prompt")
-
-
-
-class FutureBytesReprTests(TestCase):
-    """
-    Tests for L{twisted.python.compat._bytesRepr}.
-    """
-
-    def test_bytesReprNotBytes(self):
-        """
-        L{twisted.python.compat._bytesRepr} raises a
-        L{TypeError} when called any object that is not an instance of
-        L{bytes}.
-        """
-        exc = self.assertRaises(TypeError, _bytesRepr, ["not bytes"])
-        self.assertEquals(str(exc), "Expected bytes not ['not bytes']")
-
-
-    def test_bytesReprPrefix(self):
-        """
-        L{twisted.python.compat._bytesRepr} always prepends
-        ``b`` to the returned repr on both Python 2 and 3.
-        """
-        self.assertEqual(_bytesRepr(b'\x00'), "b'\\x00'")
 
 
 

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -20,7 +20,7 @@ from twisted.python.compat import (
     reduce, execfile, _PYPY, comparable, cmp, nativeString,
     networkString, unicode as unicodeCompat, lazyByteSlice, reraise,
     NativeStringIO, iterbytes, intToBytes, ioType, bytesEnviron, iteritems,
-    _coercedUnicode, unichr, raw_input, _bytesRepr, _get_async_param,
+    unichr, raw_input, _bytesRepr, _get_async_param,
 )
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
@@ -614,50 +614,6 @@ class BytesEnvironTests(TestCase):
             types.add(type(val))
 
         self.assertEqual(list(types), [bytes])
-
-
-
-class CoercedUnicodeTests(TestCase):
-    """
-    Tests for L{twisted.python.compat._coercedUnicode}.
-    """
-
-    def test_unicodeASCII(self):
-        """
-        Unicode strings with ASCII code points are unchanged.
-        """
-        result = _coercedUnicode(u'text')
-        self.assertEqual(result, u'text')
-        self.assertIsInstance(result, unicodeCompat)
-
-
-    def test_unicodeNonASCII(self):
-        """
-        Unicode strings with non-ASCII code points are unchanged.
-        """
-        result = _coercedUnicode(u'\N{SNOWMAN}')
-        self.assertEqual(result, u'\N{SNOWMAN}')
-        self.assertIsInstance(result, unicodeCompat)
-
-
-    def test_nativeASCII(self):
-        """
-        Native strings with ASCII code points are unchanged.
-
-        On Python 2, this verifies that ASCII-only byte strings are accepted,
-        whereas for Python 3 it is identical to L{test_unicodeASCII}.
-        """
-        result = _coercedUnicode('text')
-        self.assertEqual(result, u'text')
-        self.assertIsInstance(result, unicodeCompat)
-
-
-    def test_bytesPy3(self):
-        """
-        Byte strings are not accceptable in Python 3.
-        """
-        exc = self.assertRaises(TypeError, _coercedUnicode, b'bytes')
-        self.assertEqual(str(exc), "Expected str not b'bytes' (bytes)")
 
 
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -8,15 +8,12 @@ L{twisted.web._flatten}.
 
 import sys
 import traceback
-from unittest import skipIf
 
 from xml.etree.ElementTree import XML
 
 from collections import OrderedDict
 
 from zope.interface import implementer
-
-from twisted.python.compat import _PY35PLUS
 
 from twisted.trial.unittest import TestCase
 from twisted.test.testutils import XMLAssertionMixin
@@ -345,7 +342,6 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         ])
 
 
-    @skipIf(not _PY35PLUS, "coroutines not available before Python 3.5")
     def test_serializeCoroutine(self):
         """
         Test that a coroutine returning a value is substituted with the that
@@ -364,7 +360,6 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         return self.assertFlattensTo(coro('four'), b'four')
 
 
-    @skipIf(not _PY35PLUS, "coroutines not available before Python 3.5")
     def test_serializeCoroutineWithAwait(self):
         """
         Test that a coroutine returning an awaited deferred value is

--- a/src/twisted/words/protocols/jabber/client.py
+++ b/src/twisted/words/protocols/jabber/client.py
@@ -4,7 +4,7 @@
 # See LICENSE for details.
 
 
-from twisted.python.compat import _coercedUnicode, unicode
+from twisted.python.compat import unicode
 from twisted.words.protocols.jabber import error, sasl, xmlstream
 from twisted.words.protocols.jabber.jid import JID
 from twisted.words.xish import domish, utility, xpath
@@ -115,7 +115,7 @@ class IQAuthInitializer(object):
 
     def _cbAuthQuery(self, iq):
         jid = self.xmlstream.authenticator.jid
-        password = _coercedUnicode(self.xmlstream.authenticator.password)
+        password = self.xmlstream.authenticator.password
 
         # Construct auth request
         reply = xmlstream.IQ(self.xmlstream, "set")

--- a/src/twisted/words/protocols/jabber/component.py
+++ b/src/twisted/words/protocols/jabber/component.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 from twisted.application import service
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.compat import _coercedUnicode, unicode
+from twisted.python.compat import unicode
 from twisted.words.xish import domish
 from twisted.words.protocols.jabber import error, ijabber, jstrports, xmlstream
 from twisted.words.protocols.jabber.jid import internJID as JID
@@ -58,9 +58,7 @@ class ComponentInitiatingInitializer(object):
     def initialize(self):
         xs = self.xmlstream
         hs = domish.Element((self.xmlstream.namespace, "handshake"))
-        digest = xmlstream.hashPassword(
-            xs.sid,
-            _coercedUnicode(xs.authenticator.password))
+        digest = xmlstream.hashPassword(xs.sid, xs.authenticator.password)
         hs.addContent(unicode(digest))
 
         # Setup observer to watch for handshake result

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -181,14 +181,6 @@ class ElementTests(unittest.TestCase):
         self.assertEqual("native", str(element))
 
 
-    def test_addContentBytes(self):
-        """
-        Byte strings passed to C{addContent} are not acceptable on Python 3.
-        """
-        element = domish.Element(("testns", "foo"))
-        self.assertRaises(TypeError, element.addContent, b'bytes')
-
-
     def test_addElementContent(self):
         """
         Content passed to addElement becomes character data on the new child.

--- a/src/twisted/words/xish/domish.py
+++ b/src/twisted/words/xish/domish.py
@@ -13,8 +13,7 @@ for use in streaming XML applications.
 
 from zope.interface import implementer, Interface, Attribute
 
-from twisted.python.compat import (StringType, _coercedUnicode,
-                                   iteritems, itervalues)
+from twisted.python.compat import StringType, iteritems, itervalues
 from twisted.web import sux
 
 
@@ -511,9 +510,8 @@ class Element(object):
         self.children.append(node)
         return node
 
-    def addContent(self, text):
+    def addContent(self, text: str) -> str:
         """ Add some text data to this Element. """
-        text = _coercedUnicode(text)
         c = self.children
         if len(c) > 0 and isinstance(c[-1], str):
             c[-1] = c[-1] + text


### PR DESCRIPTION
Many of the definitions in `twisted.python.compat` have become obsolete now that Python 2.7 support has been dropped. For private definitions, that means we can drop them as soon as Twisted itself no longer needs them.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9921
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
