### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+          python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,7 +6,7 @@ Installation Requirements
 
 To install Twisted, you need:
 
-- Python 3.5/3.6/3.7.
+- Python 3.6/3.7/3.8.
 
 - `setuptools <https://pypi.python.org/pypi/setuptools>`_
   (installed automatically if you use pip).

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ For information on changes in this release, see the `NEWS <NEWS.rst>`_ file.
 What is this?
 -------------
 
-Twisted is an event-based framework for internet applications, supporting Python 3.5+.
+Twisted is an event-based framework for internet applications, supporting Python 3.6+.
 It includes modules for many different purposes, including the following:
 
 - ``twisted.web``: HTTP clients and servers, HTML templating, and a WSGI server

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -9,7 +9,6 @@ parameters:
 - name: pythonVersion
   type: string
   values:
-  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/azure-pipelines/tests_pipeline.yml
+++ b/azure-pipelines/tests_pipeline.yml
@@ -19,7 +19,6 @@ jobs:
 - template: 'macos_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"
@@ -28,7 +27,6 @@ jobs:
 - template: 'windows_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"
@@ -38,7 +36,6 @@ jobs:
 - template: 'windows_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"

--- a/docs/core/development/policy/coding-standard.rst
+++ b/docs/core/development/policy/coding-standard.rst
@@ -617,12 +617,11 @@ An attribute (or function, method or class) should be considered private when on
 Python 3
 --------
 
-Twisted is being ported to Python 3, targeting Python 3.5+.
+Twisted is being ported to Python 3, targeting Python 3.6+.
 Please see :doc:`Porting to Python 3 </core/howto/python3>` for details.
 
-All new modules must be Python 2.7 & 3.5+ compatible, and all new code to ported modules must be Python 2.7 & 3.5+ compatible.
-New code in non-ported modules must be written in a 2.7 & 3.5+ compatible way (explicit bytes/unicode strings, new exception raising format, etc) as to prevent extra work when that module is eventually ported.
-Code targeting Python 3 specific features must gracefully fall-back on Python 2 as much as is reasonably possible (for example, Python 2 support for 'async/await' is not reasonably possible and would not be required, but code that uses a Python 3-specific module such as ipaddress should be able to use a backport to 2.7 if available).
+All new modules must be Python 3.6+ compatible, and all new code to ported modules must be 3.6+ compatible.
+New code in non-ported modules must be written in a 3.6+ compatible way (explicit bytes/unicode strings, new exception raising format, etc) as to prevent extra work when that module is eventually ported.
 
 
 Database
@@ -640,7 +639,7 @@ All SQL keywords should be in upper case.
 C Code
 ------
 
-C code must be optional, and work across multiple platforms (MSVC++9/10/14 for Pythons 2.7 and 3.5+ on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
+C code must be optional, and work across multiple platforms (MSVC++9/10/14 for 3.6+ on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
 
 C code should be kept in external bindings packages which Twisted depends on.
 If creating new C extension modules, using `cffi <https://cffi.readthedocs.io/en/latest/>`_ is highly encouraged, as it will perform well on PyPy and CPython, and be easier to use on Python 2 and 3.

--- a/docs/core/howto/python3.rst
+++ b/docs/core/howto/python3.rst
@@ -4,7 +4,7 @@ Porting to Python 3
 Introduction
 ------------
 
-Twisted currently supports only Python 3.5+.
+Twisted currently supports only Python 3.6+.
 This document covers Twisted-specific issues in porting your code to Python 3.
 
 API Differences

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ license = MIT
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -24,7 +23,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.2
+python_requires = >=3.6.0
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/src/twisted/newsfragments/9958.removal
+++ b/src/twisted/newsfragments/9958.removal
@@ -1,0 +1,1 @@
+Python 3.5 is no longer supported.


### PR DESCRIPTION
https://twistedmatrix.com/trac/ticket/9958


This has been discussed on the mailing list: ​https://twistedmatrix.com/pipermail/twisted-python/2020-May/065066.html

This PR cannot be merged until  *AFTER* one more major Twisted release which will be announced as the last one with Python 3.5 support.