### PR TITLE
[9813] Fix maybeDeferred's handling of coroutines

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -145,7 +145,8 @@ def maybeDeferred(f, *args, **kw):
     Invoke a function that may or may not return a L{Deferred}.
 
     Call the given function with the given arguments.  If the returned
-    object is a L{Deferred}, return it.  If the returned object is a L{Failure},
+    object is a L{Deferred}, return it.  If the returned object is a coroutine,
+    execute it per L{ensureDeferred}.  If the returned object is a L{Failure},
     wrap it with L{fail} and return it.  Otherwise, wrap it in L{succeed} and
     return it.  If an exception is raised, convert it to a L{Failure}, wrap it
     in L{fail}, and then return it.

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -167,6 +167,8 @@ def maybeDeferred(f, *args, **kw):
 
     if isinstance(result, Deferred):
         return result
+    elif iscoroutine(result):
+        return _cancellableInlineCallbacks(result)
     elif isinstance(result, failure.Failure):
         return fail(result)
     else:

--- a/src/twisted/newsfragments/9813.bugfix
+++ b/src/twisted/newsfragments/9813.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.defer.maybeDeferred now converts the result of calling a coroutine function to a Deferred, rather than returning the coroutine object.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -705,6 +705,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         L{defer.maybeDeferred} converts a coroutine that immediately returns
         into a fired L{Deferred}.
         """
+
         async def coro():
             return 1234
 
@@ -716,6 +717,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         L{defer.maybeDeferred} converts a coroutine that immediately raises an
         exception into a failed L{Deferred}.
         """
+
         async def coro():
             raise IndentationError()
 


### PR DESCRIPTION
When `maybeDeferred` executes a coroutine function it should run the resulting coroutine, rather than returning a coroutine object wrapped in a `Deferred`.

This implementation only changes `maybeDeferred`. Arguably `Deferred.callback()` and `Deferred.errback()` should guard against being called with coroutines in the say way they currently reject `Deferred`s. I'm interested in what reviewers think.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9813
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
