### PR TITLE
Enable warn_unreachable in twisted.web

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -267,9 +267,3 @@ warn_unreachable = False
 
 [mypy-twisted.python.test.test_inotify]
 warn_unreachable = False
-
-[mypy-twisted.web.http_headers]
-warn_unreachable = False
-
-[mypy-twisted.web.twcgi]
-warn_unreachable = False

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -247,7 +247,7 @@ class Headers:
             return default
 
         if isinstance(name, str):
-            return [v if isinstance(v, str) else v.decode("utf8") for v in values]
+            return [v.decode("utf8") for v in values]
         return values
 
     def getAllRawHeaders(self) -> Iterator[Tuple[bytes, List[bytes]]]:

--- a/src/twisted/web/twcgi.py
+++ b/src/twisted/web/twcgi.py
@@ -32,7 +32,6 @@ class CGIDirectory(resource.Resource, filepath.FilePath):
             return CGIDirectory(fnp.path)
         else:
             return CGIScript(fnp.path)
-        return resource.NoResource()
 
     def render(self, request):
         notFound = resource.NoResource(


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9979
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
