### PR TITLE
Drop explicit inheritance from 'object' class

### DIFF
--- a/src/twisted/_threads/_convenience.py
+++ b/src/twisted/_threads/_convenience.py
@@ -10,7 +10,7 @@ Common functionality used within the implementation of various workers.
 from ._ithreads import AlreadyQuit
 
 
-class Quit(object):
+class Quit:
     """
     A flag representing whether a worker has been quit.
 

--- a/src/twisted/_threads/_memory.py
+++ b/src/twisted/_threads/_memory.py
@@ -15,7 +15,7 @@ from ._convenience import Quit
 NoMoreWork = object()
 
 @implementer(IWorker)
-class MemoryWorker(object):
+class MemoryWorker:
     """
     An L{IWorker} that queues work for later performance.
 

--- a/src/twisted/_threads/_team.py
+++ b/src/twisted/_threads/_team.py
@@ -16,7 +16,7 @@ from ._convenience import Quit
 
 
 
-class Statistics(object):
+class Statistics:
     """
     Statistics about a L{Team}'s current activity.
 
@@ -41,7 +41,7 @@ class Statistics(object):
 
 
 @implementer(IWorker)
-class Team(object):
+class Team:
     """
     A composite L{IWorker} implementation.
 

--- a/src/twisted/_threads/_threadworker.py
+++ b/src/twisted/_threads/_threadworker.py
@@ -15,7 +15,7 @@ from ._convenience import Quit
 _stop = object()
 
 @implementer(IExclusiveWorker)
-class ThreadWorker(object):
+class ThreadWorker:
     """
     An L{IExclusiveWorker} implemented based on a single thread and a queue.
 
@@ -68,7 +68,7 @@ class ThreadWorker(object):
 
 
 @implementer(IExclusiveWorker)
-class LockWorker(object):
+class LockWorker:
     """
     An L{IWorker} implemented based on a mutual-exclusion lock.
     """

--- a/src/twisted/_threads/test/test_threadworker.py
+++ b/src/twisted/_threads/test/test_threadworker.py
@@ -29,7 +29,7 @@ class WouldDeadlock(Exception):
 
 
 
-class FakeThread(object):
+class FakeThread:
     """
     A fake L{threading.Thread}.
 
@@ -56,7 +56,7 @@ class FakeThread(object):
 
 
 
-class FakeQueue(object):
+class FakeQueue:
     """
     A fake L{Queue} implementing C{put} and C{get}.
 
@@ -93,7 +93,7 @@ class FakeQueue(object):
 
 
 
-class FakeLock(object):
+class FakeLock:
     """
     A stand-in for L{threading.Lock}.
 

--- a/src/twisted/application/app.py
+++ b/src/twisted/application/app.py
@@ -26,7 +26,7 @@ from twisted.application.reactors import installReactor
 from twisted.application.reactors import NoSuchReactor
 
 
-class _BasicProfiler(object):
+class _BasicProfiler:
     """
     @ivar saveStats: if C{True}, save the stats information instead of the
         human readable format
@@ -114,7 +114,7 @@ class CProfileRunner(_BasicProfiler):
 
 
 
-class AppProfiler(object):
+class AppProfiler:
     """
     Class which selects a specific profile runner based on configuration
     options.
@@ -137,7 +137,7 @@ class AppProfiler(object):
 
 
 
-class AppLogger(object):
+class AppLogger:
     """
     An L{AppLogger} attaches the configured log observer specified on the
     commandline to a L{ServerOptions} object, a custom L{logger.ILogObserver},
@@ -340,7 +340,7 @@ def getSavePassphrase(needed):
 
 
 
-class ApplicationRunner(object):
+class ApplicationRunner:
     """
     An object which helps running an application based on a config object.
 

--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -364,7 +364,7 @@ class CooperatorService(service.Service):
 
 
 
-class StreamServerEndpointService(service.Service, object):
+class StreamServerEndpointService(service.Service):
     """
     A L{StreamServerEndpointService} is an L{IService} which runs a server on a
     listening port described by an L{IStreamServerEndpoint
@@ -446,7 +446,7 @@ class StreamServerEndpointService(service.Service, object):
 
 
 
-class _ReconnectingProtocolProxy(object):
+class _ReconnectingProtocolProxy:
     """
     A proxy for a Protocol to provide connectionLost notification to a client
     connection service, in support of reconnecting when connections are lost.
@@ -493,7 +493,7 @@ class _ReconnectingProtocolProxy(object):
 
 
 
-class _DisconnectFactory(object):
+class _DisconnectFactory:
     """
     A L{_DisconnectFactory} is a proxy for L{IProtocolFactory} that catches
     C{connectionLost} notifications and relays them.
@@ -590,7 +590,7 @@ def _firstResult(gen):
 
 
 
-class _ClientMachine(object):
+class _ClientMachine:
     """
     State machine for maintaining a single outgoing connection to an endpoint.
 
@@ -1077,7 +1077,7 @@ class _ClientMachine(object):
 
 
 
-class ClientService(service.Service, object):
+class ClientService(service.Service):
     """
     A L{ClientService} maintains a single outgoing connection to a client
     endpoint, reconnecting after a configurable timeout when a connection

--- a/src/twisted/application/reactors.py
+++ b/src/twisted/application/reactors.py
@@ -44,7 +44,7 @@ class NoSuchReactor(KeyError):
 
 
 @implementer(IPlugin, IReactorInstaller)
-class Reactor(object):
+class Reactor:
     """
     @ivar moduleName: The fully-qualified Python name of the module of which
     the install callable is an attribute.

--- a/src/twisted/application/runner/_exit.py
+++ b/src/twisted/application/runner/_exit.py
@@ -42,7 +42,7 @@ def exit(status, message=None):
 try:
     import posix as Status
 except ImportError:
-    class Status(object):  # type: ignore[no-redef]
+    class Status:  # type: ignore[no-redef]
         """
         Object to hang C{EX_*} values off of as a substitute for L{posix}.
         """

--- a/src/twisted/application/runner/_pidfile.py
+++ b/src/twisted/application/runner/_pidfile.py
@@ -86,7 +86,7 @@ class IPIDFile(Interface):
 
 
 @implementer(IPIDFile)
-class PIDFile(object):
+class PIDFile:
     """
     Concrete implementation of L{IPIDFile} based on C{IFilePath}.
 
@@ -220,7 +220,7 @@ class PIDFile(object):
 
 
 @implementer(IPIDFile)
-class NonePIDFile(object):
+class NonePIDFile:
     """
     PID file implementation that does nothing.
 

--- a/src/twisted/application/runner/_runner.py
+++ b/src/twisted/application/runner/_runner.py
@@ -24,7 +24,7 @@ from ._pidfile import nonePIDFile, AlreadyRunningError, InvalidPIDFileError
 
 
 @attrs(frozen=True)
-class Runner(object):
+class Runner:
     """
     Twisted application runner.
 

--- a/src/twisted/application/runner/test/test_exit.py
+++ b/src/twisted/application/runner/test/test_exit.py
@@ -88,7 +88,7 @@ class ExitTests(twisted.trial.unittest.TestCase):
 
 
 
-class DummyExit(object):
+class DummyExit:
     """
     Stub for L{sys.exit} that remembers whether it's been called and, if it
     has, what argument it was given.

--- a/src/twisted/application/runner/test/test_pidfile.py
+++ b/src/twisted/application/runner/test/test_pidfile.py
@@ -444,7 +444,7 @@ class NonePIDFileTests(twisted.trial.unittest.TestCase):
 
 
 @implementer(IFilePath)
-class DummyFilePath(object):
+class DummyFilePath:
     """
     In-memory L{IFilePath}.
     """

--- a/src/twisted/application/runner/test/test_runner.py
+++ b/src/twisted/application/runner/test/test_runner.py
@@ -213,7 +213,7 @@ class RunnerTests(twisted.trial.unittest.TestCase):
         # Patch the log beginner so that we don't try to start the already
         # running (started by trial) logging system.
 
-        class LogBeginner(object):
+        class LogBeginner:
             def beginLoggingTo(self, observers):
                 LogBeginner.observers = observers
 
@@ -401,7 +401,7 @@ class DummyPIDFile(NonePIDFile):
 
 
 
-class DummyExit(object):
+class DummyExit:
     """
     Stub for L{exit} that remembers whether it's been called and, if it has,
     what arguments it was given.
@@ -420,7 +420,7 @@ class DummyExit(object):
 
 
 
-class DummyKill(object):
+class DummyKill:
     """
     Stub for L{os.kill} that remembers whether it's been called and, if it has,
     what arguments it was given.
@@ -435,7 +435,7 @@ class DummyKill(object):
 
 
 
-class DummyStandardIO(object):
+class DummyStandardIO:
     """
     Stub for L{sys} which provides L{BytesIO} streams as stdout and stderr.
     """
@@ -446,7 +446,7 @@ class DummyStandardIO(object):
 
 
 
-class DummyWarningsModule(object):
+class DummyWarningsModule:
     """
     Stub for L{warnings} which provides a C{showwarning} method that is a no-op.
     """

--- a/src/twisted/application/service.py
+++ b/src/twisted/application/service.py
@@ -59,7 +59,7 @@ class IServiceMaker(Interface):
 
 
 @implementer(IPlugin, IServiceMaker)
-class ServiceMaker(object):
+class ServiceMaker:
     """
     Utility class to simplify the definition of L{IServiceMaker} plugins.
     """
@@ -154,7 +154,7 @@ class IService(Interface):
 
 
 @implementer(IService)
-class Service(object):
+class Service:
     """
     Base class for services.
 

--- a/src/twisted/application/test/test_internet.py
+++ b/src/twisted/application/test/test_internet.py
@@ -41,7 +41,7 @@ def fakeTargetFunction():
 
 
 @implementer(IStreamServerEndpoint)
-class FakeServer(object):
+class FakeServer:
     """
     In-memory implementation of L{IStreamServerEndpoint}.
 
@@ -112,7 +112,7 @@ verifyClass(IStreamServerEndpoint, FakeServer)
 
 
 @implementer(IListeningPort)
-class FakePort(object):
+class FakePort:
     """
     Fake L{IListeningPort} implementation.
 
@@ -453,7 +453,7 @@ class TimerServiceTests(TestCase):
 
 
 
-class ConnectInformation(object):
+class ConnectInformation:
     """
     Information about C{endpointForTesting}
 
@@ -485,7 +485,7 @@ def endpointForTesting(fireImmediately=False):
         C{endpoint}.
     """
     @implementer(IStreamClientEndpoint)
-    class ClientTestEndpoint(object):
+    class ClientTestEndpoint:
         def connect(self, factory):
             result = Deferred()
             info.passedFactories.append(factory)
@@ -572,7 +572,7 @@ class ClientServiceTests(SynchronousTestCase):
 
         applicationProtocols = cq.applicationProtocols = []
 
-        class RememberingFactory(Factory, object):
+        class RememberingFactory(Factory):
             protocol = protocolType
             def buildProtocol(self, addr):
                 result = super(RememberingFactory, self).buildProtocol(addr)
@@ -704,7 +704,7 @@ class ClientServiceTests(SynchronousTestCase):
         the reactor.
         """
         @implementer(IHalfCloseableProtocol, IFileDescriptorReceiver)
-        class FancyProtocol(Protocol, object):
+        class FancyProtocol(Protocol):
             """
             Provider of various interfaces.
             """

--- a/src/twisted/application/test/test_service.py
+++ b/src/twisted/application/test/test_service.py
@@ -18,7 +18,7 @@ from twisted.trial.unittest import TestCase
 
 
 @implementer(IService)
-class AlmostService(object):
+class AlmostService:
     """
     Implement IService in a way that can fail.
 

--- a/src/twisted/application/twist/_twist.py
+++ b/src/twisted/application/twist/_twist.py
@@ -18,7 +18,7 @@ from twisted.internet.interfaces import _ISupportsExitSignalCapturing
 
 
 
-class Twist(object):
+class Twist:
     """
     Run a Twisted application.
     """

--- a/src/twisted/application/twist/test/test_options.py
+++ b/src/twisted/application/twist/test/test_options.py
@@ -288,7 +288,7 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         L{TwistOptions.selectDefaultLogObserver} will not override an already
         selected observer.
         """
-        class TTYFile(object):
+        class TTYFile:
             def isatty(self):
                 return True
 

--- a/src/twisted/application/twist/test/test_twist.py
+++ b/src/twisted/application/twist/test/test_twist.py
@@ -165,7 +165,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
 
         runners = []
 
-        class Runner(object):
+        class Runner:
             def __init__(self, **kwargs):
                 self.args = kwargs
                 self.runs = 0

--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -415,7 +415,7 @@ def _keysFromFilepaths(filepaths, parseKey):
 
 
 @implementer(IAuthorizedKeysDB)
-class InMemorySSHKeyDB(object):
+class InMemorySSHKeyDB:
     """
     Object that provides SSH public keys based on a dictionary of usernames
     mapped to L{twisted.conch.ssh.keys.Key}s.
@@ -440,7 +440,7 @@ class InMemorySSHKeyDB(object):
 
 
 @implementer(IAuthorizedKeysDB)
-class UNIXAuthorizedKeysFiles(object):
+class UNIXAuthorizedKeysFiles:
     """
     Object that provides SSH public keys based on public keys listed in
     authorized_keys and authorized_keys2 files in UNIX user .ssh/ directories.
@@ -482,7 +482,7 @@ class UNIXAuthorizedKeysFiles(object):
 
 
 @implementer(ICredentialsChecker)
-class SSHPublicKeyChecker(object):
+class SSHPublicKeyChecker:
     """
     Checker that authenticates SSH public keys, based on public keys listed in
     authorized_keys and authorized_keys2 files in user .ssh/ directories.

--- a/src/twisted/conch/client/knownhosts.py
+++ b/src/twisted/conch/client/knownhosts.py
@@ -70,7 +70,7 @@ def _extractCommon(string):
 
 
 
-class _BaseEntry(object):
+class _BaseEntry:
     """
     Abstract base of both hashed and non-hashed entry objects, since they
     represent keys and key types the same way.
@@ -186,7 +186,7 @@ class PlainEntry(_BaseEntry):
 
 
 @implementer(IKnownHostEntry)
-class UnparsedEntry(object):
+class UnparsedEntry:
     """
     L{UnparsedEntry} is an entry in a L{KnownHostsFile} which can't actually be
     parsed; therefore it matches no keys and no hosts.
@@ -340,7 +340,7 @@ class HashedEntry(_BaseEntry, FancyEqMixin):
 
 
 
-class KnownHostsFile(object):
+class KnownHostsFile:
     """
     A structured representation of an OpenSSH-format ~/.ssh/known_hosts file.
 
@@ -570,7 +570,7 @@ class KnownHostsFile(object):
 
 
 
-class ConsoleUI(object):
+class ConsoleUI:
     """
     A UI object that can ask true/false questions and post notifications on the
     console, to be used during key verification.

--- a/src/twisted/conch/endpoints.py
+++ b/src/twisted/conch/endpoints.py
@@ -76,7 +76,7 @@ class _ISSHConnectionCreator(Interface):
 
 
 
-class SSHCommandAddress(object):
+class SSHCommandAddress:
     """
     An L{SSHCommandAddress} instance represents the address of an SSH server, a
     username which was used to authenticate with that server, and a command
@@ -520,7 +520,7 @@ class _CommandTransport(SSHClientTransport):
 
 
 @implementer(IStreamClientEndpoint)
-class SSHCommandClientEndpoint(object):
+class SSHCommandClientEndpoint:
     """
     L{SSHCommandClientEndpoint} exposes the command-executing functionality of
     SSH servers.
@@ -689,7 +689,7 @@ class SSHCommandClientEndpoint(object):
 
 
 
-class _ReadFile(object):
+class _ReadFile:
     """
     A weakly file-like object which can be used with L{KnownHostsFile} to
     respond in the negative to all prompts for decisions.
@@ -731,7 +731,7 @@ class _ReadFile(object):
 
 
 @implementer(_ISSHConnectionCreator)
-class _NewConnectionHelper(object):
+class _NewConnectionHelper:
     """
     L{_NewConnectionHelper} implements L{_ISSHConnectionCreator} by
     establishing a brand new SSH connection, securing it, and authenticating.
@@ -834,7 +834,7 @@ class _NewConnectionHelper(object):
 
 
 @implementer(_ISSHConnectionCreator)
-class _ExistingConnectionHelper(object):
+class _ExistingConnectionHelper:
     """
     L{_ExistingConnectionHelper} implements L{_ISSHConnectionCreator} by
     handing out an existing SSH connection which is supplied to its

--- a/src/twisted/conch/insults/insults.py
+++ b/src/twisted/conch/insults/insults.py
@@ -58,7 +58,7 @@ class ITerminalProtocol(Interface):
 
 
 @implementer(ITerminalProtocol)
-class TerminalProtocol(object):
+class TerminalProtocol:
     def makeConnection(self, terminal):
         # assert ITerminalTransport.providedBy(transport), "TerminalProtocol.makeConnection must be passed an ITerminalTransport implementor"
         self.terminal = terminal
@@ -454,7 +454,7 @@ _KEY_NAMES = ('UP_ARROW', 'DOWN_ARROW', 'RIGHT_ARROW', 'LEFT_ARROW',
 
               'ALT', 'SHIFT', 'CONTROL')
 
-class _const(object):
+class _const:
     """
     @ivar name: A string naming this constant
     """

--- a/src/twisted/conch/insults/window.py
+++ b/src/twisted/conch/insults/window.py
@@ -20,7 +20,7 @@ class YieldFocus(Exception):
 
 
 
-class BoundedTerminalWrapper(object):
+class BoundedTerminalWrapper:
     def __init__(self, terminal, width, height, xoff, yoff):
         self.width = width
         self.height = height
@@ -51,7 +51,7 @@ class BoundedTerminalWrapper(object):
 
 
 
-class Widget(object):
+class Widget:
     focused = False
     parent = None
     dirty = False

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -22,7 +22,7 @@ _counters = {}  # type: Dict[str, int]
 
 
 
-class Logging(object):
+class Logging:
     """
     Wrapper which logs attribute lookups.
 
@@ -55,7 +55,7 @@ class Logging(object):
 
 
 @implementer(insults.ITerminalTransport)
-class TransportSequence(object):
+class TransportSequence:
     """
     An L{ITerminalTransport} implementation which forwards calls to
     one or more other L{ITerminalTransport}s.
@@ -361,7 +361,7 @@ def %s(self, *a, **kw):
 
 
 
-class LocalTerminalBufferMixin(object):
+class LocalTerminalBufferMixin:
     """
     A mixin for RecvLine subclasses which records the state of the terminal.
 

--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -68,7 +68,7 @@ class _IGroupExchangeKexAlgorithm(_IKexAlgorithm):
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _Curve25519SHA256(object):
+class _Curve25519SHA256:
     """
     Elliptic Curve Key Exchange using Curve25519 and SHA256. Defined in
     U{https://datatracker.ietf.org/doc/draft-ietf-curdle-ssh-curves/}.
@@ -79,7 +79,7 @@ class _Curve25519SHA256(object):
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _Curve25519SHA256LibSSH(object):
+class _Curve25519SHA256LibSSH:
     """
     As L{_Curve25519SHA256}, but with a pre-standardized algorithm name.
     """
@@ -89,7 +89,7 @@ class _Curve25519SHA256LibSSH(object):
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH256(object):
+class _ECDH256:
     """
     Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
     RFC 5656.
@@ -100,7 +100,7 @@ class _ECDH256(object):
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH384(object):
+class _ECDH384:
     """
     Elliptic Curve Key Exchange with SHA-384 as HASH. Defined in
     RFC 5656.
@@ -111,7 +111,7 @@ class _ECDH384(object):
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH512(object):
+class _ECDH512:
     """
     Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
     RFC 5656.
@@ -122,7 +122,7 @@ class _ECDH512(object):
 
 
 @implementer(_IGroupExchangeKexAlgorithm)
-class _DHGroupExchangeSHA256(object):
+class _DHGroupExchangeSHA256:
     """
     Diffie-Hellman Group and Key Exchange with SHA-256 as HASH. Defined in
     RFC 4419, 4.2.
@@ -134,7 +134,7 @@ class _DHGroupExchangeSHA256(object):
 
 
 @implementer(_IGroupExchangeKexAlgorithm)
-class _DHGroupExchangeSHA1(object):
+class _DHGroupExchangeSHA1:
     """
     Diffie-Hellman Group and Key Exchange with SHA-1 as HASH. Defined in
     RFC 4419, 4.1.
@@ -146,7 +146,7 @@ class _DHGroupExchangeSHA1(object):
 
 
 @implementer(_IFixedGroupKexAlgorithm)
-class _DHGroup14SHA1(object):
+class _DHGroup14SHA1:
     """
     Diffie-Hellman key exchange with SHA-1 as HASH and Oakley Group 14
     (2048-bit MODP Group). Defined in RFC 4253, 8.2.

--- a/src/twisted/conch/ssh/address.py
+++ b/src/twisted/conch/ssh/address.py
@@ -19,7 +19,7 @@ from twisted.python import util
 
 
 @implementer(IAddress)
-class SSHTransportAddress(util.FancyEqMixin, object):
+class SSHTransportAddress(util.FancyEqMixin):
     """
     Object representing an SSH Transport endpoint.
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -145,7 +145,7 @@ def _normalizePassphrase(passphrase):
 
 
 
-class Key(object):
+class Key:
     """
     An object representing a key.  A key can be either a public or
     private key.  A public key can verify a signature; a private key can

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -2022,7 +2022,7 @@ class SSHClientTransport(SSHTransportBase):
 
 
 
-class _NullEncryptionContext(object):
+class _NullEncryptionContext:
     """
     An encryption context that does not actually encrypt anything.
     """
@@ -2040,7 +2040,7 @@ class _NullEncryptionContext(object):
 
 
 
-class _DummyAlgorithm(object):
+class _DummyAlgorithm:
     """
     An encryption algorithm that does not actually encrypt anything.
     """
@@ -2048,7 +2048,7 @@ class _DummyAlgorithm(object):
 
 
 
-class _DummyCipher(object):
+class _DummyCipher:
     """
     A cipher for the none encryption method.
 

--- a/src/twisted/conch/test/test_agent.py
+++ b/src/twisted/conch/test/test_agent.py
@@ -29,7 +29,7 @@ from twisted.conch.test import keydata
 from twisted.conch.error import ConchError, MissingKeyStoreError
 
 
-class StubFactory(object):
+class StubFactory:
     """
     Mock factory that provides the keys attribute required by the
     SSHAgentServerProtocol

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -234,7 +234,7 @@ class ListingTests(TestCase):
 
 
 
-class InMemorySSHChannel(StringTransport, object):
+class InMemorySSHChannel(StringTransport):
     """
     Minimal implementation of a L{SSHChannel} like class which only reads and
     writes data from memory.
@@ -251,7 +251,7 @@ class InMemorySSHChannel(StringTransport, object):
 
 
 
-class FilesystemAccessExpectations(object):
+class FilesystemAccessExpectations:
     """
     A test helper used to support expected filesystem access.
     """
@@ -292,7 +292,7 @@ class FilesystemAccessExpectations(object):
 
 
 
-class InMemorySFTPClient(object):
+class InMemorySFTPClient:
     """
     A L{filetransfer.FileTransferClient} which does filesystem operations in
     memory, without touching the local disc or the network interface.
@@ -456,7 +456,7 @@ class StdioClientTests(TestCase):
         """
         # Local import to avoid win32 issues.
         import tty
-        class FakeFcntl(object):
+        class FakeFcntl:
             def ioctl(self, fd, opt, mutate):
                 if opt != tty.TIOCGWINSZ:
                     self.fail("Only window-size queries supported.")

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -76,7 +76,7 @@ def _has_ipv6():
 HAS_IPV6 = _has_ipv6()
 
 
-class FakeStdio(object):
+class FakeStdio:
     """
     A fake for testing L{twisted.conch.scripts.conch.SSHSession.eofReceived} and
     L{twisted.conch.scripts.cftp.SSHSession.eofReceived}.

--- a/src/twisted/conch/test/test_endpoints.py
+++ b/src/twisted/conch/test/test_endpoints.py
@@ -146,7 +146,7 @@ class UnsatisfiedExecSession(SSHChannel):
 
 
 
-class TrivialRealm(object):
+class TrivialRealm:
     def __init__(self):
         self.channelLookup = {}
 
@@ -167,7 +167,7 @@ class AddressSpyFactory(Factory):
 
 
 
-class FixedResponseUI(object):
+class FixedResponseUI:
     def __init__(self, result):
         self.result = result
 
@@ -232,13 +232,13 @@ class CommandFactory(SSHFactory):
 
 
 @implementer(IAddress)
-class MemoryAddress(object):
+class MemoryAddress:
     pass
 
 
 
 @implementer(IStreamClientEndpoint)
-class SingleUseMemoryEndpoint(object):
+class SingleUseMemoryEndpoint:
     """
     L{SingleUseMemoryEndpoint} is a client endpoint which allows one connection
     to be set up and then exposes an API for moving around bytes related to
@@ -275,7 +275,7 @@ class SingleUseMemoryEndpoint(object):
 
 
 
-class SSHCommandClientEndpointTestsMixin(object):
+class SSHCommandClientEndpointTestsMixin:
     """
     Tests for L{SSHCommandClientEndpoint}, an L{IStreamClientEndpoint}
     implementations which connects a protocol with the stdin and stdout of a
@@ -1387,7 +1387,7 @@ class ExistingConnectionHelperTests(TestCase):
 
 
 
-class _PTYPath(object):
+class _PTYPath:
     """
     A L{FilePath}-like object which can be opened to create a L{_ReadFile} with
     certain contents.

--- a/src/twisted/conch/test/test_insults.py
+++ b/src/twisted/conch/test/test_insults.py
@@ -138,7 +138,7 @@ C1SevenBit = _makeControlFunctionSymbols(
 
 
 
-class Mock(object):
+class Mock:
     callReturnValue = default
 
     def __init__(self, methods=None, callReturnValue=default):

--- a/src/twisted/conch/test/test_knownhosts.py
+++ b/src/twisted/conch/test/test_knownhosts.py
@@ -990,7 +990,7 @@ class KnownHostsDatabaseTests(TestCase):
 
 
 
-class FakeFile(object):
+class FakeFile:
     """
     A fake file-like object that acts enough like a file for
     L{ConsoleUI.prompt}.
@@ -1144,7 +1144,7 @@ class ConsoleUITests(TestCase):
 
 
 
-class FakeUI(object):
+class FakeUI:
     """
     A fake UI object, adhering to the interface expected by
     L{KnownHostsFile.verifyHostKey}
@@ -1179,7 +1179,7 @@ class FakeUI(object):
 
 
 
-class FakeObject(object):
+class FakeObject:
     """
     A fake object that can have some attributes.  Used to fake
     L{SSHClientTransport} and L{SSHClientFactory}.

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -36,7 +36,7 @@ else:
 
 
 
-class SubsystemOnlyAvatar(object):
+class SubsystemOnlyAvatar:
     """
     A stub class representing an avatar that is only useful for
     getting a subsystem.
@@ -74,7 +74,7 @@ class StubAvatar:
 
 
 @implementer(session.ISession, session.ISessionSetEnv)
-class StubSessionForStubAvatar(object):
+class StubSessionForStubAvatar:
     """
     A stub ISession implementation for our StubAvatar.  The instance
     variables generally keep track of method invocations so that we can test
@@ -292,7 +292,7 @@ class MockProtocol(protocol.Protocol):
 
 
 
-class StubConnection(object):
+class StubConnection:
     """
     A stub for twisted.conch.ssh.connection.SSHConnection.  Record the data
     that channels send, and when they try to close the connection.
@@ -439,7 +439,7 @@ class StubTransportWithWriteErr(StubTransport):
 
 
 
-class StubClient(object):
+class StubClient:
     """
     A stub class representing the client to a SSHSession.
 

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -35,7 +35,7 @@ else:
 
 
 
-class ConchTestRealm(object):
+class ConchTestRealm:
     """
     A realm which expects a particular avatarId to log in once and creates a
     L{ConchTestAvatar} for that request.
@@ -132,7 +132,7 @@ class ConchTestAvatar(avatar.ConchUser):
 
 
 
-class ConchSessionForTestAvatar(object):
+class ConchSessionForTestAvatar:
     """
     An ISession adapter for ConchTestAvatar.
     """

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -158,7 +158,7 @@ class MockTransportBase(transport.SSHTransportBase):
 
 
 
-class MockCipher(object):
+class MockCipher:
     """
     A mocked-up version of twisted.conch.ssh.transport.SSHCiphers.
     """

--- a/src/twisted/conch/test/test_unix.py
+++ b/src/twisted/conch/test/test_unix.py
@@ -15,7 +15,7 @@ unix = requireModule('twisted.conch.unix')
 
 
 @implementer(IReactorProcess)
-class MockProcessSpawner(object):
+class MockProcessSpawner:
     """
     An L{IReactorProcess} that logs calls to C{spawnProcess}.
     """
@@ -42,7 +42,7 @@ class MockProcessSpawner(object):
 
 
 
-class StubUnixConchUser(object):
+class StubUnixConchUser:
     """
     Enough of UnixConchUser to exercise SSHSessionForUnixConchUser in the
     tests below.

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -131,7 +131,7 @@ class FakeTransport(transport.SSHTransportBase):
     @type lostConnection: L{bool}
     """
 
-    class Service(object):
+    class Service:
         """
         A mock service, representing the other service offered by the server.
         """
@@ -142,7 +142,7 @@ class FakeTransport(transport.SSHTransportBase):
             pass
 
 
-    class Factory(object):
+    class Factory:
         """
         A mock factory, representing the factory that spawned this user auth
         service.
@@ -186,7 +186,7 @@ class FakeTransport(transport.SSHTransportBase):
 
 
 @implementer(IRealm)
-class Realm(object):
+class Realm:
     """
     A mock realm for testing L{userauth.SSHUserAuthServer}.
 
@@ -200,7 +200,7 @@ class Realm(object):
 
 
 @implementer(ICredentialsChecker)
-class PasswordChecker(object):
+class PasswordChecker:
     """
     A very simple username/password checker which authenticates anyone whose
     password matches their username and rejects all others.
@@ -215,7 +215,7 @@ class PasswordChecker(object):
 
 
 @implementer(ICredentialsChecker)
-class PrivateKeyChecker(object):
+class PrivateKeyChecker:
     """
     A very simple public key checker which authenticates anyone whose
     public/private keypair is the same keydata.public/privateRSA_openssh.
@@ -235,7 +235,7 @@ class PrivateKeyChecker(object):
 
 
 @implementer(ICredentialsChecker)
-class AnonymousChecker(object):
+class AnonymousChecker:
     """
     A simple checker which isn't supported by L{SSHUserAuthServer}.
     """

--- a/src/twisted/cred/checkers.py
+++ b/src/twisted/cred/checkers.py
@@ -82,7 +82,7 @@ class AllowAnonymousAccess:
 
 
 @implementer(ICredentialsChecker)
-class InMemoryUsernamePasswordDatabaseDontUse(object):
+class InMemoryUsernamePasswordDatabaseDontUse:
     """
     An extremely simple credentials checker.
 

--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -129,7 +129,7 @@ class IAnonymous(ICredentials):
 
 
 @implementer(IUsernameHashedPassword, IUsernameDigestHash)
-class DigestedCredentials(object):
+class DigestedCredentials:
     """
     Yet Another Simple HTTP Digest authentication scheme.
     """
@@ -189,7 +189,7 @@ class DigestedCredentials(object):
 
 
 
-class DigestCredentialFactory(object):
+class DigestCredentialFactory:
     """
     Support for RFC2617 HTTP Digest Authentication
 
@@ -396,7 +396,7 @@ class DigestCredentialFactory(object):
 
 
 @implementer(IUsernameHashedPassword)
-class CramMD5Credentials(object):
+class CramMD5Credentials:
     """
     An encapsulation of some CramMD5 hashed credentials.
 

--- a/src/twisted/cred/portal.py
+++ b/src/twisted/cred/portal.py
@@ -42,7 +42,7 @@ class IRealm(Interface):
         """
 
 
-class Portal(object):
+class Portal:
     """
     A mediator between clients and a realm.
 

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -37,7 +37,7 @@ class ITestable(Interface):
 
 
 
-class TestAvatar(object):
+class TestAvatar:
     """
     A test avatar.
     """
@@ -74,7 +74,7 @@ class IDerivedCredentials(credentials.IUsernamePassword):
 
 
 @implementer(IDerivedCredentials, ITestable)
-class DerivedCredentials(object):
+class DerivedCredentials:
 
     def __init__(self, username, password):
         self.username = username
@@ -87,7 +87,7 @@ class DerivedCredentials(object):
 
 
 @implementer(portal.IRealm)
-class TestRealm(object):
+class TestRealm:
     """
     A basic test realm.
     """
@@ -326,7 +326,7 @@ class HashedPasswordOnDiskDatabaseTests(unittest.TestCase):
 
 
 
-class CheckersMixin(object):
+class CheckersMixin:
     """
     L{unittest.TestCase} mixin for testing that some checkers accept
     and deny specified credentials.
@@ -364,7 +364,7 @@ class CheckersMixin(object):
 
 
 
-class HashlessFilePasswordDBMixin(object):
+class HashlessFilePasswordDBMixin:
     credClass = credentials.UsernamePassword
     diskHash = None
     networkHash = staticmethod(lambda x: x)

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -21,7 +21,7 @@ class ConnectionLost(Exception):
 
 
 
-class Connection(object):
+class Connection:
     """
     A wrapper for a DB-API connection instance.
 

--- a/src/twisted/internet/_baseprocess.py
+++ b/src/twisted/internet/_baseprocess.py
@@ -19,7 +19,7 @@ _missingProcessExited = ("Since Twisted 8.2, IProcessProtocol.processExited "
 
 
 
-class BaseProcess(object):
+class BaseProcess:
     pid = None  # type: Optional[int]
     status = None  # type: Optional[int]
     lostProcess = 0

--- a/src/twisted/internet/_newtls.py
+++ b/src/twisted/internet/_newtls.py
@@ -19,7 +19,7 @@ from twisted.internet.abstract import FileDescriptor
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 
 
-class _BypassTLS(object):
+class _BypassTLS:
     """
     L{_BypassTLS} is used as the transport object for the TLS protocol object
     used to implement C{startTLS}.  Its methods skip any TLS logic which
@@ -157,7 +157,7 @@ def startTLS(transport, contextFactory, normal, bypass):
 
 
 
-class ConnectionMixin(object):
+class ConnectionMixin:
     """
     A mixin for L{twisted.internet.abstract.FileDescriptor} which adds an
     L{ITLSTransport} implementation.
@@ -243,7 +243,7 @@ class ConnectionMixin(object):
 
 
 
-class ClientMixin(object):
+class ClientMixin:
     """
     A mixin for L{twisted.internet.tcp.Client} which just marks it as a client
     for the purposes of the default TLS handshake.
@@ -256,7 +256,7 @@ class ClientMixin(object):
 
 
 
-class ServerMixin(object):
+class ServerMixin:
     """
     A mixin for L{twisted.internet.tcp.Server} which just marks it as a server
     for the purposes of the default TLS handshake.

--- a/src/twisted/internet/_posixstdio.py
+++ b/src/twisted/internet/_posixstdio.py
@@ -18,14 +18,14 @@ from twisted.python import log, failure
 
 
 @implementer(interfaces.IAddress)
-class PipeAddress(object):
+class PipeAddress:
     pass
 
 
 
 @implementer(interfaces.ITransport, interfaces.IProducer,
              interfaces.IConsumer, interfaces.IHalfCloseableDescriptor)
-class StandardIO(object):
+class StandardIO:
 
     _reader = None
     _writer = None

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -21,7 +21,7 @@ __all__ = []  # type: List[str]
 
 
 @implementer(IPushProducer)
-class _PullToPush(object):
+class _PullToPush:
     """
     An adapter that converts a non-streaming to a streaming producer.
 

--- a/src/twisted/internet/_resolver.py
+++ b/src/twisted/internet/_resolver.py
@@ -28,7 +28,7 @@ from twisted.logger import Logger
 
 
 @implementer(IHostResolution)
-class HostResolution(object):
+class HostResolution:
     """
     The in-progress resolution of a given hostname.
     """
@@ -72,7 +72,7 @@ _socktypeToType = {
 
 
 @implementer(IHostnameResolver)
-class GAIResolver(object):
+class GAIResolver:
     """
     L{IHostnameResolver} implementation that resolves hostnames by calling
     L{getaddrinfo} in a thread.
@@ -144,7 +144,7 @@ class GAIResolver(object):
 
 
 @implementer(IHostnameResolver)
-class SimpleResolverComplexifier(object):
+class SimpleResolverComplexifier:
     """
     A converter from L{IResolverSimple} to L{IHostnameResolver}.
     """
@@ -208,7 +208,7 @@ class SimpleResolverComplexifier(object):
 
 
 @implementer(IResolutionReceiver)
-class FirstOneWins(object):
+class FirstOneWins:
     """
     An L{IResolutionReceiver} which fires a L{Deferred} with its first result.
     """
@@ -254,7 +254,7 @@ class FirstOneWins(object):
 
 
 @implementer(IResolverSimple)
-class ComplexResolverSimplifier(object):
+class ComplexResolverSimplifier:
     """
     A converter from L{IHostnameResolver} to L{IResolverSimple}
     """

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -940,7 +940,7 @@ class IOpenSSLTrustRoot(Interface):
 
 
 @implementer(IOpenSSLTrustRoot)
-class OpenSSLCertificateAuthorities(object):
+class OpenSSLCertificateAuthorities:
     """
     Trust an explicitly specified set of certificates, represented by a list of
     L{OpenSSL.crypto.X509} objects.
@@ -996,7 +996,7 @@ def trustRootFromCertificates(certificates):
 
 
 @implementer(IOpenSSLTrustRoot)
-class OpenSSLDefaultPaths(object):
+class OpenSSLDefaultPaths:
     """
     Trust the set of default verify paths that OpenSSL was built with, as
     specified by U{SSL_CTX_set_default_verify_paths
@@ -1111,7 +1111,7 @@ def _tolerateErrors(wrapped):
 
 
 @implementer(IOpenSSLClientConnectionCreator)
-class ClientTLSOptions(object):
+class ClientTLSOptions:
     """
     Client creator for TLS.
 
@@ -1310,7 +1310,7 @@ def optionsForClientTLS(hostname, trustRoot=None, clientCertificate=None,
 
 
 @implementer(IOpenSSLContextFactory)
-class OpenSSLCertificateOptions(object):
+class OpenSSLCertificateOptions:
     """
     A L{CertificateOptions <twisted.internet.ssl.CertificateOptions>} specifies
     the security properties for a client or server TLS connection used with
@@ -1748,7 +1748,7 @@ OpenSSLCertificateOptions.__setstate__ = deprecated(
 
 @implementer(ICipher)
 @attr.s(frozen=True)
-class OpenSSLCipher(object):
+class OpenSSLCipher:
     """
     A representation of an OpenSSL cipher.
 
@@ -1826,7 +1826,7 @@ def _selectCiphers(wantedCiphers, availableCiphers):
 
 
 @implementer(IAcceptableCiphers)
-class OpenSSLAcceptableCiphers(object):
+class OpenSSLAcceptableCiphers:
     """
     A representation of ciphers that are acceptable for TLS connections.
     """
@@ -1887,7 +1887,7 @@ _defaultCurveName = u"prime256v1"
 
 
 
-class _ChooseDiffieHellmanEllipticCurve(object):
+class _ChooseDiffieHellmanEllipticCurve:
     """
     Chooses the best elliptic curve for Elliptic Curve Diffie-Hellman
     key exchange, and provides a C{configureECDHCurve} method to set
@@ -1984,7 +1984,7 @@ class _ChooseDiffieHellmanEllipticCurve(object):
 
 
 
-class OpenSSLDiffieHellmanParameters(object):
+class OpenSSLDiffieHellmanParameters:
     """
     A representation of key generation parameters that are required for
     Diffie-Hellman key exchange.

--- a/src/twisted/internet/_win32stdio.py
+++ b/src/twisted/internet/_win32stdio.py
@@ -18,7 +18,7 @@ from twisted.internet import _pollingfile, main
 from twisted.python.failure import Failure
 
 @implementer(IAddress)
-class Win32PipeAddress(object):
+class Win32PipeAddress:
     pass
 
 

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -26,7 +26,7 @@ def _concatenate(bObj, offset, bArray):
 
 
 
-class _ConsumerMixin(object):
+class _ConsumerMixin:
     """
     L{IConsumer} implementations can mix this in to get C{registerProducer} and
     C{unregisterProducer} methods which take care of keeping track of a
@@ -118,7 +118,7 @@ class _ConsumerMixin(object):
 
 
 @implementer(interfaces.ILoggingContext)
-class _LogOwner(object):
+class _LogOwner:
     """
     Mixin to help implement L{interfaces.ILoggingContext} for transports which
     have a protocol, the log prefix of which should also appear in the

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -20,7 +20,7 @@ from twisted.python.runtime import platform
 
 @implementer(IAddress)
 @attr.s(hash=True)
-class IPv4Address(object):
+class IPv4Address:
     """
     An L{IPv4Address} represents the address of an IPv4 socket endpoint.
 
@@ -42,7 +42,7 @@ class IPv4Address(object):
 
 @implementer(IAddress)
 @attr.s(hash=True)
-class IPv6Address(object):
+class IPv6Address:
     """
     An L{IPv6Address} represents the address of an IPv6 socket endpoint.
 
@@ -73,7 +73,7 @@ class IPv6Address(object):
 
 
 @implementer(IAddress)
-class _ProcessAddress(object):
+class _ProcessAddress:
     """
     An L{interfaces.IAddress} provider for process transports.
     """
@@ -82,7 +82,7 @@ class _ProcessAddress(object):
 
 @attr.s(hash=True)
 @implementer(IAddress)
-class HostnameAddress(object):
+class HostnameAddress:
     """
     A L{HostnameAddress} represents the address of a L{HostnameEndpoint}.
 
@@ -100,7 +100,7 @@ class HostnameAddress(object):
 
 @attr.s(hash=False, repr=False, eq=False)
 @implementer(IAddress)
-class UNIXAddress(object):
+class UNIXAddress:
     """
     Object representing a UNIX socket endpoint.
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -233,7 +233,7 @@ class DelayedCall:
 
 
 @implementer(IResolverSimple)
-class ThreadedResolver(object):
+class ThreadedResolver:
     """
     L{ThreadedResolver} uses a reactor, a threadpool, and
     L{socket.gethostbyname} to perform name lookups without blocking the
@@ -314,7 +314,7 @@ class BlockingResolver:
             return defer.succeed(address)
 
 
-class _ThreePhaseEvent(object):
+class _ThreePhaseEvent:
     """
     Collection of callables (with arguments) which can be invoked as a group in
     a particular order.
@@ -456,7 +456,7 @@ class _ThreePhaseEvent(object):
 
 
 @implementer(IReactorPluggableNameResolver, IReactorPluggableResolver)
-class PluggableResolverMixin(object):
+class PluggableResolverMixin:
     """
     A mixin which implements the pluggable resolver reactor interfaces.
 
@@ -1238,7 +1238,7 @@ class BasePort(abstract.FileDescriptor):
 
 
 
-class _SignalReactorMixin(object):
+class _SignalReactorMixin:
     """
     Private mixin to manage signals: it installs signal handlers at start time,
     and define run method.

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1376,7 +1376,7 @@ def returnValue(val):
 
 
 @attr.s
-class _CancellationStatus(object):
+class _CancellationStatus:
     """
     Cancellation status of an L{inlineCallbacks} invocation.
 
@@ -1638,7 +1638,7 @@ def inlineCallbacks(f):
 
 ## DeferredLock/DeferredQueue
 
-class _ConcurrencyPrimitive(object):
+class _ConcurrencyPrimitive:
     def __init__(self):
         self.waiting = []
 
@@ -1844,7 +1844,7 @@ class QueueUnderflow(Exception):
 
 
 
-class DeferredQueue(object):
+class DeferredQueue:
     """
     An event driven queue.
 

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -274,7 +274,7 @@ class _WrappingFactory(ClientFactory):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class StandardIOEndpoint(object):
+class StandardIOEndpoint:
     """
     A Standard Input/Output endpoint
 
@@ -409,7 +409,7 @@ class StandardErrorBehavior(Names):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class ProcessEndpoint(object):
+class ProcessEndpoint:
     """
     An endpoint for child processes
 
@@ -461,7 +461,7 @@ class ProcessEndpoint(object):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class _TCPServerEndpoint(object):
+class _TCPServerEndpoint:
     """
     A TCP server endpoint interface
     """
@@ -541,7 +541,7 @@ class TCP6ServerEndpoint(_TCPServerEndpoint):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class TCP4ClientEndpoint(object):
+class TCP4ClientEndpoint:
     """
     TCP client endpoint with an IPv4 configuration.
     """
@@ -587,7 +587,7 @@ class TCP4ClientEndpoint(object):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class TCP6ClientEndpoint(object):
+class TCP6ClientEndpoint:
     """
     TCP client endpoint with an IPv6 configuration.
 
@@ -660,7 +660,7 @@ class TCP6ClientEndpoint(object):
 
 
 @implementer(IHostnameResolver)
-class _SimpleHostnameResolver(object):
+class _SimpleHostnameResolver:
     """
     An L{IHostnameResolver} provider that invokes a provided callable
     to resolve hostnames.
@@ -730,7 +730,7 @@ class _SimpleHostnameResolver(object):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class HostnameEndpoint(object):
+class HostnameEndpoint:
     """
     A name-based endpoint that connects to the fastest amongst the resolved
     host addresses.
@@ -918,7 +918,7 @@ class HostnameEndpoint(object):
         d = Deferred()
         addresses = []
         @provider(IResolutionReceiver)
-        class EndpointReceiver(object):
+        class EndpointReceiver:
             @staticmethod
             def resolutionBegan(resolutionInProgress):
                 pass
@@ -1053,7 +1053,7 @@ class HostnameEndpoint(object):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class SSL4ServerEndpoint(object):
+class SSL4ServerEndpoint:
     """
     SSL secured TCP server endpoint with an IPv4 configuration.
     """
@@ -1096,7 +1096,7 @@ class SSL4ServerEndpoint(object):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class SSL4ClientEndpoint(object):
+class SSL4ClientEndpoint:
     """
     SSL secured TCP client endpoint with an IPv4 configuration
     """
@@ -1148,7 +1148,7 @@ class SSL4ClientEndpoint(object):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class UNIXServerEndpoint(object):
+class UNIXServerEndpoint:
     """
     UnixSocket server endpoint.
     """
@@ -1182,7 +1182,7 @@ class UNIXServerEndpoint(object):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class UNIXClientEndpoint(object):
+class UNIXClientEndpoint:
     """
     UnixSocket client endpoint.
     """
@@ -1225,7 +1225,7 @@ class UNIXClientEndpoint(object):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class AdoptedStreamServerEndpoint(object):
+class AdoptedStreamServerEndpoint:
     """
     An endpoint for listening on a file descriptor initialized outside of
     Twisted.
@@ -1419,7 +1419,7 @@ def _parseSSL(factory, port, privateKey="server.pem", certKey=None,
 
 
 @implementer(IPlugin, IStreamServerEndpointStringParser)
-class _StandardIOParser(object):
+class _StandardIOParser:
     """
     Stream server endpoint string parser for the Standard I/O type.
 
@@ -1445,7 +1445,7 @@ class _StandardIOParser(object):
 
 
 @implementer(IPlugin, IStreamServerEndpointStringParser)
-class _SystemdParser(object):
+class _SystemdParser:
     """
     Stream server endpoint string parser for the I{systemd} endpoint type.
 
@@ -1495,7 +1495,7 @@ class _SystemdParser(object):
 
 
 @implementer(IPlugin, IStreamServerEndpointStringParser)
-class _TCP6ServerParser(object):
+class _TCP6ServerParser:
     """
     Stream server endpoint string parser for the TCP6ServerEndpoint type.
 
@@ -2101,7 +2101,7 @@ def connectProtocol(endpoint, protocol):
 
 
 @implementer(interfaces.IStreamClientEndpoint)
-class _WrapperEndpoint(object):
+class _WrapperEndpoint:
     """
     An endpoint that wraps another endpoint.
     """
@@ -2125,7 +2125,7 @@ class _WrapperEndpoint(object):
 
 
 @implementer(interfaces.IStreamServerEndpoint)
-class _WrapperServerEndpoint(object):
+class _WrapperServerEndpoint:
     """
     A server endpoint that wraps another server endpoint.
     """
@@ -2238,7 +2238,7 @@ def _parseClientTLS(reactor, host, port, timeout=b'30', bindAddress=None,
 
 
 @implementer(IPlugin, IStreamClientEndpointStringParserWithReactor)
-class _TLSClientEndpointParser(object):
+class _TLSClientEndpointParser:
     """
     Stream client endpoint string parser for L{wrapClientTLS} with
     L{HostnameEndpoint}.

--- a/src/twisted/internet/inotify.py
+++ b/src/twisted/internet/inotify.py
@@ -118,7 +118,7 @@ def humanReadableMask(mask):
 
 
 
-class _Watch(object):
+class _Watch:
     """
     Watch object that represents a Watch point in the filesystem. The
     user should let INotify to create these objects
@@ -150,7 +150,7 @@ class _Watch(object):
 
 
 
-class INotify(FileDescriptor, object):
+class INotify(FileDescriptor):
     """
     The INotify file descriptor, it basically does everything related
     to INotify, from reading to notifying watch points.

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -147,7 +147,7 @@ class _SocketWaker(log.Logger):
 
 
 
-class _FDWaker(log.Logger, object):
+class _FDWaker(log.Logger):
     """
     The I{self-pipe trick<http://cr.yp.to/docs/selfpipe.html>}, used to wake
     up the main loop from another thread or a signal handler.
@@ -271,7 +271,7 @@ class _SIGCHLDWaker(_FDWaker):
 
 
 
-class _DisconnectSelectableMixin(object):
+class _DisconnectSelectableMixin:
     """
     Mixin providing the C{_disconnectSelectable} method.
     """
@@ -596,7 +596,7 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin,
         return list(removedReaders | removedWriters)
 
 
-class _PollLikeMixin(object):
+class _PollLikeMixin:
     """
     Mixin for poll-like reactors.
 

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -284,7 +284,7 @@ class ProcessReader(abstract.FileDescriptor):
 
 
 
-class _BaseProcess(BaseProcess, object):
+class _BaseProcess(BaseProcess):
     """
     Base class for Process and PTYProcess.
     """
@@ -499,7 +499,7 @@ class _BaseProcess(BaseProcess, object):
 
 
 
-class _FDDetector(object):
+class _FDDetector:
     """
     This class contains the logic necessary to decide which of the available
     system techniques should be used to detect the open file descriptors for

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -348,7 +348,7 @@ class NotPaused(SchedulerError):
 
 
 
-class _Timer(object):
+class _Timer:
     MAX_SLICE = 0.01
     def __init__(self):
         self.end = time.time() + self.MAX_SLICE
@@ -365,7 +365,7 @@ def _defaultScheduler(x):
     return reactor.callLater(_EPSILON, x)
 
 
-class CooperativeTask(object):
+class CooperativeTask:
     """
     A L{CooperativeTask} is a task object inside a L{Cooperator}, which can be
     paused, resumed, and stopped.  It can also have its completion (or
@@ -529,7 +529,7 @@ class CooperativeTask(object):
 
 
 
-class Cooperator(object):
+class Cooperator:
     """
     Cooperative task scheduler.
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -38,15 +38,15 @@ except ImportError:
     # There is no version of startTLS available
     ITLSTransport = Interface  # type: ignore[misc,assignment]
 
-    class _TLSConnectionMixin(object):  # type: ignore[no-redef]
+    class _TLSConnectionMixin:  # type: ignore[no-redef]
         TLS = False
 
 
-    class _TLSClientMixin(object):  # type: ignore[no-redef]
+    class _TLSClientMixin:  # type: ignore[no-redef]
         pass
 
 
-    class _TLSServerMixin(object):  # type: ignore[no-redef]
+    class _TLSServerMixin:  # type: ignore[no-redef]
         pass
 
 
@@ -144,7 +144,7 @@ def _getsockname(skt):
 
 
 
-class _SocketCloser(object):
+class _SocketCloser:
     """
     @ivar _shouldShutdown: Set to C{True} if C{shutdown} should be called
         before calling C{close} on the underlying socket.
@@ -178,7 +178,7 @@ class _SocketCloser(object):
 
 
 
-class _AbortingMixin(object):
+class _AbortingMixin:
     """
     Common implementation of C{abortConnection}.
 
@@ -358,7 +358,7 @@ class Connection(_TLSConnectionMixin, abstract.FileDescriptor, _SocketCloser,
 
 
 
-class _BaseBaseClient(object):
+class _BaseBaseClient:
     """
     Code shared with other (non-POSIX) reactors for management of general
     outgoing connections.
@@ -692,7 +692,7 @@ def _resolveIPv6(ip, port):
 
 
 
-class _BaseTCPClient(object):
+class _BaseTCPClient:
     """
     Code shared with other (non-POSIX) reactors for management of outgoing TCP
     connections (both TCPv4 and TCPv6).
@@ -970,7 +970,7 @@ class _IFileDescriptorReservation(Interface):
 
 @implementer(_IFileDescriptorReservation)
 @attr.s
-class _FileDescriptorReservation(object):
+class _FileDescriptorReservation:
     """
     L{_IFileDescriptorReservation} implementation.
 
@@ -1037,7 +1037,7 @@ class _FileDescriptorReservation(object):
 
 
 @implementer(_IFileDescriptorReservation)
-class _NullFileDescriptorReservation(object):
+class _NullFileDescriptorReservation:
     """
     A null implementation of L{_IFileDescriptorReservation}.
     """
@@ -1130,7 +1130,7 @@ _ACCEPT_ERRORS = (EMFILE, ENOBUFS, ENFILE, ENOMEM, ECONNABORTED)
 
 
 @attr.s
-class _BuffersLogs(object):
+class _BuffersLogs:
     """
     A context manager that buffers any log events until after its
     block exits.

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -96,7 +96,7 @@ class ConnectableProtocol(Protocol):
 
 
 
-class EndpointCreator(object):
+class EndpointCreator:
     """
     Create client and server endpoints that know how to connect to each other.
     """
@@ -223,7 +223,7 @@ class _AcceptOneClient(ServerFactory):
 
 
 
-class _SimplePullProducer(object):
+class _SimplePullProducer:
     """
     A pull producer which writes one byte whenever it is resumed.  For use by
     C{test_unregisterProducerAfterDisconnect}.
@@ -286,7 +286,7 @@ class ClosingLaterProtocol(ConnectableProtocol):
 
 
 
-class ConnectionTestsMixin(object):
+class ConnectionTestsMixin:
     """
     This mixin defines test methods which should apply to most L{ITransport}
     implementations.
@@ -413,7 +413,7 @@ class ConnectionTestsMixin(object):
 
 
 
-class LogObserverMixin(object):
+class LogObserverMixin:
     """
     Mixin for L{TestCase} subclasses which want to observe log events.
     """
@@ -425,7 +425,7 @@ class LogObserverMixin(object):
 
 
 
-class BrokenContextFactory(object):
+class BrokenContextFactory:
     """
     A context factory with a broken C{getContext} method, for exercising the
     error handling for such a case.
@@ -437,7 +437,7 @@ class BrokenContextFactory(object):
 
 
 
-class StreamClientTestsMixin(object):
+class StreamClientTestsMixin:
     """
     This mixin defines tests applicable to SOCK_STREAM client implementations.
 

--- a/src/twisted/internet/test/fakeendpoint.py
+++ b/src/twisted/internet/test/fakeendpoint.py
@@ -16,7 +16,7 @@ from twisted.internet.interfaces import (
 
 
 @implementer(IPlugin)
-class PluginBase(object):
+class PluginBase:
 
     def __init__(self, pfx):
         self.prefix = pfx
@@ -39,7 +39,7 @@ class FakeParser(PluginBase):
 
 
 
-class EndpointBase(object):
+class EndpointBase:
 
     def __init__(self, parser, args, kwargs):
         self.parser = parser

--- a/src/twisted/internet/test/test_address.py
+++ b/src/twisted/internet/test/test_address.py
@@ -24,7 +24,7 @@ else:
 
 
 
-class AddressTestCaseMixin(object):
+class AddressTestCaseMixin:
     def test_addressComparison(self):
         """
         Two different address instances, sharing the same properties are

--- a/src/twisted/internet/test/test_base.py
+++ b/src/twisted/internet/test/test_base.py
@@ -32,7 +32,7 @@ else:
 
 
 @implementer(IReactorTime, IReactorThreads)
-class FakeReactor(object):
+class FakeReactor:
     """
     A fake reactor implementation which just supports enough reactor APIs for
     L{ThreadedResolver}.
@@ -193,7 +193,7 @@ class ThreadedResolverTests(TestCase):
         calls = []
 
         @implementer(IResolverSimple)
-        class FakeResolver(object):
+        class FakeResolver:
             def getHostByName(self, name, timeouts=()):
                 calls.append(name)
                 return Deferred()
@@ -234,7 +234,7 @@ def nothing():
 
 
 
-class DelayedCallMixin(object):
+class DelayedCallMixin:
     """
     L{DelayedCall}
     """

--- a/src/twisted/internet/test/test_core.py
+++ b/src/twisted/internet/test/test_core.py
@@ -18,7 +18,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.test.reactormixins import ReactorBuilder
 
 
-class ObjectModelIntegrationMixin(object):
+class ObjectModelIntegrationMixin:
     """
     Helpers for tests about the object model of reactor-related objects.
     """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -297,7 +297,7 @@ class WrappingFactoryTests(unittest.TestCase):
         wrapped protocol's class name is returned from
         L{_WrappingProtocol.logPrefix}.
         """
-        class NoProtocol(object):
+        class NoProtocol:
             pass
         factory = TestFactory()
         factory.protocol = NoProtocol
@@ -487,7 +487,7 @@ class WrappingFactoryTests(unittest.TestCase):
 
 
 
-class ClientEndpointTestCaseMixin(object):
+class ClientEndpointTestCaseMixin:
     """
     Generic test methods to be mixed into all client endpoint test classes.
     """
@@ -629,7 +629,7 @@ class ClientEndpointTestCaseMixin(object):
 
 
 
-class ServerEndpointTestCaseMixin(object):
+class ServerEndpointTestCaseMixin:
     """
     Generic test methods to be mixed into all client endpoint test classes.
     """
@@ -740,7 +740,7 @@ class SpecificFactory(Factory):
 
 
 
-class FakeStdio(object):
+class FakeStdio:
     """
     A L{stdio.StandardIO} like object that simply captures its constructor
     arguments.
@@ -822,7 +822,7 @@ class StubApplicationProtocol(protocol.Protocol):
 
 
 @implementer(interfaces.IProcessTransport)
-class MemoryProcessTransport(StringTransportWithDisconnection, object):
+class MemoryProcessTransport(StringTransportWithDisconnection):
     """
     A fake L{IProcessTransport} provider to be used in tests.
     """
@@ -874,7 +874,7 @@ verifyClass(interfaces.IProcessTransport, MemoryProcessTransport)
 
 
 @implementer(interfaces.IReactorProcess)
-class MemoryProcessReactor(object):
+class MemoryProcessReactor:
     """
     A fake L{IReactorProcess} provider to be used in tests.
     """
@@ -1089,7 +1089,7 @@ class ProcessEndpointTransportTests(unittest.TestCase):
         the underlying process transport.
         """
         @implementer(IPushProducer)
-        class AProducer(object):
+        class AProducer:
             pass
         aProducer = AProducer()
         self.endpointTransport.registerProducer(aProducer, False)
@@ -1680,7 +1680,7 @@ def deterministicResolvingReactor(reactor, expectedAddresses=(),
         hostMap = {}
     hostMap = hostMap.copy()
     @implementer(IHostnameResolver)
-    class SimpleNameResolver(object):
+    class SimpleNameResolver:
         @staticmethod
         def resolveHostName(resolutionReceiver, hostName, portNumber=0,
                             addressTypes=None, transportSemantics='TCP'):
@@ -1742,7 +1742,7 @@ class SimpleHostnameResolverTests(unittest.SynchronousTestCase):
         self.resolutionCompleteCallCount = 0
 
         @provider(interfaces.IResolutionReceiver)
-        class _Receiver(object):
+        class _Receiver:
             @staticmethod
             def resolutionBegan(resolutionInProgress):
                 self.resolutionBeganCalls.append(resolutionInProgress)
@@ -3520,9 +3520,9 @@ class SSLClientStringTests(unittest.TestCase):
             if x.basename().lower().endswith('.pem')
         ]
         addedCerts = []
-        class ListCtx(object):
+        class ListCtx:
             def get_cert_store(self):
-                class Store(object):
+                class Store:
                     def add_cert(self, cert):
                         addedCerts.append(cert)
                 return Store()
@@ -3954,7 +3954,7 @@ class ConnectProtocolTests(unittest.TestCase):
 
 
 
-class UppercaseWrapperProtocol(policies.ProtocolWrapper, object):
+class UppercaseWrapperProtocol(policies.ProtocolWrapper):
     """
     A wrapper protocol which uppercases all strings passed through it.
     """
@@ -3990,7 +3990,7 @@ class UppercaseWrapperProtocol(policies.ProtocolWrapper, object):
 
 
 
-class UppercaseWrapperFactory(policies.WrappingFactory, object):
+class UppercaseWrapperFactory(policies.WrappingFactory):
     """
     A wrapper factory which uppercases all strings passed through it.
     """
@@ -3998,7 +3998,7 @@ class UppercaseWrapperFactory(policies.WrappingFactory, object):
 
 
 
-class NetstringTracker(basic.NetstringReceiver, object):
+class NetstringTracker(basic.NetstringReceiver):
     """
     A netstring receiver which keeps track of the strings received.
 

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 
-class Descriptor(object):
+class Descriptor:
     """
     Records reads and writes, as if it were a C{FileDescriptor}.
     """

--- a/src/twisted/internet/test/test_fdset.py
+++ b/src/twisted/internet/test/test_fdset.py
@@ -373,7 +373,7 @@ class ReactorFDSetTestsBuilder(ReactorBuilder):
 
 
 @implementer(IReadDescriptor)
-class RemovingDescriptor(object):
+class RemovingDescriptor:
     """
     A read descriptor which removes itself from the reactor as soon as it
     gets a chance to do a read and keeps track of when its own C{fileno}

--- a/src/twisted/internet/test/test_kqueuereactor.py
+++ b/src/twisted/internet/test/test_kqueuereactor.py
@@ -36,7 +36,7 @@ def makeFakeKQueue(testKQueue, testKEvent):
         C{testKEvent}.
     """
     @implementer(_IKQueue)
-    class FakeKQueue(object):
+    class FakeKQueue:
         kqueue = testKQueue
         kevent = testKEvent
 
@@ -56,7 +56,7 @@ class KQueueTests(TestCase):
         """
         L{KQueueReactor} handles L{errno.EINTR} in C{doKEvent} by returning.
         """
-        class FakeKQueue(object):
+        class FakeKQueue:
             """
             A fake KQueue that raises L{errno.EINTR} when C{control} is called,
             like a real KQueue would if it was interrupted.

--- a/src/twisted/internet/test/test_newtls.py
+++ b/src/twisted/internet/test/test_newtls.py
@@ -42,7 +42,7 @@ class BypassTLSTests(unittest.TestCase):
         default = object()
         result = []
 
-        class FakeTransport(object):
+        class FakeTransport:
             def loseConnection(self, _connDone=default):
                 result.append(_connDone)
 
@@ -59,7 +59,7 @@ class BypassTLSTests(unittest.TestCase):
 
 
 
-class FakeProducer(object):
+class FakeProducer:
     """
     A producer that does nothing.
     """

--- a/src/twisted/internet/test/test_posixprocess.py
+++ b/src/twisted/internet/test/test_posixprocess.py
@@ -23,7 +23,7 @@ from twisted.python.compat import range
 from twisted.trial.unittest import TestCase
 
 
-class FakeFile(object):
+class FakeFile:
     """
     A dummy file object which records when it is closed.
     """
@@ -45,7 +45,7 @@ class FakeFile(object):
 
 
 
-class FakeResourceModule(object):
+class FakeResourceModule:
     """
     Fake version of L{resource} which hard-codes a particular rlimit for maximum
     open files.

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -470,7 +470,7 @@ sys.stdout.flush()""".format(twistedRoot.path))
 
         @reactor.callWhenRunning
         def whenRunning():
-            class TracebackCatcher(ProcessProtocol, object):
+            class TracebackCatcher(ProcessProtocol):
                 errReceived = output.write
                 def processEnded(self, reason):
                     reactor.stop()

--- a/src/twisted/internet/test/test_protocol.py
+++ b/src/twisted/internet/test/test_protocol.py
@@ -462,7 +462,7 @@ class AdapterTests(TestCase):
         """
         result = []
         @implementer(IConsumer)
-        class Consumer(object):
+        class Consumer:
             def write(self, d):
                 result.append(d)
 

--- a/src/twisted/internet/test/test_resolver.py
+++ b/src/twisted/internet/test/test_resolver.py
@@ -46,7 +46,7 @@ from twisted.internet.base import (
 
 
 
-class DeterministicThreadPool(ThreadPool, object):
+class DeterministicThreadPool(ThreadPool):
     """
     Create a deterministic L{ThreadPool} object.
     """
@@ -87,14 +87,14 @@ def deterministicReactorThreads():
         object's C{callFromThread} method.
     """
     worker, doer = createMemoryWorker()
-    class CFT(object):
+    class CFT:
         def callFromThread(self, f, *a, **k):
             worker.do(lambda: f(*a, **k))
     return CFT(), doer
 
 
 
-class FakeAddrInfoGetter(object):
+class FakeAddrInfoGetter:
     """
     Test object implementing getaddrinfo.
     """
@@ -171,7 +171,7 @@ class FakeAddrInfoGetter(object):
 
 
 @implementer(IResolutionReceiver)
-class ResultHolder(object):
+class ResultHolder:
     """
     A resolution receiver which holds onto the results it received.
     """
@@ -409,7 +409,7 @@ class HostnameResolutionTests(UnitTest):
 
 
 @implementer(IResolverSimple)
-class SillyResolverSimple(object):
+class SillyResolverSimple:
     """
     Trivial implementation of L{IResolverSimple}
     """
@@ -436,7 +436,7 @@ class SillyResolverSimple(object):
 
 
 
-class LegacyCompatibilityTests(UnitTest, object):
+class LegacyCompatibilityTests(UnitTest):
     """
     Older applications may supply an object to the reactor via
     C{installResolver} that only provides L{IResolverSimple}.
@@ -553,7 +553,7 @@ class JustEnoughReactor(ReactorBase):
 
 
 
-class ReactorInstallationTests(UnitTest, object):
+class ReactorInstallationTests(UnitTest):
     """
     Tests for installing old and new resolvers onto a
     L{PluggableResolverMixin} and L{ReactorBase} (from which all of Twisted's

--- a/src/twisted/internet/test/test_serialport.py
+++ b/src/twisted/internet/test/test_serialport.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 
-class DoNothing(object):
+class DoNothing:
     """
     Object with methods that do nothing.
     """

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -143,7 +143,7 @@ def connect(client, destination):
 
 
 
-class FakeSocket(object):
+class FakeSocket:
     """
     A fake for L{socket.socket} objects.
 
@@ -249,7 +249,7 @@ class FakeProtocol(Protocol):
 
 
 @implementer(IReactorFDSet)
-class _FakeFDSetReactor(object):
+class _FakeFDSetReactor:
     """
     An in-memory implementation of L{IReactorFDSet}, which records the current
     sets of active L{IReadDescriptor} and L{IWriteDescriptor}s.
@@ -309,7 +309,7 @@ class TCPServerTests(TestCase):
     """
     def setUp(self):
         self.reactor = _FakeFDSetReactor()
-        class FakePort(object):
+        class FakePort:
             _realPortNumber = 3
         self.skt = FakeSocket(b"")
         self.protocol = Protocol()
@@ -450,7 +450,7 @@ class TCP6Creator(TCPCreator):
 
 
 @implementer(IResolverSimple)
-class FakeResolver(object):
+class FakeResolver:
     """
     A resolver implementation based on a C{dict} mapping names to addresses.
     """
@@ -969,7 +969,7 @@ class _IExhaustsFileDescriptors(Interface):
 
 @implementer(_IExhaustsFileDescriptors)
 @attr.s
-class _ExhaustsFileDescriptors(object):
+class _ExhaustsFileDescriptors:
     """
     A class that triggers C{EMFILE} by creating as many file
     descriptors as necessary.
@@ -1282,7 +1282,7 @@ class AssertPeerClosedOnEMFILETests(SynchronousTestCase):
     Tests for L{assertPeerClosedOnEMFILE}.
     """
     @implementer(_IExhaustsFileDescriptors)
-    class NullExhauster(object):
+    class NullExhauster:
         """
         An exhauster that does nothing.
         """
@@ -1438,7 +1438,7 @@ class StreamTransportTestsMixin(LogObserverMixin):
 
 
 
-class ConnectToTCPListenerMixin(object):
+class ConnectToTCPListenerMixin:
     """
     Provides L{connectToListener} for TCP transports.
 
@@ -1520,7 +1520,7 @@ class SocketTCPMixin(ConnectToTCPListenerMixin):
 
 
 
-class TCPPortTestsMixin(object):
+class TCPPortTestsMixin:
     """
     Tests for L{IReactorTCP.listenTCP}
     """
@@ -2111,7 +2111,7 @@ class TCPConnectionTestsBuilder(ReactorBuilder):
 
 
 
-class WriteSequenceTestsMixin(object):
+class WriteSequenceTestsMixin:
     """
     Test for L{twisted.internet.abstract.FileDescriptor.writeSequence}.
     """
@@ -2184,7 +2184,7 @@ class WriteSequenceTestsMixin(object):
         buffered, and then resumes it.
         """
         @implementer(IPushProducer)
-        class SaveActionProducer(object):
+        class SaveActionProducer:
             client = None
             server = None
 
@@ -2240,7 +2240,7 @@ class WriteSequenceTestsMixin(object):
         test = self
 
         @implementer(IPullProducer)
-        class SaveActionProducer(object):
+        class SaveActionProducer:
             client = None
 
             def __init__(self):
@@ -2280,7 +2280,7 @@ class WriteSequenceTestsMixin(object):
 
 
 
-class TCPTransportServerAddressTestMixin(object):
+class TCPTransportServerAddressTestMixin:
     """
     Test mixing for TCP server address building and log prefix.
     """
@@ -2815,7 +2815,7 @@ class ResumeThrowsClient(ProducerAbortingClient):
 
 
 
-class AbortConnectionMixin(object):
+class AbortConnectionMixin:
     """
     Unit tests for L{ITransport.abortConnection}.
     """

--- a/src/twisted/internet/test/test_testing.py
+++ b/src/twisted/internet/test/test_testing.py
@@ -328,7 +328,7 @@ class ReactorTests(TestCase):
 
 
 
-class TestConsumer(object):
+class TestConsumer:
     """
     A very basic test consumer for use with the NonStreamingProducerTests.
     """

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -54,7 +54,7 @@ class TLSMixin:
             "twisted.internet.gtk2reactor.Gtk2Reactor": msg}
 
 
-class ContextGeneratingMixin(object):
+class ContextGeneratingMixin:
     import twisted
     _pem = FilePath(
         networkString(twisted.__file__)).sibling(b"test").child(b"server.pem")
@@ -76,7 +76,7 @@ class ContextGeneratingMixin(object):
 
 
 @implementer(IStreamClientEndpoint)
-class StartTLSClientEndpoint(object):
+class StartTLSClientEndpoint:
     """
     An endpoint which wraps another one and adds a TLS layer immediately when
     connections are set up.
@@ -138,7 +138,7 @@ class StartTLSClientCreator(EndpointCreator, ContextGeneratingMixin):
 
 
 
-class BadContextTestsMixin(object):
+class BadContextTestsMixin:
     """
     Mixin for L{ReactorBuilder} subclasses which defines a helper for testing
     the handling of broken context factories.

--- a/src/twisted/internet/test/test_udp.py
+++ b/src/twisted/internet/test/test_udp.py
@@ -138,7 +138,7 @@ class DatagramTransportTestsMixin(LogObserverMixin):
 
 
 
-class UDPPortTestsMixin(object):
+class UDPPortTestsMixin:
     """
     Tests for L{IReactorUDP.listenUDP} and
     L{IReactorSocket.adoptDatagramPort}.

--- a/src/twisted/internet/test/test_udp_internals.py
+++ b/src/twisted/internet/test/test_udp_internals.py
@@ -20,7 +20,7 @@ else:
 
 
 
-class StringUDPSocket(object):
+class StringUDPSocket:
     """
     A fake UDP socket object, which returns a fixed sequence of strings and/or
     socket errors.  Useful for testing.

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -60,7 +60,7 @@ if requireModule("twisted.python.sendmsg") is not None:
 
 
 
-class UNIXFamilyMixin(object):
+class UNIXFamilyMixin:
     """
     Test-helper defining mixin for things related to AF_UNIX sockets.
     """
@@ -702,7 +702,7 @@ class UNIXDatagramTestsBuilder(UNIXFamilyMixin, ReactorBuilder):
 
 
 
-class SocketUNIXMixin(object):
+class SocketUNIXMixin:
     """
     Mixin which uses L{IReactorSocket.adoptStreamPort} to hand out listening
     UNIX ports.
@@ -747,7 +747,7 @@ class SocketUNIXMixin(object):
 
 
 
-class ListenUNIXMixin(object):
+class ListenUNIXMixin:
     """
     Mixin which uses L{IReactorTCP.listenUNIX} to hand out listening UNIX
     ports.
@@ -780,7 +780,7 @@ class ListenUNIXMixin(object):
 
 
 
-class UNIXPortTestsMixin(object):
+class UNIXPortTestsMixin:
     requiredInterfaces = (IReactorUNIX,)  # type: Optional[Sequence[Type[Interface]]]  # noqa
 
     def getExpectedStartListeningLogMessage(self, port, factory):

--- a/src/twisted/internet/test/test_win32events.py
+++ b/src/twisted/internet/test/test_win32events.py
@@ -20,7 +20,7 @@ from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.python.threadable import getThreadID
 
 
-class Listener(object):
+class Listener:
     """
     L{Listener} is an object that can be added to a L{IReactorWin32Events}
     reactor to receive callback notification when a Windows event is set.  It

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -334,7 +334,7 @@ class StringIOWithoutClosing(BytesIO):
 
 
 @implementer(IListeningPort)
-class _FakePort(object):
+class _FakePort:
     """
     A fake L{IListeningPort} to be used in tests.
 
@@ -371,7 +371,7 @@ class _FakePort(object):
 
 
 @implementer(IConnector)
-class _FakeConnector(object):
+class _FakeConnector:
     """
     A fake L{IConnector} that allows us to inspect if it has been told to stop
     connecting.
@@ -426,7 +426,7 @@ class _FakeConnector(object):
     IReactorCore,
     IReactorTCP, IReactorSSL, IReactorUNIX, IReactorSocket, IReactorFDSet
 )
-class MemoryReactor(object):
+class MemoryReactor:
     """
     A fake reactor to be used in tests.  This reactor doesn't actually do
     much that's useful yet.  It accepts TCP connection setup attempts, but
@@ -796,7 +796,7 @@ class MemoryReactorClock(MemoryReactor, Clock):
 
 
 @implementer(IReactorTCP, IReactorSSL, IReactorUNIX, IReactorSocket)
-class RaisingMemoryReactor(object):
+class RaisingMemoryReactor:
     """
     A fake reactor to be used in tests.  It accepts TCP connection setup
     attempts, but they will fail.
@@ -888,7 +888,7 @@ class RaisingMemoryReactor(object):
 
 
 
-class NonStreamingProducer(object):
+class NonStreamingProducer:
     """
     A pull producer which writes 10 times only.
     """

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -51,7 +51,7 @@ def _ancillaryDescriptor(fd):
 
 
 
-class _SendmsgMixin(object):
+class _SendmsgMixin:
     """
     Mixin for stream-oriented UNIX transports which uses sendmsg and recvmsg to
     offer additional functionality, such as copying file descriptors into other
@@ -224,7 +224,7 @@ class _SendmsgMixin(object):
                 os.close(fd)
 
 
-class _UnsupportedSendmsgMixin(object):
+class _UnsupportedSendmsgMixin:
     """
     Behaviorless placeholder used when C{twisted.python.sendmsg} is not
     available, preventing L{IUNIXTransport} from being supported.
@@ -303,7 +303,7 @@ def _inFilesystemNamespace(path):
     return path[:1] not in (b"\0", u"\0")
 
 
-class _UNIXPort(object):
+class _UNIXPort:
     def getHost(self):
         """
         Returns a UNIXAddress.

--- a/src/twisted/internet/win32eventreactor.py
+++ b/src/twisted/internet/win32eventreactor.py
@@ -308,7 +308,7 @@ class Win32Reactor(posixbase.PosixReactorBase):
 
 
 
-class _ThreadFDWrapper(object):
+class _ThreadFDWrapper:
     """
     This wraps an event handler and translates notification in the helper
     L{Win32Reactor} thread into a notification in the primary reactor thread.
@@ -359,7 +359,7 @@ class _ThreadFDWrapper(object):
 
 
 @implementer(IReactorWin32Events)
-class _ThreadedWin32EventsMixin(object):
+class _ThreadedWin32EventsMixin:
     """
     This mixin implements L{IReactorWin32Events} for another reactor by running
     a L{Win32Reactor} in a separate thread and dispatching work to it.

--- a/src/twisted/logger/__init__.py
+++ b/src/twisted/logger/__init__.py
@@ -17,7 +17,7 @@ Or in a class::
 
     from twisted.logger import Logger
 
-    class Foo(object):
+    class Foo:
         log = Logger()
 
         def oops(self, data):

--- a/src/twisted/logger/_buffer.py
+++ b/src/twisted/logger/_buffer.py
@@ -18,7 +18,7 @@ _DEFAULT_BUFFER_MAXIMUM = 64 * 1024
 
 
 @implementer(ILogObserver)
-class LimitedHistoryLogObserver(object):
+class LimitedHistoryLogObserver:
     """
     L{ILogObserver} that stores events in a buffer of a fixed size::
 

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -17,7 +17,7 @@ from ._format import formatEventAsClassicLogText
 
 
 @implementer(ILogObserver)
-class FileLogObserver(object):
+class FileLogObserver:
     """
     Log observer that writes to a file-like object.
     """

--- a/src/twisted/logger/_filter.py
+++ b/src/twisted/logger/_filter.py
@@ -94,7 +94,7 @@ def shouldLogEvent(predicates, event):
 
 
 @implementer(ILogObserver)
-class FilteringLogObserver(object):
+class FilteringLogObserver:
     """
     L{ILogObserver} that wraps another L{ILogObserver}, but filters out events
     based on applying a series of L{ILogFilterPredicate}s.
@@ -136,7 +136,7 @@ class FilteringLogObserver(object):
 
 
 @implementer(ILogFilterPredicate)
-class LogLevelFilterPredicate(object):
+class LogLevelFilterPredicate:
     """
     L{ILogFilterPredicate} that filters out events with a log level lower than
     the log level for the event's namespace.

--- a/src/twisted/logger/_flatten.py
+++ b/src/twisted/logger/_flatten.py
@@ -17,7 +17,7 @@ aFormatter = Formatter()
 
 
 
-class KeyFlattener(object):
+class KeyFlattener:
     """
     A L{KeyFlattener} computes keys for the things within curly braces in
     PEP-3101-style format strings as parsed by L{string.Formatter.parse}.

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -179,7 +179,7 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
 
 
 
-class CallMapping(object):
+class CallMapping:
     """
     Read-only mapping that turns a C{()}-suffix in key names into an invocation
     of the key rather than a lookup of the key.

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -32,7 +32,7 @@ MORE_THAN_ONCE_WARNING = (
 
 
 
-class LogBeginner(object):
+class LogBeginner:
     """
     A L{LogBeginner} holds state related to logging before logging has begun,
     and begins logging when told to do so.  Logging "begins" when someone has

--- a/src/twisted/logger/_io.py
+++ b/src/twisted/logger/_io.py
@@ -12,7 +12,7 @@ from ._levels import LogLevel
 
 
 
-class LoggingFile(object):
+class LoggingFile:
     """
     File-like object that turns C{write()} calls into logging events.
 

--- a/src/twisted/logger/_legacy.py
+++ b/src/twisted/logger/_legacy.py
@@ -16,7 +16,7 @@ from ._stdlib import fromStdlibLogLevelMapping, StringifiableFromEvent
 
 
 @implementer(ILogObserver)
-class LegacyLogObserverWrapper(object):
+class LegacyLogObserverWrapper:
     """
     L{ILogObserver} that wraps an L{twisted.python.log.ILogObserver}.
 

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -14,7 +14,7 @@ from ._levels import InvalidLogLevelError, LogLevel
 
 
 
-class Logger(object):
+class Logger:
     """
     A L{Logger} emits log messages to an observer.  You should instantiate it
     as a class or module attribute, as documented in L{this module's
@@ -78,7 +78,7 @@ class Logger(object):
         When used as a descriptor, i.e.::
 
             # File: athing.py
-            class Something(object):
+            class Something:
                 log = Logger()
                 def hello(self):
                     self.log.info("Hello")

--- a/src/twisted/logger/_observer.py
+++ b/src/twisted/logger/_observer.py
@@ -68,7 +68,7 @@ class ILogObserver(Interface):
 
 
 @implementer(ILogObserver)
-class LogPublisher(object):
+class LogPublisher:
     """
     I{ILogObserver} that fans out events to other observers.
 

--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -43,7 +43,7 @@ fromStdlibLogLevelMapping = _reverseLogLevelMapping()
 
 
 @implementer(ILogObserver)
-class STDLibLogObserver(object):
+class STDLibLogObserver:
     """
     Log observer that writes to the python standard library's C{logging}
     module.
@@ -118,7 +118,7 @@ class STDLibLogObserver(object):
 
 
 
-class StringifiableFromEvent(object):
+class StringifiableFromEvent:
     """
     An object that implements C{__str__()} in order to defer the work of
     formatting until it's converted into a C{str}.

--- a/src/twisted/logger/test/test_file.py
+++ b/src/twisted/logger/test/test_file.py
@@ -165,7 +165,7 @@ class TextFileLogObserverTests(TestCase):
 
 
 
-class DummyFile(object):
+class DummyFile:
     """
     File that counts writes and flushes.
     """

--- a/src/twisted/logger/test/test_filter.py
+++ b/src/twisted/logger/test/test_filter.py
@@ -71,7 +71,7 @@ class FilteringLogObserverTests(unittest.TestCase):
             dict(count=3),
         ]
 
-        class Filters(object):
+        class Filters:
             @staticmethod
             def twoMinus(event):
                 """

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -37,7 +37,7 @@ class FlatFormattingTests(unittest.TestCase):
         """
         counter = count()
 
-        class Ephemeral(object):
+        class Ephemeral:
             attribute = "value"
 
         event1 = dict(
@@ -96,7 +96,7 @@ class FlatFormattingTests(unittest.TestCase):
         L{formatEvent} will prefer the stored C{str()} or C{repr()} value for
         an object, in case the other version.
         """
-        class Unpersistable(object):
+        class Unpersistable:
             """
             Unpersitable object.
             """
@@ -184,7 +184,7 @@ class FlatFormattingTests(unittest.TestCase):
         if event is None:
             counter = count()
 
-            class CountStr(object):
+            class CountStr:
                 """
                 Hack
                 """
@@ -240,11 +240,11 @@ class FlatFormattingTests(unittest.TestCase):
 
         @param flattenFirst: callable to flatten an event
         """
-        class ObjectWithRepr(object):
+        class ObjectWithRepr:
             def __repr__(self) -> str:
                 return "repr"
 
-        class Something(object):
+        class Something:
             def __init__(self):
                 self.number = 7
                 self.object = ObjectWithRepr()

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -419,7 +419,7 @@ class FormatFieldTests(unittest.TestCase):
 
 
 
-class Unformattable(object):
+class Unformattable:
     """
     An object that raises an exception from C{__repr__}.
     """

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -63,11 +63,11 @@ class LogBeginnerTests(unittest.TestCase):
         self.publisher = LogPublisher()
         self.errorStream = io.StringIO()
 
-        class NotSys(object):
+        class NotSys:
             stdout = object()
             stderr = object()
 
-        class NotWarnings(object):
+        class NotWarnings:
             def __init__(self):
                 self.warnings = []
 

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -134,7 +134,7 @@ class SaveLoadTests(TestCase):
         in the same string formatting; any extractable fields will retain their
         data types.
         """
-        class Reprable(object):
+        class Reprable:
             def __init__(self, value):
                 self.value = value
 
@@ -154,7 +154,7 @@ class SaveLoadTests(TestCase):
         L{extractField} can extract fields from an object that's been saved and
         loaded from JSON.
         """
-        class Obj(object):
+        class Obj:
             def __init__(self):
                 self.value = 345
 

--- a/src/twisted/logger/test/test_legacy.py
+++ b/src/twisted/logger/test/test_legacy.py
@@ -46,7 +46,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         """
         L{LegacyLogObserverWrapper} returns the expected string.
         """
-        class LegacyObserver(object):
+        class LegacyObserver:
             def __repr__(self) -> str:
                 return "<Legacy Observer>"
 

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -39,7 +39,7 @@ class TestLogger(Logger):
 
 
 
-class LogComposedObject(object):
+class LogComposedObject:
     """
     A regular object, with a logger attached.
     """
@@ -113,7 +113,7 @@ class LoggerTests(unittest.TestCase):
         """
         observed = []
 
-        class MyObject(object):
+        class MyObject:
             log = Logger(observer=observed.append)
 
         MyObject.log.info("hello")
@@ -174,7 +174,7 @@ class LoggerTests(unittest.TestCase):
         def observer(event):
             self.assertEqual(event["log_source"], Thingo)
 
-        class Thingo(object):
+        class Thingo:
             log = TestLogger(observer=observer)
 
         Thingo.log.info()
@@ -187,7 +187,7 @@ class LoggerTests(unittest.TestCase):
         def observer(event):
             self.assertEqual(event["log_source"], thingo)
 
-        class Thingo(object):
+        class Thingo:
             log = TestLogger(observer=observer)
 
         thingo = Thingo()

--- a/src/twisted/logger/test/test_stdlib.py
+++ b/src/twisted/logger/test/test_stdlib.py
@@ -225,7 +225,7 @@ class STDLibLogObserverTests(unittest.TestCase):
 
 
 
-class StdlibLoggingContainer(object):
+class StdlibLoggingContainer:
     """
     Continer for a test configuration of stdlib logging objects.
     """

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -114,7 +114,7 @@ def _swapAllPairs(of, that, ifIs):
             for first, second in of]
 
 
-class MessageSet(object):
+class MessageSet:
     """
     A set of message identifiers usable by both L{IMAP4Client} and
     L{IMAP4Server} via L{IMailboxIMAP.store} and
@@ -5052,7 +5052,7 @@ def collapseNestedLists(items):
 
 
 @implementer(IAccount)
-class MemoryAccountWithoutNamespaces(object):
+class MemoryAccountWithoutNamespaces:
     mailboxes = None
     subscriptions = None
     top_id = 0
@@ -5309,7 +5309,7 @@ def _getMessageStructure(message):
 
 
 
-class _MessageStructure(object):
+class _MessageStructure:
     """
     L{_MessageStructure} is a helper base class for message structure classes
     representing the structure of particular kinds of messages, as defined by

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -168,7 +168,7 @@ class _HeadersPlusNLines:
 
 
 
-class _IteratorBuffer(object):
+class _IteratorBuffer:
     """
     An iterator which buffers the elements of a container and periodically
     passes them as input to a writer.

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -498,7 +498,7 @@ class Queue:
 
 
 
-class _AttemptManager(object):
+class _AttemptManager:
     """
     A manager for an attempt to relay a set of messages to a mail exchange
     server.

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1721,7 +1721,7 @@ class SimpleMailbox:
 
 
 @implementer(imap4.IMailboxInfo, imap4.IMailbox)
-class UncloseableMailbox(object):
+class UncloseableMailbox:
     """
     A mailbox that cannot be closed.
     """
@@ -1911,7 +1911,7 @@ class Account(AccountWithoutNamespaces, imap4.MemoryAccount):
 
 
 
-class SimpleServer(imap4.IMAP4Server, object):
+class SimpleServer(imap4.IMAP4Server):
     theAccount = Account(b'testuser')
     def __init__(self, *args, **kw):
         imap4.IMAP4Server.__init__(self, *args, **kw)
@@ -3614,7 +3614,7 @@ class AuthenticatorTests(IMAP4HelperMixin, TestCase):
         """
 
         @implementer(IChallengeResponse, IUsernamePassword)
-        class SPECIALAuth(object):
+        class SPECIALAuth:
 
             def getChallenge(self):
                 return b'SPECIAL'
@@ -3708,7 +3708,7 @@ class AuthenticatorTests(IMAP4HelperMixin, TestCase):
         """
 
         @implementer(IChallengeResponse)
-        class ValueErrorAuthChallenge(object):
+        class ValueErrorAuthChallenge:
             message = b"A challenge failure"
 
             def getChallenge(self):
@@ -3729,7 +3729,7 @@ class AuthenticatorTests(IMAP4HelperMixin, TestCase):
                 """
 
         @implementer(IClientAuthentication)
-        class ValueErrorAuthenticator(object):
+        class ValueErrorAuthenticator:
 
             def getName(self):
                 return b"ERROR"
@@ -3761,7 +3761,7 @@ class AuthenticatorTests(IMAP4HelperMixin, TestCase):
         as Base 64 receives an L{IllegalClientResponse}.
         """
         @implementer(IChallengeResponse)
-        class NotBase64AuthChallenge(object):
+        class NotBase64AuthChallenge:
             message = b"Malformed Response - not base64"
 
             def getChallenge(self):
@@ -4657,7 +4657,7 @@ class HandCraftedTests(IMAP4HelperMixin, TestCase):
 
 
 
-class PreauthIMAP4ClientMixin(object):
+class PreauthIMAP4ClientMixin:
     """
     Mixin for L{SynchronousTestCase} subclasses which
     provides a C{setUp} method which creates an L{IMAP4Client}
@@ -7496,7 +7496,7 @@ class DisconnectionTests(TestCase):
 
 
 
-class SynchronousMailbox(object):
+class SynchronousMailbox:
     """
     Trivial, in-memory mailbox implementation which can produce a message
     synchronously.
@@ -7696,7 +7696,7 @@ class IMAP4ServerFetchTests(TestCase):
 
 
 
-class LiteralTestsMixin(object):
+class LiteralTestsMixin:
     """
     Shared tests for literal classes.
 

--- a/src/twisted/mail/test/test_mail.py
+++ b/src/twisted/mail/test/test_mail.py
@@ -417,7 +417,7 @@ class FailingMaildirMailboxAppendMessageTask(
 
 
 
-class _AppendTestMixin(object):
+class _AppendTestMixin:
     """
     Mixin for L{MaildirMailbox.appendMessage} test cases which defines a helper
     for serially appending multiple messages to a mailbox.
@@ -788,7 +788,7 @@ class MaildirDirdbmDomainTests(TestCase):
 
 
 @implementer(mail.mail.IAliasableDomain)
-class StubAliasableDomain(object):
+class StubAliasableDomain:
     """
     Minimal testable implementation of IAliasableDomain.
     """
@@ -1321,7 +1321,7 @@ class MXTests(TestCase):
         @type correctMailExchange: C{str}
         @rtype: L{Deferred}
         """
-        class DummyResolver(object):
+        class DummyResolver:
             def lookupMailExchange(self, name):
                 if name == domain:
                     return defer.succeed((
@@ -1455,7 +1455,7 @@ class MXTests(TestCase):
         ip = '1.2.3.4'
         domain = 'example.org'
 
-        class DummyResolver(object):
+        class DummyResolver:
             """
             Fake resolver which will respond to an MX lookup with an empty
             result set.
@@ -1488,7 +1488,7 @@ class MXTests(TestCase):
         L{MXCalculator.getMX} ultimately fires with a Record_MX instance which
         gives the address in the A record for the name.
         """
-        class DummyResolver(object):
+        class DummyResolver:
             """
             Fake resolver which will fail an MX lookup but then succeed a
             getHostByName call.
@@ -1515,7 +1515,7 @@ class MXTests(TestCase):
         canonical = "canonical.example.com"
         exchange = "mail.example.com"
 
-        class DummyResolver(object):
+        class DummyResolver:
             """
             Fake resolver which will return a CNAME for an MX lookup of a name
             which is an alias and an MX for an MX lookup of the canonical name.
@@ -1548,7 +1548,7 @@ class MXTests(TestCase):
         the length specified, the returned L{Deferred} should errback with
         L{CanonicalNameChainTooLong}.
         """
-        class DummyResolver(object):
+        class DummyResolver:
             """
             Fake resolver which generates a CNAME chain of infinite length in
             response to MX lookups.
@@ -1588,7 +1588,7 @@ class MXTests(TestCase):
         canonical = "canonical.example.com"
         exchange = "mail.example.com"
 
-        class DummyResolver(object):
+        class DummyResolver:
             def lookupMailExchange(self, domain):
                 if domain != alias or lookedUp:
                     # Don't give back any results for anything except the alias
@@ -1618,7 +1618,7 @@ class MXTests(TestCase):
         firstAlias = "cname1.example.com"
         secondAlias = "cname2.example.com"
 
-        class DummyResolver(object):
+        class DummyResolver:
             def lookupMailExchange(self, domain):
                 return defer.succeed((
                         [RRHeader(name=firstAlias,
@@ -1936,7 +1936,7 @@ class AliasTests(TestCase):
 
 
 
-class DummyDomain(object):
+class DummyDomain:
     """
     Test domain for L{AddressAliasTests}.
     """
@@ -2006,7 +2006,7 @@ class AddressAliasTests(TestCase):
 
 
 
-class DummyProcess(object):
+class DummyProcess:
     __slots__ = ['onEnd']
 
 
@@ -2031,7 +2031,7 @@ class MockAliasGroup(mail.alias.AliasGroup):
 
 
 
-class StubProcess(object):
+class StubProcess:
     """
     Fake implementation of L{IProcessTransport}.
 
@@ -2343,7 +2343,7 @@ class TestDomain:
 
 
 
-class DummyQueue(object):
+class DummyQueue:
     """
     A fake relay queue to use for testing.
 
@@ -2428,7 +2428,7 @@ class DummyQueue(object):
 
 
 
-class DummySmartHostSMTPRelayingManager(object):
+class DummySmartHostSMTPRelayingManager:
     """
     A fake smart host to use for testing.
 

--- a/src/twisted/mail/test/test_options.py
+++ b/src/twisted/mail/test/test_options.py
@@ -140,7 +140,7 @@ class OptionsTests(TestCase):
 
 
 
-class SpyEndpoint(object):
+class SpyEndpoint:
     """
     SpyEndpoint remembers what factory it is told to listen with.
     """

--- a/src/twisted/mail/test/test_smtp.py
+++ b/src/twisted/mail/test/test_smtp.py
@@ -58,7 +58,7 @@ def spameater(*spam, **eggs):
 
 
 @implementer(smtp.IMessage)
-class BrokenMessage(object):
+class BrokenMessage:
     """
     L{BrokenMessage} is an L{IMessage} which raises an unexpected exception
     from its C{eomReceived} method.  This is useful for creating a server which
@@ -81,7 +81,7 @@ class BrokenMessage(object):
 
 
 
-class DummyMessage(object):
+class DummyMessage:
     """
     L{BrokenMessage} is an L{IMessage} which saves the message delivered to it
     to its domain object.
@@ -111,7 +111,7 @@ class DummyMessage(object):
 
 
 
-class DummyDomain(object):
+class DummyDomain:
     """
     L{DummyDomain} is an L{IDomain} which keeps track of messages delivered to
     it in memory.
@@ -334,7 +334,7 @@ class SMTPClientTests(TestCase, LoopbackMixin):
 
 
 
-class DummySMTPMessage(object):
+class DummySMTPMessage:
 
     def __init__(self, protocol, users):
         self.protocol = protocol
@@ -515,7 +515,7 @@ class DummyChecker:
 
 
 @implementer(smtp.IMessageDelivery)
-class SimpleDelivery(object):
+class SimpleDelivery:
     """
     L{SimpleDelivery} is a message delivery factory with no interesting
     behavior.
@@ -1010,7 +1010,7 @@ class SMTPSenderFactoryRetryTests(TestCase):
 
 
 @implementer(IRealm)
-class SingletonRealm(object):
+class SingletonRealm:
     """
     Trivial realm implementation which is constructed with an interface and an
     avatar and returns that avatar when asked for that interface.
@@ -1027,7 +1027,7 @@ class SingletonRealm(object):
 
 
 
-class NotImplementedDelivery(object):
+class NotImplementedDelivery:
     """
     Non-implementation of L{smtp.IMessageDelivery} which only has methods which
     raise L{NotImplementedError}.  Subclassed by various tests to provide the
@@ -1190,7 +1190,7 @@ class SMTPServerTests(TestCase):
         L{smtp.SMTP} instance's portal is responded to with the correct error
         code.
         """
-        class DisallowAnonymousAccess(object):
+        class DisallowAnonymousAccess:
             """
             Checker for L{IAnonymous} which rejects authentication attempts.
             """

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -26,7 +26,7 @@ RFC4034_TIME_FORMAT = '%Y%m%d%H%M%S'
 
 
 
-class SerialNumber(FancyStrMixin, object):
+class SerialNumber(FancyStrMixin):
     """
     An RFC1982 Serial Number.
 

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -411,7 +411,7 @@ class IEncodableRecord(IEncodable, IRecord):
 
 
 @implementer(IEncodable)
-class Charstr(object):
+class Charstr:
 
     def __init__(self, string=b''):
         if not isinstance(string, bytes):
@@ -646,7 +646,7 @@ class Query:
 
 
 @implementer(IEncodable)
-class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin, object):
+class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin):
     """
     An OPT record header.
 
@@ -823,7 +823,7 @@ class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin, object):
 
 
 @implementer(IEncodable)
-class _OPTVariableOption(tputil.FancyStrMixin, tputil.FancyEqMixin, object):
+class _OPTVariableOption(tputil.FancyStrMixin, tputil.FancyEqMixin):
     """
     A class to represent OPT record variable options.
 
@@ -2092,7 +2092,7 @@ class Record_TXT(tputil.FancyEqMixin, tputil.FancyStrMixin):
 
 
 @implementer(IEncodableRecord)
-class UnknownRecord(tputil.FancyEqMixin, tputil.FancyStrMixin, object):
+class UnknownRecord(tputil.FancyEqMixin, tputil.FancyStrMixin):
     """
     Encapsulate the wire data for unknown record types so that they can
     pass through the system unchanged.
@@ -2650,7 +2650,7 @@ class Message(tputil.FancyEqMixin):
 
 
 
-class _EDNSMessage(tputil.FancyEqMixin, object):
+class _EDNSMessage(tputil.FancyEqMixin):
     """
     An I{EDNS} message.
 
@@ -2962,7 +2962,7 @@ class _EDNSMessage(tputil.FancyEqMixin, object):
 
 
 
-class DNSMixin(object):
+class DNSMixin:
     """
     DNS protocol mixin shared by UDP and TCP implementations.
 

--- a/src/twisted/names/test/test_client.py
+++ b/src/twisted/names/test/test_client.py
@@ -59,7 +59,7 @@ class FakeResolver(ResolverBase):
 
 
 
-class StubPort(object):
+class StubPort:
     """
     A partial implementation of L{IListeningPort} which only keeps track of
     whether it has been stopped.
@@ -74,7 +74,7 @@ class StubPort(object):
 
 
 
-class StubDNSDatagramProtocol(object):
+class StubDNSDatagramProtocol:
     """
     L{dns.DNSDatagramProtocol}-alike.
 
@@ -515,7 +515,7 @@ class ResolverTests(unittest.TestCase):
         resolver = client.Resolver(servers=[('example.com', 53)])
         protocols = []
 
-        class FakeProtocol(object):
+        class FakeProtocol:
             def __init__(self):
                 self.transport = StubPort()
 
@@ -550,7 +550,7 @@ class ResolverTests(unittest.TestCase):
         """
         ports = []
 
-        class FakeReactor(object):
+        class FakeReactor:
             def listenUDP(self, port, *args, **kwargs):
                 ports.append(port)
                 if len(ports) == 1:
@@ -569,7 +569,7 @@ class ResolverTests(unittest.TestCase):
         """
         ports = []
 
-        class FakeReactor(object):
+        class FakeReactor:
             def listenUDP(self, port, *args, **kwargs):
                 ports.append(port)
                 raise CannotListenError(None, port, None)
@@ -589,7 +589,7 @@ class ResolverTests(unittest.TestCase):
         """
         ports = []
 
-        class FakeReactor(object):
+        class FakeReactor:
             def listenUDP(self, port, *args, **kwargs):
                 ports.append(port)
                 err = OSError(errno.EMFILE, "Out of files :(")
@@ -615,7 +615,7 @@ class ResolverTests(unittest.TestCase):
         results = [defer.fail(failure.Failure(DNSQueryTimeoutError(None))),
                    defer.succeed(dns.Message())]
 
-        class FakeProtocol(object):
+        class FakeProtocol:
             def __init__(self):
                 self.transport = StubPort()
 
@@ -638,7 +638,7 @@ class ResolverTests(unittest.TestCase):
         protocols = []
         result = defer.Deferred()
 
-        class FakeProtocol(object):
+        class FakeProtocol:
             def __init__(self):
                 self.transport = StubPort()
 
@@ -666,7 +666,7 @@ class ResolverTests(unittest.TestCase):
         results = [defer.fail(failure.Failure(DNSQueryTimeoutError(None))),
                    result]
 
-        class FakeProtocol(object):
+        class FakeProtocol:
             def __init__(self):
                 self.transport = StubPort()
 
@@ -695,7 +695,7 @@ class ResolverTests(unittest.TestCase):
         protocols = []
         result = defer.Deferred()
 
-        class FakeProtocol(object):
+        class FakeProtocol:
             def __init__(self):
                 self.transport = StubPort()
 
@@ -1183,7 +1183,7 @@ class FilterAnswersTests(unittest.TestCase):
 
 
 
-class FakeDNSDatagramProtocol(object):
+class FakeDNSDatagramProtocol:
     def __init__(self):
         self.queries = []
         self.transport = StubPort()

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -1241,7 +1241,7 @@ class MessageComparisonTests(ComparisonTestsMixin,
 
 
 
-class TestController(object):
+class TestController:
     """
     Pretend to be a DNS query processor for a DNSDatagramProtocol.
 
@@ -2608,7 +2608,7 @@ class IsSubdomainOfTests(unittest.SynchronousTestCase):
 
 
 
-class OPTNonStandardAttributes(object):
+class OPTNonStandardAttributes:
     """
     Generate byte and instance representations of an L{dns._OPTHeader}
     where all attributes are set to non-default values.
@@ -3155,7 +3155,7 @@ class RaisedArgs(Exception):
 
 
 
-class MessageEmpty(object):
+class MessageEmpty:
     """
     Generate byte string and constructor arguments for an empty
     L{dns._EDNSMessage}.
@@ -3202,7 +3202,7 @@ class MessageEmpty(object):
 
 
 
-class MessageTruncated(object):
+class MessageTruncated:
     """
     An empty response message whose TR bit is set to 1.
     """
@@ -3247,7 +3247,7 @@ class MessageTruncated(object):
 
 
 
-class MessageNonAuthoritative(object):
+class MessageNonAuthoritative:
     """
     A minimal non-authoritative message.
     """
@@ -3298,7 +3298,7 @@ class MessageNonAuthoritative(object):
 
 
 
-class MessageAuthoritative(object):
+class MessageAuthoritative:
     """
     A minimal authoritative message.
     """
@@ -3463,7 +3463,7 @@ class MessageComplete:
 
 
 
-class MessageEDNSQuery(object):
+class MessageEDNSQuery:
     """
     A minimal EDNS query message.
     """
@@ -3524,7 +3524,7 @@ class MessageEDNSQuery(object):
 
 
 
-class MessageEDNSComplete(object):
+class MessageEDNSComplete:
     """
     An example of a fully populated edns response message.
 
@@ -3652,7 +3652,7 @@ class MessageEDNSComplete(object):
 
 
 
-class MessageEDNSExtendedRCODE(object):
+class MessageEDNSExtendedRCODE:
     """
     An example of an EDNS message with an extended RCODE.
     """
@@ -3713,7 +3713,7 @@ class MessageEDNSExtendedRCODE(object):
 
 
 
-class MessageComparable(FancyEqMixin, FancyStrMixin, object):
+class MessageComparable(FancyEqMixin, FancyStrMixin):
     """
     A wrapper around L{dns.Message} which is comparable so that it can be tested
     using some of the L{dns._EDNSMessage} tests.
@@ -3778,7 +3778,7 @@ def verifyConstructorArgument(testCase, cls, argName, defaultVal, altVal,
 
 
 
-class ConstructorTestsMixin(object):
+class ConstructorTestsMixin:
     """
     Helper methods for verifying default attribute values and corresponding
     constructor arguments.
@@ -3813,7 +3813,7 @@ class ConstructorTestsMixin(object):
 
 
 
-class CommonConstructorTestsMixin(object):
+class CommonConstructorTestsMixin:
     """
     Tests for constructor arguments and their associated attributes that are
     common to both L{twisted.names.dns._EDNSMessage} and L{dns.Message}.
@@ -4124,7 +4124,7 @@ class EDNSMessageSpecificsTests(ConstructorTestsMixin,
         to create a new L{dns.Message} instance which is used to decode the
         supplied bytes.
         """
-        class FakeMessageFactory(object):
+        class FakeMessageFactory:
             """
             Fake message factory.
             """
@@ -4199,7 +4199,7 @@ class EDNSMessageSpecificsTests(ConstructorTestsMixin,
         """
         m = dns._EDNSMessage()
         dummyBytes = object()
-        class FakeMessage(object):
+        class FakeMessage:
             """
             Fake Message
             """
@@ -4450,7 +4450,7 @@ class EDNSMessageEqualityTests(ComparisonTestsMixin,
 
 
 
-class StandardEncodingTestsMixin(object):
+class StandardEncodingTestsMixin:
     """
     Tests for the encoding and decoding of various standard (not EDNS) messages.
 
@@ -4829,7 +4829,7 @@ class ResponseFromMessageTests(unittest.SynchronousTestCase):
         """
         L{dns._responseFromMessage} returns a new instance of C{cls}
         """
-        class SuppliedClass(object):
+        class SuppliedClass:
             id = 1
             queries = []
 
@@ -4897,7 +4897,7 @@ class ResponseFromMessageTests(unittest.SynchronousTestCase):
 
 
 
-class Foo(object):
+class Foo:
     """
     An example class for use in L{dns._compactRepr} tests.
     It follows the pattern of initialiser settable flags, fields and sections

--- a/src/twisted/names/test/test_examples.py
+++ b/src/twisted/names/test/test_examples.py
@@ -14,7 +14,7 @@ from twisted.trial.unittest import SkipTest, TestCase
 from twisted.python.compat import NativeStringIO
 
 
-class ExampleTestBase(object):
+class ExampleTestBase:
     """
     This is a mixin which adds an example to the path, tests it, and then
     removes it from the path and unimports the modules which the test loaded.

--- a/src/twisted/names/test/test_hosts.py
+++ b/src/twisted/names/test/test_hosts.py
@@ -15,7 +15,7 @@ from twisted.names.dns import (
 from twisted.names.hosts import Resolver, searchFileFor, searchFileForAll
 
 
-class GoodTempPathMixin(object):
+class GoodTempPathMixin:
     def path(self):
         return FilePath(self.mktemp().encode('utf-8'))
 

--- a/src/twisted/names/test/test_rootresolve.py
+++ b/src/twisted/names/test/test_rootresolve.py
@@ -568,7 +568,7 @@ ROOT_SERVERS = [
 
 
 @implementer(IResolverSimple)
-class StubResolver(object):
+class StubResolver:
     """
     An L{IResolverSimple} implementer which traces all getHostByName
     calls and their deferred results. The deferred results can be

--- a/src/twisted/names/test/test_server.py
+++ b/src/twisted/names/test/test_server.py
@@ -99,7 +99,7 @@ class RaisingDNSServerFactory(server.DNSServerFactory):
 
 
 
-class RaisingProtocol(object):
+class RaisingProtocol:
     """
     A partial fake L{IProtocol} whose methods raise an exception containing the
     supplied arguments.
@@ -123,7 +123,7 @@ class RaisingProtocol(object):
 
 
 
-class NoopProtocol(object):
+class NoopProtocol:
     """
     A partial fake L{dns.DNSProtocolMixin} with a noop L{writeMessage} method.
     """
@@ -140,7 +140,7 @@ class NoopProtocol(object):
 
 
 
-class RaisingResolver(object):
+class RaisingResolver:
     """
     A partial fake L{IResolver} whose methods raise an exception containing the
     supplied arguments.
@@ -165,7 +165,7 @@ class RaisingResolver(object):
 
 
 
-class RaisingCache(object):
+class RaisingCache:
     """
     A partial fake L{twisted.names.cache.Cache} whose methods raise an exception
     containing the supplied arguments.
@@ -294,13 +294,13 @@ class DNSServerFactoryTests(unittest.TestCase):
         authorities, caches and clients.
         """
         # Use classes here so that we can see meaningful names in test results
-        class DummyAuthority(object):
+        class DummyAuthority:
             pass
 
-        class DummyCache(object):
+        class DummyCache:
             pass
 
-        class DummyClient(object):
+        class DummyClient:
             pass
 
         self.assertEqual(
@@ -382,7 +382,7 @@ class DNSServerFactoryTests(unittest.TestCase):
         L{server.DNSServerFactory.protocol} with its self as a positional
         argument.
         """
-        class FakeProtocol(object):
+        class FakeProtocol:
             factory = None
             args = None
             kwargs = None
@@ -665,7 +665,7 @@ class DNSServerFactoryTests(unittest.TestCase):
         f = server.DNSServerFactory()
 
         d = defer.Deferred()
-        class FakeResolver(object):
+        class FakeResolver:
             def query(self, *args, **kwargs):
                 return d
         f.resolver = FakeResolver()
@@ -701,7 +701,7 @@ class DNSServerFactoryTests(unittest.TestCase):
         f = server.DNSServerFactory()
 
         d = defer.Deferred()
-        class FakeResolver(object):
+        class FakeResolver:
             def query(self, *args, **kwargs):
                 return d
         f.resolver = FakeResolver()

--- a/src/twisted/names/test/test_util.py
+++ b/src/twisted/names/test/test_util.py
@@ -19,7 +19,7 @@ from twisted.internet.interfaces import IReactorUDP, IUDPTransport
 
 
 @implementer(IUDPTransport)
-class MemoryDatagramTransport(object):
+class MemoryDatagramTransport:
     """
     This L{IUDPTransport} implementation enforces the usual connection rules
     and captures sent traffic in a list for later inspection.

--- a/src/twisted/pair/test/test_tuntap.py
+++ b/src/twisted/pair/test/test_tuntap.py
@@ -66,7 +66,7 @@ else:
 
 
 @implementer(IReactorFDSet)
-class ReactorFDSet(object):
+class ReactorFDSet:
     """
     An implementation of L{IReactorFDSet} which only keeps track of which
     descriptors have been registered for reading and writing.
@@ -124,7 +124,7 @@ class FSSetClock(Clock, ReactorFDSet):
 
 
 
-class TunHelper(object):
+class TunHelper:
     """
     A helper for tests of tun-related functionality (ip-level tunnels).
     """
@@ -206,7 +206,7 @@ class TunHelper(object):
 
 
 
-class TapHelper(object):
+class TapHelper:
     """
     A helper for tests of tap-related functionality (ethernet-level tunnels).
     """
@@ -327,7 +327,7 @@ class TunnelTests(SynchronousTestCase):
 
 
 
-class TunnelDeviceTestsMixin(object):
+class TunnelDeviceTestsMixin:
     """
     A mixin defining tests that apply to L{_IInputOutputSystem}
     implementations.
@@ -507,7 +507,7 @@ class TunnelDeviceTestsMixin(object):
 
 
 
-class FakeDeviceTestsMixin(object):
+class FakeDeviceTestsMixin:
     """
     Define a mixin for use with test cases that require an
     L{_IInputOutputSystem} provider.  This mixin hands out L{MemoryIOSystem}
@@ -655,7 +655,7 @@ class TestRealSystem(_RealSystem):
 
 
 
-class RealDeviceTestsMixin(object):
+class RealDeviceTestsMixin:
     """
     Define a mixin for use with test cases that require an
     L{_IInputOutputSystem} provider.  This mixin hands out L{TestRealSystem}
@@ -734,7 +734,7 @@ class TuntapPortTests(SynchronousTestCase):
 
 
 
-class TunnelTestsMixin(object):
+class TunnelTestsMixin:
     """
     A mixin defining tests for L{TuntapPort}.
 
@@ -1384,7 +1384,7 @@ class TapTests(TunnelTestsMixin, SynchronousTestCase):
 
 
 
-class IOSystemTestsMixin(object):
+class IOSystemTestsMixin:
     """
     Tests that apply to any L{_IInputOutputSystem} implementation.
     """

--- a/src/twisted/pair/testing.py
+++ b/src/twisted/pair/testing.py
@@ -152,7 +152,7 @@ def _udp(src, dst, payload):
 
 
 
-class Tunnel(object):
+class Tunnel:
     """
     An in-memory implementation of a tun or tap device.
 
@@ -317,7 +317,7 @@ def _privileged(original):
 
 
 @implementer(_IInputOutputSystem)
-class MemoryIOSystem(object):
+class MemoryIOSystem:
     """
     An in-memory implementation of basic I/O primitives, useful in the context
     of unit testing as a drop-in replacement for parts of the C{os} module.
@@ -516,7 +516,7 @@ class MemoryIOSystem(object):
 
 
 
-class _FakePort(object):
+class _FakePort:
     """
     A socket-like object which can be used to read UDP datagrams from
     tunnel-like file descriptors managed by a L{MemoryIOSystem}.

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -72,7 +72,7 @@ class TunnelFlags(Flags):
 
 
 @implementer(interfaces.IAddress)
-class TunnelAddress(FancyStrMixin, FancyEqMixin, object):
+class TunnelAddress(FancyStrMixin, FancyEqMixin):
     """
     A L{TunnelAddress} represents the tunnel to which a L{TuntapPort} is bound.
     """
@@ -202,7 +202,7 @@ class _IInputOutputSystem(Interface):
 
 
 
-class _RealSystem(object):
+class _RealSystem:
     """
     An interface to the parts of the operating system which L{TuntapPort}
     relies on.  This is most of an implementation of L{_IInputOutputSystem}.

--- a/src/twisted/plugin.py
+++ b/src/twisted/plugin.py
@@ -37,7 +37,7 @@ class IPlugin(Interface):
 
 
 
-class CachedPlugin(object):
+class CachedPlugin:
     def __init__(self, dropin, name, description, provided):
         self.dropin = dropin
         self.name = name
@@ -66,7 +66,7 @@ class CachedPlugin(object):
 
 
 
-class CachedDropin(object):
+class CachedDropin:
     """
     A collection of L{CachedPlugin} instances from a particular module in a
     plugin package.

--- a/src/twisted/plugins/cred_anonymous.py
+++ b/src/twisted/plugins/cred_anonymous.py
@@ -22,7 +22,7 @@ This allows anonymous authentication for servers that support it.
 
 
 @implementer(ICheckerFactory, plugin.IPlugin)
-class AnonymousCheckerFactory(object):
+class AnonymousCheckerFactory:
     """
     Generates checkers that will authenticate an anonymous request.
     """

--- a/src/twisted/plugins/cred_file.py
+++ b/src/twisted/plugins/cred_file.py
@@ -29,7 +29,7 @@ invalidFileWarning = 'Warning: not a valid file'
 
 
 @implementer(ICheckerFactory, plugin.IPlugin)
-class FileCheckerFactory(object):
+class FileCheckerFactory:
     """
     A factory for instances of L{FilePasswordDB}.
     """

--- a/src/twisted/plugins/cred_memory.py
+++ b/src/twisted/plugins/cred_memory.py
@@ -28,7 +28,7 @@ really don't want to use this for anything else. It is a toy.
 
 
 @implementer(ICheckerFactory, plugin.IPlugin)
-class InMemoryCheckerFactory(object):
+class InMemoryCheckerFactory:
     """
     A factory for in-memory credentials checkers.
 

--- a/src/twisted/plugins/cred_sshkeys.py
+++ b/src/twisted/plugins/cred_sshkeys.py
@@ -25,7 +25,7 @@ try:
         SSHPublicKeyChecker, UNIXAuthorizedKeysFiles)
 
     @implementer(ICheckerFactory, plugin.IPlugin)
-    class SSHKeyCheckerFactory(object):
+    class SSHKeyCheckerFactory:
         """
         Generates checkers that will authenticate a SSH public key
         """

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -48,7 +48,7 @@ def verifyCryptedPassword(crypted, pw):
 
 
 @implementer(ICredentialsChecker)
-class UNIXChecker(object):
+class UNIXChecker:
     """
     A credentials checker for a UNIX server. This will check that
     an authenticating username/password is a valid user on the system.
@@ -162,7 +162,7 @@ Future versions may include support for PAM authentication.
 
 
 @implementer(ICheckerFactory, plugin.IPlugin)
-class UNIXCheckerFactory(object):
+class UNIXCheckerFactory:
     """
     A factory for L{UNIXChecker}.
     """

--- a/src/twisted/plugins/twisted_trial.py
+++ b/src/twisted/plugins/twisted_trial.py
@@ -7,7 +7,7 @@ from twisted.plugin import IPlugin
 
 
 @implementer(IPlugin, IReporter)
-class _Reporter(object):
+class _Reporter:
 
     def __init__(self, name, module, description, longOpt, shortOpt, klass):
         self.name = name

--- a/src/twisted/plugins/twisted_words.py
+++ b/src/twisted/plugins/twisted_words.py
@@ -24,7 +24,7 @@ TwistedXMPPRouter = ServiceMaker(
 
 
 @provider(IPlugin, iwords.IProtocolPlugin)
-class RelayChatInterface(object):
+class RelayChatInterface:
 
     name = 'irc'
 
@@ -36,7 +36,7 @@ class RelayChatInterface(object):
 
 
 @provider(IPlugin, iwords.IProtocolPlugin)
-class PBChatInterface(object):
+class PBChatInterface:
 
     name = 'pb'
 

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -7,7 +7,7 @@ from typing import Set
 
 
 
-class _BaseSentence(object):
+class _BaseSentence:
     """
     A base sentence class for a particular protocol.
 
@@ -90,7 +90,7 @@ class _BaseSentence(object):
 
 
 
-class _PositioningSentenceProducerMixin(object):
+class _PositioningSentenceProducerMixin:
     """
     A mixin for certain protocols that produce positioning sentences.
 

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -60,7 +60,7 @@ class Directions(Names):
 
 
 @implementer(ipositioning.IPositioningReceiver)
-class BasePositioningReceiver(object):
+class BasePositioningReceiver:
     """
     A base positioning receiver.
 
@@ -134,7 +134,7 @@ class InvalidChecksum(Exception):
 
 
 
-class Angle(FancyEqMixin, object):
+class Angle(FancyEqMixin):
     """
     An object representing an angle.
 
@@ -444,7 +444,7 @@ class Coordinate(Angle):
 
 
 
-class Altitude(FancyEqMixin, object):
+class Altitude(FancyEqMixin):
     """
     An altitude.
 
@@ -510,7 +510,7 @@ class Altitude(FancyEqMixin, object):
 
 
 
-class _BaseSpeed(FancyEqMixin, object):
+class _BaseSpeed(FancyEqMixin):
     """
     An object representing the abstract concept of the speed (rate of
     movement) of a mobile object.
@@ -618,7 +618,7 @@ class Climb(_BaseSpeed):
 
 
 
-class PositionError(FancyEqMixin, object):
+class PositionError(FancyEqMixin):
     """
     Position error information.
 
@@ -797,7 +797,7 @@ class PositionError(FancyEqMixin, object):
 
 
 
-class BeaconInformation(object):
+class BeaconInformation:
     """
     Information about positioning beacons (a generalized term for the reference
     objects that help you determine your position, such as satellites or cell
@@ -849,7 +849,7 @@ class BeaconInformation(object):
 
 
 @implementer(ipositioning.IPositioningBeacon)
-class PositioningBeacon(object):
+class PositioningBeacon:
     """
     A positioning beacon.
 

--- a/src/twisted/positioning/nmea.py
+++ b/src/twisted/positioning/nmea.py
@@ -420,7 +420,7 @@ class NMEASentence(_sentence._BaseSentence):
 
 
 @implementer(ipositioning.INMEAReceiver)
-class NMEAAdapter(object):
+class NMEAAdapter:
     """
     An adapter from NMEAProtocol receivers to positioning receivers.
 

--- a/src/twisted/positioning/test/test_nmea.py
+++ b/src/twisted/positioning/test/test_nmea.py
@@ -35,7 +35,7 @@ $GPGSV,3,3,11,22,42,067,42,24,14,311,43,27,05,244,00,,,,*4D
 
 
 @implementer(ipositioning.INMEAReceiver)
-class NMEATestReceiver(object):
+class NMEATestReceiver:
     """
     An NMEA receiver for testing.
 
@@ -183,7 +183,7 @@ class ChecksumTests(TestCase):
 
 
 
-class NMEAReceiverSetup(object):
+class NMEAReceiverSetup:
     """
     A mixin for tests that need an NMEA receiver (and a protocol attached to
     it).
@@ -523,7 +523,7 @@ class FixUnitsTests(TestCase):
         Tests that when no C{valueKey} is provided, C{unitKey} is used, minus
         C{"Units"} at the end.
         """
-        class FakeSentence(object):
+        class FakeSentence:
             """
             A fake sentence that just has a "foo" attribute.
             """
@@ -540,7 +540,7 @@ class FixUnitsTests(TestCase):
         Tests that if a unit key is provided but the unit isn't, the unit is
         automatically determined from the unit key.
         """
-        class FakeSentence(object):
+        class FakeSentence:
             """
             A fake sentence that just has "foo" and "fooUnits" attributes.
             """
@@ -562,7 +562,7 @@ class FixUnitsTests(TestCase):
 
 
 
-class FixerTestMixin(object):
+class FixerTestMixin:
     """
     Mixin for tests for the fixers on L{nmea.NMEAAdapter} that adapt
     from NMEA-specific notations to generic Python objects.

--- a/src/twisted/positioning/test/test_sentence.py
+++ b/src/twisted/positioning/test/test_sentence.py
@@ -16,7 +16,7 @@ sentinelValueTwo = "someOtherStringValue"
 
 
 
-class DummyProtocol(object):
+class DummyProtocol:
     """
     A simple, fake protocol.
     """
@@ -57,7 +57,7 @@ class MixinSentence(_sentence._BaseSentence):
 
 
 
-class SentenceTestsMixin(object):
+class SentenceTestsMixin:
     """
     Tests for positioning protocols and their respective sentences.
     """

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1235,7 +1235,7 @@ CommandLocator = CommandLocator.__metaclass__(  # type: ignore[assignment,misc]
 
 
 @implementer(IResponderLocator)
-class SimpleStringLocator(object):
+class SimpleStringLocator:
     """
     Implement the L{AMP.locateResponder} method to do simple, string-based
     dispatch.
@@ -2222,7 +2222,7 @@ class ProtocolSwitchCommand(Command):
 
 
 @implementer(IFileDescriptorReceiver)
-class _DescriptorExchanger(object):
+class _DescriptorExchanger:
     """
     L{_DescriptorExchanger} is a mixin for L{BinaryBoxProtocol} which adds
     support for receiving file descriptors, a feature offered by

--- a/src/twisted/protocols/basic.py
+++ b/src/twisted/protocols/basic.py
@@ -656,7 +656,7 @@ class StringTooLongError(AssertionError):
 
 
 
-class _RecvdCompatHack(object):
+class _RecvdCompatHack:
     """
     Emulates the to-be-deprecated C{IntNStringReceiver.recvd} attribute.
 

--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -432,7 +432,7 @@ _months = [
 
 
 @implementer(interfaces.IConsumer)
-class DTP(protocol.Protocol, object):
+class DTP(protocol.Protocol):
     isConnected = False
 
     _cons = None
@@ -679,7 +679,7 @@ class DTPFactory(protocol.ClientFactory):
 
 # -- FTP-PI (Protocol Interpreter) --
 
-class ASCIIConsumerWrapper(object):
+class ASCIIConsumerWrapper:
     def __init__(self, cons):
         self.cons = cons
         self.registerProducer = cons.registerProducer
@@ -697,7 +697,7 @@ class ASCIIConsumerWrapper(object):
 
 
 @implementer(interfaces.IConsumer)
-class FileConsumer(object):
+class FileConsumer:
     """
     A consumer for FTP input that writes data to a file.
 
@@ -733,7 +733,7 @@ class FTPOverflowProtocol(basic.LineReceiver):
 
 
 
-class FTP(basic.LineReceiver, policies.TimeoutMixin, object):
+class FTP(basic.LineReceiver, policies.TimeoutMixin):
     """
     Protocol Interpreter for the File Transfer Protocol
 
@@ -1900,7 +1900,7 @@ def _testPermissions(uid, gid, spath, mode='r'):
 
 
 @implementer(IFTPShell)
-class FTPAnonymousShell(object):
+class FTPAnonymousShell:
     """
     An anonymous implementation of IFTPShell
 
@@ -2164,7 +2164,7 @@ class FTPAnonymousShell(object):
 
 
 @implementer(IReadFile)
-class _FileReader(object):
+class _FileReader:
     def __init__(self, fObj):
         self.fObj = fObj
         self._send = False
@@ -2275,7 +2275,7 @@ class FTPShell(FTPAnonymousShell):
 
 
 @implementer(IWriteFile)
-class _FileWriter(object):
+class _FileWriter:
     def __init__(self, fObj):
         self.fObj = fObj
         self._receive = False

--- a/src/twisted/protocols/haproxy/_info.py
+++ b/src/twisted/protocols/haproxy/_info.py
@@ -12,7 +12,7 @@ from ._interfaces import IProxyInfo
 
 
 @implementer(IProxyInfo)
-class ProxyInfo(object):
+class ProxyInfo:
     """
     A data container for parsed PROXY protocol information.
 

--- a/src/twisted/protocols/haproxy/_parser.py
+++ b/src/twisted/protocols/haproxy/_parser.py
@@ -44,7 +44,7 @@ def unparseEndpoint(args, kwargs):
 
 
 @implementer(IPlugin, IStreamServerEndpointStringParser)
-class HAProxyServerParser(object):
+class HAProxyServerParser:
     """
     Stream server endpoint string parser for the HAProxyServerEndpoint type.
 

--- a/src/twisted/protocols/haproxy/_v1parser.py
+++ b/src/twisted/protocols/haproxy/_v1parser.py
@@ -20,7 +20,7 @@ from . import _interfaces
 
 
 @implementer(_interfaces.IProxyParser)
-class V1Parser(object):
+class V1Parser:
     """
     PROXY protocol version one header parser.
 

--- a/src/twisted/protocols/haproxy/_v2parser.py
+++ b/src/twisted/protocols/haproxy/_v2parser.py
@@ -49,7 +49,7 @@ _LOCALCOMMAND = 'LOCAL'
 _PROXYCOMMAND = 'PROXY'
 
 @implementer(_interfaces.IProxyParser)
-class V2Parser(object):
+class V2Parser:
     """
     PROXY protocol version two header parser.
 

--- a/src/twisted/protocols/haproxy/_wrapper.py
+++ b/src/twisted/protocols/haproxy/_wrapper.py
@@ -17,7 +17,7 @@ from ._v2parser import V2Parser
 
 
 
-class HAProxyProtocolWrapper(policies.ProtocolWrapper, object):
+class HAProxyProtocolWrapper(policies.ProtocolWrapper):
     """
     A Protocol wrapper that provides HAProxy support.
 

--- a/src/twisted/protocols/loopback.py
+++ b/src/twisted/protocols/loopback.py
@@ -20,7 +20,7 @@ from twisted.python import failure
 from twisted.internet.interfaces import IAddress
 
 
-class _LoopbackQueue(object):
+class _LoopbackQueue:
     """
     Trivial wrapper around a list to give it an interface like a queue, which
     the addition of also sending notifications by way of a Deferred whenever
@@ -52,13 +52,13 @@ class _LoopbackQueue(object):
 
 
 @implementer(IAddress)
-class _LoopbackAddress(object):
+class _LoopbackAddress:
     pass
 
 
 
 @implementer(interfaces.ITransport, interfaces.IConsumer)
-class _LoopbackTransport(object):
+class _LoopbackTransport:
     disconnecting = False
     producer = None
 

--- a/src/twisted/protocols/memcache.py
+++ b/src/twisted/protocols/memcache.py
@@ -62,7 +62,7 @@ class ServerError(Exception):
 
 
 
-class Command(object):
+class Command:
     """
     Wrap a client action into an object, that holds the values used in the
     protocol.

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -127,7 +127,7 @@ def unq(s):
 
 _absent = object()
 
-class Via(object):
+class Via:
     """
     A L{Via} is a SIP Via header, representing a segment of the path taken by
     the request.

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -912,7 +912,7 @@ class IntNTestCaseMixin(LPTestCaseMixin):
 
 
 
-class RecvdAttributeMixin(object):
+class RecvdAttributeMixin:
     """
     Mixin defining tests for string receiving protocols with a C{recvd}
     attribute which should be settable by application code, to be combined with
@@ -1129,7 +1129,7 @@ class Int8Tests(unittest.SynchronousTestCase, IntNTestCaseMixin,
 
 
 
-class OnlyProducerTransport(object):
+class OnlyProducerTransport:
     """
     Transport which isn't really a transport, just looks like one to
     someone not looking very hard.

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -149,7 +149,7 @@ def buildTLSProtocol(server=False, transport=None, fakeConnection=None):
     if fakeConnection:
         @implementer(IOpenSSLServerConnectionCreator,
                      IOpenSSLClientConnectionCreator)
-        class HardCodedConnection(object):
+        class HardCodedConnection:
             def clientConnectionForTLS(self, tlsProtocol):
                 return fakeConnection
             serverConnectionForTLS = clientConnectionForTLS
@@ -212,7 +212,7 @@ class TLSMemoryBIOFactoryTests(TestCase):
         If the wrapped factory does not provide L{ILoggingContext},
         L{TLSMemoryBIOFactory.logPrefix} uses the wrapped factory's class name.
         """
-        class NoFactory(object):
+        class NoFactory:
             pass
 
         contextFactory = ServerTLSContext()
@@ -234,7 +234,7 @@ def handshakingClientAndServer(clientGreetingData=None,
     """
     authCert, serverCert = certificatesForAuthorityAndServer()
     @implementer(IHandshakeListener)
-    class Client(AccumulatingProtocol, object):
+    class Client(AccumulatingProtocol):
         handshook = False
         peerAfterHandshake = None
 
@@ -253,7 +253,7 @@ def handshakingClientAndServer(clientGreetingData=None,
             pass
 
     @implementer(IHandshakeListener)
-    class Server(AccumulatingProtocol, object):
+    class Server(AccumulatingProtocol):
         handshaked = False
         def handshakeCompleted(self):
             self.handshaked = True
@@ -343,7 +343,7 @@ class TLSMemoryBIOTests(TestCase):
         class ITransport(Interface):
             pass
 
-        class MyTransport(object):
+        class MyTransport:
             def write(self, data):
                 pass
 
@@ -993,7 +993,7 @@ class TLSMemoryBIOTests(TestCase):
         tlsClient.wrappedProtocol.connectionLost = reason.append
 
         # Pretend TLS connection is unhappy sending:
-        class Wrapper(object):
+        class Wrapper:
             def __init__(self, wrapped):
                 self._wrapped = wrapped
             def __getattr__(self, attr):
@@ -1366,7 +1366,7 @@ class TLSProducerTests(TestCase):
                 StringTransport.write(self, data)
 
 
-        class TLSConnection(object):
+        class TLSConnection:
             def __init__(self):
                 self.l = []
 
@@ -1481,7 +1481,7 @@ class TLSProducerTests(TestCase):
         clientProtocol.connectionLost = lambda reason: reason.trap(
             Error, ConnectionLost)
 
-        class Producer(object):
+        class Producer:
             stopped = False
 
             def resumeProducing(self):

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -64,7 +64,7 @@ from twisted.protocols.policies import ProtocolWrapper, WrappingFactory
 
 
 @implementer(IPushProducer)
-class _ProducerMembrane(object):
+class _ProducerMembrane:
     """
     Stand-in for producer registered with a L{TLSMemoryBIOProtocol} transport.
 
@@ -624,7 +624,7 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
 
 
 @implementer(IOpenSSLClientConnectionCreator, IOpenSSLServerConnectionCreator)
-class _ContextFactoryToConnectionFactory(object):
+class _ContextFactoryToConnectionFactory:
     """
     Adapter wrapping a L{twisted.internet.interfaces.IOpenSSLContextFactory}
     into a L{IOpenSSLClientConnectionCreator} or

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -105,7 +105,7 @@ class IVCSCommand(Interface):
 
 
 @implementer(IVCSCommand)
-class GitCommand(object):
+class GitCommand:
     """
     Subset of Git commands to release Twisted from a Git repository.
     """
@@ -197,7 +197,7 @@ def getRepositoryCommand(directory):
 
 
 
-class Project(object):
+class Project:
     """
     A representation of a project that has a version.
 
@@ -272,7 +272,7 @@ class NoDocumentsFound(Exception):
 
 
 
-class APIBuilder(object):
+class APIBuilder:
     """
     Generate API documentation from source files using
     U{pydoctor<https://github.com/twisted/pydoctor>}.  This requires
@@ -344,7 +344,7 @@ class APIBuilder(object):
 
 
 
-class SphinxBuilder(object):
+class SphinxBuilder:
     """
     Generate HTML documentation using Sphinx.
 
@@ -456,7 +456,7 @@ class NotWorkingDirectory(Exception):
 
 
 
-class BuildAPIDocsScript(object):
+class BuildAPIDocsScript:
     """
     A thing for building API documentation. See L{main}.
     """
@@ -499,7 +499,7 @@ class BuildAPIDocsScript(object):
 
 
 
-class CheckNewsfragmentScript(object):
+class CheckNewsfragmentScript:
     """
     A thing for checking whether a checkout has a newsfragment.
     """

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -145,7 +145,7 @@ _CONSOLE_SCRIPTS = [
 
 
 
-class ConditionalExtension(Extension, object):
+class ConditionalExtension(Extension):
     """
     An extension module that will only be compiled if certain conditions are
     met.
@@ -278,7 +278,7 @@ def getSetupArgs(extensions=_EXTENSIONS, readme='README.rst'):
 
 
 
-class BuildPy3(build_py, object):
+class BuildPy3(build_py):
     """
     A version of build_py that doesn't install the modules that aren't yet
     ported to Python 3.
@@ -295,7 +295,7 @@ class BuildPy3(build_py, object):
 # Helpers and distutil tweaks
 
 
-class build_ext_twisted(build_ext.build_ext, object):  # type: ignore[name-defined]  # noqa
+class build_ext_twisted(build_ext.build_ext):  # type: ignore[name-defined]  # noqa
     """
     Allow subclasses to easily detect and customize Extensions to
     build at install-time.

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -141,7 +141,7 @@ class SubcommandAction(usage.Completer):
 
 
 
-class ZshBuilder(object):
+class ZshBuilder:
     """
     Constructs zsh code that will complete options for a given usage.Options
     instance, possibly including a list of subcommand names.
@@ -223,7 +223,7 @@ class ZshSubcommandBuilder(ZshBuilder):
 
 
 
-class ZshArgumentsGenerator(object):
+class ZshArgumentsGenerator:
     """
     Generate a call to the zsh _arguments completion function
     based on data in a usage.Options instance

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -26,7 +26,7 @@ from twisted.python.util import FancyEqMixin
 
 
 
-class _Attribute(FancyEqMixin, object):
+class _Attribute(FancyEqMixin):
     """
     A text attribute.
 
@@ -168,7 +168,7 @@ class _BackgroundColorAttr(_ColorAttr):
 
 
 
-class _ColorAttribute(object):
+class _ColorAttribute:
     """
     A color text attribute.
 
@@ -195,7 +195,7 @@ class _ColorAttribute(object):
 
 
 
-class CharacterAttributesMixin(object):
+class CharacterAttributesMixin:
     """
     Mixin for character attributes that implements a C{__getattr__} method
     returning a new C{_NormalAttr} instance when attempting to access
@@ -211,7 +211,7 @@ class CharacterAttributesMixin(object):
 
 
 
-class DefaultFormattingState(FancyEqMixin, object):
+class DefaultFormattingState(FancyEqMixin):
     """
     A character attribute that does nothing, thus applying no attributes to
     text.

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -336,7 +336,7 @@ def proxyForInterface(iface, originalAttribute='original'):
 
 
 
-class _ProxiedClassMethod(object):
+class _ProxiedClassMethod:
     """
     A proxied class method.
 
@@ -372,7 +372,7 @@ class _ProxiedClassMethod(object):
 
 
 
-class _ProxyDescriptor(object):
+class _ProxyDescriptor:
     """
     A descriptor which will proxy attribute access, mutation, and
     deletion to the L{_ProxyDescriptor.originalAttribute} of the

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -106,7 +106,7 @@ class ContextTracker:
 
 
 
-class ThreadedContextTracker(object):
+class ThreadedContextTracker:
     def __init__(self):
         self.storage = local()
 

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -18,7 +18,7 @@ To mark a method, function, or class as being deprecated do this::
         ...
 
     @deprecated(Version("Twisted", 16, 0, 0))
-    class BadClass(object):
+    class BadClass:
         '''
         Docstring for BadClass.
         '''
@@ -32,7 +32,7 @@ To deprecate properties you can use::
     from incremental import Version
     from twisted.python.deprecate import deprecatedProperty
 
-    class OtherwiseUndeprecatedClass(object):
+    class OtherwiseUndeprecatedClass:
 
         @deprecatedProperty(Version('Twisted', 16, 0, 0))
         def badProperty(self):
@@ -408,7 +408,7 @@ def setWarningMethod(newMethod):
 
 
 
-class _InternalState(object):
+class _InternalState:
     """
     An L{_InternalState} is a helper object for a L{_ModuleProxy}, so that it
     can easily access its own attributes, bypassing its logic for delegating to
@@ -431,7 +431,7 @@ class _InternalState(object):
 
 
 
-class _ModuleProxy(object):
+class _ModuleProxy:
     """
     Python module wrapper to hook module-level attribute access.
 
@@ -514,7 +514,7 @@ class _ModuleProxy(object):
 
 
 
-class _DeprecatedAttribute(object):
+class _DeprecatedAttribute:
     """
     Wrapper for deprecated attributes.
 

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -129,7 +129,7 @@ def _Traceback(stackFrames, tbFrames):
 
 
 
-class _TracebackFrame(object):
+class _TracebackFrame:
     """
     Fake traceback object which can be passed to functions in the standard
     library L{traceback} module.
@@ -145,7 +145,7 @@ class _TracebackFrame(object):
 
 
 
-class _Frame(object):
+class _Frame:
     """
     A fake frame object, used by L{_Traceback}.
 
@@ -171,7 +171,7 @@ class _Frame(object):
 
 
 
-class _Code(object):
+class _Code:
     """
     A fake code object, used by L{_Traceback} via L{_Frame}.
     """

--- a/src/twisted/python/fakepwd.py
+++ b/src/twisted/python/fakepwd.py
@@ -10,7 +10,7 @@ L{twisted.python.fakepwd} provides a fake implementation of the L{pwd} API.
 __all__ = ['UserDatabase', 'ShadowDatabase']
 
 
-class _UserRecord(object):
+class _UserRecord:
     """
     L{_UserRecord} holds the user data for a single user in L{UserDatabase}.
     It corresponds to L{pwd.struct_passwd}.  See that class for attribute
@@ -37,7 +37,7 @@ class _UserRecord(object):
 
 
 
-class UserDatabase(object):
+class UserDatabase:
     """
     L{UserDatabase} holds a traditional POSIX user data in memory and makes it
     available via the same API as L{pwd}.
@@ -113,7 +113,7 @@ class UserDatabase(object):
 
 
 
-class _ShadowRecord(object):
+class _ShadowRecord:
     """
     L{_ShadowRecord} holds the shadow user data for a single user in
     L{ShadowDatabase}.  It corresponds to C{spwd.struct_spwd}.  See that class
@@ -144,7 +144,7 @@ class _ShadowRecord(object):
 
 
 
-class ShadowDatabase(object):
+class ShadowDatabase:
     """
     L{ShadowDatabase} holds a shadow user database in memory and makes it
     available via the same API as C{spwd}.

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -272,7 +272,7 @@ def _secureEnoughString(path):
 
 
 
-class AbstractFilePath(object):
+class AbstractFilePath:
     """
     Abstract implementation of an L{IFilePath}; must be completed by a
     subclass.
@@ -501,7 +501,7 @@ class AbstractFilePath(object):
 
 
 
-class RWX(FancyEqMixin, object):
+class RWX(FancyEqMixin):
     """
     A class representing read/write/execute permissions for a single user
     category (i.e. user/owner, group, or other/world).  Instantiate with
@@ -549,7 +549,7 @@ class RWX(FancyEqMixin, object):
 
 
 
-class Permissions(FancyEqMixin, object):
+class Permissions(FancyEqMixin):
     """
     A class representing read/write/execute permissions.  Instantiate with any
     portion of the file's mode that includes the permission bits.

--- a/src/twisted/python/lockfile.py
+++ b/src/twisted/python/lockfile.py
@@ -123,7 +123,7 @@ else:
 
 
 
-class FilesystemLock(object):
+class FilesystemLock:
     """
     A mutex.
 

--- a/src/twisted/python/log.py
+++ b/src/twisted/python/log.py
@@ -556,7 +556,7 @@ class FileLogObserver(_GlobalStartStopMixIn):
 
 
 
-class PythonLoggingObserver(_GlobalStartStopMixIn, object):
+class PythonLoggingObserver(_GlobalStartStopMixIn):
     """
     Output twisted messages to Python standard library L{logging} module.
 

--- a/src/twisted/python/monkey.py
+++ b/src/twisted/python/monkey.py
@@ -5,7 +5,7 @@
 
 
 
-class MonkeyPatcher(object):
+class MonkeyPatcher:
     """
     Cover up attributes with new objects. Neat for monkey-patching things for
     unit-testing purposes.

--- a/src/twisted/python/randbytes.py
+++ b/src/twisted/python/randbytes.py
@@ -31,7 +31,7 @@ class SourceNotAvailable(RuntimeError):
 
 
 
-class RandomFactory(object):
+class RandomFactory:
     """
     Factory providing L{secureRandom} and L{insecureRandom} methods.
 

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -43,7 +43,7 @@ def _isClassType(t):
 
 
 
-class Sensitive(object):
+class Sensitive:
     """
     A utility mixin that's sensitive to rebuilds.
 

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -15,7 +15,7 @@ __all__ = ['ListenFDs']
 from os import getpid
 
 
-class ListenFDs(object):
+class ListenFDs:
     """
     L{ListenFDs} provides access to file descriptors inherited from systemd.
 

--- a/src/twisted/python/test/modules_helpers.py
+++ b/src/twisted/python/test/modules_helpers.py
@@ -12,7 +12,7 @@ import sys
 from twisted.python.filepath import FilePath
 
 
-class TwistedModulesMixin(object):
+class TwistedModulesMixin:
     """
     A mixin for C{twisted.trial.unittest.SynchronousTestCase} providing useful
     methods for manipulating Python's module system.

--- a/src/twisted/python/test/test_components.py
+++ b/src/twisted/python/test/test_components.py
@@ -78,14 +78,14 @@ class Test(components.Adapter):
 
 
 @implementer(ITest2)
-class Test2(object):
+class Test2:
     temporaryAdapter = 1
     def __init__(self, orig):
         pass
 
 
 
-class RegistryUsingMixin(object):
+class RegistryUsingMixin:
     """
     Mixin for test cases which modify the global registry somehow.
     """
@@ -257,7 +257,7 @@ class BackwardsAdder(components.Adapter):
 
 
 
-class MetaNumber(object):
+class MetaNumber:
     """
     Integer wrapper for Interface adaptation tests.
     """
@@ -312,7 +312,7 @@ class IAttrXX(Interface):
 
 
 @implementer(IAttrX)
-class Xcellent(object):
+class Xcellent:
     """
     L{IAttrX} implementation for test of adapter with C{__cmp__}.
     """
@@ -327,7 +327,7 @@ class Xcellent(object):
 
 
 @comparable
-class DoubleXAdapter(object):
+class DoubleXAdapter:
     """
     Adapter with __cmp__.
     """
@@ -390,7 +390,7 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Test that an adapter from a class can be registered and then looked
         up.
         """
-        class TheOriginal(object):
+        class TheOriginal:
             pass
         return self._registerAdapterForClassOrInterface(TheOriginal)
 
@@ -426,7 +426,7 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Test that attempting to register a second adapter from a class
         raises the appropriate exception.
         """
-        class TheOriginal(object):
+        class TheOriginal:
             pass
         return self._duplicateAdapterForClassOrInterface(TheOriginal)
 
@@ -476,7 +476,7 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         value, duplicate registrations from classes are allowed to override
         the original registration.
         """
-        class TheOriginal(object):
+        class TheOriginal:
             pass
         return self._duplicateAdapterForClassOrInterfaceAllowed(TheOriginal)
 
@@ -510,7 +510,7 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Test the registration of an adapter from a class to several
         interfaces at once.
         """
-        class TheOriginal(object):
+        class TheOriginal:
             pass
         return self._multipleInterfacesForClassOrInterface(TheOriginal)
 
@@ -549,7 +549,7 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Test that an adapter to a particular interface can be registered
         from both a class and its subclass.
         """
-        class TheOriginal(object):
+        class TheOriginal:
             pass
         return self._subclassAdapterRegistrationForClassOrInterface(TheOriginal)
 
@@ -589,7 +589,7 @@ class IProxiedSubInterface(IProxiedInterface):
 
 
 @implementer(IProxiedInterface)
-class Yayable(object):  # type: ignore[misc]
+class Yayable:  # type: ignore[misc]
     # class does not implement Attribute ifaceAttribute
     # so we need to turn off mypy warning
     """
@@ -615,7 +615,7 @@ class Yayable(object):  # type: ignore[misc]
 
 
 @implementer(IProxiedSubInterface)
-class Booable(object):  # type: ignore[misc]
+class Booable:  # type: ignore[misc]
     # class does not implement Attribute ifaceAttribute
     # so we need to turn off mypy warning
     """
@@ -658,7 +658,7 @@ class IMultipleMethods(Interface):
 
 
 
-class MultipleMethodImplementor(object):
+class MultipleMethodImplementor:
     """
     A precise implementation of L{IMultipleMethods}.
     """
@@ -828,7 +828,7 @@ class ProxyForInterfaceTests(unittest.SynchronousTestCase):
         idiomatic way to ensure that signature works; test_proxyInheritance
         verifies the how-Python-actually-calls-it signature.
         """
-        class Sample(object):
+        class Sample:
             called = False
             def hello(self):
                 self.called = True

--- a/src/twisted/python/test/test_constants.py
+++ b/src/twisted/python/test/test_constants.py
@@ -89,7 +89,7 @@ class NamedConstantTests(TestCase):
 
 
 
-class _ConstantsTestsMixin(object):
+class _ConstantsTestsMixin:
     """
     Mixin defining test helpers common to multiple types of constants
     collections.
@@ -274,7 +274,7 @@ class NamesTests(TestCase, _ConstantsTestsMixin):
         A constant defined on a L{Names} subclass may be set as an attribute of
         another class and then retrieved using that attribute.
         """
-        class Another(object):
+        class Another:
             something = self.METHOD.GET
 
         self.assertIs(self.METHOD.GET, Another.something)
@@ -286,7 +286,7 @@ class NamesTests(TestCase, _ConstantsTestsMixin):
         another class and then retrieved from an instance of that class using
         that attribute.
         """
-        class Another(object):
+        class Another:
             something = self.METHOD.GET
 
         self.assertIs(self.METHOD.GET, Another().something)
@@ -474,7 +474,7 @@ class ValuesTests(TestCase, _ConstantsTestsMixin):
 
 
 
-class _FlagsTestsMixin(object):
+class _FlagsTestsMixin:
     """
     Mixin defining setup code for any tests for L{Flags} subclasses.
 

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -44,7 +44,7 @@ from twisted.trial.unittest import SynchronousTestCase
 # #5203.
 
 
-class _MockDeprecatedAttribute(object):
+class _MockDeprecatedAttribute:
     """
     Mock of L{twisted.python.deprecate._DeprecatedAttribute}.
 
@@ -700,14 +700,14 @@ class DeprecationWarningsTests(SynchronousTestCase):
 
 
 @deprecated(Version('Twisted', 1, 2, 3))
-class DeprecatedClass(object):
+class DeprecatedClass:
     """
     Class which is entirely deprecated without having a replacement.
     """
 
 
 
-class ClassWithDeprecatedProperty(object):
+class ClassWithDeprecatedProperty:
     """
     Class with a single deprecated property.
     """

--- a/src/twisted/python/test/test_fakepwd.py
+++ b/src/twisted/python/test/test_fakepwd.py
@@ -51,7 +51,7 @@ INVALID_UID = findInvalidUID()
 
 
 
-class UserDatabaseTestsMixin(object):
+class UserDatabaseTestsMixin:
     """
     L{UserDatabaseTestsMixin} defines tests which apply to any user database
     implementation.  Subclasses should mix it in, implement C{setUp} to create
@@ -244,7 +244,7 @@ class PwdModuleTests(TestCase, UserDatabaseTestsMixin):
 
 
 
-class ShadowDatabaseTestsMixin(object):
+class ShadowDatabaseTestsMixin:
     """
     L{ShadowDatabaseTestsMixin} defines tests which apply to any shadow user
     database implementation.  Subclasses should mix it in, implement C{setUp} to

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -132,7 +132,7 @@ def genVersion(*args, **kwargs):
 
 
 
-class StructureAssertingMixin(object):
+class StructureAssertingMixin:
     """
     A mixin for L{TestCase} subclasses which provides some methods for
     asserting the structure and contents of directories and files on the
@@ -541,7 +541,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
             u"def _bar():\n"
             u"    '{}'\n"
             u"@deprecated(Version('Twisted', 14, 2, 3), replacement='stuff')\n"
-            u"class Baz(object):\n"
+            u"class Baz:\n"
             u"    pass"
             u"".format(docstring, privateDocstring).encode("utf-8"))
 

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -53,7 +53,7 @@ else:
 
 
 
-class _FDHolder(object):
+class _FDHolder:
     """
     A wrapper around a FD that will remember if it has been closed or not.
     """

--- a/src/twisted/python/test/test_setup.py
+++ b/src/twisted/python/test/test_setup.py
@@ -259,7 +259,7 @@ class OptionalDependenciesTests(SynchronousTestCase):
 
 
 
-class FakeModule(object):
+class FakeModule:
     """
     A fake module, suitable for dependency injection in testing.
     """

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -38,7 +38,7 @@ class ZshScriptTestMeta(type):
 
 
 
-class ZshScriptTestMixin(object):
+class ZshScriptTestMixin:
     """
     Integration test helper to show that C{usage.Options} classes can have zsh
     completion functions generated for them without raising errors.

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -12,7 +12,7 @@ from twisted.trial.unittest import TestCase
 from twisted.python.systemd import ListenFDs
 
 
-class InheritedDescriptorsMixin(object):
+class InheritedDescriptorsMixin:
     """
     Mixin for a L{TestCase} subclass which defines test methods for some kind of
     systemd sd-daemon class.  In particular, it defines tests for a
@@ -38,7 +38,7 @@ class InheritedDescriptorsMixin(object):
 
 
 
-class MemoryOnlyMixin(object):
+class MemoryOnlyMixin:
     """
     Mixin for a L{TestCase} subclass which creates creating a fake, in-memory
     implementation of C{inheritedDescriptors}.  This provides verification that
@@ -55,7 +55,7 @@ class MemoryOnlyMixin(object):
 
 
 
-class EnvironmentMixin(object):
+class EnvironmentMixin:
     """
     Mixin for a L{TestCase} subclass which creates a real implementation of
     C{inheritedDescriptors} which is based on the environment variables set by

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -715,7 +715,7 @@ class TestURL(SynchronousTestCase):
         bad data crops up in a method call long after the code that called the
         constructor is off the stack.
         """
-        class Unexpected(object):
+        class Unexpected:
             def __str__(self) -> str:
                 return "wrong"
 

--- a/src/twisted/python/test/test_urlpath.py
+++ b/src/twisted/python/test/test_urlpath.py
@@ -11,7 +11,7 @@ from twisted.python import urlpath
 
 
 
-class _BaseURLPathTests(object):
+class _BaseURLPathTests:
     """
     Tests for instantiated L{urlpath.URLPath}s.
     """

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -610,7 +610,7 @@ class DerivedRecord(Record):
 
 
 
-class EqualToEverything(object):
+class EqualToEverything:
     """
     A class the instances of which consider themselves equal to everything.
     """
@@ -619,7 +619,7 @@ class EqualToEverything(object):
 
 
 
-class EqualToNothing(object):
+class EqualToNothing:
     """
     A class the instances of which consider themselves equal to nothing.
     """

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -14,7 +14,7 @@ from twisted.python import zipstream, filepath
 from twisted.trial import unittest
 
 
-class FileEntryMixin(object):
+class FileEntryMixin:
     """
     File entry classes should behave as file-like objects
     """

--- a/src/twisted/python/threadable.py
+++ b/src/twisted/python/threadable.py
@@ -10,7 +10,7 @@ synchronization.
 
 from functools import wraps
 
-class DummyLock(object):
+class DummyLock:
     """
     Hack to allow locks to be unpickled on an unthreaded system.
     """
@@ -87,7 +87,7 @@ def init(with_threads=1):
             if threadingmodule is not None:
                 threaded = True
 
-                class XLock(threadingmodule._RLock, object):
+                class XLock(threadingmodule._RLock):
                     def __reduce__(self):
                         return (unpickle_lock, ())
 

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -126,7 +126,7 @@ class ThreadPool:
 
         @return: an object with a C{qsize} method.
         """
-        class NotAQueue(object):
+        class NotAQueue:
             def qsize(q):
                 """
                 Pretend to be a Python threading Queue and return the

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -36,7 +36,7 @@ def _rereconstituter(name):
 
 
 
-class URLPath(object):
+class URLPath:
     """
     A representation of a URL.
 

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -34,7 +34,7 @@ class UsageError(Exception):
 error = UsageError
 
 
-class CoerceParameter(object):
+class CoerceParameter:
     """
     Utility class that can corce a parameter before storing it.
     """
@@ -552,7 +552,7 @@ class Options(dict):
 _ZSH = 'zsh'
 _BASH = 'bash'
 
-class Completer(object):
+class Completer:
     """
     A completion "action" - provides completion possibilities for a particular
     command-line option. For example we might provide the user a fixed list of
@@ -762,7 +762,7 @@ class CompleteNetInterfaces(Completer):
 
 
 
-class Completions(object):
+class Completions:
     """
     Extra metadata for the shell tab-completion system.
 

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -525,7 +525,7 @@ def raises(exception, f, *args, **kwargs):
 
 
 
-class IntervalDifferential(object):
+class IntervalDifferential:
     """
     Given a list of intervals, generate the amount of time to sleep between
     "instants".
@@ -562,7 +562,7 @@ class IntervalDifferential(object):
 
 
 
-class _IntervalDifferentialIterator(object):
+class _IntervalDifferentialIterator:
     def __init__(self, i, d):
 
         self.intervals = [[e, e, n] for (e, n) in zip(i, range(len(i)))]

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -68,7 +68,7 @@ def quoteArguments(arguments):
     return ' '.join([cmdLineQuote(a) for a in arguments])
 
 
-class _ErrorFormatter(object):
+class _ErrorFormatter:
     """
     Formatter for Windows error messages.
 

--- a/src/twisted/python/zipstream.py
+++ b/src/twisted/python/zipstream.py
@@ -66,7 +66,7 @@ class ChunkingZipFile(zipfile.ZipFile):
 
 
 
-class _FileEntry(object):
+class _FileEntry:
     """
     Abstract superclass of both compressed and uncompressed variants of
     file-like objects within a zip archive.

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -17,7 +17,7 @@ from twisted.logger import Logger
 
 
 @attr.s(frozen=True)
-class _Process(object):
+class _Process:
     """
     The parameters of a process to be restarted.
 

--- a/src/twisted/runner/test/test_procmon.py
+++ b/src/twisted/runner/test/test_procmon.py
@@ -17,7 +17,7 @@ from twisted.test.proto_helpers import MemoryReactor
 
 
 
-class DummyProcess(object):
+class DummyProcess:
     """
     An incomplete and fake L{IProcessTransport} implementation for testing how
     L{ProcessMonitor} behaves when its monitored processes exit.

--- a/src/twisted/scripts/test/test_scripts.py
+++ b/src/twisted/scripts/test/test_scripts.py
@@ -46,7 +46,7 @@ def outputFromPythonScript(script, *args):
 
 
 
-class ScriptTestsMixin(object):
+class ScriptTestsMixin:
     """
     Mixin for L{TestCase} subclasses which defines a helper function for testing
     a Twisted-using script.

--- a/src/twisted/scripts/trial.py
+++ b/src/twisted/scripts/trial.py
@@ -159,7 +159,7 @@ def _checkKnownRunOrder(order):
 
 
 
-class _BasicOptions(object):
+class _BasicOptions:
     """
     Basic options shared between trial and its local workers.
     """

--- a/src/twisted/spread/test/test_jelly.py
+++ b/src/twisted/spread/test/test_jelly.py
@@ -17,7 +17,7 @@ from twisted.trial.unittest import TestCase
 from twisted.test.proto_helpers import StringTransport
 
 
-class TestNode(jelly.Jellyable, object):
+class TestNode(jelly.Jellyable):
     """
     An object to test jellyfying of new style class instances.
     """
@@ -77,14 +77,14 @@ class C:
 
 
 
-class D(object):
+class D:
     """
     Dummy new-style class.
     """
 
 
 
-class E(object):
+class E:
     """
     Dummy new-style class with slots.
     """

--- a/src/twisted/spread/test/test_pb.py
+++ b/src/twisted/spread/test/test_pb.py
@@ -56,7 +56,7 @@ class DummyPerspective(pb.Avatar):
 
 
 @implementer(portal.IRealm)
-class DummyRealm(object):
+class DummyRealm:
     def requestAvatar(self, avatarId, mind, *interfaces):
         for iface in interfaces:
             if iface is pb.IPerspective:
@@ -177,7 +177,7 @@ def connectServerAndClient(test, clientFactory, serverFactory):
 
 
 
-class _ReconnectingFakeConnectorState(object):
+class _ReconnectingFakeConnectorState:
     """
     Manages connection notifications for a
     L{_ReconnectingFakeConnector} instance.
@@ -446,13 +446,13 @@ class Observer(pb.Referenceable):
         other.callRemote('unobserve',self)
 
 
-class NewStyleCopy(pb.Copyable, pb.RemoteCopy, object):
+class NewStyleCopy(pb.Copyable, pb.RemoteCopy):
     def __init__(self, s):
         self.s = s
 pb.setUnjellyableForClass(NewStyleCopy, NewStyleCopy)
 
 
-class NewStyleCopy2(pb.Copyable, pb.RemoteCopy, object):
+class NewStyleCopy2(pb.Copyable, pb.RemoteCopy):
     allocated = 0
     initialized = 0
     value = 1
@@ -469,7 +469,7 @@ class NewStyleCopy2(pb.Copyable, pb.RemoteCopy, object):
 pb.setUnjellyableForClass(NewStyleCopy2, NewStyleCopy2)
 
 
-class NewStyleCacheCopy(pb.Cacheable, pb.RemoteCache, object):
+class NewStyleCacheCopy(pb.Cacheable, pb.RemoteCache):
     def getStateToCacheAndObserveFor(self, perspective, observer):
         return self.__dict__
 
@@ -1240,7 +1240,7 @@ class MyPerspective(pb.Avatar):
 
 
 
-class TestRealm(object):
+class TestRealm:
     """
     A realm which repeatedly gives out a single instance of L{MyPerspective}
     for non-anonymous logins and which gives out a new instance of L{Echoer}

--- a/src/twisted/spread/test/test_pbfailure.py
+++ b/src/twisted/spread/test/test_pbfailure.py
@@ -418,7 +418,7 @@ class PBFailureUnsafeTests(PBFailureTests):
 
 
 
-class DummyInvoker(object):
+class DummyInvoker:
     """
     A behaviorless object to be used as the invoker parameter to
     L{jelly.jelly}.

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -49,7 +49,7 @@ class TLSNegotiation:
 
 
 @implementer(interfaces.IAddress)
-class FakeAddress(object):
+class FakeAddress:
     """
     The default address type for the host and peer of L{FakeTransport}
     connections.
@@ -502,7 +502,7 @@ def _factoriesShouldConnect(clientInfo, serverInfo):
 
 
 
-class ConnectionCompleter(object):
+class ConnectionCompleter:
     """
     A L{ConnectionCompleter} can cause synthetic TCP connections established by
     L{MemoryReactor.connectTCP} and L{MemoryReactor.listenTCP} to succeed or

--- a/src/twisted/test/myrebuilder1.py
+++ b/src/twisted/test/myrebuilder1.py
@@ -3,7 +3,7 @@ class A:
     def a(self):
         return 'a'
 
-class B(A, object):
+class B(A):
     def b(self):
         return 'b'
 

--- a/src/twisted/test/myrebuilder2.py
+++ b/src/twisted/test/myrebuilder2.py
@@ -3,7 +3,7 @@ class A:
     def a(self):
         return 'b'
 
-class B(A, object):
+class B(A):
     def b(self):
         return 'c'
 

--- a/src/twisted/test/test_adbapi.py
+++ b/src/twisted/test/test_adbapi.py
@@ -25,7 +25,7 @@ CREATE TABLE simple (
 
 
 
-class ADBAPITestBase(object):
+class ADBAPITestBase:
     """
     Test the asynchronous DB-API code.
     """
@@ -267,7 +267,7 @@ class ADBAPITestBase(object):
 
 
 
-class ReconnectTestBase(object):
+class ReconnectTestBase:
     """
     Test the asynchronous DB-API code with reconnect.
     """
@@ -350,7 +350,7 @@ class ReconnectTestBase(object):
 
 
 
-class DBTestConnector(object):
+class DBTestConnector:
     """
     A class which knows how to test for the presence of
     and establish a connection to a relational database.
@@ -638,7 +638,7 @@ makeSQLTests(ReconnectTestBase, 'ReconnectTests', globals())
 
 
 
-class FakePool(object):
+class FakePool:
     """
     A fake L{ConnectionPool} for tests.
 
@@ -677,7 +677,7 @@ class ConnectionTests(unittest.TestCase):
         If an error happens during rollback, L{ConnectionLost} is raised but
         the original error is logged.
         """
-        class ConnectionRollbackRaise(object):
+        class ConnectionRollbackRaise:
             def rollback(self):
                 raise RuntimeError("problem!")
 
@@ -700,7 +700,7 @@ class TransactionTests(unittest.TestCase):
         If the cursor creation raises an error in L{Transaction.reopen}, it
         reconnects but log the error occurred.
         """
-        class ConnectionCursorRaise(object):
+        class ConnectionCursorRaise:
             count = 0
 
             def reconnect(self):
@@ -720,7 +720,7 @@ class TransactionTests(unittest.TestCase):
 
 
 
-class NonThreadPool(object):
+class NonThreadPool:
     def callInThreadWithCallback(self, onResult, f, *a, **kw):
         success = True
         try:
@@ -746,7 +746,7 @@ class DummyConnectionPool(ConnectionPool):
 
 
 
-class EventReactor(object):
+class EventReactor:
     """
     Partial L{IReactorCore} implementation with simple event-related
     methods.
@@ -789,7 +789,7 @@ class ConnectionPoolTests(unittest.TestCase):
         If rollback fails, L{ConnectionPool.runWithConnection} raises the
         original exception and log the error of the rollback.
         """
-        class ConnectionRollbackRaise(object):
+        class ConnectionRollbackRaise:
             def __init__(self, pool):
                 pass
 
@@ -815,7 +815,7 @@ class ConnectionPoolTests(unittest.TestCase):
         """
         L{ConnectionPool._close} logs exceptions.
         """
-        class ConnectionCloseRaise(object):
+        class ConnectionCloseRaise:
             def close(self):
                 raise RuntimeError("problem!")
 
@@ -832,14 +832,14 @@ class ConnectionPoolTests(unittest.TestCase):
         If rollback fails, L{ConnectionPool.runInteraction} raises the
         original exception and log the error of the rollback.
         """
-        class ConnectionRollbackRaise(object):
+        class ConnectionRollbackRaise:
             def __init__(self, pool):
                 pass
 
             def rollback(self):
                 raise RuntimeError("problem!")
 
-        class DummyTransaction(object):
+        class DummyTransaction:
             def __init__(self, pool, connection):
                 pass
 

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -517,7 +517,7 @@ class ParsingTests(TestCase):
 
 
 
-class FakeLocator(object):
+class FakeLocator:
     """
     This is a fake implementation of the interface implied by
     L{CommandLocator}.
@@ -3125,7 +3125,7 @@ class ListOfOptionalTests(TestCase):
 
 
 @implementer(interfaces.IUNIXTransport)
-class UNIXStringTransport(object):
+class UNIXStringTransport:
     """
     An in-memory implementation of L{interfaces.IUNIXTransport} which collects
     all data given to it for later inspection.

--- a/src/twisted/test/test_compat.py
+++ b/src/twisted/test/test_compat.py
@@ -212,7 +212,7 @@ class PYPYTest(SynchronousTestCase):
 
 
 @comparable
-class Comparable(object):
+class Comparable:
     """
     Objects that can be compared to each other, but not others.
     """

--- a/src/twisted/test/test_cooperator.py
+++ b/src/twisted/test/test_cooperator.py
@@ -12,7 +12,7 @@ from twisted.trial import unittest
 
 
 
-class FakeDelayedCall(object):
+class FakeDelayedCall:
     """
     Fake delayed call which lets us simulate the scheduler.
     """
@@ -32,7 +32,7 @@ class FakeDelayedCall(object):
 
 
 
-class FakeScheduler(object):
+class FakeScheduler:
     """
     A fake scheduler for testing against.
     """

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -69,7 +69,7 @@ def fakeCallbackCanceller(deferred):
 
 
 
-class ImmediateFailureMixin(object):
+class ImmediateFailureMixin:
     """
     Add additional assertion methods.
     """

--- a/src/twisted/test/test_factories.py
+++ b/src/twisted/test/test_factories.py
@@ -14,7 +14,7 @@ from twisted.internet.task import Clock
 from twisted.internet.protocol import ReconnectingClientFactory, Protocol
 
 
-class FakeConnector(object):
+class FakeConnector:
     """
     A fake connector class, to be used to mock connections failed or lost.
     """
@@ -39,7 +39,7 @@ class ReconnectingFactoryTests(TestCase):
         connected, it does not subsequently attempt to reconnect if the
         connection is later lost.
         """
-        class NoConnectConnector(object):
+        class NoConnectConnector:
             def stopConnecting(self):
                 raise RuntimeError("Shouldn't be called, we're connected.")
             def connect(self):

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -554,7 +554,7 @@ class BrokenExceptionMetaclass(type):
 
 
 
-class BrokenExceptionType(Exception, object):
+class BrokenExceptionType(Exception):
     """
     The aforementioned exception type which cnanot be presented as a string via
     L{str}.

--- a/src/twisted/test/test_ftp.py
+++ b/src/twisted/test/test_ftp.py
@@ -1310,7 +1310,7 @@ class DTPFactoryTests(TestCase):
         """
         self.reactor = task.Clock()
 
-        class ProtocolInterpreter(object):
+        class ProtocolInterpreter:
             dtpInstance = None
 
         self.protocolInterpreter = ProtocolInterpreter()
@@ -1450,7 +1450,7 @@ class DTPTests(TestCase):
         """
         self.reactor = task.Clock()
 
-        class ProtocolInterpreter(object):
+        class ProtocolInterpreter:
             dtpInstance = None
 
         self.protocolInterpreter = ProtocolInterpreter()
@@ -3558,7 +3558,7 @@ class FTPShellTests(TestCase, IFTPShellTestsMixin):
 
 
 @implementer(IConsumer)
-class TestConsumer(object):
+class TestConsumer:
     """
     A simple consumer for tests. It only works with non-streaming producers.
 
@@ -3601,7 +3601,7 @@ class TestConsumer(object):
 
 
 
-class TestProducer(object):
+class TestProducer:
     """
     A dumb producer.
     """

--- a/src/twisted/test/test_internet.py
+++ b/src/twisted/test/test_internet.py
@@ -1154,7 +1154,7 @@ class ProtocolTests(TestCase):
         self.assertIsInstance(protocol, factory.protocol)
 
 
-class DummyProducer(object):
+class DummyProducer:
     """
     Very uninteresting producer implementation used by tests to ensure the
     right methods are called by the consumer with which it is registered.

--- a/src/twisted/test/test_iosim.py
+++ b/src/twisted/test/test_iosim.py
@@ -60,7 +60,7 @@ class FakeTransportTests(TestCase):
 
 
 @implementer(IPushProducer)
-class StrictPushProducer(object):
+class StrictPushProducer:
     """
     An L{IPushProducer} implementation which produces nothing but enforces
     preconditions on its state transition methods.

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -712,7 +712,7 @@ class FileObserverTests(LogPublisherTestCaseMixin,
         self._startLoggingCleanup()
         newPublisher = NewLogPublisher()
 
-        class SysModule(object):
+        class SysModule:
             stdout = object()
             stderr = object()
 
@@ -969,7 +969,7 @@ class DefaultObserverTests(unittest.SynchronousTestCase):
         DefaultObserver.emit() does not raise when it observes an error event
         with a message that causes L{repr} to raise.
         """
-        class Ouch(object):
+        class Ouch:
             def __repr__(self) -> str:
                 return str(1 / 0)
 

--- a/src/twisted/test/test_loopback.py
+++ b/src/twisted/test/test_loopback.py
@@ -263,7 +263,7 @@ class LoopbackAsyncTests(LoopbackTestCaseMixin, unittest.TestCase):
         Test a push producer registered against a loopback transport.
         """
         @implementer(IPushProducer)
-        class PushProducer(object):
+        class PushProducer:
             resumed = False
 
             def __init__(self, toProduce):
@@ -299,7 +299,7 @@ class LoopbackAsyncTests(LoopbackTestCaseMixin, unittest.TestCase):
         Test a pull producer registered against a loopback transport.
         """
         @implementer(IPullProducer)
-        class PullProducer(object):
+        class PullProducer:
             def __init__(self, toProduce):
                 self.toProduce = toProduce
 

--- a/src/twisted/test/test_modules.py
+++ b/src/twisted/test/test_modules.py
@@ -448,7 +448,7 @@ class PythonPathTests(TestCase):
         Make sure that the behavior when encountering an unknown importer
         type is not catastrophic failure.
         """
-        class SecretImporter(object):
+        class SecretImporter:
             pass
 
         def hook(name):

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -20,11 +20,11 @@ class VersionTests(TestCase):
     def test_nullVersionUpgrade(self):
         global NullVersioned
 
-        class NullVersioned(object):
+        class NullVersioned:
             def __init__(self):
                 self.ok = 0
         pkcl = pickle.dumps(NullVersioned())
-        class NullVersioned(styles.Versioned, object):
+        class NullVersioned(styles.Versioned):
             persistenceVersion = 1
             def upgradeToVersion1(self):
                 self.ok = 1
@@ -218,7 +218,7 @@ class Pickleable:
 
 
 
-class NotPickleable(object):
+class NotPickleable:
     """
     A class that is not pickleable.
     """
@@ -231,7 +231,7 @@ class NotPickleable(object):
 
 
 
-class CopyRegistered(object):
+class CopyRegistered:
     """
     A class that is pickleable only because it is registered with the
     C{copyreg} module.
@@ -245,7 +245,7 @@ class CopyRegistered(object):
 
 
 
-class CopyRegisteredLoaded(object):
+class CopyRegisteredLoaded:
     """
     L{CopyRegistered} after unserialization.
     """
@@ -388,7 +388,7 @@ class AOTTests(TestCase):
         an unknown type without a C{__dict__} property or C{__getstate__}
         method.
         """
-        class UnknownType(object):
+        class UnknownType:
             @property
             def __dict__(self):
                 raise AttributeError()

--- a/src/twisted/test/test_plugin.py
+++ b/src/twisted/test/test_plugin.py
@@ -368,7 +368,7 @@ def pluginFileContents(name):
         "from twisted.test.test_plugin import ITestPlugin\n"
         "\n"
         "@provider(IPlugin, ITestPlugin)\n"
-        "class {0}(object):\n"
+        "class {0}:\n"
         "    pass\n"
     ).format(name).encode('ascii')
 

--- a/src/twisted/test/test_policies.py
+++ b/src/twisted/test/test_policies.py
@@ -182,7 +182,7 @@ class WrapperTests(unittest.TestCase):
         If the wrapped factory doesn't have a L{logPrefix} method,
         L{WrappingFactory.logPrefix} falls back to the factory class name.
         """
-        class NoFactory(object):
+        class NoFactory:
             pass
 
         server = NoFactory()
@@ -208,7 +208,7 @@ class WrapperTests(unittest.TestCase):
         If the wrapped protocol doesn't have a L{logPrefix} method,
         L{ProtocolWrapper.logPrefix} falls back to the protocol class name.
         """
-        class NoProtocol(object):
+        class NoProtocol:
             pass
 
         server = Server()
@@ -293,7 +293,7 @@ class WrapperTests(unittest.TestCase):
         C{startedConnecting} on the underlying factory.
         """
         result = []
-        class Factory(object):
+        class Factory:
             def startedConnecting(self, connector):
                 result.append(connector)
 
@@ -309,7 +309,7 @@ class WrapperTests(unittest.TestCase):
         C{clientConnectionLost} on the underlying factory.
         """
         result = []
-        class Factory(object):
+        class Factory:
             def clientConnectionLost(self, connector, reason):
                 result.append((connector, reason))
 
@@ -326,7 +326,7 @@ class WrapperTests(unittest.TestCase):
         C{clientConnectionFailed} on the underlying factory.
         """
         result = []
-        class Factory(object):
+        class Factory:
             def clientConnectionFailed(self, connector, reason):
                 result.append((connector, reason))
 

--- a/src/twisted/test/test_postfix.py
+++ b/src/twisted/test/test_postfix.py
@@ -35,7 +35,7 @@ class PostfixTCPMapQuoteTests(unittest.TestCase):
 
 
 
-class PostfixTCPMapServerTestCase(object):
+class PostfixTCPMapServerTestCase:
     data = {
         # 'key': 'value',
         }  # type: Dict[bytes, bytes]

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -992,7 +992,7 @@ class Accumulator(protocol.ProcessProtocol):
 
 
 
-class PosixProcessBase(object):
+class PosixProcessBase:
     """
     Test running processes.
     """
@@ -1210,7 +1210,7 @@ class PosixProcessBase(object):
 
 
 
-class MockSignal(object):
+class MockSignal:
     """
     Neuter L{signal.signal}, but pass other attributes unscathed
     """
@@ -1223,7 +1223,7 @@ class MockSignal(object):
 
 
 
-class MockOS(object):
+class MockOS:
     """
     The mock OS: overwrite L{os}, L{fcntl} and {sys} functions with fake ones.
 

--- a/src/twisted/test/test_randbytes.py
+++ b/src/twisted/test/test_randbytes.py
@@ -11,7 +11,7 @@ from twisted.python import randbytes
 
 
 
-class SecureRandomTestCaseBase(object):
+class SecureRandomTestCaseBase:
     """
     Base class for secureRandom test cases.
     """

--- a/src/twisted/test/test_rebuild.py
+++ b/src/twisted/test/test_rebuild.py
@@ -14,7 +14,7 @@ f = crash_test_dummy.foo
 
 class Foo: pass
 class Bar(Foo): pass
-class Baz(object): pass
+class Baz: pass
 class Buz(Bar, Baz): pass
 
 class HashRaisesRuntimeError:
@@ -229,7 +229,7 @@ class NewStyleTests(TestCase):
         Try to rebuild a new style class with slots defined.
         """
         classDefinition = (
-            "class SlottedClass(object):\n"
+            "class SlottedClass:\n"
             "    __slots__ = ['a']\n")
 
         exec(classDefinition, self.m.__dict__)

--- a/src/twisted/test/test_reflect.py
+++ b/src/twisted/test/test_reflect.py
@@ -17,7 +17,7 @@ from twisted.python.reflect import (
     addMethodNamesToDict, fullyQualifiedName)
 
 
-class Base(object):
+class Base:
     """
     A no-op class which can be used to verify the behavior of
     method-discovering APIs.
@@ -37,7 +37,7 @@ class Sub(Base):
 
 
 
-class Separate(object):
+class Separate:
     """
     A no-op class with methods with differing prefixes.
     """
@@ -158,7 +158,7 @@ class AddMethodNamesToDictTests(TestCase):
         If C{baseClass} is passed to L{addMethodNamesToDict}, only methods which
         are a subclass of C{baseClass} are added to the result dictionary.
         """
-        class Alternate(object):
+        class Alternate:
             pass
 
         class Child(Separate, Alternate):
@@ -171,7 +171,7 @@ class AddMethodNamesToDictTests(TestCase):
 
 
 
-class Summer(object):
+class Summer:
     """
     A class we look up as part of the LookupsTests.
     """
@@ -378,7 +378,7 @@ class LookupsTests(TestCase):
 
 
 
-class Breakable(object):
+class Breakable:
 
     breakRepr = False
     breakStr = False
@@ -849,7 +849,7 @@ class ObjectGrepTests(TestCase):
 
 class GetClassTests(TestCase):
     def test_new(self):
-        class NewClass(object):
+        class NewClass:
             pass
         new = NewClass()
         self.assertEqual(reflect.getClass(NewClass).__name__, 'type')

--- a/src/twisted/test/test_sob.py
+++ b/src/twisted/test/test_sob.py
@@ -25,7 +25,7 @@ objects = [
 {1:"hello"},
 ]
 
-class FakeModule(object):
+class FakeModule:
     pass
 
 class PersistTests(unittest.TestCase):

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -328,7 +328,7 @@ def loopbackTLSConnection(trustRoot, privateKeyFile, chainedCertFile=None):
     @return: 3-tuple of server-protocol, client-protocol, and L{IOPump}
     @rtype: L{tuple}
     """
-    class ContextFactory(object):
+    class ContextFactory:
         def getContext(self):
             """
             Create a context for the server side of the connection.
@@ -446,7 +446,7 @@ class WritingProtocol(protocol.Protocol):
 
 
 
-class FakeContext(object):
+class FakeContext:
     """
     Introspectable fake of an C{OpenSSL.SSL.Context}.
 
@@ -650,7 +650,7 @@ class ClientOptionsTests(SynchronousTestCase):
 
 
 
-class FakeChooseDiffieHellmanEllipticCurve(object):
+class FakeChooseDiffieHellmanEllipticCurve:
     """
     A fake implementation of L{_ChooseDiffieHellmanEllipticCurve}
     """
@@ -671,7 +671,7 @@ class FakeChooseDiffieHellmanEllipticCurve(object):
 
 
 
-class OpenSSLOptionsTestsMixin(object):
+class OpenSSLOptionsTestsMixin:
     """
     A mixin for L{OpenSSLOptions} test cases creates client and server
     certificates, signs them with a CA, and provides a L{loopback}
@@ -948,7 +948,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         If acceptable ciphers are passed, they are used.
         """
         @implementer(interfaces.IAcceptableCiphers)
-        class FakeAcceptableCiphers(object):
+        class FakeAcceptableCiphers:
             def selectCiphers(self, _):
                 return [sslverify.OpenSSLCipher(u'sentinel')]
 
@@ -1343,7 +1343,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         If C{dhParams} is set, they are loaded into each new context.
         """
-        class FakeDiffieHellmanParameters(object):
+        class FakeDiffieHellmanParameters:
             _dhFile = FilePath(b'dh.params')
 
         dhParams = FakeDiffieHellmanParameters()
@@ -2229,7 +2229,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         matches and raising L{VerificationError} if it doesn't.
         """
         name = 'something.example.com'
-        class Connection(object):
+        class Connection:
             def get_peer_certificate(self):
                 """
                 Fake of L{OpenSSL.SSL.Connection.get_peer_certificate}.
@@ -2753,7 +2753,7 @@ class OpenSSLCipherTests(TestCase):
         If ciphers have the same name but different types, they're still
         different.
         """
-        class DifferentCipher(object):
+        class DifferentCipher:
             fullName = self.cipherName
 
         self.assertNotEqual(
@@ -2875,7 +2875,7 @@ class DiffieHellmanParametersTests(TestCase):
 
 
 
-class FakeLibState(object):
+class FakeLibState:
     """
     State for L{FakeLib}
 
@@ -2900,7 +2900,7 @@ class FakeLibState(object):
 
 
 
-class FakeLib(object):
+class FakeLib:
     """
     An introspectable fake of cryptography's lib object.
 
@@ -2971,7 +2971,7 @@ class FakeLibTests(TestCase):
 
 
 
-class FakeCryptoState(object):
+class FakeCryptoState:
     """
     State for L{FakeCrypto}
 
@@ -3003,7 +3003,7 @@ class FakeCryptoState(object):
 
 
 
-class FakeCrypto(object):
+class FakeCrypto:
     """
     An introspectable fake of pyOpenSSL's L{OpenSSL.crypto} module.
 

--- a/src/twisted/test/test_task.py
+++ b/src/twisted/test/test_task.py
@@ -949,7 +949,7 @@ class DeferLaterTests(unittest.TestCase):
 
 
 
-class _FakeReactor(object):
+class _FakeReactor:
 
     def __init__(self):
         self._running = False

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -86,7 +86,7 @@ class ClosingFactory(protocol.ServerFactory):
 
 
 
-class MyProtocolFactoryMixin(object):
+class MyProtocolFactoryMixin:
     """
     Mixin for factories which create L{AccumulatingProtocol} instances.
 
@@ -986,7 +986,7 @@ class WriteDataTests(TestCase):
         addr = port.getHost()
 
         @implementer(IPullProducer)
-        class Infinite(object):
+        class Infinite:
             """
             A producer which will write to its consumer as long as
             resumeProducing is called.

--- a/src/twisted/test/test_tcp_internals.py
+++ b/src/twisted/test/test_tcp_internals.py
@@ -164,7 +164,7 @@ class SelectReactorTests(TestCase):
 
         @param socketErrorNumber: The errno to simulate from accept.
         """
-        class FakeSocket(object):
+        class FakeSocket:
             """
             Pretend to be a socket in an overloaded system.
             """
@@ -308,7 +308,7 @@ class SelectReactorTests(TestCase):
         maximumNumberOfAccepts = 123
         acceptCalls = [0]
 
-        class FakeSocketWithAcceptLimit(object):
+        class FakeSocketWithAcceptLimit:
             """
             Pretend to be a socket in an overloaded system whose
             C{accept} method can only be called
@@ -357,7 +357,7 @@ class SelectReactorTests(TestCase):
             if isinstance(error, (int, compat.long))
         ) + 1
 
-        class FakeSocketWithUnknownAcceptError(object):
+        class FakeSocketWithUnknownAcceptError:
             """
             Pretend to be a socket in an overloaded system whose
             C{accept} method can only be called

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -20,7 +20,7 @@ from twisted._threads import Team, createMemoryWorker
 
 
 
-class Synchronization(object):
+class Synchronization:
     failures = 0
 
     def __init__(self, N, waiting):
@@ -140,7 +140,7 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
             pass
 
         # weakref needs an object subclass
-        class Dumb(object):
+        class Dumb:
             pass
 
         # And here's the unique object
@@ -201,7 +201,7 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
             return Dumb()
 
         # weakref needs an object subclass
-        class Dumb(object):
+        class Dumb:
             pass
 
         # And here's the unique object
@@ -644,7 +644,7 @@ class MemoryPool(threadpool.ThreadPool):
 
 
 
-class PoolHelper(object):
+class PoolHelper:
     """
     A L{PoolHelper} constructs a L{threadpool.ThreadPool} that doesn't actually
     use threads, by using the internal interfaces in L{twisted._threads}.

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -113,7 +113,7 @@ def patchUserDatabase(patch, user, uid, group, gid):
 
 
 
-class MockServiceMaker(object):
+class MockServiceMaker:
     """
     A non-implementation of L{twisted.application.service.IServiceMaker}.
     """
@@ -166,7 +166,7 @@ class ServerOptionsTests(TestCase):
         subCommands is built from IServiceMaker plugins, and is sorted
         alphabetically.
         """
-        class FakePlugin(object):
+        class FakePlugin:
             def __init__(self, name):
                 self.tapname = name
                 self._options = 'options for ' + name
@@ -208,7 +208,7 @@ class ServerOptionsTests(TestCase):
         """
         Reactor names are listed alphabetically by I{--help-reactors}.
         """
-        class FakeReactorInstaller(object):
+        class FakeReactorInstaller:
             def __init__(self, name):
                 self.shortName = 'name of ' + name
                 self.description = 'description of ' + name
@@ -464,7 +464,7 @@ class TapFileTests(TestCase):
 
 
 
-class TestLoggerFactory(object):
+class TestLoggerFactory:
     """
     A logger factory for L{TestApplicationRunner}.
     """
@@ -587,7 +587,7 @@ class ApplicationRunnerTests(TestCase):
                 pass
 
         @implementer(service.IService, service.IProcess)
-        class FakeService(object):
+        class FakeService:
 
             parent = None
             running = None
@@ -728,7 +728,7 @@ class ApplicationRunnerTests(TestCase):
         the reactor does not implement L{_ISupportsExitSignalCapturing}.
         """
 
-        class DummyReactorWithExitSignalAttribute(object):
+        class DummyReactorWithExitSignalAttribute:
             """
             A dummy reactor, providing a C{run} method, and setting the
             _exitSignal attribute to a nonzero value.
@@ -1083,7 +1083,7 @@ class UnixApplicationRunnerRemovePIDTests(TestCase):
 
 
 
-class FakeNonDaemonizingReactor(object):
+class FakeNonDaemonizingReactor:
     """
     A dummy reactor, providing C{beforeDaemonize} and C{afterDaemonize}
     methods, but not announcing this, and logging whether the methods have been
@@ -1124,7 +1124,7 @@ class FakeDaemonizingReactor(FakeNonDaemonizingReactor):
 
 
 
-class DummyReactor(object):
+class DummyReactor:
     """
     A dummy reactor, only providing a C{run} method and checking that it
     has been called.
@@ -1368,7 +1368,7 @@ def _setupSyslog(testCase):
     """
     logMessages = []
 
-    class fakesyslogobserver(object):
+    class fakesyslogobserver:
         def __init__(self, prefix):
             logMessages.append(prefix)
 
@@ -1419,7 +1419,7 @@ class AppLoggerTests(TestCase):
         @rtype: Callable that implements L{ILogObserver}.
         """
         @implementer(ILogObserver)
-        class TestObserver(object):
+        class TestObserver:
             _logs = []
 
             def __call__(self, event):
@@ -1636,7 +1636,7 @@ class AppLoggerTests(TestCase):
         logger = app.AppLogger({})
 
         @implementer(LegacyILogObserver)
-        class LoggerObserver(object):
+        class LoggerObserver:
             """
             An observer which implements the legacy L{LegacyILogObserver}.
             """

--- a/src/twisted/test/test_twisted.py
+++ b/src/twisted/test/test_twisted.py
@@ -16,7 +16,7 @@ from twisted.trial.unittest import TestCase
 
 # This is somewhat generally useful and should probably be part of a public API
 # somewhere.  See #5977.
-class SetAsideModule(object):
+class SetAsideModule:
     """
     L{SetAsideModule} is a context manager for temporarily removing a module
     from C{sys.modules}.

--- a/src/twisted/test/test_unix.py
+++ b/src/twisted/test/test_unix.py
@@ -225,7 +225,7 @@ class UnixSocketTests(unittest.TestCase):
         class being used and the filename on which the port is listening or
         indicates that the port is not listening.
         """
-        class NewStyleFactory(object):
+        class NewStyleFactory:
             def doStart(self):
                 pass
 
@@ -365,7 +365,7 @@ class DatagramUnixSocketTests(unittest.TestCase):
         new-style protocol class being used and the filename on which the port
         is listening or indicates that the port is not listening.
         """
-        class NewStyleProtocol(object):
+        class NewStyleProtocol:
             def makeConnection(self, transport):
                 pass
 

--- a/src/twisted/test/test_usage.py
+++ b/src/twisted/test/test_usage.py
@@ -619,7 +619,7 @@ class FlagFunctionTests(unittest.TestCase):
     Tests for L{usage.flagFunction}.
     """
 
-    class SomeClass(object):
+    class SomeClass:
         """
         Dummy class for L{usage.flagFunction} tests.
         """

--- a/src/twisted/test/testutils.py
+++ b/src/twisted/test/testutils.py
@@ -76,7 +76,7 @@ def returnConnected(server, client):
 
 
 
-class XMLAssertionMixin(object):
+class XMLAssertionMixin:
     """
     Test mixin defining a method for comparing serialized XML documents.
 
@@ -99,7 +99,7 @@ class XMLAssertionMixin(object):
 
 
 
-class _Equal(object):
+class _Equal:
     """
     A class the instances of which are equal to anything and everything.
     """
@@ -108,7 +108,7 @@ class _Equal(object):
 
 
 
-class _NotEqual(object):
+class _NotEqual:
     """
     A class the instances of which are equal to nothing.
     """
@@ -117,7 +117,7 @@ class _NotEqual(object):
 
 
 
-class ComparisonTestsMixin(object):
+class ComparisonTestsMixin:
     """
     A mixin which defines a method for making assertions about the correctness
     of an implementation of C{==} and C{!=}.

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -26,7 +26,7 @@ from twisted.trial._dist import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT
 
 
 
-class DistTrialRunner(object):
+class DistTrialRunner:
     """
     A specialized runner for distributed trial. The runner launches a number of
     local worker processes which will run tests.

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -33,7 +33,7 @@ from zope.interface import implementer, verify
 
 
 
-class FakeTransport(object):
+class FakeTransport:
     """
     A simple fake process transport.
     """
@@ -160,7 +160,7 @@ class CountingReactorTests(SynchronousTestCase):
 
 
 
-class EternalTerminationPredicateFactory(object):
+class EternalTerminationPredicateFactory:
     """
     A rigged terminationPredicateFactory for which time never pass.
     """

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -291,7 +291,7 @@ class FakeAMProtocol(AMP):
 
 
 
-class FakeTransport(object):
+class FakeTransport:
     """
     A fake process transport implementation for testing.
     """

--- a/src/twisted/trial/_dist/test/test_workerreporter.py
+++ b/src/twisted/trial/_dist/test/test_workerreporter.py
@@ -11,7 +11,7 @@ from twisted.trial._dist.workerreporter import WorkerReporter
 from twisted.trial._dist import managercommands
 
 
-class FakeAMProtocol(object):
+class FakeAMProtocol:
     """
     A fake C{AMP} implementations to track C{callRemote} calls.
     """

--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -39,7 +39,7 @@ class WorkerLogObserverTests(TestCase):
         """
         calls = []
 
-        class FakeClient(object):
+        class FakeClient:
 
             def callRemote(self, method, **kwargs):
                 calls.append((method, kwargs))
@@ -118,7 +118,7 @@ class MainTests(TestCase):
         """
         excInfos = []
 
-        class FakeStream(object):
+        class FakeStream:
             count = 0
 
             def read(oself, size):
@@ -141,7 +141,7 @@ class MainTests(TestCase):
         error pops out.
         """
 
-        class FakeStream(object):
+        class FakeStream:
             count = 0
 
             def read(oself, size):

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -192,7 +192,7 @@ class LocalWorkerAMP(AMP):
 
 
 @implementer(IAddress)
-class LocalWorkerAddress(object):
+class LocalWorkerAddress:
     """
     A L{IAddress} implementation meant to provide stub addresses for
     L{ITransport.getPeer} and L{ITransport.getHost}.
@@ -201,7 +201,7 @@ class LocalWorkerAddress(object):
 
 
 @implementer(ITransport)
-class LocalWorkerTransport(object):
+class LocalWorkerTransport:
     """
     A stub transport implementation used to support L{AMP} over a
     L{ProcessProtocol} transport.

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -36,7 +36,7 @@ from twisted.trial._dist import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT
 
 
 
-class WorkerLogObserver(object):
+class WorkerLogObserver:
     """
     A log observer that forward its output to a C{AMP} protocol.
     """

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -45,7 +45,7 @@ class FailTest(AssertionError):
 
 
 
-class Todo(object):
+class Todo:
     """
     Internal object used to mark a L{TestCase} as 'todo'. Tests marked 'todo'
     are reported differently in Trial L{TestResult}s. If todo'd tests fail,
@@ -111,7 +111,7 @@ def makeTodo(value):
 
 
 
-class _Warning(object):
+class _Warning:
     """
     A L{_Warning} instance represents one warning emitted through the Python
     warning system (L{warnings}).  This is used to insulate callers of
@@ -200,7 +200,7 @@ class UnsupportedTrialFeature(Exception):
 
 
 
-class PyUnitResultAdapter(object):
+class PyUnitResultAdapter:
     """
     Wrap a C{TestResult} from the standard library's C{unittest} so that it
     supports the extended result types from Trial, and also supports
@@ -273,7 +273,7 @@ class PyUnitResultAdapter(object):
 
 
 
-class _AssertRaisesContext(object):
+class _AssertRaisesContext:
     """
     A helper for implementing C{assertRaises}.  This is a context manager and a
     helper method to support the non-context manager version of
@@ -367,7 +367,7 @@ class _AssertRaisesContext(object):
 
 
 
-class _Assertions(pyunit.TestCase, object):
+class _Assertions(pyunit.TestCase):
     """
     Replaces many of the built-in TestCase assertions. In general, these
     assertions provide better error messages and are easier to use in
@@ -861,7 +861,7 @@ class _Assertions(pyunit.TestCase, object):
 
 
 
-class _LogObserver(object):
+class _LogObserver:
     """
     Observes the Twisted logs and catches any errors.
 

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -57,7 +57,7 @@ class BrokenTestCaseWarning(Warning):
 
 
 
-class SafeStream(object):
+class SafeStream:
     """
     Wraps a stream object so that all C{write} calls are wrapped in
     L{untilConcludes<twisted.python.util.untilConcludes>}.
@@ -77,7 +77,7 @@ class SafeStream(object):
 
 
 @implementer(itrial.IReporter)
-class TestResult(pyunit.TestResult, object):
+class TestResult(pyunit.TestResult):
     """
     Accumulates the results of several L{twisted.trial.unittest.TestCase}s.
 
@@ -876,7 +876,7 @@ class TimingTextReporter(VerboseTextReporter):
 
 
 
-class _AnsiColorizer(object):
+class _AnsiColorizer:
     """
     A colorizer is an object that loosely wraps around a stream, allowing
     callers to write text to the stream in a particular color.
@@ -927,7 +927,7 @@ class _AnsiColorizer(object):
 
 
 
-class _Win32Colorizer(object):
+class _Win32Colorizer:
     """
     See _AnsiColorizer docstring.
     """
@@ -979,7 +979,7 @@ class _Win32Colorizer(object):
 
 
 
-class _NullColorizer(object):
+class _NullColorizer:
     """
     See _AnsiColorizer docstring.
     """
@@ -998,7 +998,7 @@ class _NullColorizer(object):
 
 
 @implementer(itrial.IReporter)
-class SubunitReporter(object):
+class SubunitReporter:
     """
     Reports test output via Subunit.
 

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -276,7 +276,7 @@ def isTestCase(obj):
 
 
 @implementer(ITestCase)
-class TestHolder(object):
+class TestHolder:
     """
     Placeholder for a L{TestCase} inside a reporter. As far as a L{TestResult}
     is concerned, this looks exactly like a unit test.
@@ -358,7 +358,7 @@ class ErrorHolder(TestHolder):
 
 
 
-class TestLoader(object):
+class TestLoader:
     """
     I find tests inside function, modules, files -- whatever -- then return
     them wrapped inside a Test (either a L{TestSuite} or a L{TestCase}).
@@ -776,7 +776,7 @@ def _qualNameWalker(qualName):
 
 
 
-class TrialRunner(object):
+class TrialRunner:
     """
     A specialised runner that the trial front end uses.
     """

--- a/src/twisted/trial/test/erroneous.py
+++ b/src/twisted/trial/test/erroneous.py
@@ -21,7 +21,7 @@ class FoolishError(Exception):
 
 
 
-class FailureInSetUpMixin(object):
+class FailureInSetUpMixin:
     def setUp(self):
         raise FoolishError("I am a broken setUp method")
 
@@ -42,7 +42,7 @@ class AsynchronousTestFailureInSetUp(
 
 
 
-class FailureInTearDownMixin(object):
+class FailureInTearDownMixin:
     def tearDown(self):
         raise FoolishError("I am a broken tearDown method")
 
@@ -63,7 +63,7 @@ class AsynchronousTestFailureInTearDown(
 
 
 
-class FailureButTearDownRunsMixin(object):
+class FailureButTearDownRunsMixin:
     """
     A test fails, but its L{tearDown} still runs.
     """

--- a/src/twisted/trial/test/mockdoctest.py
+++ b/src/twisted/trial/test/mockdoctest.py
@@ -6,7 +6,7 @@
 
 
 
-class Counter(object):
+class Counter:
     """a simple counter object for testing trial's doctest support
 
          >>> c = Counter()

--- a/src/twisted/trial/test/moduletest.py
+++ b/src/twisted/trial/test/moduletest.py
@@ -6,6 +6,6 @@
 # in the first line
 # The class declaration is irrelevant
 
-class Foo(object):
+class Foo:
     pass
 

--- a/src/twisted/trial/test/novars.py
+++ b/src/twisted/trial/test/novars.py
@@ -2,5 +2,5 @@
 # declarations.  This one is supposed to have none.
 # The class declaration is irrelevant
 
-class Bar(object):
+class Bar:
     pass

--- a/src/twisted/trial/test/packages.py
+++ b/src/twisted/trial/test/packages.py
@@ -53,7 +53,7 @@ class PyunitTest(pyunit.TestCase):
         pass
 
 
-class NotATest(object):
+class NotATest:
     def test_foo(self):
         pass
 
@@ -77,7 +77,7 @@ Do NOT change the names the tests in this module.
 
 from twisted.trial import unittest
 
-class X(object):
+class X:
 
     def test_foo(self):
         pass

--- a/src/twisted/trial/test/sample.py
+++ b/src/twisted/trial/test/sample.py
@@ -86,7 +86,7 @@ class PyunitTest(pyunit.TestCase):
 
 
 
-class NotATest(object):
+class NotATest:
 
 
     def test_foo(self):

--- a/src/twisted/trial/test/scripttest.py
+++ b/src/twisted/trial/test/scripttest.py
@@ -10,5 +10,5 @@
 # in the second line
 # The class declaration is irrelevant
 
-class Foo(object):
+class Foo:
     pass

--- a/src/twisted/trial/test/skipping.py
+++ b/src/twisted/trial/test/skipping.py
@@ -16,7 +16,7 @@ from twisted.trial.unittest import (
     SynchronousTestCase, TestCase, SkipTest, FailTest)
 
 
-class SkippingMixin(object):
+class SkippingMixin:
     def test_skip1(self):
         raise SkipTest('skip1')
 
@@ -44,7 +44,7 @@ class AsynchronousSkipping(SkippingMixin, TestCase):
 
 
 
-class SkippingSetUpMixin(object):
+class SkippingSetUpMixin:
     def setUp(self):
         raise SkipTest('skipSetUp')
 
@@ -68,7 +68,7 @@ class AsynchronousSkippingSetUp(SkippingSetUpMixin, TestCase):
 
 
 
-class DeprecatedReasonlessSkipMixin(object):
+class DeprecatedReasonlessSkipMixin:
     def test_1(self):
         raise SkipTest()
 
@@ -86,7 +86,7 @@ class AsynchronousDeprecatedReasonlessSkip(
 
 
 
-class SkippedClassMixin(object):
+class SkippedClassMixin:
     skip = 'class'
 
     def setUp(self):
@@ -122,7 +122,7 @@ class AsynchronousSkippedClass(SkippedClassMixin, TestCase):
 
 
 
-class TodoMixin(object):
+class TodoMixin:
     def test_todo1(self):
         self.fail("deliberate failure")
     test_todo1.todo = "todo1"  # type: ignore[attr-defined]
@@ -150,7 +150,7 @@ class AsynchronousTodo(TodoMixin, TestCase):
 
 
 
-class SetUpTodoMixin(object):
+class SetUpTodoMixin:
     def setUp(self):
         raise RuntimeError("deliberate error")
 
@@ -171,7 +171,7 @@ class AsynchronousSetUpTodo(SetUpTodoMixin, TestCase):
 
 
 
-class TearDownTodoMixin(object):
+class TearDownTodoMixin:
     def tearDown(self):
         raise RuntimeError("deliberate error")
 
@@ -192,7 +192,7 @@ class AsynchronousTearDownTodo(TearDownTodoMixin, TestCase):
 
 
 
-class TodoClassMixin(object):
+class TodoClassMixin:
     todo = "class"
 
     def test_todo1(self):
@@ -223,7 +223,7 @@ class AsynchronousTodoClass(TodoClassMixin, TestCase):
 
 
 
-class StrictTodoMixin(object):
+class StrictTodoMixin:
     def test_todo1(self):
         raise RuntimeError("expected failure")
     test_todo1.todo = (RuntimeError, "todo1")  # type: ignore[attr-defined]
@@ -264,7 +264,7 @@ class AsynchronousStrictTodo(StrictTodoMixin, TestCase):
 
 
 
-class AddCleanupMixin(object):
+class AddCleanupMixin:
     def setUp(self):
         self.log = ['setUp']
 

--- a/src/twisted/trial/test/suppression.py
+++ b/src/twisted/trial/test/suppression.py
@@ -32,7 +32,7 @@ class ModuleWarning(Warning):
 
 
 
-class EmitMixin(object):
+class EmitMixin:
     """
     Mixin for emiting a variety of warnings.
     """
@@ -59,13 +59,13 @@ class SuppressionMixin(EmitMixin):
 
 
 
-class SetUpSuppressionMixin(object):
+class SetUpSuppressionMixin:
     def setUp(self):
         self._emit()
 
 
 
-class TearDownSuppressionMixin(object):
+class TearDownSuppressionMixin:
     def tearDown(self):
         self._emit()
 

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -25,7 +25,7 @@ from twisted.python.failure import Failure
 from twisted.trial import unittest
 from twisted.internet.defer import Deferred, fail, succeed
 
-class MockEquality(FancyEqMixin, object):
+class MockEquality(FancyEqMixin):
     compareAttributes = ("name",)
 
     def __init__(self, name):
@@ -36,7 +36,7 @@ class MockEquality(FancyEqMixin, object):
         return "MockEquality(%s)" % (self.name,)
 
 
-class ComparisonError(object):
+class ComparisonError:
     """
     An object which raises exceptions from its comparison methods.
     """

--- a/src/twisted/trial/test/test_log.py
+++ b/src/twisted/trial/test/test_log.py
@@ -24,11 +24,11 @@ def makeFailure():
 
 
 
-class Mask(object):
+class Mask:
     """
     Hide C{MockTest}s from Trial's automatic test finder.
     """
-    class FailureLoggingMixin(object):
+    class FailureLoggingMixin:
         def test_silent(self):
             """
             Don't log any errors.
@@ -159,7 +159,7 @@ class ObserverTests(unittest.SynchronousTestCase):
 
 
 
-class LogErrorsMixin(object):
+class LogErrorsMixin:
     """
     High-level tests demonstrating the expected behaviour of logged errors
     during tests.

--- a/src/twisted/trial/test/test_pyunitcompat.py
+++ b/src/twisted/trial/test/test_pyunitcompat.py
@@ -68,7 +68,7 @@ class PyUnitResultTests(SynchronousTestCase):
         C{run} does *not* provide L{IReporter}.
         """
         @implementer(IReporter)
-        class StubReporter(object):
+        class StubReporter:
             """
             A reporter which records data about calls made to it.
 

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -32,7 +32,7 @@ from io import BytesIO
 
 
 
-class BrokenStream(object):
+class BrokenStream:
     """
     Stream-ish object that raises a signal interrupt error. We use this to make
     sure that Trial still manages to write what it needs to write.
@@ -825,7 +825,7 @@ class UncleanWarningTodoTests(TodoTests):
 
 
 
-class MockColorizer(object):
+class MockColorizer:
     """
     Used by TreeReporterTests to make sure that output is colored correctly.
     """
@@ -1545,7 +1545,7 @@ class AdaptedReporterTests(unittest.SynchronousTestCase):
 
 
 
-class FakeStream(object):
+class FakeStream:
     """
     A fake stream which C{isatty} method returns some predictable.
 
@@ -1600,7 +1600,7 @@ class AnsiColorizerTests(unittest.SynchronousTestCase):
         to call C{curses.setupterm} if C{curses.tigetnum} previously failed
         with a C{curses.error}.
         """
-        class fakecurses(object):
+        class fakecurses:
             error = RuntimeError
             setUp = 0
 
@@ -1626,7 +1626,7 @@ class AnsiColorizerTests(unittest.SynchronousTestCase):
         to call C{curses.setupterm} if C{curses.tigetnum} returns something
         different than C{curses.error}.
         """
-        class fakecurses(object):
+        class fakecurses:
             error = RuntimeError
 
             def tigetnum(self, value):
@@ -1641,7 +1641,7 @@ class AnsiColorizerTests(unittest.SynchronousTestCase):
         L{reporter._AnsiColorizer.supported} returns C{False} if
         C{curses.tigetnum} returns less than 2 supported colors.
         """
-        class fakecurses(object):
+        class fakecurses:
             error = RuntimeError
 
             def tigetnum(self, value):
@@ -1656,7 +1656,7 @@ class AnsiColorizerTests(unittest.SynchronousTestCase):
         L{reporter._AnsiColorizer.supported} returns C{False} if
         C{curses.tigetnum} raises an error, and calls C{curses.setupterm} once.
         """
-        class fakecurses(object):
+        class fakecurses:
             error = RuntimeError
             setUp = 0
 

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -29,7 +29,7 @@ from twisted.internet import defer
 
 
 
-class CapturingDebugger(object):
+class CapturingDebugger:
 
     def __init__(self):
         self._calls = []
@@ -41,7 +41,7 @@ class CapturingDebugger(object):
 
 
 @implementer(IReporter)
-class CapturingReporter(object):
+class CapturingReporter:
     """
     Reporter that keeps a log of all actions performed on it.
     """
@@ -135,7 +135,7 @@ class CapturingReporter(object):
 
 
 
-class TrialRunnerTestsMixin(object):
+class TrialRunnerTestsMixin:
     """
     Mixin defining tests for L{runner.TrialRunner}.
     """
@@ -232,7 +232,7 @@ class TrialRunnerWithUncleanWarningsReporterTests(TrialRunnerTestsMixin,
 
 
 
-class DryRunMixin(object):
+class DryRunMixin:
     """
     Mixin for testing that 'dry run' mode works with various
     L{pyunit.TestCase} subclasses.
@@ -809,7 +809,7 @@ class TestHolderTests(unittest.SynchronousTestCase):
 
 
 
-class ErrorHolderTestsMixin(object):
+class ErrorHolderTestsMixin:
     """
     This mixin defines test methods which can be applied to a
     L{runner.ErrorHolder} constructed with either a L{Failure} or a
@@ -821,7 +821,7 @@ class ErrorHolderTestsMixin(object):
     """
     exceptionForTests = ZeroDivisionError('integer division or modulo by zero')
 
-    class TestResultStub(object):
+    class TestResultStub:
         """
         Stub for L{TestResult}.
         """

--- a/src/twisted/trial/test/test_suppression.py
+++ b/src/twisted/trial/test/test_suppression.py
@@ -13,7 +13,7 @@ from twisted.trial import unittest
 from twisted.trial.test import suppression
 
 
-class SuppressionMixin(object):
+class SuppressionMixin:
     """
     Tests for the warning suppression features of
     L{twisted.trial.unittest.SynchronousTestCase}.

--- a/src/twisted/trial/test/test_testcase.py
+++ b/src/twisted/trial/test/test_testcase.py
@@ -10,7 +10,7 @@ L{twisted.trial.unittest.TestCase}.
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 
 
-class TestCaseMixin(object):
+class TestCaseMixin:
     """
     L{TestCase} tests.
     """

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -42,7 +42,7 @@ from twisted.trial._asyncrunner import (
     )
 
 
-class ResultsTestMixin(object):
+class ResultsTestMixin:
     """
     Provide useful APIs for test cases that are about test cases.
     """
@@ -73,7 +73,7 @@ class ResultsTestMixin(object):
         self.assertEqual(self.reporter.testsRun, numTests)
 
 
-class SuccessMixin(object):
+class SuccessMixin:
     """
     Tests for the reporting of successful tests in L{twisted.trial.unittest.TestCase}.
     """
@@ -630,7 +630,7 @@ class ReactorCleanupTests(unittest.SynchronousTestCase):
 
 
 
-class FixtureMixin(object):
+class FixtureMixin:
     """
     Tests for fixture helper methods (e.g. setUp, tearDown).
     """
@@ -732,7 +732,7 @@ class AsynchronousSuppressionTests(SuppressionMixin, unittest.TestCase):
 
 
 
-class GCMixin(object):
+class GCMixin:
     """
     I provide a few mock tests that log setUp, tearDown, test execution and
     garbage collection. I'm used to test whether gc.collect gets called.
@@ -872,7 +872,7 @@ class UnhandledDeferredTests(unittest.SynchronousTestCase):
         self.flushLoggedErrors()
 
 
-class AddCleanupMixin(object):
+class AddCleanupMixin:
     """
     Test the addCleanup method of TestCase.
     """
@@ -998,7 +998,7 @@ class AsynchronousAddCleanupTests(AddCleanupMixin, unittest.TestCase):
                          self.test.log)
 
 
-class SuiteClearingMixin(object):
+class SuiteClearingMixin:
     """
     Tests for our extension that allows us to clear out a L{TestSuite}.
     """
@@ -1052,7 +1052,7 @@ class AsynchronousSuiteClearingTests(SuiteClearingMixin, unittest.TestCase):
     TestCase = unittest.TestCase
 
 
-class TestDecoratorMixin(object):
+class TestDecoratorMixin:
     """
     Tests for our test decoration features.
     """
@@ -1223,7 +1223,7 @@ class AsynchronousTestDecoratorTests(TestDecoratorMixin, unittest.TestCase):
     TestCase = unittest.TestCase
 
 
-class MonkeyPatchMixin(object):
+class MonkeyPatchMixin:
     """
     Tests for the patch() helper method in L{unittest.TestCase}.
     """
@@ -1302,7 +1302,7 @@ class AsynchronousMonkeyPatchTests(MonkeyPatchMixin, unittest.TestCase):
     TestCase = unittest.TestCase
 
 
-class IterateTestsMixin(object):
+class IterateTestsMixin:
     """
     L{_iterateTests} returns a list of all test cases in a test suite or test
     case.

--- a/src/twisted/trial/test/test_util.py
+++ b/src/twisted/trial/test/test_util.py
@@ -248,7 +248,7 @@ Sel2""")
 
 
 
-class StubReactor(object):
+class StubReactor:
     """
     A reactor stub which contains enough functionality to be used with the
     L{_Janitor}.
@@ -295,7 +295,7 @@ class StubReactor(object):
 
 
 
-class StubErrorReporter(object):
+class StubErrorReporter:
     """
     A subset of L{twisted.trial.itrial.IReporter} which records L{addError}
     calls.
@@ -382,7 +382,7 @@ class JanitorTests(SynchronousTestCase):
         The Janitor will kill processes during reactor cleanup.
         """
         @implementer(IProcessTransport)
-        class StubProcessTransport(object):
+        class StubProcessTransport:
             """
             A stub L{IProcessTransport} provider which records signals.
             @ivar signals: The signals passed to L{signalProcess}.
@@ -409,7 +409,7 @@ class JanitorTests(SynchronousTestCase):
         The Janitor returns string representations of the selectables that it
         cleaned up from the reactor cleanup method.
         """
-        class Selectable(object):
+        class Selectable:
             """
             A stub Selectable which only has an interesting string
             representation.

--- a/src/twisted/trial/test/test_warning.py
+++ b/src/twisted/trial/test/test_warning.py
@@ -17,7 +17,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from twisted.trial._synctest import _collectWarnings, _setWarningRegistryToNone
 
 
-class Mask(object):
+class Mask:
     """
     Hide a test case definition from trial's automatic discovery mechanism.
     """
@@ -473,7 +473,7 @@ class CollectWarningsTests(SynchronousTestCase):
         """
         d = {}
 
-        class A(object):
+        class A:
             def __init__(self, key):
                 self.__dict__['_key'] = key
 

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -68,7 +68,7 @@ class DirtyReactorAggregateError(Exception):
 
 
 
-class _Janitor(object):
+class _Janitor:
     """
     The guy that cleans up after you.
 

--- a/src/twisted/web/_auth/basic.py
+++ b/src/twisted/web/_auth/basic.py
@@ -20,7 +20,7 @@ from twisted.web.iweb import ICredentialFactory
 
 
 @implementer(ICredentialFactory)
-class BasicCredentialFactory(object):
+class BasicCredentialFactory:
     """
     Credential Factory for HTTP Basic Authentication
 

--- a/src/twisted/web/_auth/digest.py
+++ b/src/twisted/web/_auth/digest.py
@@ -14,7 +14,7 @@ from twisted.cred import credentials
 from twisted.web.iweb import ICredentialFactory
 
 @implementer(ICredentialFactory)
-class DigestCredentialFactory(object):
+class DigestCredentialFactory:
     """
     Wrapper for L{digest.DigestCredentialFactory} that implements the
     L{ICredentialFactory} interface.

--- a/src/twisted/web/_auth/wrapper.py
+++ b/src/twisted/web/_auth/wrapper.py
@@ -26,7 +26,7 @@ from zope.interface import implementer
 
 
 @implementer(IResource)
-class UnauthorizedResource(object):
+class UnauthorizedResource:
     """
     Simple IResource to escape Resource dispatch
     """
@@ -80,7 +80,7 @@ class UnauthorizedResource(object):
 
 
 @implementer(IResource)
-class HTTPAuthSessionWrapper(object):
+class HTTPAuthSessionWrapper:
     """
     Wrap a portal, enforcing supported header-based authentication schemes.
 

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -11,7 +11,7 @@ from twisted.web.error import MissingRenderMethod, UnexposedMethodError
 from twisted.web.error import MissingTemplateLoader
 
 
-class Expose(object):
+class Expose:
     """
     Helper for exposing methods for various uses using a simple decorator-style
     callable.
@@ -124,7 +124,7 @@ def renderer():
 
 
 @implementer(IRenderable)
-class Element(object):
+class Element:
     """
     Base for classes which can render part of a page.
 

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -891,7 +891,7 @@ class H2Connection(Protocol, TimeoutMixin):
 
 
 @implementer(ITransport, IConsumer, IPushProducer)
-class H2Stream(object):
+class H2Stream:
     """
     A class representing a single HTTP/2 stream.
 

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -26,7 +26,7 @@ from twisted.python.compat import iteritems
 
 
 
-class slot(object):
+class slot:
     """
     Marker for markup insertion in a template.
 
@@ -72,7 +72,7 @@ class slot(object):
 
 
 
-class Tag(object):
+class Tag:
     """
     A L{Tag} represents an XML tags with a tag name, attributes, and children.
     A L{Tag} can be constructed using the special L{twisted.web.template.tags}
@@ -273,7 +273,7 @@ voidElements = ('img', 'br', 'hr', 'base', 'meta', 'link', 'param', 'area',
                 'embed', 'keygen', 'source', 'track', 'wbs')
 
 
-class CDATA(object):
+class CDATA:
     """
     A C{<![CDATA[]]>} block from a template.  Given a separate representation in
     the DOM so that they may be round-tripped through rendering without losing
@@ -291,7 +291,7 @@ class CDATA(object):
 
 
 
-class Comment(object):
+class Comment:
     """
     A C{<!-- -->} comment from a template.  Given a separate representation in
     the DOM so that they may be round-tripped through rendering without losing
@@ -310,7 +310,7 @@ class Comment(object):
 
 
 
-class CharRef(object):
+class CharRef:
     """
     A numeric character reference.  Given a separate representation in the DOM
     so that non-ASCII characters may be output as pure ASCII.

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -582,7 +582,7 @@ class HTTPDownloader(HTTPClientFactory):
 
 
 
-class URI(object):
+class URI:
     """
     A URI object.
 
@@ -876,7 +876,7 @@ def _requireSSL(decoratee):
 
 
 
-class WebClientContextFactory(object):
+class WebClientContextFactory:
     """
     This class is deprecated.  Please simply use L{Agent} as-is, or if you want
     to customize something, use L{BrowserLikePolicyForHTTPS}.
@@ -920,7 +920,7 @@ class WebClientContextFactory(object):
 
 
 @implementer(IPolicyForHTTPS)
-class BrowserLikePolicyForHTTPS(object):
+class BrowserLikePolicyForHTTPS:
     """
     SSL connection creator for web clients.
     """
@@ -966,7 +966,7 @@ deprecatedModuleAttribute(Version("Twisted", 14, 0, 0),
 
 
 @implementer(IPolicyForHTTPS)
-class HostnameCachingHTTPSPolicy(object):
+class HostnameCachingHTTPSPolicy:
     """
     IPolicyForHTTPS that wraps a L{IPolicyForHTTPS} and caches the created
     L{IOpenSSLClientConnectionCreator}.
@@ -1033,7 +1033,7 @@ class HostnameCachingHTTPSPolicy(object):
 
 
 @implementer(IOpenSSLContextFactory)
-class _ContextFactoryWithContext(object):
+class _ContextFactoryWithContext:
     """
     A L{_ContextFactoryWithContext} is like a
     L{twisted.internet.ssl.ContextFactory} with a pre-created context.
@@ -1065,7 +1065,7 @@ class _ContextFactoryWithContext(object):
 
 
 @implementer(IPolicyForHTTPS)
-class _DeprecatedToCurrentPolicyForHTTPS(object):
+class _DeprecatedToCurrentPolicyForHTTPS:
     """
     Adapt a web context factory to a normal context factory.
 
@@ -1106,7 +1106,7 @@ class _DeprecatedToCurrentPolicyForHTTPS(object):
 
 
 @implementer(IBodyProducer)
-class FileBodyProducer(object):
+class FileBodyProducer:
     """
     L{FileBodyProducer} produces bytes from an input file object incrementally
     and writes them to a consumer.
@@ -1249,7 +1249,7 @@ class _HTTP11ClientFactory(protocol.Factory):
 
 
 
-class _RetryingHTTP11ClientProtocol(object):
+class _RetryingHTTP11ClientProtocol:
     """
     A wrapper for L{HTTP11ClientProtocol} that automatically retries requests.
 
@@ -1314,7 +1314,7 @@ class _RetryingHTTP11ClientProtocol(object):
 
 
 
-class HTTPConnectionPool(object):
+class HTTPConnectionPool:
     """
     A pool of persistent HTTP connections.
 
@@ -1471,7 +1471,7 @@ class HTTPConnectionPool(object):
 
 
 
-class _AgentBase(object):
+class _AgentBase:
     """
     Base class offering common facilities for L{Agent}-type classes.
 
@@ -1534,7 +1534,7 @@ class _AgentBase(object):
 
 
 @implementer(IAgentEndpointFactory)
-class _StandardEndpointFactory(object):
+class _StandardEndpointFactory:
     """
     Standard HTTP endpoint destinations - TCP for HTTP, TCP+TLS for HTTPS.
 
@@ -1785,7 +1785,7 @@ class ProxyAgent(_AgentBase):
 
 
 
-class _FakeUrllib2Request(object):
+class _FakeUrllib2Request:
     """
     A fake C{urllib2.Request} object for C{cookielib} to work with.
 
@@ -1861,7 +1861,7 @@ class _FakeUrllib2Request(object):
 
 
 
-class _FakeUrllib2Response(object):
+class _FakeUrllib2Response:
     """
     A fake C{urllib2.Response} object for C{cookielib} to work with.
 
@@ -1875,7 +1875,7 @@ class _FakeUrllib2Response(object):
 
 
     def info(self):
-        class _Meta(object):
+        class _Meta:
             def getheaders(zelf, name):
                 # PY2
                 headers = self.response.headers.getRawHeaders(name, [])
@@ -1891,7 +1891,7 @@ class _FakeUrllib2Response(object):
 
 
 @implementer(IAgent)
-class CookieAgent(object):
+class CookieAgent:
     """
     L{CookieAgent} extends the basic L{Agent} to add RFC-compliant
     handling of HTTP cookies.  Cookies are written to and extracted
@@ -2030,7 +2030,7 @@ class _GzipProtocol(proxyForInterface(IProtocol)):  # type: ignore[misc]
 
 
 @implementer(IAgent)
-class ContentDecoderAgent(object):
+class ContentDecoderAgent:
     """
     An L{Agent} wrapper to handle encoded content.
 
@@ -2105,7 +2105,7 @@ class ContentDecoderAgent(object):
 
 
 @implementer(IAgent)
-class RedirectAgent(object):
+class RedirectAgent:
     """
     An L{Agent} wrapper which handles HTTP redirects.
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1672,7 +1672,7 @@ class _MalformedChunkedDataError(Exception):
 
 
 
-class _IdentityTransferDecoder(object):
+class _IdentityTransferDecoder:
     """
     Protocol for accumulating bytes up to a specified length.  This handles the
     case where no I{Transfer-Encoding} is specified.
@@ -1747,7 +1747,7 @@ class _IdentityTransferDecoder(object):
 
 
 
-class _ChunkedTransferDecoder(object):
+class _ChunkedTransferDecoder:
     """
     Protocol for decoding I{chunked} Transfer-Encoding, as defined by RFC 2616,
     section 3.6.1.  This protocol can interpret the contents of a request or
@@ -1873,7 +1873,7 @@ class _ChunkedTransferDecoder(object):
 
 
 @implementer(interfaces.IPushProducer)
-class _NoPushProducer(object):
+class _NoPushProducer:
     """
     A no-op version of L{interfaces.IPushProducer}, used to abstract over the
     possibility that a L{HTTPChannel} transport does not provide
@@ -2721,7 +2721,7 @@ def combinedLogFormatter(timestamp, request):
 
 
 @implementer(interfaces.IAddress)
-class _XForwardedForAddress(object):
+class _XForwardedForAddress:
     """
     L{IAddress} which represents the client IP to log for a request, as gleaned
     from an X-Forwarded-For header.

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -41,7 +41,7 @@ def _sanitizeLinearWhitespace(headerComponent):
 
 
 @comparable
-class Headers(object):
+class Headers:
     """
     Stores HTTP headers in a key and multiple value format.
 

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -131,7 +131,7 @@ class MismatchedTags(Exception):
 
 
 
-class Node(object):
+class Node:
     nodeName = "Node"
 
     def __init__(self, parentNode=None):

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -618,7 +618,7 @@ class Request(Copyable, http.Request, components.Componentized):
 
 
 @implementer(iweb._IRequestEncoderFactory)
-class GzipEncoderFactory(object):
+class GzipEncoderFactory:
     """
     @cvar compressLevel: The compression level used by the compressor, default
         to 9 (highest).
@@ -650,7 +650,7 @@ class GzipEncoderFactory(object):
 
 
 @implementer(iweb._IRequestEncoder)
-class _GzipEncoder(object):
+class _GzipEncoder:
     """
     An encoder which supports gzip.
 

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -701,7 +701,7 @@ class File(resource.Resource, filepath.FilePath):
 
 
 @implementer(interfaces.IPullProducer)
-class StaticProducer(object):
+class StaticProducer:
     """
     Superclass for classes that implement the business of producing.
 

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -53,7 +53,7 @@ NOT_DONE_YET = 1
 _moduleLog = Logger()
 
 
-class _NSContext(object):
+class _NSContext:
     """
     A mapping from XML namespaces onto their prefixes in the document.
     """
@@ -358,7 +358,7 @@ def _flatsaxParse(fl):
 
 
 @implementer(ITemplateLoader)
-class TagLoader(object):
+class TagLoader:
     """
     An L{ITemplateLoader} that loads existing L{IRenderable} providers.
 
@@ -380,7 +380,7 @@ class TagLoader(object):
 
 
 @implementer(ITemplateLoader)
-class XMLString(object):
+class XMLString:
     """
     An L{ITemplateLoader} that loads and parses XML from a string.
 
@@ -413,7 +413,7 @@ class XMLString(object):
 
 
 @implementer(ITemplateLoader)
-class XMLFile(object):
+class XMLFile:
     """
     An L{ITemplateLoader} that loads and parses XML from a file.
 
@@ -495,7 +495,7 @@ VALID_HTML_TAG_NAMES = set([
 
 
 
-class _TagFactory(object):
+class _TagFactory:
     """
     A factory for L{Tag} objects; the implementation of the L{tags} object.
 

--- a/src/twisted/web/test/injectionhelpers.py
+++ b/src/twisted/web/test/injectionhelpers.py
@@ -16,7 +16,7 @@ NONASCII = frozenset(range(128, 256))
 
 
 
-class MethodInjectionTestsMixin(object):
+class MethodInjectionTestsMixin:
     """
     A mixin that runs HTTP method injection tests.  Define
     L{MethodInjectionTestsMixin.attemptRequestWithMaliciousMethod} in
@@ -77,7 +77,7 @@ class MethodInjectionTestsMixin(object):
 
 
 
-class URIInjectionTestsMixin(object):
+class URIInjectionTestsMixin:
     """
     A mixin that runs HTTP URI injection tests.  Define
     L{MethodInjectionTestsMixin.attemptRequestWithMaliciousURI} in a

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -44,7 +44,7 @@ sanitizedBytes = sanitizedText.encode('ascii')
 
 
 @implementer(IAddress)
-class NullAddress(object):
+class NullAddress:
     """
     A null implementation of L{IAddress}.
     """
@@ -217,7 +217,7 @@ class DummyChannel:
 
 
 
-class DummyRequest(object):
+class DummyRequest:
     """
     Represents a dummy or fake request. See L{twisted.web.server.Request}.
 

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -72,7 +72,7 @@ else:
 
 
     @implementer(IOpenSSLTrustRoot)
-    class CustomOpenSSLTrustRoot(object):
+    class CustomOpenSSLTrustRoot:
         called = False
         context = None
 
@@ -108,7 +108,7 @@ class StubHTTPProtocol(Protocol):
 
 
 
-class FileConsumer(object):
+class FileConsumer:
     def __init__(self, outputFile):
         self.outputFile = outputFile
 
@@ -158,11 +158,11 @@ class FileBodyProducerTests(TestCase):
         without either a C{seek} or C{tell} method, its C{length} attribute is
         set to C{UNKNOWN_LENGTH}.
         """
-        class HasSeek(object):
+        class HasSeek:
             def seek(self, offset, whence):
                 pass
 
-        class HasTell(object):
+        class HasTell:
             def tell(self):
                 pass
 
@@ -238,7 +238,7 @@ class FileBodyProducerTests(TestCase):
         L{FileBodyProducer.startProducing} fires with a L{Failure} wrapping
         that exception.
         """
-        class BrokenFile(object):
+        class BrokenFile:
             def read(self, count):
                 raise IOError("Simulated bad thing")
         producer = FileBodyProducer(BrokenFile(), self.cooperator)
@@ -398,7 +398,7 @@ class FakeReactorAndConnectMixin:
         drr.advance = mrc.advance
         return drr
 
-    class StubEndpoint(object):
+    class StubEndpoint:
         """
         Endpoint that wraps existing endpoint, substitutes StubHTTPProtocol, and
         resulting protocol instances are attached to the given test case.
@@ -445,7 +445,7 @@ class FakeReactorAndConnectMixin:
 
 
 
-class DummyEndpoint(object):
+class DummyEndpoint:
     """
     An endpoint that uses a fake transport.
     """
@@ -457,7 +457,7 @@ class DummyEndpoint(object):
 
 
 
-class BadEndpoint(object):
+class BadEndpoint:
     """
     An endpoint that shouldn't be called.
     """
@@ -710,7 +710,7 @@ class HTTPConnectionPoolTests(TestCase, FakeReactorAndConnectMixin):
         is called the protocol is returned to the cache correctly, using the
         right key.
         """
-        class StringEndpoint(object):
+        class StringEndpoint:
             def connect(self, factory):
                 p = factory.buildProtocol(None)
                 p.makeConnection(StringTransport())
@@ -796,7 +796,7 @@ class HTTPConnectionPoolTests(TestCase, FakeReactorAndConnectMixin):
 
 
 
-class AgentTestsMixin(object):
+class AgentTestsMixin:
     """
     Tests for any L{IAgent} implementation.
     """
@@ -808,7 +808,7 @@ class AgentTestsMixin(object):
 
 
 
-class IntegrationTestingMixin(object):
+class IntegrationTestingMixin:
     """
     Transport-to-Agent integration tests for both HTTP and HTTPS.
     """
@@ -918,7 +918,7 @@ class IntegrationTestingMixin(object):
 
 
 @implementer(IAgentEndpointFactory)
-class StubEndpointFactory(object):
+class StubEndpointFactory:
     """
     A stub L{IAgentEndpointFactory} for use in testing.
     """
@@ -1011,7 +1011,7 @@ class AgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin,
                                  (b"http", b"foo", 80))
                 return endpoint
 
-        class DummyPool(object):
+        class DummyPool:
             connected = False
             persistent = False
             def getConnection(this, key, ep):
@@ -1485,7 +1485,7 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin,
         """
         expectedHost = b'example.org'
         expectedPort = 20443
-        class JustEnoughConnection(object):
+        class JustEnoughConnection:
             handshakeStarted = False
             connectState = False
             def do_handshake(self):
@@ -1502,7 +1502,7 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin,
         contextArgs = []
 
         @implementer(IOpenSSLClientConnectionCreator)
-        class JustEnoughCreator(object):
+        class JustEnoughCreator:
             def __init__(self, hostname, port):
                 self.hostname = hostname
                 self.port = port
@@ -1521,7 +1521,7 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin,
 
         expectedConnection = JustEnoughConnection()
         @implementer(IPolicyForHTTPS)
-        class StubBrowserLikePolicyForHTTPS(object):
+        class StubBrowserLikePolicyForHTTPS:
             def creatorForNetloc(self, hostname, port):
                 """
                 Emulate L{BrowserLikePolicyForHTTPS}.
@@ -1604,7 +1604,7 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin,
             from twisted.web.iweb import IPolicyForHTTPS
             from zope.interface import implementer
             @implementer(IPolicyForHTTPS)
-            class Policy(object):
+            class Policy:
                 def creatorForNetloc(self, hostname, port):
                     return optionsForClientTLS(hostname.decode("ascii"),
                                                trustRoot=authority)
@@ -1951,7 +1951,7 @@ class HTTPConnectionPoolRetryTests(TestCase, FakeReactorAndConnectMixin):
 
 
 
-class CookieTestsMixin(object):
+class CookieTestsMixin:
     """
     Mixin for unit tests dealing with cookies.
     """
@@ -2452,7 +2452,7 @@ class ContentDecoderAgentWithGzipTests(TestCase,
         C{flush} on the zlib decompressor object to get uncompressed data which
         may have been buffered.
         """
-        class decompressobj(object):
+        class decompressobj:
 
             def __init__(self, wbits):
                 pass
@@ -2497,7 +2497,7 @@ class ContentDecoderAgentWithGzipTests(TestCase,
         If the C{flush} call in C{connectionLost} fails, the C{zlib.error}
         exception is caught and turned into a L{ResponseFailed}.
         """
-        class decompressobj(object):
+        class decompressobj:
 
             def __init__(self, wbits):
                 pass
@@ -2622,7 +2622,7 @@ class ProxyAgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin):
         with and a key of C{("http-proxy", endpoint)}.
         """
         endpoint = DummyEndpoint()
-        class DummyPool(object):
+        class DummyPool:
             connected = False
             persistent = False
             def getConnection(this, key, ep):
@@ -2643,7 +2643,7 @@ class ProxyAgentTests(TestCase, FakeReactorAndConnectMixin, AgentTestsMixin):
 
 
 
-class _RedirectAgentTestsMixin(object):
+class _RedirectAgentTestsMixin:
     """
     Test cases mixin for L{RedirectAgentTests} and
     L{BrowserLikeRedirectAgentTests}.
@@ -3036,7 +3036,7 @@ class AbortableStringTransport(StringTransport):
 
 
 
-class DummyResponse(object):
+class DummyResponse:
     """
     Fake L{IResponse} for testing readBody that captures the protocol passed to
     deliverBody and uses it to make a connection with a transport.

--- a/src/twisted/web/test/test_client.py
+++ b/src/twisted/web/test/test_client.py
@@ -12,7 +12,7 @@ from twisted.trial import unittest
 from twisted.web import client
 
 @implementer(interfaces.IStreamClientEndpoint)
-class DummyEndPoint(object):
+class DummyEndPoint:
 
     """An endpoint that does not connect anywhere"""
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -163,7 +163,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         tag.
         """
         @implementer(IRenderable)
-        class Arbitrary(object):
+        class Arbitrary:
             def __init__(self, value):
                 self.value = value
             def render(self, request):
@@ -383,7 +383,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         Test that flattening respects all of the IRenderable interface.
         """
         @implementer(IRenderable)
-        class FakeElement(object):
+        class FakeElement:
             def render(ign,ored):
                 return tags.p(
                     'hello, ',
@@ -451,7 +451,7 @@ class FlattenerErrorTests(TestCase):
         exception.
         """
         @implementer(IRenderable)
-        class Renderable(object):
+        class Renderable:
             def __repr__(self) -> str:
                 return "renderable repr"
 

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -221,7 +221,7 @@ def parametrizeTimeoutMixin(protocol, reactor):
     return protocol
 
 
-class ResponseTestMixin(object):
+class ResponseTestMixin:
     """
     A mixin that provides a simple means of comparing an actual response string
     to an expected response string by performing the minimal parsing.
@@ -3480,7 +3480,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
         """
         eqCalls = []
 
-        class _NotARequest(object):
+        class _NotARequest:
 
             def __eq__(self, other: object) -> bool:
                 eqCalls.append(other)
@@ -3500,7 +3500,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
         """
         eqCalls = []
 
-        class _NotARequest(object):
+        class _NotARequest:
 
             def __ne__(self, other: object) -> bool:
                 eqCalls.append(other)

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -45,7 +45,7 @@ except ImportError:
 
 
 # Define some helpers for the rest of these tests.
-class FrameFactory(object):
+class FrameFactory:
     """
     A class containing lots of helper methods and state to build frames. This
     allows test cases to easily build correct HTTP/2 frames to feed to
@@ -167,7 +167,7 @@ class FrameFactory(object):
 
 
 
-class FrameBuffer(object):
+class FrameBuffer:
     """
     A test object that converts data received from Twisted's HTTP/2 stack and
     turns it into a sequence of hyperframe frame objects.
@@ -391,7 +391,7 @@ DummyProducerHandlerProxy = _makeRequestProxyFactory(DummyProducerHandler)
 
 
 
-class NotifyingRequestFactory(object):
+class NotifyingRequestFactory:
     """
     A L{http.Request} factory that calls L{http.Request.notifyFinish} on all
     L{http.Request} objects before it returns them, and squirrels the resulting
@@ -422,7 +422,7 @@ NotifyingRequestFactoryProxy = _makeRequestProxyFactory(
 
 
 
-class HTTP2TestHelpers(object):
+class HTTP2TestHelpers:
     """
     A superclass that contains no tests but provides test helpers for HTTP/2
     tests.

--- a/src/twisted/web/test/test_httpauth.py
+++ b/src/twisted/web/test/test_httpauth.py
@@ -309,7 +309,7 @@ class UnauthorizedResourceTests(RequestMixin, unittest.TestCase):
 
 
 implementer(portal.IRealm)
-class Realm(object):
+class Realm:
     """
     A simple L{IRealm} implementation which gives out L{WebAvatar} for any
     avatarId.
@@ -489,7 +489,7 @@ class HTTPAuthHeaderTests(unittest.TestCase):
         argument.
         """
         @implementer(ICredentialFactory)
-        class DumbCredentialFactory(object):
+        class DumbCredentialFactory:
             scheme = b'dumb'
 
             def __init__(self):
@@ -598,7 +598,7 @@ class HTTPAuthHeaderTests(unittest.TestCase):
         class UnexpectedException(Exception):
             pass
 
-        class BadFactory(object):
+        class BadFactory:
             scheme = b'bad'
 
             def getChallenge(self, client):
@@ -633,7 +633,7 @@ class HTTPAuthHeaderTests(unittest.TestCase):
         class UnexpectedException(Exception):
             pass
 
-        class BrokenChecker(object):
+        class BrokenChecker:
             credentialInterfaces = (IUsernamePassword,)
 
             def requestAvatarId(self, credentials):

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -179,7 +179,7 @@ class MakeStatefulDispatcherTests(TestCase):
 
 
 
-class _HTTPParserTests(object):
+class _HTTPParserTests:
     """
     Base test class for L{HTTPParser} which is responsible for the bulk of
     the task of parsing HTTP bytes.

--- a/src/twisted/web/test/test_proxy.py
+++ b/src/twisted/web/test/test_proxy.py
@@ -107,7 +107,7 @@ class ReverseProxyResourceTests(TestCase):
 
 
 
-class DummyChannel(object):
+class DummyChannel:
     """
     A dummy HTTP channel, that does nothing but holds a transport and saves
     connection lost.
@@ -531,7 +531,7 @@ class ProxyRequestTests(TestCase):
 
 
 
-class DummyFactory(object):
+class DummyFactory:
     """
     A simple holder for C{host} and C{port} information.
     """

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -151,7 +151,7 @@ class ElementTests(TestCase):
         L{Element.render} loads a document from the C{loader} attribute and
         returns it.
         """
-        class TemplateLoader(object):
+        class TemplateLoader:
             def load(self):
                 return "result"
 
@@ -217,7 +217,7 @@ class XMLFileReprTests(TestCase):
 
 
 
-class XMLLoaderTestsMixin(object):
+class XMLLoaderTestsMixin:
     """
     @ivar templateString: Simple template to use to exercise the loaders.
 
@@ -675,7 +675,7 @@ class FailingElement(Element):
 
 
 
-class FakeSite(object):
+class FakeSite:
     """
     A minimal L{Site} object that we can use to test displayTracebacks
     """

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1244,7 +1244,7 @@ class NewRenderResource(resource.Resource):
 
 
 @implementer(resource.IResource)
-class HeadlessResource(object):
+class HeadlessResource:
     """
     A resource that implements GET but not HEAD.
     """
@@ -1386,7 +1386,7 @@ class NewRenderTests(unittest.TestCase):
         When implemented C{render} method does not return bytes an internal
         server error is returned.
         """
-        class RiggedRepr(object):
+        class RiggedRepr:
             def __repr__(self) -> str:
                 return 'my>repr'
 
@@ -1532,7 +1532,7 @@ class DummyRequestForLogTest(DummyRequest):
 
 
 
-class AccessLogTestsMixin(object):
+class AccessLogTestsMixin:
     """
     A mixin for L{TestCase} subclasses defining tests that apply to
     L{HTTPFactory} and its subclasses.
@@ -1689,7 +1689,7 @@ class CombinedLogFormatterTests(unittest.TestCase):
         A request made from an unknown address type is logged as C{"-"}.
         """
         @implementer(interfaces.IAddress)
-        class UnknowableAddress(object):
+        class UnknowableAddress:
             """
             An L{IAddress} which L{combinedLogFormatter} cannot have
             foreknowledge of.

--- a/src/twisted/web/test/test_wsgi.py
+++ b/src/twisted/web/test/test_wsgi.py
@@ -2147,7 +2147,7 @@ class ApplicationTests(WSGITestsMixin, TestCase):
         """
         responseContent = b'foo'
 
-        class Application(object):
+        class Application:
             def __init__(self, environ, startResponse):
                 startResponse('200 OK', [])
 

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -157,7 +157,7 @@ class UnhandledCommand(RuntimeError):
 
 
 
-class _CommandDispatcherMixin(object):
+class _CommandDispatcherMixin:
     """
     Dispatch commands to handlers based on their name.
 

--- a/src/twisted/words/protocols/jabber/client.py
+++ b/src/twisted/words/protocols/jabber/client.py
@@ -77,7 +77,7 @@ class IQ(domish.Element):
 
 
 
-class IQAuthInitializer(object):
+class IQAuthInitializer:
     """
     Non-SASL Authentication initializer for the initiating entity.
 
@@ -237,7 +237,7 @@ class BasicAuthenticator(xmlstream.ConnectAuthenticator):
 
 
 
-class CheckVersionInitializer(object):
+class CheckVersionInitializer:
     """
     Initializer that checks if the minimum common stream version number is 1.0.
     """

--- a/src/twisted/words/protocols/jabber/component.py
+++ b/src/twisted/words/protocols/jabber/component.py
@@ -42,7 +42,7 @@ def componentFactory(componentid, password):
     a = ConnectComponentAuthenticator(componentid, password)
     return xmlstream.XmlStreamFactory(a)
 
-class ComponentInitiatingInitializer(object):
+class ComponentInitiatingInitializer:
     """
     External server-side component authentication initializer for the
     initiating entity.
@@ -325,7 +325,7 @@ def buildServiceManager(jid, password, strport):
 
 
 
-class Router(object):
+class Router:
     """
     XMPP Server's Router.
 

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -133,7 +133,7 @@ def internJID(jidstring):
 
 
 
-class JID(object):
+class JID:
     """
     Represents a stringprep'd Jabber ID.
 

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -44,7 +44,7 @@ class ISASLMechanism(Interface):
 
 
 @implementer(ISASLMechanism)
-class Anonymous(object):
+class Anonymous:
     """
     Implements the ANONYMOUS SASL authentication mechanism.
 
@@ -63,7 +63,7 @@ class Anonymous(object):
 
 
 @implementer(ISASLMechanism)
-class Plain(object):
+class Plain:
     """
     Implements the PLAIN SASL authentication mechanism.
 
@@ -101,7 +101,7 @@ class Plain(object):
 
 
 @implementer(ISASLMechanism)
-class DigestMD5(object):
+class DigestMD5:
     """
     Implements the DIGEST-MD5 SASL authentication mechanism.
 

--- a/src/twisted/words/protocols/jabber/xmlstream.py
+++ b/src/twisted/words/protocols/jabber/xmlstream.py
@@ -307,7 +307,7 @@ class FeatureNotAdvertized(Exception):
 
 
 @implementer(ijabber.IInitiatingInitializer)
-class BaseFeatureInitiatingInitializer(object):
+class BaseFeatureInitiatingInitializer:
     """
     Base class for initializers with a stream feature.
 
@@ -900,7 +900,7 @@ def toResponse(stanza, stanzaType=None):
 
 
 @implementer(ijabber.IXMPPHandler)
-class XMPPHandler(object):
+class XMPPHandler:
     """
     XMPP protocol handler.
 
@@ -975,7 +975,7 @@ class XMPPHandler(object):
 
 
 @implementer(ijabber.IXMPPHandlerCollection)
-class XMPPHandlerCollection(object):
+class XMPPHandlerCollection:
     """
     Collection of XMPP subprotocol handlers.
 

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -43,7 +43,7 @@ from twisted.words.protocols import irc
 
 
 @implementer(iwords.IGroup)
-class Group(object):
+class Group:
     def __init__(self, name):
         self.name = name
         self.users = {}
@@ -127,7 +127,7 @@ class Group(object):
 
 
 @implementer(iwords.IUser)
-class User(object):
+class User:
     realm = None
     mind = None
 
@@ -1174,7 +1174,7 @@ pb.setUnjellyableForClass(ChatAvatar, AvatarReference)
 
 
 @implementer(portal.IRealm, iwords.IChatService)
-class WordsRealm(object):
+class WordsRealm:
     _encoding = 'utf-8'
 
     def __init__(self, name):

--- a/src/twisted/words/test/test_basesupport.py
+++ b/src/twisted/words/test/test_basesupport.py
@@ -31,7 +31,7 @@ class DummyAccount(basesupport.AbstractAccount):
         self.loginCallbackCalled = True
         return basesupport.AbstractAccount._cb_logOn(self, result)
 
-class DummyUI(object):
+class DummyUI:
     """
     Provide just the interface required to be passed to AbstractAccount.logOn.
     """

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1156,7 +1156,7 @@ class CTCPTests(IRCTestCase):
 
 
 
-class NoticingClient(IRCClientWithoutLogin, object):
+class NoticingClient(IRCClientWithoutLogin):
     methods = {
         'created': ('when',),
         'yourHost': ('info',),

--- a/src/twisted/words/test/test_jabberclient.py
+++ b/src/twisted/words/test/test_jabberclient.py
@@ -57,7 +57,7 @@ class CheckVersionInitializerTests(unittest.TestCase):
 
 
 
-class InitiatingInitializerHarness(object):
+class InitiatingInitializerHarness:
     """
     Testing harness for interacting with XML stream initializers.
 

--- a/src/twisted/words/test/test_jabbersasl.py
+++ b/src/twisted/words/test/test_jabbersasl.py
@@ -13,7 +13,7 @@ from twisted.words.xish import domish
 NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl'
 
 @implementer(sasl_mechanisms.ISASLMechanism)
-class DummySASLMechanism(object):
+class DummySASLMechanism:
     """
     Dummy SASL mechanism.
 

--- a/src/twisted/words/test/test_jabberxmlstream.py
+++ b/src/twisted/words/test/test_jabberxmlstream.py
@@ -956,7 +956,7 @@ class ToResponseTests(unittest.TestCase):
         self.assertFalse(response.hasAttribute('type'))
 
 
-class DummyFactory(object):
+class DummyFactory:
     """
     Dummy XmlStream factory that only registers bootstrap observers.
     """
@@ -1026,7 +1026,7 @@ class XMPPHandlerTests(unittest.TestCase):
         """
         Test that data is passed on for sending by the stream manager.
         """
-        class DummyStreamManager(object):
+        class DummyStreamManager:
             def __init__(self):
                 self.outlist = []
 
@@ -1350,7 +1350,7 @@ class XmlStreamServerFactoryTests(GenericXmlStreamFactoryTestsMixin):
         """
         Set up a server factory with an authenticator factory function.
         """
-        class TestAuthenticator(object):
+        class TestAuthenticator:
             def __init__(self):
                 self.xmlstreams = []
 

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -142,7 +142,7 @@ class RealmTests(unittest.TestCase):
 
 
 
-class TestCaseUserAgg(object):
+class TestCaseUserAgg:
     def __init__(self, user, realm, factory, address=address.IPv4Address('TCP', '127.0.0.1', 54321)):
         self.user = user
         self.transport = proto_helpers.StringTransportWithDisconnection()

--- a/src/twisted/words/xish/domish.py
+++ b/src/twisted/words/xish/domish.py
@@ -312,7 +312,7 @@ class IElement(Interface):
 
 
 @implementer(IElement)
-class Element(object):
+class Element:
     """ Represents an XML element node.
 
     An Element contains a series of attributes (name/value pairs), content

--- a/src/twisted/words/xish/utility.py
+++ b/src/twisted/words/xish/utility.py
@@ -12,7 +12,7 @@ from twisted.python import log
 from twisted.python.compat import iteritems
 from twisted.words.xish import xpath
 
-class _MethodWrapper(object):
+class _MethodWrapper:
     """
     Internal class for tracking method calls.
     """
@@ -339,7 +339,7 @@ class EventDispatcher:
 
 
 
-class XmlPipe(object):
+class XmlPipe:
     """
     XML stream pipe.
 

--- a/src/twisted/words/xish/xmlstream.py
+++ b/src/twisted/words/xish/xmlstream.py
@@ -168,7 +168,7 @@ class XmlStream(protocol.Protocol, utility.EventDispatcher):
 
 
 
-class BootstrapMixin(object):
+class BootstrapMixin:
     """
     XmlStream factory mixin to install bootstrap event observers.
 

--- a/src/twisted/words/xish/xpathparser.g
+++ b/src/twisted/words/xish/xpathparser.g
@@ -63,7 +63,7 @@ class NoMoreTokens(Exception):
     """Another exception object, for when we run out of tokens"""
     pass
 
-class Token(object):
+class Token:
     """Yapps token.
 
     This is a container for a scanned token.
@@ -89,7 +89,7 @@ class Token(object):
         return output
 
 in_name=0
-class Scanner(object):
+class Scanner:
     """Yapps scanner.
 
     The Yapps scanner can work in context sensitive or context
@@ -377,7 +377,7 @@ class Scanner(object):
             raise SyntaxError(tok.pos, 'Trying to find '+type+': '+ ', '.join(self.last_types)+", got "+tok.type, context=context)
         return tok.value
 
-class Parser(object):
+class Parser:
     """Base class for Yapps-generated parsers.
 
     """
@@ -399,7 +399,7 @@ class Parser(object):
         """Returns the matched text, and moves to the next token"""
         return self._scanner.scan(type, **kw)
 
-class Context(object):
+class Context:
     """Class to represent the parser's call stack.
 
     Every rule creates a Context that links to its parent rule.  The

--- a/src/twisted/words/xish/xpathparser.py
+++ b/src/twisted/words/xish/xpathparser.py
@@ -28,7 +28,7 @@
 # 3.) Edit the output to depend on the embedded runtime, and remove extraneous
 #     imports:
 #
-#         sed -e '/^# Begin/,${/^[^ ].*mport/d}' -e '/^[^#]/s/runtime\.//g' \
+#         sed -e '/^# Begin/,${/^[^ ].*mport/d}' -e 's/runtime\.//g' \
 #             -e "s/^\(from __future\)/exec(r'''\n\1/" -e"\$a''')"
 #             xpathparser.py.proto > xpathparser.py
 
@@ -64,7 +64,7 @@ class NoMoreTokens(Exception):
     """Another exception object, for when we run out of tokens"""
     pass
 
-class Token(object):
+class Token:
     """Yapps token.
 
     This is a container for a scanned token.
@@ -90,7 +90,7 @@ class Token(object):
         return output
 
 in_name=0
-class Scanner(object):
+class Scanner:
     """Yapps scanner.
 
     The Yapps scanner can work in context sensitive or context
@@ -378,7 +378,7 @@ class Scanner(object):
             raise SyntaxError(tok.pos, 'Trying to find '+type+': '+ ', '.join(self.last_types)+", got "+tok.type, context=context)
         return tok.value
 
-class Parser(object):
+class Parser:
     """Base class for Yapps-generated parsers.
 
     """
@@ -400,7 +400,7 @@ class Parser(object):
         """Returns the matched text, and moves to the next token"""
         return self._scanner.scan(type, **kw)
 
-class Context(object):
+class Context:
     """Class to represent the parser's call stack.
 
     Every rule creates a Context that links to its parent rule.  The

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     wheel: wheel
 
     ; Code quality checkers
-    manifest-checker: check-manifest
+    manifest-checker: check-manifest>=0.42
 
     twine: twine
 
@@ -137,7 +137,7 @@ commands =
 
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
-    manifest-checker: check-manifest --ignore "docs/_build*,docs/historic/*,admin*,bin/admin*,twisted/topfiles/*.Old"
+    manifest-checker: check-manifest --ignore "docs/_build/**,docs/historic/**,admin/**,bin/admin/**"
 
     twine: twine check {distdir}/*.*
 


### PR DESCRIPTION
Inheriting from `object` was necessary in Python 2 to force new-style classes. In Python 3, it's just noise.

Substitutions were done automatically with `sed`, except:
- `twisted/words/xish/xpathparser.g` was done by hand and `xpathparser.py` was re-generated from that
- `twisted/test/test_plugin.py` was done by hand

I also had to update the definitions for `check-manifest` in `tox.ini`, since the old ignore pattern no longer works with the latest release of `check-manifest`.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9927
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
