### PR TITLE
fix the readthedocs build, enable readthedocs PR builds and move readthedocs config into .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,8 @@ formats:
   - epub
 
 python:
-  version: 2.7
+  version: 3.8
   system_packages: False
   install:
-    - method: setuptools
+    - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+version: 2
+
+sphinx:
+  builder: html
+  fail_on_warning: true
+
+formats:
+  - pdf
+  - epub
+
+python:
+  version: 2.7
+  system_packages: False
+  install:
+    - method: setuptools
+      path: .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ exclude appveyor.yml
 exclude .coveralls.yml
 exclude .circleci
 exclude .git-blame-ignore-revs
+exclude .readthedocs.yml
 recursive-exclude .circleci *
 exclude azure-pipelines
 recursive-exclude azure-pipelines *

--- a/src/twisted/newsfragments/9980.misc
+++ b/src/twisted/newsfragments/9980.misc
@@ -1,0 +1,1 @@
+fix the readthedocs build, enable readthedocs PR builds and move readthedocs config into .readthedocs.yml


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9980
* [ ] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
