### PR TITLE
deprecate inlineCallbacks

### DIFF
--- a/docs/core/examples/echoclient_ssl.py
+++ b/docs/core/examples/echoclient_ssl.py
@@ -7,7 +7,6 @@ from twisted.python.modules import getModule
 
 import echoclient
 
-@defer.deferredCoro
 async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling('public.pem').getContent()

--- a/docs/core/examples/echoclient_ssl.py
+++ b/docs/core/examples/echoclient_ssl.py
@@ -7,19 +7,19 @@ from twisted.python.modules import getModule
 
 import echoclient
 
-@defer.inlineCallbacks
-def main(reactor):
+@defer.deferredCoro
+async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling('public.pem').getContent()
     authority = ssl.Certificate.loadPEM(certData)
     options = ssl.optionsForClientTLS(u'example.com', authority)
     endpoint = endpoints.SSL4ClientEndpoint(reactor, 'localhost', 8000,
                                             options)
-    echoClient = yield endpoint.connect(factory)
+    echoClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     echoClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 if __name__ == '__main__':
     import echoclient_ssl

--- a/docs/core/examples/ssl_clientauth_client.py
+++ b/docs/core/examples/ssl_clientauth_client.py
@@ -7,7 +7,6 @@ from twisted.python.modules import getModule
 
 import echoclient
 
-@defer.deferredCoro
 async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling('public.pem').getContent()

--- a/docs/core/examples/ssl_clientauth_client.py
+++ b/docs/core/examples/ssl_clientauth_client.py
@@ -7,8 +7,8 @@ from twisted.python.modules import getModule
 
 import echoclient
 
-@defer.inlineCallbacks
-def main(reactor):
+@defer.deferredCoro
+async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling('public.pem').getContent()
     authData = getModule(__name__).filePath.sibling('server.pem').getContent()
@@ -18,11 +18,11 @@ def main(reactor):
                                       clientCertificate)
     endpoint = endpoints.SSL4ClientEndpoint(reactor, 'localhost', 8000,
                                             options)
-    echoClient = yield endpoint.connect(factory)
+    echoClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     echoClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 if __name__ == '__main__':
     import ssl_clientauth_client

--- a/docs/core/examples/starttls_client.py
+++ b/docs/core/examples/starttls_client.py
@@ -16,7 +16,6 @@ class StartTLSClient(LineReceiver):
             self.sendLine(b"secure text")
             self.transport.loseConnection()
 
-@defer.deferredCoro
 async def main(reactor):
     factory = protocol.Factory.forProtocol(StartTLSClient)
     certData = getModule(__name__).filePath.sibling('server.pem').getContent()

--- a/docs/core/examples/starttls_client.py
+++ b/docs/core/examples/starttls_client.py
@@ -16,19 +16,19 @@ class StartTLSClient(LineReceiver):
             self.sendLine(b"secure text")
             self.transport.loseConnection()
 
-@defer.inlineCallbacks
-def main(reactor):
+@defer.deferredCoro
+async def main(reactor):
     factory = protocol.Factory.forProtocol(StartTLSClient)
     certData = getModule(__name__).filePath.sibling('server.pem').getContent()
     factory.options = ssl.optionsForClientTLS(
         u"example.com", ssl.PrivateCertificate.loadPEM(certData)
     )
     endpoint = endpoints.HostnameEndpoint(reactor, 'localhost', 8000)
-    startTLSClient = yield endpoint.connect(factory)
+    startTLSClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     startTLSClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 if __name__ == "__main__":
     import starttls_client

--- a/docs/core/howto/defer-intro.rst
+++ b/docs/core/howto/defer-intro.rst
@@ -111,10 +111,10 @@ Perhaps we want something that looks a little like this::
 Thank goodness we can!
 
 
-Using coroutines
-~~~~~~~~~~~~~~~~
+Coroutines with async/await 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-await" functionality can be used with Deferreds by the use of :api:`twisted.internet.defer.ensureDeferred <ensureDeferred>`.
+"async"/ "await" coroutine functionality can be used with Deferreds by the use of :api:`twisted.internet.defer.ensureDeferred <ensureDeferred>`.
 
 Calling a coroutine (that is, the result of a function defined by ``async def funcname():``) with :api:`twisted.internet.defer.ensureDeferred <ensureDeferred>` will allow you to "await" on Deferreds inside it, and will return a standard Deferred.
 You can mix and match code which uses regular Deferreds, and ``ensureDeferred`` freely.
@@ -213,7 +213,7 @@ A low level solution: Deferred
 
 At this point you know everything you need to know about consuming asynchronous APIs. The ``ensureDeferred`` is built on a low level api described below. It's generally recommended to exlusively use coroutines, but sometimes you'll see code using the lower-level raw-deferred interface.
 
-Twisted tackles this problem with :api:`twisted.internet.defer.Deferred <Deferred>`\s, a type of object designed to do one thing, and one thing only: encode an order of execution separately from the order of lines in Python source code.
+Twisted tackles this problem with :api:`twisted.internet.defer.Deferred <Deferred>`\s, a type of object designed to do one thing, and one thing only: to bridge low-level callback-based code with high-level async/await code.
 
 It doesn't deal with threads, parallelism, signals, or subprocesses.
 It doesn't know anything about an event loop, greenlets, or scheduling.

--- a/docs/core/howto/defer-intro.rst
+++ b/docs/core/howto/defer-intro.rst
@@ -312,86 +312,6 @@ Because if ``f`` raises, ``g`` will be passed a :api:`twisted.python.failure.Fai
 Otherwise, ``g`` will be passed the asynchronous equivalent of the return value of ``f()`` (i.e. ``y``).
 
 
-Inline callbacks - using 'yield'
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Twisted features a decorator named ``inlineCallbacks`` which allows you to work with Deferreds without writing callback functions.
-
-This is done by writing your code as generators, which *yield* ``Deferred``\ s instead of attaching callbacks.
-
-Consider the following function written in the traditional ``Deferred`` style:
-
-.. code-block:: python
-
-    def getUsers():
-       d = makeRequest("GET", "/users")
-       d.addCallback(json.loads)
-       return d
-
-using ``inlineCallbacks``, we can write this as:
-
-.. code-block:: python
-
-    from twisted.internet.defer import inlineCallbacks, returnValue
-
-    @inlineCallbacks
-    def getUsers(self):
-        responseBody = yield makeRequest("GET", "/users")
-        returnValue(json.loads(responseBody))
-
-a couple of things are happening here:
-
-#. instead of calling ``addCallback`` on the ``Deferred`` returned by ``makeRequest``, we *yield* it.
-   This causes Twisted to return the ``Deferred``\ 's result to us.
-
-#. we use ``returnValue`` to propagate the final result of our function.
-   Because this function is a generator, we cannot use the return statement; that would be a syntax error.
-
-.. note::
-
-    .. versionadded:: 15.0
-
-    On Python 3, instead of writing ``returnValue(json.loads(responseBody))`` you can instead write ``return json.loads(responseBody)``.
-    This can be a significant readability advantage, but unfortunately if you need compatibility with Python 2, this isn't an option.
-
-Both versions of ``getUsers`` present exactly the same API to their callers: both return a ``Deferred`` that fires with the parsed JSON body of the request.
-Though the ``inlineCallbacks`` version looks like synchronous code, which blocks while waiting for the request to finish, each ``yield`` statement allows other code to run while waiting for the ``Deferred`` being yielded to fire.
-
-``inlineCallbacks`` become even more powerful when dealing with complex control flow and error handling.
-For example, what if ``makeRequest`` fails due to a connection error?
-For the sake of this example, let's say we want to log the exception and return an empty list.
-
-.. code-block:: python
-
-    def getUsers():
-       d = makeRequest("GET", "/users")
-
-       def connectionError(failure):
-           failure.trap(ConnectionError)
-           log.failure("makeRequest failed due to connection error",
-                       failure)
-           return []
-
-       d.addCallbacks(json.loads, connectionError)
-       return d
-
-With ``inlineCallbacks``, we can rewrite this as:
-
-.. code-block:: python
-
-    @inlineCallbacks
-    def getUsers(self):
-        try:
-            responseBody = yield makeRequest("GET", "/users")
-        except ConnectionError:
-           log.failure("makeRequest failed due to connection error")
-           returnValue([])
-
-        returnValue(json.loads(responseBody))
-
-Our exception handling is simplified because we can use Python's familiar ``try`` / ``except`` syntax for handling ``ConnectionError``\ s.
-
-
 Coroutines with async/await
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -465,7 +385,6 @@ You have been introduced to asynchronous code and have seen how to use :api:`twi
 - Do something after an error has been handled successfully
 - Wrap multiple asynchronous operations with one error handler
 - Do something after an asynchronous operation, regardless of whether it succeeded or failed
-- Write code without callbacks using ``inlineCallbacks``
 - Write coroutines that interact with Deferreds using ``ensureDeferred``
 
 These are very basic uses of :api:`twisted.internet.defer.Deferred <Deferred>`.

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -519,9 +519,9 @@ class OurServerOurClientTests(SFTPTestBase):
         self._emptyBuffers()
         return self.assertFailure(d, NotImplementedError)
 
-    @defer.inlineCallbacks
     @skipIf(_PY37PLUS, "Broken by PEP 479 and deprecated.")
-    def test_openDirectoryIterator(self):
+    @defer.deferredCoro
+    async def test_openDirectoryIterator(self):
         """
         Check that the object returned by
         L{filetransfer.FileTransferClient.openDirectory} can be used
@@ -535,18 +535,18 @@ class OurServerOurClientTests(SFTPTestBase):
 
         d = self.client.openDirectory(b"")
         self._emptyBuffers()
-        openDir = yield d
+        openDir = await d
 
         filenames = set()
         try:
             for f in openDir:
                 self._emptyBuffers()
-                (filename, _, fileattrs) = yield f
+                (filename, _, fileattrs) = await f
                 filenames.add(filename)
         finally:
             d = openDir.close()
             self._emptyBuffers()
-            yield d
+            await d
 
         self._emptyBuffers()
 
@@ -563,17 +563,17 @@ class OurServerOurClientTests(SFTPTestBase):
             ),
         )
 
-    @defer.inlineCallbacks
-    def test_openDirectoryIteratorDeprecated(self):
+    @defer.deferredCoro
+    async def test_openDirectoryIteratorDeprecated(self):
         """
         Using client.openDirectory as an iterator is deprecated.
         """
         d = self.client.openDirectory(b"")
         self._emptyBuffers()
-        openDir = yield d
+        openDir = await d
         oneFile = openDir.next()
         self._emptyBuffers()
-        yield oneFile
+        await oneFile
 
         warnings = self.flushWarnings()
         message = (
@@ -584,8 +584,8 @@ class OurServerOurClientTests(SFTPTestBase):
         self.assertEqual(DeprecationWarning, warnings[0]["category"])
         self.assertEqual(message, warnings[0]["message"])
 
-    @defer.inlineCallbacks
-    def test_closedConnectionCancelsRequests(self):
+    @defer.deferredCoro
+    async def test_closedConnectionCancelsRequests(self):
         """
         If there are requests outstanding when the connection
         is closed for any reason, they should fail.
@@ -593,7 +593,7 @@ class OurServerOurClientTests(SFTPTestBase):
 
         d = self.client.openFile(b"testfile1", filetransfer.FXF_READ, {})
         self._emptyBuffers()
-        fh = yield d
+        fh = await d
 
         # Intercept the handling of the read request on the server side
         gotReadRequest = []

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -19,6 +19,7 @@ from twisted.python import components
 from twisted.python.compat import _PY37PLUS
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import TestCase
+from twisted.trial.util import _deferredCoro
 
 try:
     from twisted.conch import unix
@@ -520,7 +521,7 @@ class OurServerOurClientTests(SFTPTestBase):
         return self.assertFailure(d, NotImplementedError)
 
     @skipIf(_PY37PLUS, "Broken by PEP 479 and deprecated.")
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_openDirectoryIterator(self):
         """
         Check that the object returned by
@@ -563,7 +564,7 @@ class OurServerOurClientTests(SFTPTestBase):
             ),
         )
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_openDirectoryIteratorDeprecated(self):
         """
         Using client.openDirectory as an iterator is deprecated.
@@ -584,7 +585,7 @@ class OurServerOurClientTests(SFTPTestBase):
         self.assertEqual(DeprecationWarning, warnings[0]["category"])
         self.assertEqual(message, warnings[0]["message"])
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_closedConnectionCancelsRequests(self):
         """
         If there are requests outstanding when the connection

--- a/src/twisted/conch/test/test_manhole.py
+++ b/src/twisted/conch/test/test_manhole.py
@@ -11,6 +11,7 @@ Tests for L{twisted.conch.manhole}.
 import traceback
 
 from twisted.trial import unittest
+from twisted.trial.util import _deferredCoro
 from twisted.internet import error, defer
 from twisted.test.proto_helpers import StringTransport
 from twisted.conch.test.test_recvline import (
@@ -304,7 +305,7 @@ class ManholeLoopbackMixin:
 
         return partialLine.addCallback(gotPartialLine).addCallback(gotClearedLine)
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_controlD(self):
         """
         A CTRL+D in the middle of a line doesn't close a connection,
@@ -325,7 +326,7 @@ class ManholeLoopbackMixin:
         d = self.recvlineClient.onDisconnection
         await self.assertFailure(d, error.ConnectionDone)
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_ControlL(self):
         """
         CTRL+L is generally used as a redraw-screen command in terminal
@@ -369,7 +370,7 @@ class ManholeLoopbackMixin:
 
         return d.addCallback(cb)
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_deferred(self):
         """
         When a deferred is returned to the manhole REPL, it is displayed with

--- a/src/twisted/conch/test/test_manhole.py
+++ b/src/twisted/conch/test/test_manhole.py
@@ -304,29 +304,29 @@ class ManholeLoopbackMixin:
 
         return partialLine.addCallback(gotPartialLine).addCallback(gotClearedLine)
 
-    @defer.inlineCallbacks
-    def test_controlD(self):
+    @defer.deferredCoro
+    async def test_controlD(self):
         """
         A CTRL+D in the middle of a line doesn't close a connection,
         but at the beginning of a line it does.
         """
         self._testwrite(b"1 + 1")
-        yield self.recvlineClient.expect(br"\+ 1")
+        await self.recvlineClient.expect(br"\+ 1")
         self._assertBuffer([b">>> 1 + 1"])
 
         self._testwrite(manhole.CTRL_D + b" + 1")
-        yield self.recvlineClient.expect(br"\+ 1")
+        await self.recvlineClient.expect(br"\+ 1")
         self._assertBuffer([b">>> 1 + 1 + 1"])
 
         self._testwrite(b"\n")
-        yield self.recvlineClient.expect(b"3\n>>> ")
+        await self.recvlineClient.expect(b"3\n>>> ")
 
         self._testwrite(manhole.CTRL_D)
         d = self.recvlineClient.onDisconnection
-        yield self.assertFailure(d, error.ConnectionDone)
+        await self.assertFailure(d, error.ConnectionDone)
 
-    @defer.inlineCallbacks
-    def test_ControlL(self):
+    @defer.deferredCoro
+    async def test_ControlL(self):
         """
         CTRL+L is generally used as a redraw-screen command in terminal
         applications.  Manhole doesn't currently respect this usage of it,
@@ -336,11 +336,11 @@ class ManholeLoopbackMixin:
         # Start off with a newline so that when we clear the display we can
         # tell by looking for the missing first empty prompt line.
         self._testwrite(b"\n1 + 1")
-        yield self.recvlineClient.expect(br"\+ 1")
+        await self.recvlineClient.expect(br"\+ 1")
         self._assertBuffer([b">>> ", b">>> 1 + 1"])
 
         self._testwrite(manhole.CTRL_L + b" + 1")
-        yield self.recvlineClient.expect(br"1 \+ 1 \+ 1")
+        await self.recvlineClient.expect(br"1 \+ 1 \+ 1")
         self._assertBuffer([b">>> 1 + 1 + 1"])
 
     def test_controlA(self):
@@ -369,8 +369,8 @@ class ManholeLoopbackMixin:
 
         return d.addCallback(cb)
 
-    @defer.inlineCallbacks
-    def test_deferred(self):
+    @defer.deferredCoro
+    async def test_deferred(self):
         """
         When a deferred is returned to the manhole REPL, it is displayed with
         a sequence number, and when the deferred fires, the result is printed.
@@ -381,12 +381,12 @@ class ManholeLoopbackMixin:
             b"d\n"
         )
 
-        yield self.recvlineClient.expect(b"<Deferred #0>")
+        await self.recvlineClient.expect(b"<Deferred #0>")
 
         self._testwrite(b"c = reactor.callLater(0.1, d.callback, 'Hi!')\n")
-        yield self.recvlineClient.expect(b">>> ")
+        await self.recvlineClient.expect(b">>> ")
 
-        yield self.recvlineClient.expect(b"Deferred #0 called back: 'Hi!'\n>>> ")
+        await self.recvlineClient.expect(b"Deferred #0 called back: 'Hi!'\n>>> ")
         self._assertBuffer(
             [
                 b">>> from twisted.internet import defer, reactor",

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -11,6 +11,7 @@ from zope.interface import implementer, Interface
 from binascii import hexlify, unhexlify
 
 from twisted.trial import unittest
+from twisted.trial.util import _deferredCoro
 from twisted.python.compat import nativeString, networkString
 from twisted.python import components
 from twisted.python.versions import Version
@@ -333,7 +334,7 @@ class CheckersMixin:
         which are expected to be unauthorized.
     """
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_positive(self):
         """
         The given credentials are accepted by all the checkers, and give
@@ -344,7 +345,7 @@ class CheckersMixin:
                 r = await chk.requestAvatarId(cred)
                 self.assertEqual(r, avatarId)
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_negative(self):
         """
         The given credentials are rejected by all the checkers.

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -333,26 +333,26 @@ class CheckersMixin:
         which are expected to be unauthorized.
     """
 
-    @defer.inlineCallbacks
-    def test_positive(self):
+    @defer.deferredCoro
+    async def test_positive(self):
         """
         The given credentials are accepted by all the checkers, and give
         the expected C{avatarID}s
         """
         for chk in self.getCheckers():
             for (cred, avatarId) in self.getGoodCredentials():
-                r = yield chk.requestAvatarId(cred)
+                r = await chk.requestAvatarId(cred)
                 self.assertEqual(r, avatarId)
 
-    @defer.inlineCallbacks
-    def test_negative(self):
+    @defer.deferredCoro
+    async def test_negative(self):
         """
         The given credentials are rejected by all the checkers.
         """
         for chk in self.getCheckers():
             for cred in self.getBadCredentials():
                 d = chk.requestAvatarId(cred)
-                yield self.assertFailure(d, error.UnauthorizedLogin)
+                await self.assertFailure(d, error.UnauthorizedLogin)
 
 
 class HashlessFilePasswordDBMixin:

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -927,46 +927,6 @@ def ensureDeferred(coro):
     return coro
 
 
-def deferredCoro(fn):
-    """
-    Wrap a coroutine function that awaits L{Deferred}s with a deferred returning
-    function.
-
-    Coroutine functions return a coroutine object, similar to how generators
-    work. This function turns that coroutine into a Deferred, meaning that it
-    can be used in regular Twisted code. For example::
-
-        import treq
-        from twisted.internet defer, task
-
-        async def crawl(pages):
-            results = {}
-            for page in pages:
-                results[page] = await treq.content(await treq.get(page))
-            return results
-
-        @defer.deferredCoro
-        async def main(reactor):
-            pages = [
-                "http://localhost:8080"
-            ]
-            print(await crawl(pages))
-
-        task.react(main)
-
-    @param fn: The coroutinefunction object to wrap.
-    @type fn: A coroutinefunction
-
-    @rtype: A callable returning L{Deferred}
-    """
-
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        return ensureDeferred(fn(*args, **kwargs))
-
-    return wrapper
-
-
 class DebugInfo:
     """
     Deferred debug helper.

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -865,9 +865,9 @@ def react(main, argv=(), _reactor=None):
 
           task.react(main, ('alice', 'secret'))
 
-    @param main: A callable which returns a L{Deferred}. It should
-        take the reactor as its first parameter, followed by the elements of
-        C{argv}.
+    @param main: A coroutinefunction or a callable which returns a L{Deferred}.
+        It should take the reactor as its first parameter, followed by the
+        elements of C{argv}.
 
     @param argv: A list of arguments to pass to C{main}. If omitted the
         callable will be invoked with no additional arguments.
@@ -879,7 +879,7 @@ def react(main, argv=(), _reactor=None):
     """
     if _reactor is None:
         from twisted.internet import reactor as _reactor
-    finished = main(_reactor, *argv)
+    finished = defer.ensureDeferred(main(_reactor, *argv))
     codes = [0]
 
     stopping = []

--- a/src/twisted/newsfragments/9939.removal
+++ b/src/twisted/newsfragments/9939.removal
@@ -1,0 +1,1 @@
+twisted.internet.defer.inlineCallbacks is deprecated. This deprecation is intended to encourage the use of coroutine functions when writing new code. There are no current plans to remove @inlineCallbacks

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -121,6 +121,11 @@ def versionToUsefulObject(version):
     """
     from incremental import Version
 
+    return Version(
+        version.args[0].s,
+        *[x.s if isinstance(x, ast.Str) else x.n for x in version.args[1:] if x],
+    )
+
     package = version.args[0].s
     major = getattr(version.args[1], "n", getattr(version.args[1], "s", None))
     return Version(package, major, *(x.n for x in version.args[2:] if x))

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -22,7 +22,7 @@ else:
 
 from unittest import skipIf
 
-from twisted.internet import reactor, defer
+from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ProcessDone
 from twisted.internet.protocol import ProcessProtocol
@@ -30,6 +30,7 @@ from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
 
 from twisted.trial.unittest import TestCase
+from twisted.trial.util import _deferredCoro
 
 if platform.isLinux():
     from socket import MSG_DONTWAIT
@@ -274,7 +275,7 @@ class SendmsgTests(TestCase):
                 "or maybe send1msg blocked for a while"
             )
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_sendSubProcessFD(self):
         """
         Calling L{sendmsg} with SOL_SOCKET, SCM_RIGHTS, and a platform-endian

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -22,8 +22,8 @@ else:
 
 from unittest import skipIf
 
-from twisted.internet import reactor
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet import reactor, defer
+from twisted.internet.defer import Deferred
 from twisted.internet.error import ProcessDone
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python.filepath import FilePath
@@ -274,15 +274,15 @@ class SendmsgTests(TestCase):
                 "or maybe send1msg blocked for a while"
             )
 
-    @inlineCallbacks
-    def test_sendSubProcessFD(self):
+    @defer.deferredCoro
+    async def test_sendSubProcessFD(self):
         """
         Calling L{sendmsg} with SOL_SOCKET, SCM_RIGHTS, and a platform-endian
         packed file descriptor number should send that file descriptor to a
         different process, where it can be retrieved by using L{recv1msg}.
         """
         sspp = _spawn("pullpipe", self.output.fileno())
-        yield sspp.started
+        await sspp.started
         pipeOut, pipeIn = _makePipe()
         self.addCleanup(pipeOut.close)
         self.addCleanup(pipeIn.close)
@@ -294,7 +294,7 @@ class SendmsgTests(TestCase):
                 [(SOL_SOCKET, SCM_RIGHTS, pack("i", pipeIn.fileno()))],
             )
 
-        yield sspp.stopped
+        await sspp.stopped
         self.assertEqual(read(pipeOut.fileno(), 1024), b"Test fixture data: blonk.\n")
         # Make sure that the pipe is actually closed now.
         self.assertEqual(read(pipeOut.fileno(), 1024), b"")

--- a/src/twisted/test/test_defgen.py
+++ b/src/twisted/test/test_defgen.py
@@ -359,7 +359,7 @@ class DeprecateDeferredGeneratorTests(unittest.SynchronousTestCase):
             warnings[0]["message"],
             "twisted.internet.defer.deferredGenerator was deprecated in "
             "Twisted 15.0.0; please use "
-            "twisted.internet.defer.inlineCallbacks instead",
+            "async/await coroutines instead",
         )
 
     def test_waitForDeferredDeprecated(self):
@@ -376,5 +376,5 @@ class DeprecateDeferredGeneratorTests(unittest.SynchronousTestCase):
             warnings[0]["message"],
             "twisted.internet.defer.waitForDeferred was deprecated in "
             "Twisted 15.0.0; please use "
-            "twisted.internet.defer.inlineCallbacks instead",
+            "async/await coroutines instead",
         )

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -51,6 +51,7 @@ from io import BytesIO
 from twisted.python.log import msg
 from twisted.internet import reactor, protocol, error, interfaces, defer
 from twisted.trial import unittest
+from twisted.trial.util import _deferredCoro
 from twisted.python import runtime, procutils
 from twisted.python.compat import networkString
 from twisted.python.filepath import FilePath
@@ -2453,7 +2454,7 @@ class Win32CreateProcessFlagsTests(unittest.TestCase):
     Check the flags passed to CreateProcess.
     """
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def test_flags(self):
         """
         Verify that the flags passed to win32process.CreateProcess() prevent a

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -2453,8 +2453,8 @@ class Win32CreateProcessFlagsTests(unittest.TestCase):
     Check the flags passed to CreateProcess.
     """
 
-    @defer.inlineCallbacks
-    def test_flags(self):
+    @defer.deferredCoro
+    async def test_flags(self):
         """
         Verify that the flags passed to win32process.CreateProcess() prevent a
         new console window from being created. Use the following script
@@ -2531,7 +2531,7 @@ class Win32CreateProcessFlagsTests(unittest.TestCase):
         comspec = str(os.environ["COMSPEC"])
         cmd = [comspec, "/c", exe, scriptPath.path]
         _dumbwin32proc.Process(reactor, processProto, None, cmd, {}, None)
-        yield d
+        await d
         self.assertEqual(flags, [_dumbwin32proc.win32process.CREATE_NO_WINDOW])
 
 

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -256,8 +256,8 @@ def profiled(f, outputFile):
     return _
 
 
-@defer.inlineCallbacks
-def _runSequentially(callables, stopOnFirstError=False):
+@defer.deferredCoro
+async def _runSequentially(callables, stopOnFirstError=False):
     """
     Run the given callables one after the other. If a callable returns a
     Deferred, wait until it has finished before running the next callable.
@@ -273,15 +273,14 @@ def _runSequentially(callables, stopOnFirstError=False):
     """
     results = []
     for f in callables:
-        d = defer.maybeDeferred(f)
         try:
-            thing = yield d
+            thing = await defer.maybeDeferred(f)
             results.append((defer.SUCCESS, thing))
         except Exception:
             results.append((defer.FAILURE, Failure()))
             if stopOnFirstError:
                 break
-    defer.returnValue(results)
+    return results
 
 
 class _NoTrialMarker(Exception):

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -19,6 +19,7 @@ Maintainer: Jonathan Lange
 """
 
 
+import functools
 from random import randrange
 
 from twisted.internet import defer, utils, interfaces
@@ -256,7 +257,20 @@ def profiled(f, outputFile):
     return _
 
 
-@defer.deferredCoro
+def _deferredCoro(fn):
+    """
+    Wrap a coroutine function that awaits L{Deferred}s with a deferred returning
+    function.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return defer.ensureDeferred(fn(*args, **kwargs))
+
+    return wrapper
+
+
+@_deferredCoro
 async def _runSequentially(callables, stopOnFirstError=False):
     """
     Run the given callables one after the other. If a callable returns a

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -8,10 +8,11 @@ Tests for L{twisted.words.service}.
 import time
 
 from twisted.cred import portal, credentials, checkers
-from twisted.internet import address, defer, reactor
+from twisted.internet import address, reactor
 from twisted.internet.defer import Deferred, DeferredList, maybeDeferred, succeed
 from twisted.spread import pb
 from twisted.test import proto_helpers
+from twisted.trial.util import _deferredCoro
 from twisted.trial import unittest
 from twisted.words import ewords, service
 from twisted.words.protocols import irc
@@ -805,7 +806,7 @@ class PBProtocolTests(unittest.TestCase):
             ]
         )
 
-    @defer.deferredCoro
+    @_deferredCoro
     async def testGroups(self):
         async def loggedInAvatar(name, password, mind):
             nameBytes = name


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9939
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
