### PR TITLE
Increase TLS version used in tests, to unbreak tests on pypy3 on Ubuntu 20.4

### DIFF
--- a/src/twisted/test/ssl_helpers.py
+++ b/src/twisted/test/ssl_helpers.py
@@ -21,13 +21,13 @@ class ClientTLSContext(ssl.ClientContextFactory):
     isClient = 1
 
     def getContext(self):
-        return SSL.Context(SSL.TLSv1_METHOD)
+        return SSL.Context(SSL.SSLv23_METHOD)
 
 
 class ServerTLSContext:
     isClient = 0
 
-    def __init__(self, filename=certPath, method=SSL.TLSv1_METHOD):
+    def __init__(self, filename=certPath, method=SSL.SSLv23_METHOD):
         self.filename = filename
         self._method = method
 

--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -244,13 +244,13 @@ if SSL is not None:
     class ServerTLSContext(ssl.DefaultOpenSSLContextFactory):
         """
         A context factory with a default method set to
-        L{OpenSSL.SSL.TLSv1_METHOD}.
+        L{OpenSSL.SSL.SSLv23_METHOD}.
         """
 
         isClient = False
 
         def __init__(self, *args, **kw):
-            kw["sslmethod"] = SSL.TLSv1_METHOD
+            kw["sslmethod"] = SSL.SSLv23_METHOD
             ssl.DefaultOpenSSLContextFactory.__init__(self, *args, **kw)
 
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -333,7 +333,7 @@ def loopbackTLSConnection(trustRoot, privateKeyFile, chainedCertFile=None):
             @return: an SSL context using a certificate and key.
             @rtype: C{OpenSSL.SSL.Context}
             """
-            ctx = SSL.Context(SSL.TLSv1_METHOD)
+            ctx = SSL.Context(SSL.SSLv23_METHOD)
             if chainedCertFile is not None:
                 ctx.use_certificate_chain_file(chainedCertFile)
             ctx.use_privatekey_file(privateKeyFile)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -1764,18 +1764,18 @@ class OpenSSLOptionsECDHIntegrationTests(OpenSSLOptionsTestsMixin, TestCase):
         # and OpenSSL only supports ECHDE groups with TLS 1.3:
         # https://wiki.openssl.org/index.php/TLS1.3#Groups
         #
-        # so TLS 1.3 implies ECDHE.  Force this test to use TLS 1.2 to
+        # so TLS 1.3 implies ECDHE.  Force this test to use TLS 1.3 to
         # ensure ECDH is selected when it might not be.
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
                 certificate=self.sCert,
                 requireCertificate=False,
-                lowerMaximumSecurityTo=sslverify.TLSVersion.TLSv1_2,
+                lowerMaximumSecurityTo=sslverify.TLSVersion.TLSv1_3,
             ),
             sslverify.OpenSSLCertificateOptions(
                 requireCertificate=False,
-                lowerMaximumSecurityTo=sslverify.TLSVersion.TLSv1_2,
+                lowerMaximumSecurityTo=sslverify.TLSVersion.TLSv1_3,
             ),
             onData=onData,
         )


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9986
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [X] I have updated the automated tests.
* [X] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
