### PR TITLE
run epub build on PRs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,8 +329,8 @@ epub_copyright = u'2014, Twisted Matrix Labs'
 # The depth of the table of contents in toc.ncx.
 #epub_tocdepth = 3
 
-# Allow duplicate toc entries.
-#epub_tocdup = True
+# Disallow duplicate toc entries.
+epub_tocdup = False
 
 # Choose between 'default' and 'includehidden'.
 #epub_tocscope = 'default'

--- a/tox.ini
+++ b/tox.ini
@@ -146,7 +146,8 @@ commands =
     black: black {env:BLACK_LINT_ARGS} {posargs:{[default]sources}}
 
     apidocs: {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
-    narrativedocs: sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
+    narrativedocs: sphinx-build -aW -W --keep-going -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
+    narrativedocs: sphinx-build -aW -W --keep-going -b epub -d {toxinidir}/docs/_build/doctrees-epub {toxinidir}/docs {toxinidir}/docs/_build/epub
 
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 


### PR DESCRIPTION
currently readthedocs only builds the html docs in CI https://github.com/readthedocs/readthedocs.org/issues/7116

This is just a draft PR to try and replicate the rtd issue in a PR

## Contributor Checklist:

* [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [ ] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
