### PR TITLE
Make the twisted tests work when pyOpenSSL deletes NPN

### DIFF
--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -62,8 +62,11 @@ if requireModule("OpenSSL"):
     try:
         ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.set_npn_advertise_callback(lambda c: None)
-    except NotImplementedError:
-        skipNPN = "OpenSSL 1.0.1 or greater required for NPN support"
+    except (NotImplementedError, AttributeError):
+        skipNPN = (
+            "NPN is deprecated (and OpenSSL 1.0.1 or greater required for NPN"
+            " support)"
+        )
 
     try:
         ctx = SSL.Context(SSL.SSLv23_METHOD)


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
