### PR TITLE
Enable disallow_untyped_defs and check_untyped_defs on more files in twisted.python

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -159,28 +159,16 @@ warn_return_any = False
 [mypy-twisted.protocols.test.test_basic]
 allow_incomplete_defs = True
 
-[mypy-twisted.python._appdirs]
-allow_untyped_defs = True
-
-[mypy-twisted.python._inotify]
-allow_untyped_defs = True
-
 [mypy-twisted.python._pydoctor]
 allow_untyped_defs = True
 
 [mypy-twisted.python._release]
 allow_untyped_defs = True
 
-[mypy-twisted.python._setup]
-allow_untyped_defs = True
-
 [mypy-twisted.python._shellcomp]
 allow_untyped_defs = True
 
 [mypy-twisted.python._textattributes]
-allow_untyped_defs = True
-
-[mypy-twisted.python._tzhelper]
 allow_untyped_defs = True
 
 [mypy-twisted.python.compat]
@@ -250,29 +238,10 @@ allow_untyped_defs = True
 [mypy-twisted.python.roots]
 allow_untyped_defs = True
 
-[mypy-twisted.python.runtime]
-allow_untyped_defs = True
-
-[mypy-twisted.python.sendmsg]
-allow_untyped_defs = True
-
 [mypy-twisted.python.shortcut]
 allow_untyped_defs = True
 
 [mypy-twisted.python.syslog]
-allow_untyped_defs = True
-
-[mypy-twisted.python.systemd]
-allow_untyped_defs = True
-
-[mypy-twisted.python.test.modules_helpers]
-allow_untyped_defs = True
-check_untyped_defs = False
-
-[mypy-twisted.python.test.pullpipe]
-allow_untyped_defs = True
-
-[mypy-twisted.python.test.test_appdirs]
 allow_untyped_defs = True
 
 [mypy-twisted.python.test.test_components]

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -567,7 +567,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
             data = b"some data"
             ancillary = [(None, None, b"")]
             flags = 0
-            return sendmsg.RecievedMessage(data, ancillary, flags)
+            return sendmsg.ReceivedMessage(data, ancillary, flags)
 
         events = []
         addObserver(events.append)

--- a/src/twisted/python/_appdirs.py
+++ b/src/twisted/python/_appdirs.py
@@ -6,23 +6,21 @@
 Application data directory support.
 """
 
-
 import appdirs
 import inspect
+from typing import cast
 
 from twisted.python.compat import currentframe
 
 
-def getDataDirectory(moduleName=None):
+def getDataDirectory(moduleName: str = "") -> str:
     """
     Get a data directory for the caller function, or C{moduleName} if given.
 
     @param moduleName: The module name if you don't wish to have the caller's
         module.
-    @type moduleName: L{str}
 
     @returns: A directory for putting data in.
-    @rtype: L{str}
     """
     if not moduleName:
         caller = currentframe(1)
@@ -30,4 +28,4 @@ def getDataDirectory(moduleName=None):
         assert module is not None
         moduleName = module.__name__
 
-    return appdirs.user_data_dir(moduleName)
+    return cast(str, appdirs.user_data_dir(moduleName))

--- a/src/twisted/python/_inotify.py
+++ b/src/twisted/python/_inotify.py
@@ -11,6 +11,9 @@ required.
 
 import ctypes
 import ctypes.util
+from typing import cast
+
+from twisted.python.filepath import FilePath
 
 
 class INotifyError(Exception):
@@ -19,37 +22,32 @@ class INotifyError(Exception):
     """
 
 
-def init():
+def init() -> int:
     """
     Create an inotify instance and return the associated file descriptor.
     """
-    fd = libc.inotify_init()
+    fd = cast(int, libc.inotify_init())
     if fd < 0:
         raise INotifyError("INotify initialization error.")
     return fd
 
 
-def add(fd, path, mask):
+def add(fd: int, path: FilePath, mask: int) -> int:
     """
     Add a watch for the given path to the inotify file descriptor, and return
     the watch descriptor.
 
     @param fd: The file descriptor returned by C{libc.inotify_init}.
-    @type fd: L{int}
-
     @param path: The path to watch via inotify.
-    @type path: L{twisted.python.filepath.FilePath}
-
     @param mask: Bitmask specifying the events that inotify should monitor.
-    @type mask: L{int}
     """
-    wd = libc.inotify_add_watch(fd, path.asBytesMode().path, mask)
+    wd = cast(int, libc.inotify_add_watch(fd, path.asBytesMode().path, mask))
     if wd < 0:
         raise INotifyError("Failed to add watch on '%r' - (%r)" % (path, wd))
     return wd
 
 
-def remove(fd, wd):
+def remove(fd: int, wd: int) -> None:
     """
     Remove the given watch descriptor from the inotify file descriptor.
     """
@@ -76,7 +74,7 @@ def remove(fd, wd):
     libc.inotify_rm_watch(fd, wd)
 
 
-def initializeModule(libc):
+def initializeModule(libc: ctypes.CDLL) -> None:
     """
     Initialize the module, checking if the expected APIs exist and setting the
     argtypes and restype for C{inotify_init}, C{inotify_add_watch}, and

--- a/src/twisted/python/_tzhelper.py
+++ b/src/twisted/python/_tzhelper.py
@@ -6,7 +6,8 @@
 Time zone utilities.
 """
 
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime as DateTime, timedelta as TimeDelta, tzinfo as TZInfo
+from typing import Optional
 
 __all__ = [
     "FixedOffsetTimeZone",
@@ -14,32 +15,31 @@ __all__ = [
 ]
 
 
-class FixedOffsetTimeZone(tzinfo):
+class FixedOffsetTimeZone(TZInfo):
     """
     Represents a fixed timezone offset (without daylight saving time).
 
     @ivar name: A L{str} giving the name of this timezone; the name just
         includes how much time this offset represents.
 
-    @ivar offset: A L{timedelta} giving the amount of time this timezone is
+    @ivar offset: A L{TimeDelta} giving the amount of time this timezone is
         offset.
     """
 
-    def __init__(self, offset, name=None):
+    def __init__(self, offset: TimeDelta, name: Optional[str] = None) -> None:
         """
         Construct a L{FixedOffsetTimeZone} with a fixed offset.
 
         @param offset: a delta representing the offset from UTC.
-        @type offset: L{timedelta}
-
         @param name: A name to be given for this timezone.
-        @type name: L{str} or L{None}
         """
         self.offset = offset
         self.name = name
 
     @classmethod
-    def fromSignHoursMinutes(cls, sign, hours, minutes):
+    def fromSignHoursMinutes(
+        cls, sign: str, hours: int, minutes: int
+    ) -> "FixedOffsetTimeZone":
         """
         Construct a L{FixedOffsetTimeZone} from an offset described by sign
         ('+' or '-'), hours, and minutes.
@@ -48,16 +48,11 @@ class FixedOffsetTimeZone(tzinfo):
 
         @param sign: A string describing the positive or negative-ness of the
             offset.
-
         @param hours: The number of hours in the offset.
-        @type hours: L{int}
-
         @param minutes: The number of minutes in the offset
-        @type minutes: L{int}
 
         @return: A time zone with the given offset, and a name describing the
             offset.
-        @rtype: L{FixedOffsetTimeZone}
         """
         name = "%s%02i:%02i" % (sign, hours, minutes)
         if sign == "-":
@@ -65,46 +60,40 @@ class FixedOffsetTimeZone(tzinfo):
             minutes = -minutes
         elif sign != "+":
             raise ValueError("Invalid sign for timezone %r" % (sign,))
-        return cls(timedelta(hours=hours, minutes=minutes), name)
+        return cls(TimeDelta(hours=hours, minutes=minutes), name)
 
     @classmethod
-    def fromLocalTimeStamp(cls, timeStamp):
+    def fromLocalTimeStamp(cls, timeStamp: int) -> "FixedOffsetTimeZone":
         """
         Create a time zone with a fixed offset corresponding to a time stamp in
         the system's locally configured time zone.
-
-        @param timeStamp: a time stamp
-        @type timeStamp: L{int}
-
-        @return: a time zone
-        @rtype: L{FixedOffsetTimeZone}
         """
-        offset = datetime.fromtimestamp(timeStamp) - datetime.utcfromtimestamp(
+        offset = DateTime.fromtimestamp(timeStamp) - DateTime.utcfromtimestamp(
             timeStamp
         )
         return cls(offset)
 
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: Optional[DateTime]) -> TimeDelta:
         """
-        Return this timezone's offset from UTC.
+        Return the given timezone's offset from UTC.
         """
         return self.offset
 
-    def dst(self, dt):
+    def dst(self, dt: Optional[DateTime]) -> TimeDelta:
         """
-        Return a zero C{datetime.timedelta} for the daylight saving time
+        Return a zero L{TimeDelta} for the daylight saving time
         offset, since there is never one.
         """
-        return timedelta(0)
+        return TimeDelta(0)
 
-    def tzname(self, dt):
+    def tzname(self, dt: Optional[DateTime]) -> str:
         """
         Return a string describing this timezone.
         """
         if self.name is not None:
             return self.name
         # XXX this is wrong; the tests are
-        dt = datetime.fromtimestamp(0, self)
+        dt = DateTime.fromtimestamp(0, self)
         return dt.strftime("UTC%z")
 
 

--- a/src/twisted/python/runtime.py
+++ b/src/twisted/python/runtime.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, Optional
 import warnings
 
 
-def shortPythonVersion():
+def shortPythonVersion() -> str:
     """
     Returns the Python version as a dot-separated string.
     """
@@ -37,45 +37,44 @@ class Platform:
     Gives us information about the platform we're running on.
     """
 
-    type = knownPlatforms.get(os.name)
+    type = knownPlatforms.get(os.name)  # type: Optional[str]
     seconds = staticmethod(_timeFunctions.get(type, time.time))
     _platform = sys.platform
 
-    def __init__(self, name=None, platform=None):
+    def __init__(
+        self, name: Optional[str] = None, platform: Optional[str] = None
+    ) -> None:
         if name is not None:
             self.type = knownPlatforms.get(name)
             self.seconds = _timeFunctions.get(self.type, time.time)
         if platform is not None:
             self._platform = platform
 
-    def isKnown(self):
+    def isKnown(self) -> bool:
         """
         Do we know about this platform?
 
         @return: Boolean indicating whether this is a known platform or not.
-        @rtype: C{bool}
         """
         return self.type != None
 
-    def getType(self):
+    def getType(self) -> Optional[str]:
         """
         Get platform type.
 
         @return: Either 'posix', 'win32' or 'java'
-        @rtype: C{str}
         """
         return self.type
 
-    def isMacOSX(self):
+    def isMacOSX(self) -> bool:
         """
         Check if current platform is macOS.
 
         @return: C{True} if the current platform has been detected as macOS.
-        @rtype: C{bool}
         """
         return self._platform == "darwin"
 
-    def isWinNT(self):
+    def isWinNT(self) -> bool:
         """
         Are we running in Windows NT?
 
@@ -84,7 +83,6 @@ class Platform:
 
         @return: C{True} if the current platform has been detected as
             Windows NT.
-        @rtype: C{bool}
         """
         warnings.warn(
             "twisted.python.runtime.Platform.isWinNT was deprecated in "
@@ -94,44 +92,40 @@ class Platform:
         )
         return self.isWindows()
 
-    def isWindows(self):
+    def isWindows(self) -> bool:
         """
         Are we running in Windows?
 
         @return: C{True} if the current platform has been detected as
             Windows.
-        @rtype: C{bool}
         """
         return self.getType() == "win32"
 
-    def isVista(self):
+    def isVista(self) -> bool:
         """
         Check if current platform is Windows Vista or Windows Server 2008.
 
         @return: C{True} if the current platform has been detected as Vista
-        @rtype: C{bool}
         """
         if getattr(sys, "getwindowsversion", None) is not None:
             return sys.getwindowsversion()[0] == 6
         else:
             return False
 
-    def isLinux(self):
+    def isLinux(self) -> bool:
         """
         Check if current platform is Linux.
 
         @return: C{True} if the current platform has been detected as Linux.
-        @rtype: C{bool}
         """
         return self._platform.startswith("linux")
 
-    def isDocker(self, _initCGroupLocation="/proc/1/cgroup"):
+    def isDocker(self, _initCGroupLocation: str = "/proc/1/cgroup") -> bool:
         """
         Check if the current platform is Linux in a Docker container.
 
         @return: C{True} if the current platform has been detected as Linux
             inside a Docker container.
-        @rtype: C{bool}
         """
         if not self.isLinux():
             return False
@@ -154,13 +148,12 @@ class Platform:
 
         return False
 
-    def _supportsSymlinks(self):
+    def _supportsSymlinks(self) -> bool:
         """
         Check for symlink support usable for Twisted's purposes.
 
         @return: C{True} if symlinks are supported on the current platform,
                  otherwise C{False}.
-        @rtype: L{bool}
         """
         if self.isWindows():
             # We do the isWindows() check as newer Pythons support the symlink
@@ -180,12 +173,11 @@ class Platform:
             else:
                 return True
 
-    def supportsThreads(self):
+    def supportsThreads(self) -> bool:
         """
         Can threads be created?
 
         @return: C{True} if the threads are supported on the current platform.
-        @rtype: C{bool}
         """
         try:
             import threading
@@ -194,7 +186,7 @@ class Platform:
         except ImportError:
             return False
 
-    def supportsINotify(self):
+    def supportsINotify(self) -> bool:
         """
         Return C{True} if we can use the inotify API on this platform.
 

--- a/src/twisted/python/sendmsg.py
+++ b/src/twisted/python/sendmsg.py
@@ -8,57 +8,51 @@ sendmsg(2) and recvmsg(2) support for Python.
 
 
 from collections import namedtuple
-from socket import SCM_RIGHTS, CMSG_SPACE
+from socket import SCM_RIGHTS, CMSG_SPACE, socket as Socket
+from typing import List, Tuple
 
 
 __all__ = ["sendmsg", "recvmsg", "getSocketFamily", "SCM_RIGHTS"]
 
 
-RecievedMessage = namedtuple("RecievedMessage", ["data", "ancillary", "flags"])
+ReceivedMessage = namedtuple("ReceivedMessage", ["data", "ancillary", "flags"])
 
 
-def sendmsg(socket, data, ancillary=[], flags=0):
+def sendmsg(
+    socket: Socket,
+    data: bytes,
+    ancillary: List[Tuple[int, int, bytes]] = [],
+    flags: int = 0,
+) -> int:
     """
     Send a message on a socket.
 
     @param socket: The socket to send the message on.
-    @type socket: L{socket.socket}
-
     @param data: Bytes to write to the socket.
-    @type data: bytes
-
     @param ancillary: Extra data to send over the socket outside of the normal
         datagram or stream mechanism.  By default no ancillary data is sent.
-    @type ancillary: C{list} of C{tuple} of C{int}, C{int}, and C{bytes}.
-
     @param flags: Flags to affect how the message is sent.  See the C{MSG_}
         constants in the sendmsg(2) manual page.  By default no flags are set.
-    @type flags: C{int}
 
     @return: The return value of the underlying syscall, if it succeeds.
     """
     return socket.sendmsg([data], ancillary, flags)
 
 
-def recvmsg(socket, maxSize=8192, cmsgSize=4096, flags=0):
+def recvmsg(
+    socket: Socket, maxSize: int = 8192, cmsgSize: int = 4096, flags: int = 0
+) -> ReceivedMessage:
     """
     Receive a message on a socket.
 
     @param socket: The socket to receive the message on.
-    @type socket: L{socket.socket}
-
     @param maxSize: The maximum number of bytes to receive from the socket using
         the datagram or stream mechanism. The default maximum is 8192.
-    @type maxSize: L{int}
-
     @param cmsgSize: The maximum number of bytes to receive from the socket
         outside of the normal datagram or stream mechanism. The default maximum
         is 4096.
-    @type cmsgSize: L{int}
-
     @param flags: Flags to affect how the message is sent.  See the C{MSG_}
         constants in the sendmsg(2) manual page. By default no flags are set.
-    @type flags: L{int}
 
     @return: A named 3-tuple of the bytes received using the datagram/stream
         mechanism, a L{list} of L{tuple}s giving ancillary received data, and
@@ -71,16 +65,13 @@ def recvmsg(socket, maxSize=8192, cmsgSize=4096, flags=0):
     # own default of 4096. -hawkie
     data, ancillary, flags = socket.recvmsg(maxSize, CMSG_SPACE(cmsgSize), flags)[0:3]
 
-    return RecievedMessage(data=data, ancillary=ancillary, flags=flags)
+    return ReceivedMessage(data=data, ancillary=ancillary, flags=flags)
 
 
-def getSocketFamily(socket):
+def getSocketFamily(socket: Socket) -> int:
     """
     Return the family of the given socket.
 
     @param socket: The socket to get the family of.
-    @type socket: L{socket.socket}
-
-    @rtype: L{int}
     """
     return socket.family

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -13,7 +13,7 @@ feature are supported.
 __all__ = ["ListenFDs"]
 
 from os import getpid
-from typing import List
+from typing import Iterable, List, Mapping, Optional
 
 
 class ListenFDs:
@@ -27,7 +27,6 @@ class ListenFDs:
         consecutively numbered, with a fixed lowest "starting" descriptor.  This
         gives the default starting descriptor.  Since this must agree with the
         value systemd is using, it typically should not be overridden.
-    @type _START: C{int}
 
     @ivar _descriptors: A C{list} of C{int} giving the descriptors which were
         inherited.
@@ -35,7 +34,7 @@ class ListenFDs:
 
     _START = 3
 
-    def __init__(self, descriptors):
+    def __init__(self, descriptors: List[int]) -> None:
         """
         @param descriptors: The descriptors which will be returned from calls to
             C{inheritedDescriptors}.
@@ -43,7 +42,11 @@ class ListenFDs:
         self._descriptors = descriptors
 
     @classmethod
-    def fromEnvironment(cls, environ=None, start=None):
+    def fromEnvironment(
+        cls,
+        environ: Optional[Mapping[str, str]] = None,
+        start: Optional[int] = None,
+    ) -> "ListenFDs":
         """
         @param environ: A dictionary-like object to inspect to discover
             inherited descriptors.  By default, L{None}, indicating that the
@@ -83,8 +86,8 @@ class ListenFDs:
 
         return cls(descriptors)
 
-    def inheritedDescriptors(self):
+    def inheritedDescriptors(self) -> Iterable[int]:
         """
-        @return: The configured list of descriptors.
+        @return: The configured descriptors.
         """
         return list(self._descriptors)

--- a/src/twisted/python/test/modules_helpers.py
+++ b/src/twisted/python/test/modules_helpers.py
@@ -6,8 +6,9 @@ Facilities for helping test code which interacts with Python's module system
 to load code.
 """
 
-
 import sys
+from types import ModuleType
+from typing import List, Iterable, Tuple
 
 from twisted.python.filepath import FilePath
 
@@ -18,38 +19,38 @@ class TwistedModulesMixin:
     methods for manipulating Python's module system.
     """
 
-    def replaceSysPath(self, sysPath):
+    def replaceSysPath(self, sysPath: List[str]) -> None:
         """
         Replace sys.path, for the duration of the test, with the given value.
         """
         originalSysPath = sys.path[:]
 
-        def cleanUpSysPath():
+        def cleanUpSysPath() -> None:
             sys.path[:] = originalSysPath
 
-        self.addCleanup(cleanUpSysPath)
+        self.addCleanup(cleanUpSysPath)  # type: ignore[attr-defined]
         sys.path[:] = sysPath
 
-    def replaceSysModules(self, sysModules):
+    def replaceSysModules(self, sysModules: Iterable[Tuple[str, ModuleType]]) -> None:
         """
         Replace sys.modules, for the duration of the test, with the given value.
         """
         originalSysModules = sys.modules.copy()
 
-        def cleanUpSysModules():
+        def cleanUpSysModules() -> None:
             sys.modules.clear()
             sys.modules.update(originalSysModules)
 
-        self.addCleanup(cleanUpSysModules)
+        self.addCleanup(cleanUpSysModules)  # type: ignore[attr-defined]
         sys.modules.clear()
         sys.modules.update(sysModules)
 
-    def pathEntryWithOnePackage(self, pkgname="test_package"):
+    def pathEntryWithOnePackage(self, pkgname: str = "test_package") -> FilePath:
         """
         Generate a L{FilePath} with one package, named C{pkgname}, on it, and
         return the L{FilePath} of the path entry.
         """
-        entry = FilePath(self.mktemp())
+        entry = FilePath(self.mktemp())  # type: ignore[attr-defined]
         pkg = entry.child("test_package")
         pkg.makedirs()
         pkg.child("__init__.py").setContent(b"")

--- a/src/twisted/python/test/pullpipe.py
+++ b/src/twisted/python/test/pullpipe.py
@@ -2,15 +2,16 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
-import sys
 import os
 import socket
 from struct import unpack
+import sys
+from typing import Tuple
 
 from twisted.python.sendmsg import recvmsg
 
 
-def recvfd(socketfd):
+def recvfd(socketfd: int) -> Tuple[int, bytes]:
     """
     Receive a file descriptor from a L{sendmsg} message on the given C{AF_UNIX}
     socket.

--- a/src/twisted/python/test/test_appdirs.py
+++ b/src/twisted/python/test/test_appdirs.py
@@ -22,7 +22,7 @@ class AppdirsTests(unittest.TestCase):
     if not _appdirs:
         skip = "appdirs package not installed"
 
-    def test_moduleName(self):
+    def test_moduleName(self) -> None:
         """
         Calling L{appdirs.getDataDirectory} will return a user data directory
         in the system convention, with the module of the caller as the
@@ -31,7 +31,7 @@ class AppdirsTests(unittest.TestCase):
         res = _appdirs.getDataDirectory()
         self.assertTrue(res.endswith("twisted.python.test.test_appdirs"))
 
-    def test_manual(self):
+    def test_manual(self) -> None:
         """
         Calling L{appdirs.getDataDirectory} with a C{moduleName} argument will
         make a data directory with that name instead.

--- a/src/twisted/python/test/test_setup.py
+++ b/src/twisted/python/test/test_setup.py
@@ -40,7 +40,7 @@ class SetupTests(SynchronousTestCase):
             "whatever", ["whatever.c"], condition=lambda b: False
         )
 
-        args = getSetupArgs(extensions=[good_ext, bad_ext], readme=None)
+        args = getSetupArgs(extensions=[good_ext, bad_ext], readme="")
 
         # ext_modules should be set even though it's not used.  See comment
         # in getSetupArgs
@@ -60,7 +60,7 @@ class SetupTests(SynchronousTestCase):
             "whatever", ["whatever.c"], define_macros=[("whatever", 2)]
         )
 
-        args = getSetupArgs(extensions=[ext], readme=None)
+        args = getSetupArgs(extensions=[ext], readme="")
 
         builder = args["cmdclass"]["build_ext"](Distribution())
         self.patch(os, "name", "nt")


### PR DESCRIPTION
Enable Mypy `disallow_untyped_defs` and `check_untyped_defs` on more files in twisted.python

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9992
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
