### PR TITLE
Remove mentions of 'unicode' type from twisted.logger._format

### DIFF
--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -19,8 +19,7 @@ timeFormatRFC3339 = "%Y-%m-%dT%H:%M:%S%z"
 
 def formatEvent(event):
     """
-    Formats an event as a L{unicode}, using the format in
-    C{event["log_format"]}.
+    Formats an event as a L{str}, using the format in C{event["log_format"]}.
 
     This implementation should never raise an exception; if the formatting
     cannot be done, the returned string will describe the event generically so
@@ -30,7 +29,7 @@ def formatEvent(event):
     @type event: L{dict}
 
     @return: A formatted string.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     return eventAsText(
         event,
@@ -42,7 +41,7 @@ def formatEvent(event):
 
 def formatUnformattableEvent(event, error):
     """
-    Formats an event as a L{unicode} that describes the event generically and a
+    Formats an event as a L{str} that describes the event generically and a
     formatting error.
 
     @param event: A logging event.
@@ -52,7 +51,7 @@ def formatUnformattableEvent(event, error):
     @type error: L{Exception}
 
     @return: A formatted string.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     try:
         return "Unable to format event {event!r}: {error}".format(
@@ -100,13 +99,13 @@ def formatTime(when, timeFormat=timeFormatRFC3339, default="-"):
     @type then: L{float}
 
     @param timeFormat: A time format.
-    @type timeFormat: L{unicode} or L{None}
+    @type timeFormat: L{str} or L{None}
 
     @param default: Text to return if C{when} or C{timeFormat} is L{None}.
-    @type default: L{unicode}
+    @type default: L{str}
 
     @return: A formatted time.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     if timeFormat is None or when is None:
         return default
@@ -161,10 +160,10 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
 
     @param formatTime: A time formatter
     @type formatTime: L{callable} that takes an C{event} argument and returns
-        a L{unicode}
+        a L{str}
 
     @return: A formatted event, or L{None} if no output is appropriate.
-    @rtype: L{unicode} or L{None}
+    @rtype: L{str} or L{None}
     """
     eventText = eventAsText(event, formatTime=formatTime)
     if not eventText:
@@ -203,7 +202,7 @@ class CallMapping:
 
 def formatWithCall(formatString, mapping):
     """
-    Format a string like L{unicode.format}, but:
+    Format a string like L{str.format}, but:
 
         - taking only a name mapping; no positional arguments
 
@@ -220,20 +219,19 @@ def formatWithCall(formatString, mapping):
         'just a string, a function.'
 
     @param formatString: A PEP-3101 format string.
-    @type formatString: L{unicode}
+    @type formatString: L{str}
 
     @param mapping: A L{dict}-like object to format.
 
     @return: The string with formatted values interpolated.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     return str(aFormatter.vformat(formatString, (), CallMapping(mapping)))
 
 
 def _formatEvent(event):
     """
-    Formats an event as a L{unicode}, using the format in
-    C{event["log_format"]}.
+    Formats an event as a L{str}, using the format in C{event["log_format"]}.
 
     This implementation should never raise an exception; if the formatting
     cannot be done, the returned string will describe the event generically so
@@ -243,7 +241,7 @@ def _formatEvent(event):
     @type event: L{dict}
 
     @return: A formatted string.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     try:
         if "log_flattened" in event:
@@ -253,14 +251,12 @@ def _formatEvent(event):
         if format is None:
             return ""
 
-        # Make sure format is unicode.
+        # Make sure format is a string.
         if isinstance(format, bytes):
             # If we get bytes, assume it's UTF-8 bytes
             format = format.decode("utf-8")
         elif not isinstance(format, str):
-            raise TypeError(
-                "Log format must be unicode or bytes, not {0!r}".format(format)
-            )
+            raise TypeError("Log format must be str or bytes, not {0!r}".format(format))
 
         return formatWithCall(format, event)
 
@@ -279,7 +275,7 @@ def _formatTraceback(failure):
     @type failure: L{twisted.python.failure.Failure}
 
     @return: The formatted traceback.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     try:
         traceback = failure.getTraceback()
@@ -301,7 +297,7 @@ def _formatSystem(event):
     @type event: L{dict}
 
     @return: A formatted string representing the "log_system" key.
-    @rtype: L{unicode}
+    @rtype: L{str}
     """
     system = event.get("log_system", None)
     if system is None:
@@ -331,8 +327,8 @@ def eventAsText(
     formatTime=formatTime,
 ):
     r"""
-    Format an event as a unicode string.  Optionally, attach timestamp,
-    traceback, and system information.
+    Format an event as a string.  Optionally, attach timestamp, traceback, and
+    system information.
 
     The full output format is:
     C{u"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
@@ -369,10 +365,10 @@ def eventAsText(
 
     @param formatTime: A time formatter
     @type formatTime: L{callable} that takes an C{event} argument and returns
-        a L{unicode}
+        a L{str}
 
     @return: A formatted string with specified options.
-    @rtype: L{unicode}
+    @rtype: L{str}
 
     @since: Twisted 18.9.0
     """

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -120,14 +120,14 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
     Format an event as a line of human-readable text for, e.g. traditional log
     file output.
 
-    The output format is C{u"{timeStamp} [{system}] {event}\\n"}, where:
+    The output format is C{"{timeStamp} [{system}] {event}\\n"}, where:
 
         - C{timeStamp} is computed by calling the given C{formatTime} callable
           on the event's C{"log_time"} value
 
         - C{system} is the event's C{"log_system"} value, if set, otherwise,
-          the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.  Each
-          defaults to C{u"-"} is not set.
+          the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.  Each
+          defaults to C{"-"} is not set.
 
         - C{event} is the event, as formatted by L{formatEvent}.
 
@@ -138,17 +138,17 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
         >>> from twisted.logger import LogLevel
         >>>
         >>> formatEventAsClassicLogText(dict())  # No format, returns None
-        >>> formatEventAsClassicLogText(dict(log_format=u"Hello!"))
+        >>> formatEventAsClassicLogText(dict(log_format="Hello!"))
         u'- [-#-] Hello!\\n'
         >>> formatEventAsClassicLogText(dict(
-        ...     log_format=u"Hello!",
+        ...     log_format="Hello!",
         ...     log_time=time(),
         ...     log_namespace="my_namespace",
         ...     log_level=LogLevel.info,
         ... ))
         u'2013-10-22T17:30:02-0700 [my_namespace#info] Hello!\\n'
         >>> formatEventAsClassicLogText(dict(
-        ...     log_format=u"Hello!",
+        ...     log_format="Hello!",
         ...     log_time=time(),
         ...     log_system="my_system",
         ... ))
@@ -289,8 +289,8 @@ def _formatTraceback(failure):
 def _formatSystem(event):
     """
     Format the system specified in the event in the "log_system" key if set,
-    otherwise the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.
-    Each defaults to C{u"-"} is not set.  If formatting fails completely,
+    otherwise the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.
+    Each defaults to C{"-"} is not set.  If formatting fails completely,
     "UNFORMATTABLE" is returned.
 
     @param event: The event containing the system specification.
@@ -331,14 +331,14 @@ def eventAsText(
     system information.
 
     The full output format is:
-    C{u"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
+    C{"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
 
         - C{timeStamp} is the event's C{"log_time"} value formatted with
           the provided C{formatTime} callable.
 
         - C{system} is the event's C{"log_system"} value, if set, otherwise,
-          the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.  Each
-          defaults to C{u"-"} is not set.
+          the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.  Each
+          defaults to C{"-"} is not set.
 
         - C{event} is the event, as formatted by L{formatEvent}.
 

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -202,13 +202,13 @@ class CallMapping:
 
 def formatWithCall(formatString, mapping):
     """
-    Format a string like L{str.format}, but:
+    Format a string like L{str.format()}, but:
 
         - taking only a name mapping; no positional arguments
 
         - with the additional syntax that an empty set of parentheses
           correspond to a formatting item that should be called, and its result
-          C{str}'d, rather than calling C{str} on the element directly as
+          L{str()}'d, rather than calling L{str()} on the element directly as
           normal.
 
     For example::

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -92,7 +92,7 @@ class FormattingTests(unittest.TestCase):
         event = dict(log_format=object(), foo=1, bar=2)
         result = formatEvent(event)
 
-        self.assertIn("Log format must be unicode or bytes", result)
+        self.assertIn("Log format must be str or bytes", result)
         self.assertIn(repr(event), result)
 
     def test_formatUnformattableEvent(self):


### PR DESCRIPTION
This fixes two pydoctor warnings and cleans up the documentation output a bit as well.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10001
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
