### PR TITLE
Added HTTP 308 support

### DIFF
--- a/src/twisted/web/_responses.py
+++ b/src/twisted/web/_responses.py
@@ -26,6 +26,7 @@ SEE_OTHER                       = 303
 NOT_MODIFIED                    = 304
 USE_PROXY                       = 305
 TEMPORARY_REDIRECT              = 307
+PERMANENT_REDIRECT              = 308
 
 BAD_REQUEST                     = 400
 UNAUTHORIZED                    = 401
@@ -79,6 +80,7 @@ RESPONSES = {
     USE_PROXY: b"Use Proxy",
     # 306 not defined??
     TEMPORARY_REDIRECT: b"Temporary Redirect",
+    PERMANENT_REDIRECT: b"Permanent Redirect",
 
     # 400
     BAD_REQUEST: b"Bad Request",

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -2128,7 +2128,7 @@ class RedirectAgent:
     """
 
     _redirectResponses = [http.MOVED_PERMANENTLY, http.FOUND,
-                          http.TEMPORARY_REDIRECT]
+                          http.TEMPORARY_REDIRECT, http.PERMANENT_REDIRECT]
     _seeOtherResponses = [http.SEE_OTHER]
 
 
@@ -2221,7 +2221,8 @@ class BrowserLikeRedirectAgent(RedirectAgent):
     @since: 13.1
     """
     _redirectResponses = [http.TEMPORARY_REDIRECT]
-    _seeOtherResponses = [http.MOVED_PERMANENTLY, http.FOUND, http.SEE_OTHER]
+    _seeOtherResponses = [http.MOVED_PERMANENTLY, http.FOUND, http.SEE_OTHER,
+                          http.PERMANENT_REDIRECT]
 
 
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -33,7 +33,7 @@ __all__ = [
     'NO_CONTENT', 'RESET_CONTENT', 'PARTIAL_CONTENT', 'MULTI_STATUS',
 
     'MULTIPLE_CHOICE', 'MOVED_PERMANENTLY', 'FOUND', 'SEE_OTHER',
-    'NOT_MODIFIED', 'USE_PROXY', 'TEMPORARY_REDIRECT',
+    'NOT_MODIFIED', 'USE_PROXY', 'TEMPORARY_REDIRECT', 'PERMANENT_REDIRECT',
 
     'BAD_REQUEST', 'UNAUTHORIZED', 'PAYMENT_REQUIRED', 'FORBIDDEN', 'NOT_FOUND',
     'NOT_ALLOWED', 'NOT_ACCEPTABLE', 'PROXY_AUTH_REQUIRED', 'REQUEST_TIMEOUT',
@@ -102,7 +102,7 @@ from twisted.web._responses import (ACCEPTED, BAD_GATEWAY, BAD_REQUEST,
                                     OK, PARTIAL_CONTENT, PAYMENT_REQUIRED,
                                     PRECONDITION_FAILED, PROXY_AUTH_REQUIRED,
                                     REQUEST_ENTITY_TOO_LARGE, REQUEST_TIMEOUT,
-                                    REQUEST_URI_TOO_LONG,
+                                    REQUEST_URI_TOO_LONG, PERMANENT_REDIRECT,
                                     REQUESTED_RANGE_NOT_SATISFIABLE,
                                     RESET_CONTENT, RESPONSES, SEE_OTHER,
                                     SERVICE_UNAVAILABLE, SWITCHING,

--- a/src/twisted/web/newsfragments/9940.bugfix
+++ b/src/twisted/web/newsfragments/9940.bugfix
@@ -1,0 +1,1 @@
+twisted.web.RedirectAgent now supports 308 redirects

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -2727,6 +2727,13 @@ class _RedirectAgentTestsMixin:
         self._testRedirectDefault(307)
 
 
+    def test_redirect308(self):
+        """
+        L{client.RedirectAgent} follows redirects on status code 308.
+        """
+        self._testRedirectDefault(308)
+
+
     def _testRedirectToGet(self, code, method):
         """
         L{client.RedirectAgent} changes the method to I{GET} when getting


### PR DESCRIPTION
Added support for `308 Permanent Redirects` on the `RedirectAgent`.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9940
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
