### PR TITLE
Enable more Mypy checks in twisted.python.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -159,26 +159,242 @@ warn_return_any = False
 [mypy-twisted.protocols.test.test_basic]
 allow_incomplete_defs = True
 
-[mypy-twisted.python.*]
+[mypy-twisted.python._appdirs]
+allow_untyped_defs = True
+
+[mypy-twisted.python._inotify]
+allow_untyped_defs = True
+
+[mypy-twisted.python._pydoctor]
+allow_untyped_defs = True
+
+[mypy-twisted.python._release]
+allow_untyped_defs = True
+
+[mypy-twisted.python._setup]
+allow_untyped_defs = True
+
+[mypy-twisted.python._shellcomp]
+allow_untyped_defs = True
+
+[mypy-twisted.python._textattributes]
+allow_untyped_defs = True
+
+[mypy-twisted.python._tzhelper]
+allow_untyped_defs = True
+
+[mypy-twisted.python.compat]
+allow_untyped_defs = True
+
+[mypy-twisted.python.components]
+allow_untyped_defs = True
+
+[mypy-twisted.python.context]
+allow_untyped_defs = True
+
+[mypy-twisted.python.deprecate]
+allow_untyped_defs = True
+
+[mypy-twisted.python.failure]
 allow_untyped_defs = True
 check_untyped_defs = False
 
-[mypy-twisted.python._setup]
-allow_incomplete_defs = True
-warn_return_any = False
+[mypy-twisted.python.fakepwd]
+allow_untyped_defs = True
 
-[mypy-twisted.python.compat]
-allow_incomplete_defs = True
-warn_return_any = False
+[mypy-twisted.python.filepath]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.formmethod]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.htmlizer]
+allow_untyped_defs = True
+
+[mypy-twisted.python.lockfile]
+allow_untyped_defs = True
+
+[mypy-twisted.python.log]
+allow_untyped_defs = True
+
+[mypy-twisted.python.logfile]
+allow_untyped_defs = True
+check_untyped_defs = False
 
 [mypy-twisted.python.modules]
-warn_return_any = False
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.monkey]
+allow_untyped_defs = True
+
+[mypy-twisted.python.procutils]
+allow_untyped_defs = True
+
+[mypy-twisted.python.randbytes]
+allow_untyped_defs = True
+
+[mypy-twisted.python.rebuild]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.reflect]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.release]
+allow_untyped_defs = True
+
+[mypy-twisted.python.roots]
+allow_untyped_defs = True
+
+[mypy-twisted.python.runtime]
+allow_untyped_defs = True
+
+[mypy-twisted.python.sendmsg]
+allow_untyped_defs = True
+
+[mypy-twisted.python.shortcut]
+allow_untyped_defs = True
+
+[mypy-twisted.python.syslog]
+allow_untyped_defs = True
+
+[mypy-twisted.python.systemd]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.modules_helpers]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.pullpipe]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_appdirs]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_components]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_constants]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_deprecate]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_dist3]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_fakepwd]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_htmlizer]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_inotify]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_pydoctor]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_release]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_runtime]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_sendmsg]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_setup]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_shellcomp]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_syslog]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_systemd]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_textattributes]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_tzhelper]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_url]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_urlpath]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_util]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.test.test_versions]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_win32]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_zippath]
+allow_untyped_defs = True
+
+[mypy-twisted.python.test.test_zipstream]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.text]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.threadable]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.threadpool]
+allow_untyped_defs = True
 
 [mypy-twisted.python.urlpath]
-warn_return_any = False
+allow_untyped_defs = True
+check_untyped_defs = False
 
 [mypy-twisted.python.usage]
-warn_return_any = False
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.util]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.win32]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.python.zippath]
+allow_untyped_defs = True
+
+[mypy-twisted.python.zipstream]
+allow_untyped_defs = True
+check_untyped_defs = False
 
 [mypy-twisted.runner.*]
 allow_untyped_defs = True

--- a/src/twisted/python/_appdirs.py
+++ b/src/twisted/python/_appdirs.py
@@ -26,6 +26,8 @@ def getDataDirectory(moduleName=None):
     """
     if not moduleName:
         caller = currentframe(1)
-        moduleName = inspect.getmodule(caller).__name__
+        module = inspect.getmodule(caller)
+        assert module is not None
+        moduleName = module.__name__
 
     return appdirs.user_data_dir(moduleName)

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -10,6 +10,7 @@ This documentation does not link to pydoctor API as there is no public API yet.
 """
 
 import ast
+from typing import Optional
 
 from pydoctor import model, zopeinterface, astbuilder
 from pydoctor.sphinx import SphinxInventory
@@ -59,7 +60,7 @@ class TwistedSphinxInventory(SphinxInventory):
             if name == "zope.interface.adapter.AdapterRegistry":
                 # FIXME:
                 # https://github.com/zopefoundation/zope.interface/issues/41
-                relativeLink = "adapter.html"
+                relativeLink = "adapter.html"  # type: Optional[str]
             else:
                 # Not a known exception.
                 relativeLink = None

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -14,6 +14,7 @@ which must run on multiple platforms (eg the setup.py script).
 
 import os
 import sys
+from typing import Dict
 
 from zope.interface import Interface, implementer
 
@@ -217,7 +218,7 @@ class Project:
         @return: A L{incremental.Version} specifying the version number of the
             project based on live python modules.
         """
-        namespace = {}
+        namespace = {}  # type: Dict[str, object]
         directory = self.directory
         while not namespace:
             if directory.path == "/":

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -38,6 +38,7 @@ import os
 import platform
 import re
 import sys
+from typing import Any, Dict, cast
 
 from distutils.command import build_ext
 from distutils.errors import CompileError
@@ -68,7 +69,7 @@ STATIC_PACKAGE_METADATA = dict(
         "Programming Language :: Python :: 3.8",
     ],
     python_requires=">=3.5",
-)
+)  # type: Dict[str, Any]
 
 
 _dev = [
@@ -323,7 +324,7 @@ class build_ext_twisted(build_ext.build_ext):  # type: ignore[name-defined]  # n
         Check to see which extension modules to build and then build them.
         """
         self.prepare_extensions()
-        build_ext.build_ext.build_extensions(self)
+        build_ext.build_ext.build_extensions(self)  # type: ignore[attr-defined]
 
     def _remove_conftest(self):
         for filename in ("conftest.c", "conftest.o", "conftest.obj"):
@@ -355,7 +356,7 @@ class build_ext_twisted(build_ext.build_ext):  # type: ignore[name-defined]  # n
         return self._compile_helper("#include <{}>\n".format(header_name))
 
 
-def _checkCPython(sys=sys, platform=platform) -> bool:
+def _checkCPython(platform: Any = platform) -> bool:
     """
     Checks if this implementation is CPython.
 
@@ -368,7 +369,7 @@ def _checkCPython(sys=sys, platform=platform) -> bool:
     @return: C{False} if the implementation is definitely not CPython, C{True}
         otherwise.
     """
-    return platform.python_implementation() == "CPython"
+    return cast(bool, platform.python_implementation() == "CPython")
 
 
 _isCPython = _checkCPython()  # type: bool

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -25,9 +25,12 @@ The main public documentation exists in the L{twisted.python.usage.Options}
 docstring, the L{twisted.python.usage.Completions} docstring, and the
 Options howto.
 """
+
 import getopt
 import inspect
 import itertools
+from types import MethodType
+from typing import Dict, List, Set
 
 from twisted.python import reflect, util, usage
 from twisted.python.compat import ioType
@@ -115,7 +118,7 @@ def shellComplete(config, cmdName, words, shellCompFile):
 
                     gen = ZshSubcommandBuilder(
                         subOptions, config, cmdName, shellCompFile
-                    )
+                    )  # type: ZshBuilder
                     gen.write()
                     return
 
@@ -302,8 +305,8 @@ class ZshArgumentsGenerator:
 
         aCL = reflect.accumulateClassList
 
-        optFlags = []
-        optParams = []
+        optFlags = []  # type: List[List[object]]
+        optParams = []  # type: List[List[object]]
 
         aCL(options.__class__, "optFlags", optFlags)
         aCL(options.__class__, "optParameters", optParams)
@@ -465,10 +468,10 @@ class ZshArgumentsGenerator:
         strings.sort()  # need deterministic order for reliable unit-tests
         return "(%s)" % " ".join(strings)
 
-    def makeExcludesDict(self):
+    def makeExcludesDict(self) -> Dict[str, Set[str]]:
         """
         @return: A C{dict} that maps each option name appearing in
-            self.mutuallyExclusive to a list of those option names that is it
+            self.mutuallyExclusive to a set of those option names that is it
             mutually exclusive with (can't appear on the cmd line with).
         """
 
@@ -478,7 +481,7 @@ class ZshArgumentsGenerator:
             if optList[1] != None:
                 longToShort[optList[0]] = optList[1]
 
-        excludes = {}
+        excludes = {}  # type: Dict[str, Set[str]]
         for lst in self.mutuallyExclusive:
             for i, longname in enumerate(lst):
                 tmp = set(lst[:i] + lst[i + 1 :])
@@ -613,13 +616,13 @@ class ZshArgumentsGenerator:
         optList = self.allOptionsNameToDefinition[longname]
         return optList[0] or None
 
-    def addAdditionalOptions(self):
+    def addAdditionalOptions(self) -> None:
         """
         Add additional options to the optFlags and optParams lists.
         These will be defined by 'opt_foo' methods of the Options subclass
         @return: L{None}
         """
-        methodsDict = {}
+        methodsDict = {}  # type: Dict[str, MethodType]
         reflect.accumulateMethods(self.options, methodsDict, "opt_")
         methodToShort = {}
         for name in methodsDict.copy():

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -21,7 +21,7 @@ Serializing a formatting structure is done with L{flatten}.
 """
 
 
-from typing import ClassVar, Sequence
+from typing import ClassVar, List, Sequence
 from twisted.python.util import FancyEqMixin
 
 
@@ -295,7 +295,7 @@ def flatten(output, attrs, attributeRenderer="toVT102"):
     @return: A string expressing the text and display attributes specified by
         L{output}.
     """
-    flattened = []
+    flattened = []  # type: List[str]
     output.serialize(flattened.append, attrs, attributeRenderer)
     return "".join(flattened)
 

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -38,6 +38,7 @@ from io import StringIO as NativeStringIO
 from io import TextIOBase
 from sys import intern
 from types import MethodType as _MethodType
+from typing import Any, cast
 from urllib.parse import quote as urlquote
 from urllib.parse import unquote as urlunquote
 
@@ -200,6 +201,7 @@ def currentframe(n=0):
     """
     f = inspect.currentframe()
     for x in range(n + 1):
+        assert f is not None
         f = f.f_back
     return f
 
@@ -246,38 +248,38 @@ def comparable(klass):
     C{__cmp__} to implement their comparisons.
     """
 
-    def __eq__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __eq__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c == 0
 
-    def __ne__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __ne__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c != 0
 
-    def __lt__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __lt__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c < 0
 
-    def __le__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __le__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c <= 0
 
-    def __gt__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __gt__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c > 0
 
-    def __ge__(self, other: object) -> bool:
-        c = self.__cmp__(other)
+    def __ge__(self: Any, other: object) -> bool:
+        c = cast(bool, self.__cmp__(other))
         if c is NotImplemented:
             return c
         return c >= 0
@@ -484,11 +486,10 @@ def bytesEnviron():
     This function is POSIX only; environment variables are always text strings
     on Windows.
     """
-    target = dict()
-    for x, y in os.environ.items():
-        target[os.environ.encodekey(x)] = os.environ.encodevalue(y)
+    encodekey = os.environ.encodekey  # type: ignore[attr-defined]
+    encodevalue = os.environ.encodevalue  # type: ignore[attr-defined]
 
-    return target
+    return {encodekey(x): encodevalue(y) for x, y in os.environ.items()}
 
 
 def _constructMethod(cls, name, self):

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -31,6 +31,7 @@ interface.
 
 
 from io import StringIO
+from typing import Dict, Callable
 
 # zope3 imports
 from zope.interface import interface, declarations
@@ -80,7 +81,7 @@ def getAdapterFactory(fromInterface, toInterface, default):
     self = globalRegistry
     if not isinstance(fromInterface, interface.InterfaceClass):
         fromInterface = declarations.implementedBy(fromInterface)
-    factory = self.lookup1(fromInterface, toInterface)
+    factory = self.lookup1(fromInterface, toInterface)  # type: ignore[attr-defined]
     if factory is None:
         factory = default
     return factory
@@ -332,7 +333,7 @@ def proxyForInterface(iface, originalAttribute="original"):
     def __init__(self, original):
         setattr(self, originalAttribute, original)
 
-    contents = {"__init__": __init__}
+    contents = {"__init__": __init__}  # type: Dict[str, object]
     for name in iface:
         contents[name] = _ProxyDescriptor(name, originalAttribute)
     proxy = type("(Proxy for %s)" % (reflect.qual(iface),), (object,), contents)

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -31,7 +31,7 @@ interface.
 
 
 from io import StringIO
-from typing import Dict, Callable
+from typing import Dict
 
 # zope3 imports
 from zope.interface import interface, declarations

--- a/src/twisted/python/formmethod.py
+++ b/src/twisted/python/formmethod.py
@@ -99,7 +99,7 @@ class String(Argument):
         s = str(val)
         if len(s) < self.min:
             raise InputError("Value must be at least %s characters long" % self.min)
-        if self.max != None and len(s) > self.max:
+        if self.max is not None and len(s) > self.max:
             raise InputError("Value must be at most %s characters long" % self.max)
         return str(val)
 
@@ -121,7 +121,7 @@ class VerifiedPassword(String):
         s = str(vals[0])
         if len(s) < self.min:
             raise InputError("Value must be at least %s characters long" % self.min)
-        if self.max != None and len(s) > self.max:
+        if self.max is not None and len(s) > self.max:
             raise InputError("Value must be at most %s characters long" % self.max)
         return s
 

--- a/src/twisted/python/htmlizer.py
+++ b/src/twisted/python/htmlizer.py
@@ -54,7 +54,9 @@ class TokenPrinter:
                 else:
                     type = "variable"
         else:
-            type = tokenize.tok_name.get(type).lower()
+            type = tokenize.tok_name.get(type)
+            assert type is not None
+            type = type.lower()
         self.writer(token, type)
         self.currentCol = ecol
         self.currentLine += token.count(b"\n")
@@ -75,7 +77,7 @@ class HTMLWriter:
 
     def __init__(self, writer):
         self.writer = writer
-        noSpan = []
+        noSpan = []  # type: List[str]
         reflect.accumulateClassList(self.__class__, "noSpan", noSpan)
         self.noSpan = noSpan
 

--- a/src/twisted/python/logfile.py
+++ b/src/twisted/python/logfile.py
@@ -9,10 +9,11 @@ A rotating, browsable log file.
 
 
 # System Imports
-import os
 import glob
-import time
+import os
 import stat
+import time
+from typing import BinaryIO, Optional, cast
 
 from twisted.python import threadable
 
@@ -24,7 +25,9 @@ class BaseLogFile:
 
     synchronized = ["write", "rotate"]
 
-    def __init__(self, name, directory, defaultMode=None):
+    def __init__(
+        self, name: str, directory: str, defaultMode: Optional[int] = None
+    ) -> None:
         """
         Create a log file.
 
@@ -37,7 +40,9 @@ class BaseLogFile:
         self.name = name
         self.path = os.path.join(directory, name)
         if defaultMode is None and os.path.exists(self.path):
-            self.defaultMode = stat.S_IMODE(os.stat(self.path)[stat.ST_MODE])
+            self.defaultMode = stat.S_IMODE(
+                os.stat(self.path)[stat.ST_MODE]
+            )  # type: Optional[int]
         else:
             self.defaultMode = defaultMode
         self._openFile()
@@ -65,18 +70,18 @@ class BaseLogFile:
         """
         self.closed = False
         if os.path.exists(self.path):
-            self._file = open(self.path, "rb+", 0)
+            self._file = cast(BinaryIO, open(self.path, "rb+", 0))
             self._file.seek(0, 2)
         else:
             if self.defaultMode is not None:
                 # Set the lowest permissions
                 oldUmask = os.umask(0o777)
                 try:
-                    self._file = open(self.path, "wb+", 0)
+                    self._file = cast(BinaryIO, open(self.path, "wb+", 0))
                 finally:
                     os.umask(oldUmask)
             else:
-                self._file = open(self.path, "wb+", 0)
+                self._file = cast(BinaryIO, open(self.path, "wb+", 0))
         if self.defaultMode is not None:
             try:
                 os.chmod(self.path, self.defaultMode)
@@ -112,7 +117,7 @@ class BaseLogFile:
         """
         self.closed = True
         self._file.close()
-        self._file = None
+        del self._file
 
     def reopen(self):
         """
@@ -317,7 +322,7 @@ class LogReader:
         The comments about binary-mode for L{BaseLogFile._openFile} also apply
         here.
         """
-        self._file = open(name, "r")
+        self._file = open(name, "r")  # Optional[BinaryIO]
 
     def readLines(self, lines=10):
         """Read a list of lines from the log file.

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -64,6 +64,7 @@ from os.path import dirname, split as splitpath
 
 import sys
 import inspect
+from typing import cast
 import warnings
 import zipimport
 
@@ -400,7 +401,7 @@ class PythonModule(_ModuleIteratorHelper):
         PythonModules with the same name are equal.
         """
         if isinstance(other, PythonModule):
-            return other.name == self.name
+            return cast(bool, other.name == self.name)
         return NotImplemented
 
     def walkModules(self, importPackages=False):

--- a/src/twisted/python/runtime.py
+++ b/src/twisted/python/runtime.py
@@ -38,7 +38,7 @@ class Platform:
     """
 
     type = knownPlatforms.get(os.name)
-    seconds = staticmethod(_timeFunctions.get(type, time.time))  # noqa
+    seconds = staticmethod(_timeFunctions.get(type, time.time))
     _platform = sys.platform
 
     def __init__(self, name=None, platform=None):

--- a/src/twisted/python/runtime.py
+++ b/src/twisted/python/runtime.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import time
+from typing import Callable, Dict, Optional
 import warnings
 
 
@@ -28,7 +29,7 @@ knownPlatforms = {
 _timeFunctions = {
     #'win32': time.clock,
     "win32": time.time,
-}
+}  # type: Dict[Optional[str], Callable]
 
 
 class Platform:
@@ -37,7 +38,7 @@ class Platform:
     """
 
     type = knownPlatforms.get(os.name)
-    seconds = staticmethod(_timeFunctions.get(type, time.time))  # type: ignore[arg-type]  # noqa
+    seconds = staticmethod(_timeFunctions.get(type, time.time))  # noqa
     _platform = sys.platform
 
     def __init__(self, name=None, platform=None):

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -13,6 +13,7 @@ feature are supported.
 __all__ = ["ListenFDs"]
 
 from os import getpid
+from typing import List
 
 
 class ListenFDs:
@@ -58,11 +59,13 @@ class ListenFDs:
             descriptors which have been inherited.
         """
         if environ is None:
-            from os import environ
+            from os import environ as _environ
+
+            environ = _environ
         if start is None:
             start = cls._START
 
-        descriptors = []
+        descriptors = []  # type: List[int]
 
         try:
             pid = int(environ["LISTEN_PID"])
@@ -75,7 +78,7 @@ class ListenFDs:
                 except (KeyError, ValueError):
                     pass
                 else:
-                    descriptors = range(start, start + count)
+                    descriptors = list(range(start, start + count))
                     del environ["LISTEN_PID"], environ["LISTEN_FDS"]
 
         return cls(descriptors)

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -9,8 +9,8 @@ In most cases you can just use C{reactor.callInThread} and friends
 instead of creating a thread pool directly.
 """
 
-
-import threading
+from threading import Thread, currentThread
+from typing import List
 
 from twisted._threads import pool as _pool
 from twisted.python import log, context
@@ -43,8 +43,8 @@ class ThreadPool:
     started = False
     name = None
 
-    threadFactory = threading.Thread
-    currentThread = staticmethod(threading.currentThread)
+    threadFactory = Thread
+    currentThread = staticmethod(currentThread)
     _pool = staticmethod(_pool)
 
     def __init__(self, minthreads=5, maxthreads=20, name=None):
@@ -65,10 +65,12 @@ class ThreadPool:
         self.min = minthreads
         self.max = maxthreads
         self.name = name
-        self.threads = []
+        self.threads = []  # type: List[Thread]
 
         def trackingThreadFactory(*a, **kw):
-            thread = self.threadFactory(*a, name=self._generateName(), **kw)
+            thread = self.threadFactory(  # type: ignore[misc]
+                *a, name=self._generateName(), **kw
+            )
             self.threads.append(thread)
             return thread
 
@@ -233,24 +235,26 @@ class ThreadPool:
 
         def inContext():
             try:
-                result = inContext.theWork()
+                result = inContext.theWork()  # type: ignore[attr-defined]
                 ok = True
             except:
                 result = Failure()
                 ok = False
 
-            inContext.theWork = None
-            if inContext.onResult is not None:
-                inContext.onResult(ok, result)
-                inContext.onResult = None
+            inContext.theWork = None  # type: ignore[attr-defined]
+            if inContext.onResult is not None:  # type: ignore[attr-defined]
+                inContext.onResult(ok, result)  # type: ignore[attr-defined]
+                inContext.onResult = None  # type: ignore[attr-defined]
             elif not ok:
                 log.err(result)
 
         # Avoid closing over func, ctx, args, kw so that we can carefully
         # manage their lifecycle.  See
         # test_threadCreationArgumentsCallInThreadWithCallback.
-        inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
-        inContext.onResult = onResult
+        inContext.theWork = lambda: context.call(  # type: ignore[attr-defined]
+            ctx, func, *args, **kw
+        )
+        inContext.onResult = onResult  # type: ignore[attr-defined]
 
         self._team.do(inContext)
 

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -6,10 +6,8 @@
 L{URLPath}, a representation of a URL.
 """
 
-
+from typing import cast
 from urllib.parse import quote as urlquote, unquote as urlunquote, urlunsplit
-
-from twisted.python.compat import nativeString
 
 from hyperlink import URL as _URL
 
@@ -26,7 +24,7 @@ def _rereconstituter(name):
     @return: a descriptor which retrieves the private version of the attribute
         on get and calls rerealize on set.
     """
-    privateName = nativeString("_") + name
+    privateName = "_" + name
     return property(
         lambda self: getattr(self, privateName),
         lambda self, value: (
@@ -264,7 +262,7 @@ class URLPath:
         """
         The L{str} of a L{URLPath} is its URL text.
         """
-        return nativeString(self._url.asURI().asText())
+        return cast(str, self._url.asURI().asText())
 
     def __repr__(self) -> str:
         """

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -12,7 +12,7 @@ See the constructor of L{ZipArchive} for use.
 import errno
 import os
 import time
-from typing import Dict, List
+from typing import Dict
 
 from zipfile import ZipFile
 

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -9,9 +9,10 @@ See the constructor of L{ZipArchive} for use.
 """
 
 
+import errno
 import os
 import time
-import errno
+from typing import Dict, List
 
 from zipfile import ZipFile
 
@@ -219,7 +220,7 @@ class ZipArchive(ZipPath):
         self.pathInArchive = _coerceToFilesystemEncoding(archivePathname, "")
         # zipfile is already wasting O(N) memory on cached ZipInfo instances,
         # so there's no sense in trying to do this lazily or intelligently
-        self.childmap = {}  # map parent: list of children
+        self.childmap = {}  # type: Dict[str, Dict[str, int]]
 
         for name in self.zipfile.namelist():
             name = _coerceToFilesystemEncoding(self.path, name).split(self.sep)


### PR DESCRIPTION
This PR enables a variety of low-hanging-fruit typing cases that we can turn back on.

It's setting up for later work on specific modules.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9991
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
