### PR TITLE
Enable warn_unreachable for remaining files in twisted.internet.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -253,12 +253,6 @@ warn_unreachable = False
 [mypy-twisted.conch.test.test_ssh]
 warn_unreachable = False
 
-[mypy-twisted.internet.defer]
-warn_unreachable = False
-
-[mypy-twisted.internet.test.test_endpoints]
-warn_unreachable = False
-
 [mypy-twisted.persisted.aot]
 warn_unreachable = False
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -17,19 +17,21 @@ Maintainer: Glyph Lefkowitz
 """
 
 
-import attr
+from asyncio import iscoroutine
+from functools import wraps
+from sys import exc_info, version_info
 import traceback
 import types
+from typing import Optional
 import warnings
-from asyncio import iscoroutine
-from sys import exc_info, version_info
-from functools import wraps
+
+import attr
 from incremental import Version
 
 # Twisted imports
-from twisted.python.compat import cmp, comparable
-from twisted.python import lockfile, failure
 from twisted.logger import Logger
+from twisted.python import lockfile, failure
+from twisted.python.compat import cmp, comparable
 from twisted.python.deprecate import warnAboutFunction, deprecated
 
 try:
@@ -264,7 +266,7 @@ class Deferred:
     # sets it directly.
     debug = False
 
-    _chainedTo = None
+    _chainedTo = None  # type: Optional[Deferred]
 
     def __init__(self, canceller=None):
         """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -1324,7 +1324,7 @@ class TCP4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         address = IPv4Address("TCP", "0.0.0.0", 0)
 
         if listenArgs is None:
-            listenArgs = {}
+            listenArgs = {}  # type: ignore[unreachable]
 
         return (
             endpoints.TCP4ServerEndpoint(reactor, address.port, **listenArgs),
@@ -1439,7 +1439,7 @@ class TCP6EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         address = IPv6Address("TCP", interface, 0)
 
         if listenArgs is None:
-            listenArgs = {}
+            listenArgs = {}  # type: ignore[unreachable]
 
         return (
             endpoints.TCP6ServerEndpoint(reactor, address.port, **listenArgs),
@@ -2812,7 +2812,7 @@ class SSL4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         address = IPv4Address("TCP", "localhost", 80)
 
         if connectArgs is None:
-            connectArgs = {}
+            connectArgs = {}  # type: ignore[unreachable]
 
         return (
             endpoints.SSL4ClientEndpoint(

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -1323,9 +1323,6 @@ class TCP4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         """
         address = IPv4Address("TCP", "0.0.0.0", 0)
 
-        if listenArgs is None:
-            listenArgs = {}  # type: ignore[unreachable]
-
         return (
             endpoints.TCP4ServerEndpoint(reactor, address.port, **listenArgs),
             (
@@ -1437,9 +1434,6 @@ class TCP6EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         """
         interface = listenArgs.get("interface", "::")
         address = IPv6Address("TCP", interface, 0)
-
-        if listenArgs is None:
-            listenArgs = {}  # type: ignore[unreachable]
 
         return (
             endpoints.TCP6ServerEndpoint(reactor, address.port, **listenArgs),
@@ -2810,9 +2804,6 @@ class SSL4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
             L{IReactorSSL.connectSSL}
         """
         address = IPv4Address("TCP", "localhost", 80)
-
-        if connectArgs is None:
-            connectArgs = {}  # type: ignore[unreachable]
 
         return (
             endpoints.SSL4ClientEndpoint(


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9976
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
