### PR TITLE
9978 unreachable inotify

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -265,9 +265,6 @@ warn_unreachable = False
 [mypy-twisted.persisted.sob]
 warn_unreachable = False
 
-[mypy-twisted.python.test.test_inotify]
-warn_unreachable = False
-
 [mypy-twisted.web.http_headers]
 warn_unreachable = False
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9978
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
