### PR TITLE
Change Pull Request template to mention `tox -e black-reformat`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,7 +7,8 @@ Please note that the trac ticket, news fragment, and review submission portions 
 ## Contributor Checklist:
 
 * [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
-* [ ] The changes pass minimal style checks (see: https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted )
+* [ ] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
+* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
 * [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
 * [ ] I have updated the automated tests.
 * [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -9,6 +9,6 @@ Please note that the trac ticket, news fragment, and review submission portions 
 * [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
 * [ ] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
 * [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
-* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles )
+* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
 * [ ] I have updated the automated tests.
 * [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9956
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

