### PR TITLE
gtk3: remove check for DISPLAY variable

### DIFF
--- a/src/twisted/internet/gtk3reactor.py
+++ b/src/twisted/internet/gtk3reactor.py
@@ -19,22 +19,8 @@ If you wish to use a GApplication, register it with the reactor::
 Then use twisted.internet APIs as usual.
 """
 
-
-import os
-
 from twisted.internet import gireactor
 from twisted.python import runtime
-
-# Newer versions of gtk3/pygoject raise a RuntimeError, or just break in a
-# confusing manner, if the program is not running under X11.  We therefore try
-# to fail in a more reasonable manner, and check for $DISPLAY as a reasonable
-# approximation of availability of X11. This is somewhat over-aggressive,
-# since some older versions of gtk3/pygobject do work with missing $DISPLAY,
-# but it's too hard to figure out which, so we always require it.
-if (runtime.platform.getType() == 'posix' and
-    not runtime.platform.isMacOSX() and not os.environ.get("DISPLAY")):
-    raise ImportError(
-        "Gtk3 requires X11, and no DISPLAY environment variable is set")
 
 
 class Gtk3Reactor(gireactor.GIReactor):

--- a/src/twisted/internet/test/test_gireactor.py
+++ b/src/twisted/internet/test/test_gireactor.py
@@ -6,7 +6,6 @@ GI/GTK3 reactor tests.
 """
 
 
-import os
 import sys
 from unittest import skipIf
 try:
@@ -27,11 +26,9 @@ else:
         gtk3reactor = _gtk3reactor
         from gi.repository import Gtk
 
-from twisted.python.runtime import platform
 from twisted.internet.error import ReactorAlreadyRunning
 from twisted.trial.unittest import TestCase, SkipTest
 from twisted.internet.test.reactormixins import ReactorBuilder
-from twisted.test.test_twisted import SetAsideModule
 
 # Skip all tests if gi is unavailable:
 if gireactor is None:
@@ -187,29 +184,3 @@ class PygtkCompatibilityTests(TestCase):
             raise SkipTest("This version of gi doesn't include pygtkcompat.")
         import gobject
         self.assertTrue(gobject.__name__.startswith("gi."))
-
-
-
-class Gtk3ReactorTests(TestCase):
-    """
-    Tests for L{gtk3reactor}.
-    """
-
-    @skipIf(platform.getType() != "posix" or platform.isMacOSX(),
-            "This test is only relevant when using X11")
-    def test_requiresDISPLAY(self):
-        """
-        On X11, L{gtk3reactor} is unimportable if the C{DISPLAY} environment
-        variable is not set.
-        """
-        display = os.environ.get("DISPLAY", None)
-        if display is not None:
-            self.addCleanup(os.environ.__setitem__, "DISPLAY", display)
-            del os.environ["DISPLAY"]
-        with SetAsideModule("twisted.internet.gtk3reactor"):
-            exc = self.assertRaises(ImportError,
-                                    __import__, "twisted.internet.gtk3reactor")
-            self.assertEqual(
-                exc.args[0],
-                "Gtk3 requires X11, and no DISPLAY environment "
-                "variable is set")

--- a/src/twisted/newsfragments/9904.bugfix
+++ b/src/twisted/newsfragments/9904.bugfix
@@ -1,0 +1,1 @@
+The Gtk3 reactor now runs on Wayland-only sessions


### PR DESCRIPTION
It appear to work well enough without that check.
With Wayland becoming more pupolar, this check is in
the way of running applications.

Fixes: #9904

## Remove this section

Please have a look at [our developer documentation](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch) before submitting your Pull Request.

Please note that the trac ticket, news fragment, and review submission portions of this process apply to *all* pull requests, no matter how small; if you don't do them, it's likely that nobody will even notice your PR needs a review.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9904
* [x] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
