### PR TITLE
Add type hints for twisted.logger

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -93,10 +93,6 @@ allow_incomplete_defs = True
 [mypy-twisted.internet.testing]
 allow_incomplete_defs = True
 
-[mypy-twisted.logger.*]
-allow_untyped_defs = True
-check_untyped_defs = False
-
 [mypy-twisted.mail.*]
 allow_untyped_defs = True
 check_untyped_defs = False

--- a/src/twisted/logger/__init__.py
+++ b/src/twisted/logger/__init__.py
@@ -34,12 +34,9 @@ In the first example above, the namespace would be C{some.module}, and in the
 second example, it would be C{some.module.Foo}.
 
 @var globalLogPublisher: The L{LogPublisher} that all L{Logger} instances that
-    are not otherwise parameterized will point to by default.
-@type globalLogPublisher: L{LogPublisher}
-
+    are not otherwise parameterized will publish events to by default.
 @var globalLogBeginner: The L{LogBeginner} used to activate the main log
     observer, whether it's a log file, or an observer pointing at stderr.
-@type globalLogBeginner: L{LogBeginner}
 """
 
 __all__ = [
@@ -54,11 +51,13 @@ __all__ = [
     "eventAsText",
     # From ._flatten
     "extractField",
+    # From ._interfaces
+    "ILogObserver",
+    "LogEvent",
     # From ._logger
     "Logger",
     "_loggerFor",
     # From ._observer
-    "ILogObserver",
     "LogPublisher",
     # From ._buffer
     "LimitedHistoryLogObserver",
@@ -101,9 +100,11 @@ from ._format import (
     eventAsText,
 )
 
+from ._interfaces import ILogObserver, LogEvent
+
 from ._logger import Logger, _loggerFor
 
-from ._observer import ILogObserver, LogPublisher
+from ._observer import LogPublisher
 
 from ._buffer import LimitedHistoryLogObserver
 

--- a/src/twisted/logger/_buffer.py
+++ b/src/twisted/logger/_buffer.py
@@ -7,10 +7,11 @@ Log observer that maintains a buffer.
 """
 
 from collections import deque
+from typing import Deque, Optional
 
 from zope.interface import implementer
 
-from ._observer import ILogObserver
+from ._interfaces import ILogObserver, LogEvent
 
 
 _DEFAULT_BUFFER_MAXIMUM = 64 * 1024
@@ -34,23 +35,21 @@ class LimitedHistoryLogObserver:
         >>>
     """
 
-    def __init__(self, size=_DEFAULT_BUFFER_MAXIMUM):
+    def __init__(self, size: Optional[int] = _DEFAULT_BUFFER_MAXIMUM) -> None:
         """
         @param size: The maximum number of events to buffer.  If L{None}, the
             buffer is unbounded.
-        @type size: L{int}
         """
-        self._buffer = deque(maxlen=size)
+        self._buffer = deque(maxlen=size)  # type: Deque[LogEvent]
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         self._buffer.append(event)
 
-    def replayTo(self, otherObserver):
+    def replayTo(self, otherObserver: ILogObserver) -> None:
         """
         Re-play the buffered events to another log observer.
 
         @param otherObserver: An observer to replay events to.
-        @type otherObserver: L{ILogObserver}
         """
         for event in self._buffer:
             otherObserver(event)

--- a/src/twisted/logger/_capture.py
+++ b/src/twisted/logger/_capture.py
@@ -7,14 +7,17 @@ Context manager for capturing logs.
 """
 
 from contextlib import contextmanager
+from typing import List, Iterator, Sequence, cast
 
 from twisted.logger import globalLogPublisher
 
+from ._interfaces import ILogObserver, LogEvent
+
 
 @contextmanager
-def capturedLogs():
-    events = []
-    observer = events.append
+def capturedLogs() -> Iterator[Sequence[LogEvent]]:
+    events = []  # type: List[LogEvent]
+    observer = cast(ILogObserver, events.append)
 
     globalLogPublisher.addObserver(observer)
 

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -6,13 +6,16 @@
 File log observer.
 """
 
+from typing import Any, Callable, IO, Optional
+
 from zope.interface import implementer
 
 from twisted.python.compat import ioType
-from ._observer import ILogObserver
+
 from ._format import formatTime
 from ._format import timeFormatRFC3339
 from ._format import formatEventAsClassicLogText
+from ._interfaces import ILogObserver, LogEvent
 
 
 @implementer(ILogObserver)
@@ -21,63 +24,55 @@ class FileLogObserver:
     Log observer that writes to a file-like object.
     """
 
-    def __init__(self, outFile, formatEvent):
+    def __init__(
+        self, outFile: IO[Any], formatEvent: Callable[[LogEvent], Optional[str]]
+    ) -> None:
         """
         @param outFile: A file-like object.  Ideally one should be passed which
             accepts L{unicode} data.  Otherwise, UTF-8 L{bytes} will be used.
-        @type outFile: L{io.IOBase}
-
         @param formatEvent: A callable that formats an event.
-        @type formatEvent: L{callable} that takes an C{event} argument and
-            returns a formatted event as L{unicode}.
         """
         if ioType(outFile) is not str:
-            self._encoding = "utf-8"
+            self._encoding = "utf-8"  # type: Optional[str]
         else:
             self._encoding = None
 
         self._outFile = outFile
         self.formatEvent = formatEvent
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         """
         Write event to file.
 
         @param event: An event.
-        @type event: L{dict}
         """
         text = self.formatEvent(event)
 
-        if text is None:
-            text = ""
-
-        if self._encoding is not None:
-            text = text.encode(self._encoding)
-
         if text:
-            self._outFile.write(text)
+            if self._encoding is None:
+                self._outFile.write(text)
+            else:
+                self._outFile.write(text.encode(self._encoding))
             self._outFile.flush()
 
 
-def textFileLogObserver(outFile, timeFormat=timeFormatRFC3339):
+def textFileLogObserver(
+    outFile: IO[Any], timeFormat: Optional[str] = timeFormatRFC3339
+) -> FileLogObserver:
     """
     Create a L{FileLogObserver} that emits text to a specified (writable)
     file-like object.
 
     @param outFile: A file-like object.  Ideally one should be passed which
         accepts L{unicode} data.  Otherwise, UTF-8 L{bytes} will be used.
-    @type outFile: L{io.IOBase}
-
     @param timeFormat: The format to use when adding timestamp prefixes to
         logged events.  If L{None}, or for events with no C{"log_timestamp"}
         key, the default timestamp prefix of C{u"-"} is used.
-    @type timeFormat: L{unicode} or L{None}
 
     @return: A file log observer.
-    @rtype: L{FileLogObserver}
     """
 
-    def formatEvent(event):
+    def formatEvent(event: LogEvent) -> Optional[str]:
         return formatEventAsClassicLogText(
             event, formatTime=lambda e: formatTime(e, timeFormat)
         )

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -29,7 +29,7 @@ class FileLogObserver:
     ) -> None:
         """
         @param outFile: A file-like object.  Ideally one should be passed which
-            accepts L{unicode} data.  Otherwise, UTF-8 L{bytes} will be used.
+            accepts text data.  Otherwise, UTF-8 L{bytes} will be used.
         @param formatEvent: A callable that formats an event.
         """
         if ioType(outFile) is not str:
@@ -64,7 +64,7 @@ def textFileLogObserver(
     file-like object.
 
     @param outFile: A file-like object.  Ideally one should be passed which
-        accepts L{unicode} data.  Otherwise, UTF-8 L{bytes} will be used.
+        accepts text data.  Otherwise, UTF-8 L{bytes} will be used.
     @param timeFormat: The format to use when adding timestamp prefixes to
         logged events.  If L{None}, or for events with no C{"log_timestamp"}
         key, the default timestamp prefix of C{"-"} is used.

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -67,7 +67,7 @@ def textFileLogObserver(
         accepts L{unicode} data.  Otherwise, UTF-8 L{bytes} will be used.
     @param timeFormat: The format to use when adding timestamp prefixes to
         logged events.  If L{None}, or for events with no C{"log_timestamp"}
-        key, the default timestamp prefix of C{u"-"} is used.
+        key, the default timestamp prefix of C{"-"} is used.
 
     @return: A file log observer.
     """

--- a/src/twisted/logger/_filter.py
+++ b/src/twisted/logger/_filter.py
@@ -7,13 +7,15 @@ Filtering log observer.
 """
 
 from functools import partial
+from typing import Dict, Iterable
 
 from zope.interface import Interface, implementer
 
 from constantly import NamedConstant, Names
 
+from ._interfaces import ILogObserver, LogEvent
 from ._levels import InvalidLogLevelError, LogLevel
-from ._observer import ILogObserver
+from ._observer import bitbucketLogObserver
 
 
 class PredicateResult(Names):
@@ -46,7 +48,7 @@ class ILogFilterPredicate(Interface):
     A predicate that determined whether an event should be logged.
     """
 
-    def __call__(event):
+    def __call__(event: LogEvent) -> NamedConstant:
         """
         Determine whether an event should be logged.
 
@@ -54,7 +56,7 @@ class ILogFilterPredicate(Interface):
         """
 
 
-def shouldLogEvent(predicates, event):
+def shouldLogEvent(predicates: Iterable[ILogFilterPredicate], event: LogEvent) -> bool:
     """
     Determine whether an event should be logged, based on the result of
     C{predicates}.
@@ -70,13 +72,9 @@ def shouldLogEvent(predicates, event):
     run out, at which point we return C{True}.
 
     @param predicates: The predicates to use.
-    @type predicates: iterable of L{ILogFilterPredicate}
-
     @param event: An event
-    @type event: L{dict}
 
     @return: True if the message should be forwarded on, C{False} if not.
-    @rtype: L{bool}
     """
     for predicate in predicates:
         result = predicate(event)
@@ -97,31 +95,31 @@ class FilteringLogObserver:
     based on applying a series of L{ILogFilterPredicate}s.
     """
 
-    def __init__(self, observer, predicates, negativeObserver=lambda event: None):
+    def __init__(
+        self,
+        observer: ILogObserver,
+        predicates: Iterable[ILogFilterPredicate],
+        negativeObserver: ILogObserver = bitbucketLogObserver,
+    ) -> None:
         """
         @param observer: An observer to which this observer will forward
             events when C{predictates} yield a positive result.
-        @type observer: L{ILogObserver}
-
         @param predicates: Predicates to apply to events before forwarding to
             the wrapped observer.
-        @type predicates: ordered iterable of predicates
-
         @param negativeObserver: An observer to which this observer will
             forward events when C{predictates} yield a negative result.
-        @type negativeObserver: L{ILogObserver}
         """
         self._observer = observer
         self._shouldLogEvent = partial(shouldLogEvent, list(predicates))
         self._negativeObserver = negativeObserver
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         """
         Forward to next observer if predicate allows it.
         """
         if self._shouldLogEvent(event):
             if "log_trace" in event:
-                event["log_trace"].append((self, self.observer))
+                event["log_trace"].append((self, self._observer))
             self._observer(event)
         else:
             self._negativeObserver(event)
@@ -136,16 +134,15 @@ class LogLevelFilterPredicate:
     Events that not not have a log level or namespace are also dropped.
     """
 
-    def __init__(self, defaultLogLevel=LogLevel.info):
+    def __init__(self, defaultLogLevel: NamedConstant = LogLevel.info) -> None:
         """
         @param defaultLogLevel: The default minimum log level.
-        @type defaultLogLevel: L{LogLevel}
         """
-        self._logLevelsByNamespace = {}
+        self._logLevelsByNamespace = {}  # type: Dict[str, NamedConstant]
         self.defaultLogLevel = defaultLogLevel
         self.clearLogLevels()
 
-    def logLevelForNamespace(self, namespace):
+    def logLevelForNamespace(self, namespace: str) -> NamedConstant:
         """
         Determine an appropriate log level for the given namespace.
 
@@ -154,15 +151,13 @@ class LogLevelFilterPredicate:
         C{logLevelForNamespace("mypackage.subpackage")} will return
         C{LogLevel.debug}.
 
-        @param namespace: A logging namespace, or L{None} for the default
+        @param namespace: A logging namespace.  Use C{""} for the default
             namespace.
-        @type namespace: L{str} (native string)
 
         @return: The log level for the specified namespace.
-        @rtype: L{LogLevel}
         """
         if not namespace:
-            return self._logLevelsByNamespace[None]
+            return self._logLevelsByNamespace[""]
 
         if namespace in self._logLevelsByNamespace:
             return self._logLevelsByNamespace[namespace]
@@ -176,17 +171,14 @@ class LogLevelFilterPredicate:
                 return self._logLevelsByNamespace[namespace]
             index -= 1
 
-        return self._logLevelsByNamespace[None]
+        return self._logLevelsByNamespace[""]
 
-    def setLogLevelForNamespace(self, namespace, level):
+    def setLogLevelForNamespace(self, namespace: str, level: NamedConstant) -> None:
         """
         Sets the log level for a logging namespace.
 
         @param namespace: A logging namespace.
-        @type namespace: L{str} (native string)
-
         @param level: The log level for the given namespace.
-        @type level: L{LogLevel}
         """
         if level not in LogLevel.iterconstants():
             raise InvalidLogLevelError(level)
@@ -194,26 +186,26 @@ class LogLevelFilterPredicate:
         if namespace:
             self._logLevelsByNamespace[namespace] = level
         else:
-            self._logLevelsByNamespace[None] = level
+            self._logLevelsByNamespace[""] = level
 
-    def clearLogLevels(self):
+    def clearLogLevels(self) -> None:
         """
         Clears all log levels to the default.
         """
         self._logLevelsByNamespace.clear()
-        self._logLevelsByNamespace[None] = self.defaultLogLevel
+        self._logLevelsByNamespace[""] = self.defaultLogLevel
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> NamedConstant:
         eventLevel = event.get("log_level", None)
-        namespace = event.get("log_namespace", None)
-        namespaceLevel = self.logLevelForNamespace(namespace)
+        if eventLevel is None:
+            return PredicateResult.no
 
-        if (
-            eventLevel is None
-            or namespace is None
-            or LogLevel._priorityForLevel(eventLevel)
-            < LogLevel._priorityForLevel(namespaceLevel)
-        ):
+        namespace = event.get("log_namespace", "")
+        if not namespace:
+            return PredicateResult.no
+
+        namespaceLevel = self.logLevelForNamespace(namespace)
+        if eventLevel < namespaceLevel:
             return PredicateResult.no
 
         return PredicateResult.maybe

--- a/src/twisted/logger/_flatten.py
+++ b/src/twisted/logger/_flatten.py
@@ -8,8 +8,11 @@ relevant fields from the format string and persisting them for later
 examination.
 """
 
-from string import Formatter
 from collections import defaultdict
+from string import Formatter
+from typing import Any, Dict, Optional
+
+from ._interfaces import LogEvent
 
 
 aFormatter = Formatter()
@@ -21,34 +24,36 @@ class KeyFlattener:
     PEP-3101-style format strings as parsed by L{string.Formatter.parse}.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a L{KeyFlattener}.
         """
-        self.keys = defaultdict(lambda: 0)
+        self.keys = defaultdict(lambda: 0)  # type: Dict[str, int]
 
-    def flatKey(self, fieldName, formatSpec, conversion):
+    def flatKey(
+        self, fieldName: str, formatSpec: Optional[str], conversion: Optional[str]
+    ) -> str:
         """
         Compute a string key for a given field/format/conversion.
 
         @param fieldName: A format field name.
-        @type fieldName: L{str}
-
         @param formatSpec: A format spec.
-        @type formatSpec: L{str}
-
         @param conversion: A format field conversion type.
-        @type conversion: L{str}
 
         @return: A key specific to the given field, format and conversion, as
             well as the occurrence of that combination within this
             L{KeyFlattener}'s lifetime.
-        @rtype: L{str}
         """
+        if formatSpec is None:
+            formatSpec = ""
+
+        if conversion is None:
+            conversion = ""
+
         result = "{fieldName}!{conversion}:{formatSpec}".format(
             fieldName=fieldName,
-            formatSpec=(formatSpec or ""),
-            conversion=(conversion or ""),
+            formatSpec=formatSpec,
+            conversion=conversion,
         )
         self.keys[result] += 1
         n = self.keys[result]
@@ -57,14 +62,13 @@ class KeyFlattener:
         return result
 
 
-def flattenEvent(event):
+def flattenEvent(event: LogEvent) -> None:
     """
     Flatten the given event by pre-associating format fields with specific
     objects and callable results in a L{dict} put into the C{"log_flattened"}
     key in the event.
 
     @param event: A logging event.
-    @type event: L{dict}
     """
     if event.get("log_format", None) is None:
         return
@@ -117,7 +121,7 @@ def flattenEvent(event):
         event["log_flattened"] = fields
 
 
-def extractField(field, event):
+def extractField(field: str, event: LogEvent) -> Any:
     """
     Extract a given format field from the given event.
 
@@ -126,43 +130,47 @@ def extractField(field, event):
         format string: for example, C{"key[2].attribute"}.  If a conversion is
         specified (the thing after the C{"!"} character in a format field) then
         the result will always be L{unicode}.
-    @type field: L{str} (native string)
-
     @param event: A log event.
-    @type event: L{dict}
 
     @return: A value extracted from the field.
-    @rtype: L{object}
 
     @raise KeyError: if the field is not found in the given event.
     """
     keyFlattener = KeyFlattener()
+
     [[literalText, fieldName, formatSpec, conversion]] = aFormatter.parse(
         "{" + field + "}"
     )
+
+    assert fieldName is not None
+
     key = keyFlattener.flatKey(fieldName, formatSpec, conversion)
+
     if "log_flattened" not in event:
         flattenEvent(event)
+
     return event["log_flattened"][key]
 
 
-def flatFormat(event):
+def flatFormat(event: LogEvent) -> str:
     """
     Format an event which has been flattened with L{flattenEvent}.
 
     @param event: A logging event.
-    @type event: L{dict}
 
     @return: A formatted string.
-    @rtype: L{unicode}
     """
     fieldValues = event["log_flattened"]
-    s = []
     keyFlattener = KeyFlattener()
-    formatFields = aFormatter.parse(event["log_format"])
-    for literalText, fieldName, formatSpec, conversion in formatFields:
+    s = []
+
+    for literalText, fieldName, formatSpec, conversion in aFormatter.parse(
+        event["log_format"]
+    ):
         s.append(literalText)
+
         if fieldName is not None:
             key = keyFlattener.flatKey(fieldName, formatSpec, conversion or "s")
             s.append(str(fieldValues[key]))
+
     return "".join(s)

--- a/src/twisted/logger/_flatten.py
+++ b/src/twisted/logger/_flatten.py
@@ -129,7 +129,7 @@ def extractField(field: str, event: LogEvent) -> Any:
         text that would normally fall between a pair of curly braces in a
         format string: for example, C{"key[2].attribute"}.  If a conversion is
         specified (the thing after the C{"!"} character in a format field) then
-        the result will always be L{unicode}.
+        the result will always be str.
     @param event: A log event.
 
     @return: A value extracted from the field.

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -6,31 +6,34 @@
 Tools for formatting logging events.
 """
 
+from collections.abc import Mapping as MappingABC
 from datetime import datetime as DateTime
+from typing import Any, Callable, Iterator, Mapping, Optional, Union, cast
+
+from constantly import NamedConstant
 
 from twisted.python.failure import Failure
 from twisted.python.reflect import safe_repr
 from twisted.python._tzhelper import FixedOffsetTimeZone
 
 from ._flatten import flatFormat, aFormatter
+from ._interfaces import LogEvent
+
 
 timeFormatRFC3339 = "%Y-%m-%dT%H:%M:%S%z"
 
 
-def formatEvent(event):
+def formatEvent(event: LogEvent) -> str:
     """
-    Formats an event as a L{unicode}, using the format in
-    C{event["log_format"]}.
+    Formats an event as text, using the format in C{event["log_format"]}.
 
     This implementation should never raise an exception; if the formatting
     cannot be done, the returned string will describe the event generically so
     that a useful message is emitted regardless.
 
     @param event: A logging event.
-    @type event: L{dict}
 
     @return: A formatted string.
-    @rtype: L{unicode}
     """
     return eventAsText(
         event,
@@ -40,19 +43,15 @@ def formatEvent(event):
     )
 
 
-def formatUnformattableEvent(event, error):
+def formatUnformattableEvent(event: LogEvent, error: BaseException) -> str:
     """
-    Formats an event as a L{unicode} that describes the event generically and a
+    Formats an event as text that describes the event generically and a
     formatting error.
 
     @param event: A logging event.
-    @type event: L{dict}
-
     @param error: The formatting error.
-    @type error: L{Exception}
 
     @return: A formatted string.
-    @rtype: L{unicode}
     """
     try:
         return "Unable to format event {event!r}: {error}".format(
@@ -80,7 +79,11 @@ def formatUnformattableEvent(event, error):
         )
 
 
-def formatTime(when, timeFormat=timeFormatRFC3339, default="-"):
+def formatTime(
+    when: Optional[float],
+    timeFormat: Optional[str] = timeFormatRFC3339,
+    default: str = "-",
+) -> str:
     """
     Format a timestamp as text.
 
@@ -97,16 +100,10 @@ def formatTime(when, timeFormat=timeFormatRFC3339, default="-"):
         >>>
 
     @param when: A timestamp.
-    @type then: L{float}
-
     @param timeFormat: A time format.
-    @type timeFormat: L{unicode} or L{None}
-
     @param default: Text to return if C{when} or C{timeFormat} is L{None}.
-    @type default: L{unicode}
 
     @return: A formatted time.
-    @rtype: L{unicode}
     """
     if timeFormat is None or when is None:
         return default
@@ -116,7 +113,9 @@ def formatTime(when, timeFormat=timeFormatRFC3339, default="-"):
         return str(datetime.strftime(timeFormat))
 
 
-def formatEventAsClassicLogText(event, formatTime=formatTime):
+def formatEventAsClassicLogText(
+    event: LogEvent, formatTime: Callable[[Optional[float]], str] = formatTime
+) -> Optional[str]:
     """
     Format an event as a line of human-readable text for, e.g. traditional log
     file output.
@@ -157,14 +156,9 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
         >>>
 
     @param event: an event.
-    @type event: L{dict}
-
     @param formatTime: A time formatter
-    @type formatTime: L{callable} that takes an C{event} argument and returns
-        a L{unicode}
 
     @return: A formatted event, or L{None} if no output is appropriate.
-    @rtype: L{unicode} or L{None}
     """
     eventText = eventAsText(event, formatTime=formatTime)
     if not eventText:
@@ -173,7 +167,7 @@ def formatEventAsClassicLogText(event, formatTime=formatTime):
     return eventText + "\n"
 
 
-class CallMapping:
+class CallMapping(MappingABC):
     """
     Read-only mapping that turns a C{()}-suffix in key names into an invocation
     of the key rather than a lookup of the key.
@@ -181,14 +175,20 @@ class CallMapping:
     Implementation support for L{formatWithCall}.
     """
 
-    def __init__(self, submapping):
+    def __init__(self, submapping: Mapping[str, Any]) -> None:
         """
         @param submapping: Another read-only mapping which will be used to look
             up items.
         """
         self._submapping = submapping
 
-    def __getitem__(self, key):
+    def __iter__(self) -> Iterator:
+        return iter(self._submapping)
+
+    def __len__(self) -> int:
+        return len(self._submapping)
+
+    def __getitem__(self, key: str) -> Any:
         """
         Look up an item in the submapping for this L{CallMapping}, calling it
         if C{key} ends with C{"()"}.
@@ -201,9 +201,9 @@ class CallMapping:
         return value
 
 
-def formatWithCall(formatString, mapping):
+def formatWithCall(formatString: str, mapping: Mapping[str, Any]) -> str:
     """
-    Format a string like L{unicode.format}, but:
+    Format a string like L{str.format}, but:
 
         - taking only a name mapping; no positional arguments
 
@@ -220,47 +220,40 @@ def formatWithCall(formatString, mapping):
         'just a string, a function.'
 
     @param formatString: A PEP-3101 format string.
-    @type formatString: L{unicode}
-
     @param mapping: A L{dict}-like object to format.
 
     @return: The string with formatted values interpolated.
-    @rtype: L{unicode}
     """
     return str(aFormatter.vformat(formatString, (), CallMapping(mapping)))
 
 
-def _formatEvent(event):
+def _formatEvent(event: LogEvent) -> str:
     """
-    Formats an event as a L{unicode}, using the format in
-    C{event["log_format"]}.
+    Formats an event as a string, using the format in C{event["log_format"]}.
 
     This implementation should never raise an exception; if the formatting
     cannot be done, the returned string will describe the event generically so
     that a useful message is emitted regardless.
 
     @param event: A logging event.
-    @type event: L{dict}
 
     @return: A formatted string.
-    @rtype: L{unicode}
     """
     try:
         if "log_flattened" in event:
             return flatFormat(event)
 
-        format = event.get("log_format", None)
+        format = cast(Optional[Union[str, bytes]], event.get("log_format", None))
         if format is None:
             return ""
 
-        # Make sure format is unicode.
-        if isinstance(format, bytes):
-            # If we get bytes, assume it's UTF-8 bytes
+        # Make sure format is text.
+        if isinstance(format, str):
+            pass
+        elif isinstance(format, bytes):
             format = format.decode("utf-8")
-        elif not isinstance(format, str):
-            raise TypeError(
-                "Log format must be unicode or bytes, not {0!r}".format(format)
-            )
+        else:
+            raise TypeError("Log format must be str, not {0!r}".format(format))
 
         return formatWithCall(format, event)
 
@@ -268,7 +261,7 @@ def _formatEvent(event):
         return formatUnformattableEvent(event, e)
 
 
-def _formatTraceback(failure):
+def _formatTraceback(failure: Failure) -> str:
     """
     Format a failure traceback, assuming UTF-8 and using a replacement
     strategy for errors.  Every effort is made to provide a usable
@@ -276,21 +269,17 @@ def _formatTraceback(failure):
     captured exception are logged.
 
     @param failure: The failure to retrieve a traceback from.
-    @type failure: L{twisted.python.failure.Failure}
 
     @return: The formatted traceback.
-    @rtype: L{unicode}
     """
     try:
         traceback = failure.getTraceback()
-        if isinstance(traceback, bytes):
-            traceback = traceback.decode("utf-8", errors="replace")
     except BaseException as e:
         traceback = "(UNABLE TO OBTAIN TRACEBACK FROM EVENT):" + str(e)
     return traceback
 
 
-def _formatSystem(event):
+def _formatSystem(event: LogEvent) -> str:
     """
     Format the system specified in the event in the "log_system" key if set,
     otherwise the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.
@@ -298,21 +287,19 @@ def _formatSystem(event):
     "UNFORMATTABLE" is returned.
 
     @param event: The event containing the system specification.
-    @type event: L{dict}
 
     @return: A formatted string representing the "log_system" key.
-    @rtype: L{unicode}
     """
-    system = event.get("log_system", None)
+    system = cast(Optional[str], event.get("log_system", None))
     if system is None:
-        level = event.get("log_level", None)
+        level = cast(Optional[NamedConstant], event.get("log_level", None))
         if level is None:
             levelName = "-"
         else:
             levelName = level.name
 
         system = "{namespace}#{level}".format(
-            namespace=event.get("log_namespace", "-"),
+            namespace=cast(str, event.get("log_namespace", "-")),
             level=levelName,
         )
     else:
@@ -324,15 +311,15 @@ def _formatSystem(event):
 
 
 def eventAsText(
-    event,
-    includeTraceback=True,
-    includeTimestamp=True,
-    includeSystem=True,
-    formatTime=formatTime,
-):
+    event: LogEvent,
+    includeTraceback: bool = True,
+    includeTimestamp: bool = True,
+    includeSystem: bool = True,
+    formatTime: Callable[[float], str] = formatTime,
+) -> str:
     r"""
-    Format an event as a unicode string.  Optionally, attach timestamp,
-    traceback, and system information.
+    Format an event as text.  Optionally, attach timestamp, traceback, and
+    system information.
 
     The full output format is:
     C{u"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
@@ -354,25 +341,14 @@ def eventAsText(
     is returned, even if includeSystem or includeTimestamp are true.
 
     @param event: A logging event.
-    @type event: L{dict}
-
     @param includeTraceback: If true and a C{"log_failure"} key exists, append
         a traceback.
-    @type includeTraceback: L{bool}
-
     @param includeTimestamp: If true include a formatted timestamp before the
         event.
-    @type includeTimestamp: L{bool}
-
     @param includeSystem:  If true, include the event's C{"log_system"} value.
-    @type includeSystem: L{bool}
-
     @param formatTime: A time formatter
-    @type formatTime: L{callable} that takes an C{event} argument and returns
-        a L{unicode}
 
     @return: A formatted string with specified options.
-    @rtype: L{unicode}
 
     @since: Twisted 18.9.0
     """
@@ -387,7 +363,7 @@ def eventAsText(
 
     timeStamp = ""
     if includeTimestamp:
-        timeStamp = "".join([formatTime(event.get("log_time", None)), " "])
+        timeStamp = "".join([formatTime(cast(float, event.get("log_time", None))), " "])
 
     system = ""
     if includeSystem:

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -120,14 +120,14 @@ def formatEventAsClassicLogText(
     Format an event as a line of human-readable text for, e.g. traditional log
     file output.
 
-    The output format is C{u"{timeStamp} [{system}] {event}\\n"}, where:
+    The output format is C{"{timeStamp} [{system}] {event}\\n"}, where:
 
         - C{timeStamp} is computed by calling the given C{formatTime} callable
           on the event's C{"log_time"} value
 
         - C{system} is the event's C{"log_system"} value, if set, otherwise,
-          the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.  Each
-          defaults to C{u"-"} is not set.
+          the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.  Each
+          defaults to C{"-"} is not set.
 
         - C{event} is the event, as formatted by L{formatEvent}.
 
@@ -138,17 +138,17 @@ def formatEventAsClassicLogText(
         >>> from twisted.logger import LogLevel
         >>>
         >>> formatEventAsClassicLogText(dict())  # No format, returns None
-        >>> formatEventAsClassicLogText(dict(log_format=u"Hello!"))
+        >>> formatEventAsClassicLogText(dict(log_format="Hello!"))
         u'- [-#-] Hello!\\n'
         >>> formatEventAsClassicLogText(dict(
-        ...     log_format=u"Hello!",
+        ...     log_format="Hello!",
         ...     log_time=time(),
         ...     log_namespace="my_namespace",
         ...     log_level=LogLevel.info,
         ... ))
         u'2013-10-22T17:30:02-0700 [my_namespace#info] Hello!\\n'
         >>> formatEventAsClassicLogText(dict(
-        ...     log_format=u"Hello!",
+        ...     log_format="Hello!",
         ...     log_time=time(),
         ...     log_system="my_system",
         ... ))
@@ -282,8 +282,8 @@ def _formatTraceback(failure: Failure) -> str:
 def _formatSystem(event: LogEvent) -> str:
     """
     Format the system specified in the event in the "log_system" key if set,
-    otherwise the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.
-    Each defaults to C{u"-"} is not set.  If formatting fails completely,
+    otherwise the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.
+    Each defaults to C{"-"} is not set.  If formatting fails completely,
     "UNFORMATTABLE" is returned.
 
     @param event: The event containing the system specification.
@@ -322,14 +322,14 @@ def eventAsText(
     system information.
 
     The full output format is:
-    C{u"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
+    C{"{timeStamp} [{system}] {event}\n{traceback}\n"} where:
 
         - C{timeStamp} is the event's C{"log_time"} value formatted with
           the provided C{formatTime} callable.
 
         - C{system} is the event's C{"log_system"} value, if set, otherwise,
-          the C{"log_namespace"} and C{"log_level"}, joined by a C{u"#"}.  Each
-          defaults to C{u"-"} is not set.
+          the C{"log_namespace"} and C{"log_level"}, joined by a C{"#"}.  Each
+          defaults to C{"-"} is not set.
 
         - C{event} is the event, as formatted by L{formatEvent}.
 

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -8,19 +8,21 @@ and implementation of logic for managing that global state.
 """
 
 import sys
+from typing import Any, IO, Iterable, Optional, Tuple, Type, cast
 import warnings
 
 from twisted.python.compat import currentframe
 from twisted.python.reflect import qual
 
 from ._buffer import LimitedHistoryLogObserver
-from ._observer import LogPublisher
-from ._filter import FilteringLogObserver, LogLevelFilterPredicate
-from ._logger import Logger
-from ._format import eventAsText
-from ._levels import LogLevel
-from ._io import LoggingFile
 from ._file import FileLogObserver
+from ._filter import FilteringLogObserver, LogLevelFilterPredicate
+from ._format import eventAsText
+from ._interfaces import ILogObserver
+from ._io import LoggingFile
+from ._levels import LogLevel
+from ._logger import Logger
+from ._observer import LogPublisher
 
 
 MORE_THAN_ONCE_WARNING = (
@@ -51,47 +53,36 @@ class LogBeginner:
         2. Save (a limited number of) log events in a
            L{LimitedHistoryLogObserver}.
 
-    @ivar _initialBuffer: A buffer of messages logged before logging began.
-    @type _initialBuffer: L{LimitedHistoryLogObserver}
-
-    @ivar _publisher: The log publisher passed in to L{LogBeginner}'s
-        constructor.
-    @type _publisher: L{LogPublisher}
-
-    @ivar _log: The logger used to log messages about the operation of the
-        L{LogBeginner} itself.
-    @type _log: L{Logger}
-
-    @ivar _temporaryObserver: If not L{None}, an L{ILogObserver} that observes
-        events on C{_publisher} for this L{LogBeginner}.
-    @type _temporaryObserver: L{ILogObserver} or L{None}
-
-    @ivar _stdio: An object with C{stderr} and C{stdout} attributes (like the
-        L{sys} module) which will be replaced when redirecting standard I/O.
-    @type _stdio: L{object}
-
     @cvar _DEFAULT_BUFFER_SIZE: The default size for the initial log events
         buffer.
-    @type _DEFAULT_BUFFER_SIZE: L{int}
+
+    @ivar _initialBuffer: A buffer of messages logged before logging began.
+    @ivar _publisher: The log publisher passed in to L{LogBeginner}'s
+        constructor.
+    @ivar _log: The logger used to log messages about the operation of the
+        L{LogBeginner} itself.
+    @ivar _stdio: An object with C{stderr} and C{stdout} attributes (like the
+        L{sys} module) which will be replaced when redirecting standard I/O.
+    @ivar _temporaryObserver: If not L{None}, an L{ILogObserver} that observes
+        events on C{_publisher} for this L{LogBeginner}.
     """
 
     _DEFAULT_BUFFER_SIZE = 200
 
     def __init__(
         self,
-        publisher,
-        errorStream,
-        stdio,
-        warningsModule,
-        initialBufferSize=None,
-    ):
+        publisher: LogPublisher,
+        errorStream: IO[Any],
+        stdio: object,
+        warningsModule: Any,
+        initialBufferSize: Optional[int] = None,
+    ) -> None:
         """
         Initialize this L{LogBeginner}.
 
         @param initialBufferSize: The size of the event buffer into which
             events are collected until C{beginLoggingTo} is called.  Or
             C{None} to use the default size.
-        @type initialBufferSize: L{int} or L{types.NoneType}
         """
         if initialBufferSize is None:
             initialBufferSize = self._DEFAULT_BUFFER_SIZE
@@ -114,11 +105,17 @@ class LogBeginner:
                 ),
                 [LogLevelFilterPredicate(defaultLogLevel=LogLevel.critical)],
             ),
-        )
+        )  # type: Optional[ILogObserver]
+        self._previousBegin = ("", 0)
         publisher.addObserver(self._temporaryObserver)
         self._oldshowwarning = warningsModule.showwarning
 
-    def beginLoggingTo(self, observers, discardBuffer=False, redirectStandardIO=True):
+    def beginLoggingTo(
+        self,
+        observers: Iterable[ILogObserver],
+        discardBuffer: bool = False,
+        redirectStandardIO: bool = True,
+    ) -> None:
         """
         Begin logging to the given set of observers.  This will:
 
@@ -143,19 +140,15 @@ class LogBeginner:
             is intended to be invoked I{once}.
 
         @param observers: The observers to register.
-        @type observers: iterable of L{ILogObserver}s
-
         @param discardBuffer: Whether to discard the buffer and not re-play it
             to the added observers.  (This argument is provided mainly for
             compatibility with legacy concerns.)
-        @type discardBuffer: L{bool}
-
         @param redirectStandardIO: If true, redirect standard output and
             standard error to the observers.
-        @type redirectStandardIO: L{bool}
         """
         caller = currentframe(1)
-        filename, lineno = caller.f_code.co_filename, caller.f_lineno
+        filename = caller.f_code.co_filename
+        lineno = caller.f_lineno
 
         for observer in observers:
             self._publisher.addObserver(observer)
@@ -176,7 +169,7 @@ class LogBeginner:
                 lineThen=previousLine,
             )
 
-        self._previousBegin = filename, lineno
+        self._previousBegin = (filename, lineno)
         if redirectStandardIO:
             streams = [("stdout", LogLevel.info), ("stderr", LogLevel.error)]
         else:
@@ -191,7 +184,15 @@ class LogBeginner:
             )
             setattr(self._stdio, stream, loggingFile)
 
-    def showwarning(self, message, category, filename, lineno, file=None, line=None):
+    def showwarning(
+        self,
+        message: str,
+        category: Type[Warning],
+        filename: str,
+        lineno: int,
+        file: Optional[IO[Any]] = None,
+        line: Optional[str] = None,
+    ) -> None:
         """
         Twisted-enabled wrapper around L{warnings.showwarning}.
 
@@ -200,27 +201,16 @@ class LogBeginner:
         function is called.
 
         @param message: A warning message to emit.
-        @type message: L{str}
-
         @param category: A warning category to associate with C{message}.
-        @type category: L{warnings.Warning}
-
         @param filename: A file name for the source code file issuing the
             warning.
-        @type warning: L{str}
-
         @param lineno: A line number in the source file where the warning was
             issued.
-        @type lineno: L{int}
-
         @param file: A file to write the warning message to.  If L{None},
             write to L{sys.stderr}.
-        @type file: file-like object
-
         @param line: A line of source code to include with the warning message.
             If L{None}, attempt to read the line from C{filename} and
             C{lineno}.
-        @type line: L{str}
         """
         if file is None:
             self._log.warn(

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -8,7 +8,7 @@ and implementation of logic for managing that global state.
 """
 
 import sys
-from typing import Any, IO, Iterable, Optional, Tuple, Type, cast
+from typing import Any, IO, Iterable, Optional, Type
 import warnings
 
 from twisted.python.compat import currentframe

--- a/src/twisted/logger/_interfaces.py
+++ b/src/twisted/logger/_interfaces.py
@@ -56,7 +56,7 @@ class ILogObserver(Interface):
                   importance of and audience for this event.
 
                 - C{"log_namespace"}: a namespace for the emitter of the event,
-                  given as a unicode string.
+                  given as a L{str}.
 
                 - C{"log_system"}: a string indicating the network event or
                   method call which resulted in the message being logged.

--- a/src/twisted/logger/_interfaces.py
+++ b/src/twisted/logger/_interfaces.py
@@ -1,0 +1,63 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Logger interfaces.
+"""
+
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING
+
+from zope.interface import Interface
+
+if TYPE_CHECKING:
+    from ._logger import Logger
+
+
+LogEvent = Dict[str, Any]
+LogTrace = List[Tuple["Logger", "ILogObserver"]]
+
+
+class ILogObserver(Interface):
+    """
+    An observer which can handle log events.
+
+    Unlike most interfaces within Twisted, an L{ILogObserver} I{must be
+    thread-safe}.  Log observers may be called indiscriminately from many
+    different threads, as any thread may wish to log a message at any time.
+    """
+
+    def __call__(event: LogEvent) -> None:
+        """
+        Log an event.
+
+        @param event: A dictionary with arbitrary keys as defined by the
+            application emitting logging events, as well as keys added by the
+            logging system.  The logging system reserves the right to set any
+            key beginning with the prefix C{"log_"}; applications should not
+            use any key so named.  Currently, the following keys are used by
+            the logging system in some way, if they are present (they are all
+            optional):
+
+                - C{"log_format"}: a PEP-3101-style format string which draws
+                  upon the keys in the event as its values, used to format the
+                  event for human consumption.
+
+                - C{"log_flattened"}: a dictionary mapping keys derived from
+                  the names and format values used in the C{"log_format"}
+                  string to their values.  This is used to preserve some
+                  structured information for use with
+                  L{twisted.logger.extractField}.
+
+                - C{"log_trace"}: A L{list} designed to capture information
+                  about which L{LogPublisher}s have observed the event.
+
+                - C{"log_level"}: a L{log level
+                  <twisted.logger.LogLevel>} constant, indicating the
+                  importance of and audience for this event.
+
+                - C{"log_namespace"}: a namespace for the emitter of the event,
+                  given as a unicode string.
+
+                - C{"log_system"}: a string indicating the network event or
+                  method call which resulted in the message being logged.
+        """

--- a/src/twisted/logger/_io.py
+++ b/src/twisted/logger/_io.py
@@ -7,8 +7,12 @@ File-like object that logs.
 """
 
 import sys
+from typing import AnyStr, Iterable, Optional
+
+from constantly import NamedConstant
 
 from ._levels import LogLevel
+from ._logger import Logger
 
 
 class LoggingFile:
@@ -21,23 +25,21 @@ class LoggingFile:
 
     @ivar softspace: File-like L{'softspace' attribute <file.softspace>}; zero
         or one.
-    @type softspace: L{int}
     """
 
     softspace = 0
 
-    def __init__(self, logger, level=LogLevel.info, encoding=None):
+    def __init__(
+        self,
+        logger: Logger,
+        level: NamedConstant = LogLevel.info,
+        encoding: Optional[str] = None,
+    ) -> None:
         """
         @param logger: the logger to log through.
-
         @param level: the log level to emit events with.
-
         @param encoding: The encoding to expect when receiving bytes via
             C{write()}.  If L{None}, use C{sys.getdefaultencoding()}.
-        @type encoding: L{str}
-
-        @param log: The logger to send events to.
-        @type log: L{Logger}
         """
         self.level = level
         self.log = logger
@@ -51,53 +53,48 @@ class LoggingFile:
         self._closed = False
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """
         Read-only property.  Is the file closed?
 
         @return: true if closed, otherwise false.
-        @rtype: L{bool}
         """
         return self._closed
 
     @property
-    def encoding(self):
+    def encoding(self) -> str:
         """
         Read-only property.   File encoding.
 
         @return: an encoding.
-        @rtype: L{str}
         """
         return self._encoding
 
     @property
-    def mode(self):
+    def mode(self) -> str:
         """
         Read-only property.  File mode.
 
         @return: "w"
-        @rtype: L{str}
         """
         return "w"
 
     @property
-    def newlines(self):
+    def newlines(self) -> None:
         """
         Read-only property.  Types of newlines encountered.
 
         @return: L{None}
-        @rtype: L{None}
         """
         return None
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         The name of this file; a repr-style string giving information about its
         namespace.
 
         @return: A file name.
-        @rtype: L{str}
         """
         return "<{0} {1}#{2}>".format(
             self.__class__.__name__,
@@ -105,73 +102,69 @@ class LoggingFile:
             self.level.name,
         )
 
-    def close(self):
+    def close(self) -> None:
         """
         Close this file so it can no longer be written to.
         """
         self._closed = True
 
-    def flush(self):
+    def flush(self) -> None:
         """
         No-op; this file does not buffer.
         """
         pass
 
-    def fileno(self):
+    def fileno(self) -> int:
         """
         Returns an invalid file descriptor, since this is not backed by an FD.
 
         @return: C{-1}
-        @rtype: L{int}
         """
         return -1
 
-    def isatty(self):
+    def isatty(self) -> bool:
         """
         A L{LoggingFile} is not a TTY.
 
         @return: C{False}
-        @rtype: L{bool}
         """
         return False
 
-    def write(self, string):
+    def write(self, message: AnyStr) -> None:
         """
         Log the given message.
 
-        @param string: Data to write.
-        @type string: L{bytes} in this file's preferred encoding or L{unicode}
+        @param message: The message to write.
         """
         if self._closed:
             raise ValueError("I/O operation on closed file")
 
-        if isinstance(string, bytes):
-            string = string.decode(self._encoding)
+        if isinstance(message, bytes):
+            text = message.decode(self._encoding)
+        else:
+            text = message
 
-        lines = (self._buffer + string).split("\n")
+        lines = (self._buffer + text).split("\n")
         self._buffer = lines[-1]
         lines = lines[0:-1]
 
         for line in lines:
             self.log.emit(self.level, format="{log_io}", log_io=line)
 
-    def writelines(self, lines):
+    def writelines(self, lines: Iterable[AnyStr]) -> None:
         """
         Log each of the given lines as a separate message.
 
         @param lines: Data to write.
-        @type lines: iterable of L{unicode} or L{bytes} in this file's
-            declared encoding
         """
         for line in lines:
             self.write(line)
 
-    def _unsupported(self, *args):
+    def _unsupported(self, *args: object) -> None:
         """
         Template for unsupported operations.
 
         @param args: Arguments.
-        @type args: tuple of L{object}
         """
         raise IOError("unsupported operation")
 

--- a/src/twisted/logger/_io.py
+++ b/src/twisted/logger/_io.py
@@ -19,9 +19,8 @@ class LoggingFile:
     """
     File-like object that turns C{write()} calls into logging events.
 
-    Note that because event formats are C{unicode}, C{bytes} received via
-    C{write()} are converted to C{unicode}, which is the opposite of what
-    C{file} does.
+    Note that because event formats are L{str}, C{bytes} received via C{write()}
+    are converted to C{str}, which is the opposite of what C{file} does.
 
     @ivar softspace: File-like L{'softspace' attribute <file.softspace>}; zero
         or one.

--- a/src/twisted/logger/_json.py
+++ b/src/twisted/logger/_json.py
@@ -9,9 +9,11 @@ Tools for saving and loading log events in a structured format.
 from constantly import NamedConstant
 from json import dumps, loads
 from uuid import UUID
+from typing import Any, AnyStr, Dict, IO, Iterable, Optional, Union, cast
 
-from ._flatten import flattenEvent
 from ._file import FileLogObserver
+from ._flatten import flattenEvent
+from ._interfaces import LogEvent
 from ._levels import LogLevel
 from ._logger import Logger
 
@@ -20,16 +22,17 @@ from twisted.python.failure import Failure
 log = Logger()
 
 
-def failureAsJSON(failure):
+JSONDict = Dict[str, Any]
+
+
+def failureAsJSON(failure: Failure) -> JSONDict:
     """
     Convert a failure to a JSON-serializable data structure.
 
     @param failure: A failure to serialize.
-    @type failure: L{Failure}
 
     @return: a mapping of strings to ... stuff, mostly reminiscent of
         L{Failure.__getstate__}
-    @rtype: L{dict}
     """
     return dict(
         failure.__getstate__(),
@@ -40,42 +43,16 @@ def failureAsJSON(failure):
     )
 
 
-def asBytes(obj):
-    """
-    On Python 2, we really need native strings in a variety of places;
-    attribute names will sort of work in a __dict__, but they're subtly wrong;
-    however, printing tracebacks relies on I/O to containers that only support
-    bytes.  This function converts _all_ native strings within a
-    JSON-deserialized object to bytes.
-
-    @param obj: An object to convert to bytes.
-    @type obj: L{object}
-
-    @return: A string of UTF-8 bytes.
-    @rtype: L{bytes}
-    """
-    if isinstance(obj, list):
-        return map(asBytes, obj)
-    elif isinstance(obj, dict):
-        return dict((asBytes(k), asBytes(v)) for k, v in obj.items())
-    elif isinstance(obj, str):
-        return obj.encode("utf-8")
-    else:
-        return obj
-
-
-def failureFromJSON(failureDict):
+def failureFromJSON(failureDict: JSONDict) -> Failure:
     """
     Load a L{Failure} from a dictionary deserialized from JSON.
 
     @param failureDict: a JSON-deserialized object like one previously returned
         by L{failureAsJSON}.
-    @type failureDict: L{dict} mapping L{str} to attributes
 
     @return: L{Failure}
-    @rtype: L{Failure}
     """
-    f = Failure.__new__(Failure)
+    f = cast(Failure, Failure.__new__(Failure))
     typeInfo = failureDict["type"]
     failureDict["type"] = type(typeInfo["__name__"], (), typeInfo)
     f.__dict__ = failureDict
@@ -104,7 +81,7 @@ classInfo = [
 uuidToLoader = dict([(uuid, loader) for (predicate, uuid, saver, loader) in classInfo])
 
 
-def objectLoadHook(aDict):
+def objectLoadHook(aDict: JSONDict) -> object:
     """
     Dictionary-to-object-translation hook for certain value types used within
     the logging system.
@@ -112,17 +89,15 @@ def objectLoadHook(aDict):
     @see: the C{object_hook} parameter to L{json.load}
 
     @param aDict: A dictionary loaded from a JSON object.
-    @type aDict: L{dict}
 
     @return: C{aDict} itself, or the object represented by C{aDict}
-    @rtype: L{object}
     """
     if "__class_uuid__" in aDict:
         return uuidToLoader[UUID(aDict["__class_uuid__"])](aDict)
     return aDict
 
 
-def objectSaveHook(pythonObject):
+def objectSaveHook(pythonObject: object) -> JSONDict:
     """
     Object-to-serializable hook for certain value types used within the logging
     system.
@@ -130,7 +105,6 @@ def objectSaveHook(pythonObject):
     @see: the C{default} parameter to L{json.dump}
 
     @param pythonObject: Any object.
-    @type pythonObject: L{object}
 
     @return: If the object is one of the special types the logging system
         supports, a specially-formatted dictionary; otherwise, a marker
@@ -144,7 +118,7 @@ def objectSaveHook(pythonObject):
     return {"unpersistable": True}
 
 
-def eventAsJSON(event):
+def eventAsJSON(event: LogEvent) -> str:
     """
     Encode an event as JSON, flattening it if necessary to preserve as much
     structure as possible.
@@ -153,49 +127,42 @@ def eventAsJSON(event):
     serialized.
 
     @param event: A log event dictionary.
-    @type event: L{dict} with arbitrary keys and values
 
     @return: A string of the serialized JSON; note that this will contain no
         newline characters, and may thus safely be stored in a line-delimited
         file.
-    @rtype: L{str}
     """
 
-    def default(unencodable):
+    def default(unencodable: object) -> Union[JSONDict, str]:
         """
         Serialize an object not otherwise serializable by L{dumps}.
 
         @param unencodable: An unencodable object.
+
         @return: C{unencodable}, serialized
         """
         if isinstance(unencodable, bytes):
             return unencodable.decode("charmap")
         return objectSaveHook(unencodable)
 
-    kw = dict(default=default, skipkeys=True)
-
     flattenEvent(event)
-    result = dumps(event, **kw)
-    if not isinstance(result, str):
-        return str(result, "utf-8", "replace")
-    return result
+    return dumps(event, default=default, skipkeys=True)
 
 
-def eventFromJSON(eventText):
+def eventFromJSON(eventText: str) -> JSONDict:
     """
     Decode a log event from JSON.
 
     @param eventText: The output of a previous call to L{eventAsJSON}
-    @type eventText: L{str}
 
     @return: A reconstructed version of the log event.
-    @rtype: L{dict}
     """
-    loaded = loads(eventText, object_hook=objectLoadHook)
-    return loaded
+    return cast(JSONDict, loads(eventText, object_hook=objectLoadHook))
 
 
-def jsonFileLogObserver(outFile, recordSeparator="\x1e"):
+def jsonFileLogObserver(
+    outFile: IO[Any], recordSeparator: str = "\x1e"
+) -> FileLogObserver:
     """
     Create a L{FileLogObserver} that emits JSON-serialized events to a
     specified (writable) file-like object.
@@ -211,48 +178,42 @@ def jsonFileLogObserver(outFile, recordSeparator="\x1e"):
 
     @param outFile: A file-like object.  Ideally one should be passed which
         accepts L{str} data.  Otherwise, UTF-8 L{bytes} will be used.
-    @type outFile: L{io.IOBase}
-
     @param recordSeparator: The record separator to use.
-    @type recordSeparator: L{str}
 
     @return: A file log observer.
-    @rtype: L{FileLogObserver}
     """
     return FileLogObserver(
         outFile, lambda event: "{0}{1}\n".format(recordSeparator, eventAsJSON(event))
     )
 
 
-def eventsFromJSONLogFile(inFile, recordSeparator=None, bufferSize=4096):
+def eventsFromJSONLogFile(
+    inFile: IO[Any],
+    recordSeparator: Optional[str] = None,
+    bufferSize: int = 4096,
+) -> Iterable[LogEvent]:
     """
     Load events from a file previously saved with L{jsonFileLogObserver}.
     Event records that are truncated or otherwise unreadable are ignored.
 
     @param inFile: A (readable) file-like object.  Data read from C{inFile}
         should be L{str} or UTF-8 L{bytes}.
-    @type inFile: iterable of lines
-
     @param recordSeparator: The expected record separator.
         If L{None}, attempt to automatically detect the record separator from
         one of C{"\\x1e"} or C{""}.
-    @type recordSeparator: L{str}
-
     @param bufferSize: The size of the read buffer used while reading from
         C{inFile}.
-    @type bufferSize: integer
 
     @return: Log events as read from C{inFile}.
-    @rtype: iterable of L{dict}
     """
 
-    def asBytes(s):
-        if type(s) is bytes:
+    def asBytes(s: AnyStr) -> bytes:
+        if isinstance(s, bytes):
             return s
         else:
             return s.encode("utf-8")
 
-    def eventFromBytearray(record):
+    def eventFromBytearray(record: bytearray) -> Optional[LogEvent]:
         try:
             text = bytes(record).decode("utf-8")
         except UnicodeDecodeError:
@@ -273,24 +234,24 @@ def eventsFromJSONLogFile(inFile, recordSeparator=None, bufferSize=4096):
 
         if first == b"\x1e":
             # This looks json-text-sequence compliant.
-            recordSeparator = first
+            recordSeparatorBytes = first
         else:
             # Default to simpler newline-separated stream, which does not use
             # a record separator.
-            recordSeparator = b""
+            recordSeparatorBytes = b""
 
     else:
-        recordSeparator = asBytes(recordSeparator)
+        recordSeparatorBytes = asBytes(recordSeparator)
         first = b""
 
-    if recordSeparator == b"":
-        recordSeparator = b"\n"  # Split on newlines below
+    if recordSeparatorBytes == b"":
+        recordSeparatorBytes = b"\n"  # Split on newlines below
 
         eventFromRecord = eventFromBytearray
 
     else:
 
-        def eventFromRecord(record):
+        def eventFromRecord(record: bytearray) -> Optional[LogEvent]:
             if record[-1] == ord("\n"):
                 return eventFromBytearray(record)
             else:
@@ -313,7 +274,7 @@ def eventsFromJSONLogFile(inFile, recordSeparator=None, bufferSize=4096):
             break
 
         buffer += asBytes(newData)
-        records = buffer.split(recordSeparator)
+        records = buffer.split(recordSeparatorBytes)
 
         for record in records[:-1]:
             if len(record) > 0:

--- a/src/twisted/logger/_legacy.py
+++ b/src/twisted/logger/_legacy.py
@@ -6,42 +6,45 @@
 Integration with L{twisted.python.log}.
 """
 
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+
 from zope.interface import implementer
 
-from ._levels import LogLevel
 from ._format import formatEvent
-from ._observer import ILogObserver
+from ._interfaces import ILogObserver, LogEvent
+from ._levels import LogLevel
 from ._stdlib import fromStdlibLogLevelMapping, StringifiableFromEvent
+
+if TYPE_CHECKING:
+    from twisted.python.log import ILogObserver as ILegacyLogObserver
 
 
 @implementer(ILogObserver)
 class LegacyLogObserverWrapper:
     """
-    L{ILogObserver} that wraps an L{twisted.python.log.ILogObserver}.
+    L{ILogObserver} that wraps a L{twisted.python.log.ILegacyLogObserver}.
 
     Received (new-style) events are modified prior to forwarding to
     the legacy observer to ensure compatibility with observers that
     expect legacy events.
     """
 
-    def __init__(self, legacyObserver):
+    def __init__(self, legacyObserver: "ILegacyLogObserver") -> None:
         """
         @param legacyObserver: a legacy observer to which this observer will
             forward events.
-        @type legacyObserver: L{twisted.python.log.ILogObserver}
         """
         self.legacyObserver = legacyObserver
 
     def __repr__(self) -> str:
         return "{self.__class__.__name__}({self.legacyObserver})".format(self=self)
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         """
         Forward events to the legacy observer after editing them to
         ensure compatibility.
 
         @param event: an event
-        @type event: L{dict}
         """
 
         # The "message" key is required by textFromEventDict()
@@ -87,7 +90,11 @@ class LegacyLogObserverWrapper:
         self.legacyObserver(event)
 
 
-def publishToNewObserver(observer, eventDict, textFromEventDict):
+def publishToNewObserver(
+    observer: ILogObserver,
+    eventDict: Dict[str, Any],
+    textFromEventDict: Callable[[Dict[str, Any]], Optional[str]],
+) -> None:
     """
     Publish an old-style (L{twisted.python.log}) event to a new-style
     (L{twisted.logger}) observer.
@@ -96,20 +103,13 @@ def publishToNewObserver(observer, eventDict, textFromEventDict):
         L{LegacyLogObserverWrapper}, and may now be getting sent back to a
         new-style observer.  In this case, it's already a new-style event,
         adapted to also look like an old-style event, and we don't need to
-        tweak it again to be a new-style event, hence the checks for
+        tweak it again to be a new-style event, hence this checks for
         already-defined new-style keys.
 
     @param observer: A new-style observer to handle this event.
-    @type observer: L{ILogObserver}
-
     @param eventDict: An L{old-style <twisted.python.log>}, log event.
-    @type eventDict: L{dict}
-
     @param textFromEventDict: callable that can format an old-style event as a
         string.  Passed here rather than imported to avoid circular dependency.
-    @type textFromEventDict: 1-arg L{callable} taking L{dict} returning L{str}
-
-    @return: L{None}
     """
 
     if "log_time" not in eventDict:

--- a/src/twisted/logger/_levels.py
+++ b/src/twisted/logger/_levels.py
@@ -14,10 +14,9 @@ class InvalidLogLevelError(Exception):
     Someone tried to use a L{LogLevel} that is unknown to the logging system.
     """
 
-    def __init__(self, level):
+    def __init__(self, level: NamedConstant) -> None:
         """
-        @param level: A log level.
-        @type level: L{LogLevel}
+        @param level: A log level from L{LogLevel}.
         """
         super(InvalidLogLevelError, self).__init__(str(level))
         self.level = level
@@ -65,15 +64,13 @@ class LogLevel(Names):
     critical = NamedConstant()
 
     @classmethod
-    def levelWithName(cls, name):
+    def levelWithName(cls, name: str) -> NamedConstant:
         """
         Get the log level with the given name.
 
         @param name: The name of a log level.
-        @type name: L{str} (native string)
 
         @return: The L{LogLevel} with the specified C{name}.
-        @rtype: L{LogLevel}
 
         @raise InvalidLogLevelError: if the C{name} does not name a valid log
             level.
@@ -82,25 +79,3 @@ class LogLevel(Names):
             return cls.lookupByName(name)
         except ValueError:
             raise InvalidLogLevelError(name)
-
-    @classmethod
-    def _priorityForLevel(cls, level):
-        """
-        We want log levels to have defined ordering - the order of definition -
-        but they aren't value constants (the only value is the name).  This is
-        arguably a bug in Twisted, so this is just a workaround for U{until
-        this is fixed in some way
-        <https://twistedmatrix.com/trac/ticket/6523>}.
-
-        @param level: A log level.
-        @type level: L{LogLevel}
-
-        @return: A numeric index indicating priority (lower is higher level).
-        @rtype: L{int}
-        """
-        return cls._levelPriorities[level]
-
-
-LogLevel._levelPriorities = dict(
-    (level, index) for (index, level) in (enumerate(LogLevel.iterconstants()))
-)

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -7,9 +7,12 @@ Logger class.
 """
 
 from time import time
+from typing import Any, Optional, cast
 
 from twisted.python.compat import currentframe
 from twisted.python.failure import Failure
+
+from ._interfaces import ILogObserver, LogTrace
 from ._levels import InvalidLogLevelError, LogLevel
 
 
@@ -19,44 +22,38 @@ class Logger:
     as a class or module attribute, as documented in L{this module's
     documentation <twisted.logger>}.
 
-    @type namespace: L{str}
     @ivar namespace: the namespace for this logger
-
-    @type source: L{object}
     @ivar source: The object which is emitting events via this logger
-
-    @type observer: L{ILogObserver}
     @ivar observer: The observer that this logger will send events to.
     """
 
     @staticmethod
-    def _namespaceFromCallingContext():
+    def _namespaceFromCallingContext() -> str:
         """
         Derive a namespace from the module containing the caller's caller.
 
         @return: the fully qualified python name of a module.
-        @rtype: L{str} (native string)
         """
         try:
-            return currentframe(2).f_globals["__name__"]
+            return cast(str, currentframe(2).f_globals["__name__"])
         except KeyError:
             return "<unknown>"
 
-    def __init__(self, namespace=None, source=None, observer=None):
+    def __init__(
+        self,
+        namespace: Optional[str] = None,
+        source: Optional[object] = None,
+        observer: Optional["ILogObserver"] = None,
+    ) -> None:
         """
         @param namespace: The namespace for this logger.  Uses a dotted
             notation, as used by python modules.  If not L{None}, then the name
             of the module of the caller is used.
-        @type namespace: L{str} (native string)
-
         @param source: The object which is emitting events via this
             logger; this is automatically set on instances of a class
             if this L{Logger} is an attribute of that class.
-        @type source: L{object}
-
         @param observer: The observer that this logger will send events to.
             If L{None}, use the L{global log publisher <globalLogPublisher>}.
-        @type observer: L{ILogObserver}
         """
         if namespace is None:
             namespace = self._namespaceFromCallingContext()
@@ -67,11 +64,11 @@ class Logger:
         if observer is None:
             from ._global import globalLogPublisher
 
-            self.observer = globalLogPublisher
+            self.observer = globalLogPublisher  # type: ILogObserver
         else:
             self.observer = observer
 
-    def __get__(self, oself, type=None):
+    def __get__(self, instance: object, owner: Optional[type] = None) -> object:
         """
         When used as a descriptor, i.e.::
 
@@ -90,13 +87,15 @@ class Logger:
         C{Something}, and C{Something().log.source} would be an instance of
         C{Something}.
         """
-        if oself is None:
-            source = type
+        assert owner is not None
+
+        if instance is None:
+            source = owner  # type: Any
         else:
-            source = oself
+            source = instance
 
         return self.__class__(
-            ".".join([type.__module__, type.__name__]),
+            ".".join([owner.__module__, owner.__name__]),
             source,
             observer=self.observer,
         )
@@ -104,16 +103,16 @@ class Logger:
     def __repr__(self) -> str:
         return "<%s %r>" % (self.__class__.__name__, self.namespace)
 
-    def emit(self, level, format=None, **kwargs):
+    def emit(
+        self, level: LogLevel, format: Optional[str] = None, **kwargs: object
+    ) -> None:
         """
         Emit a log event to all log observers at the given level.
 
         @param level: a L{LogLevel}
-
         @param format: a message format using new-style (PEP 3101)
             formatting.  The logging event (which is a L{dict}) is
             used to render this format string.
-
         @param kwargs: additional key/value pairs to include in the event.
             Note that values which are later mutated may result in
             non-deterministic behavior from observers that schedule work for
@@ -139,11 +138,17 @@ class Logger:
         )
 
         if "log_trace" in event:
-            event["log_trace"].append((self, self.observer))
+            cast(LogTrace, event["log_trace"]).append((self, self.observer))
 
         self.observer(event)
 
-    def failure(self, format, failure=None, level=LogLevel.critical, **kwargs):
+    def failure(
+        self,
+        format: str,
+        failure: Optional[Failure] = None,
+        level: LogLevel = LogLevel.critical,
+        **kwargs: object
+    ) -> None:
         """
         Log a failure and emit a traceback.
 
@@ -172,12 +177,9 @@ class Logger:
         @param format: a message format using new-style (PEP 3101) formatting.
             The logging event (which is a L{dict}) is used to render this
             format string.
-
         @param failure: a L{Failure} to log.  If L{None}, a L{Failure} is
             created from the exception in flight.
-
         @param level: a L{LogLevel} to use.
-
         @param kwargs: additional key/value pairs to include in the event.
             Note that values which are later mutated may result in
             non-deterministic behavior from observers that schedule work for
@@ -188,7 +190,7 @@ class Logger:
 
         self.emit(level, format, log_failure=failure, **kwargs)
 
-    def debug(self, format=None, **kwargs):
+    def debug(self, format: Optional[str] = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.debug}.
 
@@ -203,7 +205,7 @@ class Logger:
         """
         self.emit(LogLevel.debug, format, **kwargs)
 
-    def info(self, format=None, **kwargs):
+    def info(self, format: Optional[str] = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.info}.
 
@@ -218,7 +220,7 @@ class Logger:
         """
         self.emit(LogLevel.info, format, **kwargs)
 
-    def warn(self, format=None, **kwargs):
+    def warn(self, format: Optional[str] = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.warn}.
 
@@ -233,7 +235,7 @@ class Logger:
         """
         self.emit(LogLevel.warn, format, **kwargs)
 
-    def error(self, format=None, **kwargs):
+    def error(self, format: Optional[str] = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.error}.
 
@@ -248,7 +250,7 @@ class Logger:
         """
         self.emit(LogLevel.error, format, **kwargs)
 
-    def critical(self, format=None, **kwargs):
+    def critical(self, format: Optional[str] = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.critical}.
 

--- a/src/twisted/logger/_observer.py
+++ b/src/twisted/logger/_observer.py
@@ -6,62 +6,18 @@
 Basic log observers.
 """
 
-from zope.interface import Interface, implementer
+from typing import Callable, Optional
+
+from zope.interface import implementer
 
 from twisted.python.failure import Failure
+from ._interfaces import ILogObserver, LogEvent
 from ._logger import Logger
 
 
 OBSERVER_DISABLED = (
     "Temporarily disabling observer {observer} due to exception: {log_failure}"
 )
-
-
-class ILogObserver(Interface):
-    """
-    An observer which can handle log events.
-
-    Unlike most interfaces within Twisted, an L{ILogObserver} I{must be
-    thread-safe}.  Log observers may be called indiscriminately from many
-    different threads, as any thread may wish to log a message at any time.
-    """
-
-    def __call__(event):
-        """
-        Log an event.
-
-        @type event: C{dict} with (native) C{str} keys.
-        @param event: A dictionary with arbitrary keys as defined by the
-            application emitting logging events, as well as keys added by the
-            logging system.  The logging system reserves the right to set any
-            key beginning with the prefix C{"log_"}; applications should not
-            use any key so named.  Currently, the following keys are used by
-            the logging system in some way, if they are present (they are all
-            optional):
-
-                - C{"log_format"}: a PEP-3101-style format string which draws
-                  upon the keys in the event as its values, used to format the
-                  event for human consumption.
-
-                - C{"log_flattened"}: a dictionary mapping keys derived from
-                  the names and format values used in the C{"log_format"}
-                  string to their values.  This is used to preserve some
-                  structured information for use with
-                  L{twisted.logger.extractField}.
-
-                - C{"log_trace"}: A L{list} designed to capture information
-                  about which L{LogPublisher}s have observed the event.
-
-                - C{"log_level"}: a L{log level
-                  <twisted.logger.LogLevel>} constant, indicating the
-                  importance of and audience for this event.
-
-                - C{"log_namespace"}: a namespace for the emitter of the event,
-                  given as a unicode string.
-
-                - C{"log_system"}: a string indicating the network event or
-                  method call which resulted in the message being logged.
-        """
 
 
 @implementer(ILogObserver)
@@ -73,11 +29,11 @@ class LogPublisher:
     events to each.
     """
 
-    def __init__(self, *observers):
+    def __init__(self, *observers: ILogObserver) -> None:
         self._observers = list(observers)
         self.log = Logger(observer=self)
 
-    def addObserver(self, observer):
+    def addObserver(self, observer: ILogObserver) -> None:
         """
         Registers an observer with this publisher.
 
@@ -88,7 +44,7 @@ class LogPublisher:
         if observer not in self._observers:
             self._observers.append(observer)
 
-    def removeObserver(self, observer):
+    def removeObserver(self, observer: ILogObserver) -> None:
         """
         Unregisters an observer with this publisher.
 
@@ -99,23 +55,22 @@ class LogPublisher:
         except ValueError:
             pass
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         """
         Forward events to contained observers.
         """
-        if "log_trace" in event:
+        if "log_trace" not in event:
+            trace = None  # type: Optional[Callable[[ILogObserver], None]]
 
-            def trace(observer):
+        else:
+
+            def trace(observer: ILogObserver) -> None:
                 """
                 Add tracing information for an observer.
 
                 @param observer: an observer being forwarded to
-                @type observer: L{ILogObserver}
                 """
                 event["log_trace"].append((self, observer))
-
-        else:
-            trace = None
 
         brokenObservers = []
 
@@ -136,17 +91,23 @@ class LogPublisher:
                 observer=brokenObserver,
             )
 
-    def _errorLoggerForObserver(self, observer):
+    def _errorLoggerForObserver(self, observer: ILogObserver) -> Logger:
         """
         Create an error-logger based on this logger, which does not contain the
         given bad observer.
 
         @param observer: The observer which previously had an error.
-        @type observer: L{ILogObserver}
 
-        @return: L{None}
+        @return: A L{Logger} without the given observer.
         """
         errorPublisher = LogPublisher(
             *[obs for obs in self._observers if obs is not observer]
         )
         return Logger(observer=errorPublisher)
+
+
+@implementer(ILogObserver)
+def bitbucketLogObserver(event: LogEvent) -> None:
+    """
+    I{ILogObserver} that does nothing with the events it sees.
+    """

--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -7,13 +7,17 @@ Integration with Python standard library logging.
 """
 
 import logging as stdlibLogging
+from typing import Mapping, Tuple
+
+from constantly import NamedConstant
 
 from zope.interface import implementer
 
 from twisted.python.compat import currentframe
+
+from ._interfaces import ILogObserver, LogEvent
 from ._levels import LogLevel
 from ._format import formatEvent
-from ._observer import ILogObserver
 
 
 # Mappings to Python's logging module
@@ -23,10 +27,10 @@ toStdlibLogLevelMapping = {
     LogLevel.warn: stdlibLogging.WARNING,
     LogLevel.error: stdlibLogging.ERROR,
     LogLevel.critical: stdlibLogging.CRITICAL,
-}
+}  # type: Mapping[NamedConstant, int]
 
 
-def _reverseLogLevelMapping():
+def _reverseLogLevelMapping() -> Mapping[int, NamedConstant]:
     """
     Reverse the above mapping, adding both the numerical keys used above and
     the corresponding string keys also used by python logging.
@@ -64,42 +68,39 @@ class STDLibLogObserver:
 
     defaultStackDepth = 4
 
-    def __init__(self, name="twisted", stackDepth=defaultStackDepth):
+    def __init__(
+        self, name: str = "twisted", stackDepth: int = defaultStackDepth
+    ) -> None:
         """
         @param loggerName: logger identifier.
-        @type loggerName: C{str}
-
         @param stackDepth: The depth of the stack to investigate for caller
             metadata.
-        @type stackDepth: L{int}
         """
         self.logger = stdlibLogging.getLogger(name)
-        self.logger.findCaller = self._findCaller
+        self.logger.findCaller = self._findCaller  # type: ignore[assignment]
         self.stackDepth = stackDepth
 
-    def _findCaller(self, stackInfo=False, stackLevel=1):
+    def _findCaller(
+        self, stackInfo: bool = False, stackLevel: int = 1
+    ) -> Tuple[str, int, str, None]:
         """
         Based on the stack depth passed to this L{STDLibLogObserver}, identify
         the calling function.
 
         @param stackInfo: Whether or not to construct stack information.
             (Currently ignored.)
-        @type stackInfo: L{bool}
-
         @param stackLevel: The number of stack frames to skip when determining
             the caller (currently ignored; use stackDepth on the instance).
-        @type stackLevel: L{int}
 
         @return: Depending on Python version, either a 3-tuple of (filename,
             lineno, name) or a 4-tuple of that plus stack information.
-        @rtype: L{tuple}
         """
         f = currentframe(self.stackDepth)
         co = f.f_code
         extra = (None,)
         return (co.co_filename, f.f_lineno, co.co_name) + extra
 
-    def __call__(self, event):
+    def __call__(self, event: LogEvent) -> None:
         """
         Format an event and bridge it to Python logging.
         """
@@ -119,17 +120,14 @@ class StringifiableFromEvent:
     formatting until it's converted into a C{str}.
     """
 
-    def __init__(self, event):
+    def __init__(self, event: LogEvent) -> None:
         """
         @param event: An event.
-        @type event: L{dict}
         """
         self.event = event
 
-    def __unicode__(self):
+    def __str__(self) -> str:
         return formatEvent(self.event)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return str(self).encode("utf-8")
-
-    __str__ = __unicode__

--- a/src/twisted/logger/_util.py
+++ b/src/twisted/logger/_util.py
@@ -6,29 +6,32 @@
 Logging utilities.
 """
 
+from typing import List
 
-def formatTrace(trace):
+from ._interfaces import LogTrace
+from ._logger import Logger
+
+
+def formatTrace(trace: LogTrace) -> str:
     """
     Format a trace (that is, the contents of the C{log_trace} key of a log
     event) as a visual indication of the message's propagation through various
     observers.
 
     @param trace: the contents of the C{log_trace} key from an event.
-    @type trace: object
 
     @return: A multi-line string with indentation and arrows indicating the
         flow of the message through various observers.
-    @rtype: L{unicode}
     """
 
-    def formatWithName(obj):
+    def formatWithName(obj: object) -> str:
         if hasattr(obj, "name"):
-            return "{0} ({1})".format(obj, obj.name)
+            return "{0} ({1})".format(obj, obj.name)  # type: ignore[attr-defined]
         else:
             return "{0}".format(obj)
 
     result = []
-    lineage = []
+    lineage = []  # type: List[Logger]
 
     for parent, child in trace:
         if not lineage or lineage[-1] is not parent:

--- a/src/twisted/logger/test/test_buffer.py
+++ b/src/twisted/logger/test/test_buffer.py
@@ -5,13 +5,15 @@
 Test cases for L{twisted.logger._buffer}.
 """
 
+from typing import List, cast
+
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
 
 from twisted.trial import unittest
 
-from .._observer import ILogObserver
 from .._buffer import LimitedHistoryLogObserver
+from .._interfaces import ILogObserver, LogEvent
 
 
 class LimitedHistoryLogObserverTests(unittest.TestCase):
@@ -19,7 +21,7 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
     Tests for L{LimitedHistoryLogObserver}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{LimitedHistoryLogObserver} provides L{ILogObserver}.
         """
@@ -29,7 +31,7 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         except BrokenMethodImplementation as e:
             self.fail(e)
 
-    def test_order(self):
+    def test_order(self) -> None:
         """
         L{LimitedHistoryLogObserver} saves history in the order it is received.
         """
@@ -40,11 +42,11 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         for event in events:
             observer(event)
 
-        outEvents = []
-        observer.replayTo(outEvents.append)
+        outEvents = []  # type: List[LogEvent]
+        observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events, outEvents)
 
-    def test_limit(self):
+    def test_limit(self) -> None:
         """
         When more events than a L{LimitedHistoryLogObserver}'s maximum size are
         buffered, older events will be dropped.
@@ -55,6 +57,7 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
 
         for event in events:
             observer(event)
-        outEvents = []
-        observer.replayTo(outEvents.append)
+
+        outEvents = []  # type: List[LogEvent]
+        observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events[-size:], outEvents)

--- a/src/twisted/logger/test/test_capture.py
+++ b/src/twisted/logger/test/test_capture.py
@@ -5,6 +5,8 @@
 Test cases for L{twisted.logger._capture}.
 """
 
+from typing import cast
+
 from twisted.logger import Logger, LogLevel
 from twisted.trial.unittest import TestCase
 
@@ -18,15 +20,15 @@ class LogCaptureTests(TestCase):
 
     log = Logger()
 
-    def test_capture(self):
+    def test_capture(self) -> None:
         """
         Events logged within context are captured.
         """
         foo = object()
 
         with capturedLogs() as captured:
-            self.log.debug("Capture this, please", foo=foo)
-            self.log.info("Capture this too, please", foo=foo)
+            cast(Logger, self.log).debug("Capture this, please", foo=foo)
+            cast(Logger, self.log).info("Capture this too, please", foo=foo)
 
         self.assertTrue(len(captured) == 2)
         self.assertEqual(captured[0]["log_format"], "Capture this, please")

--- a/src/twisted/logger/test/test_file.py
+++ b/src/twisted/logger/test/test_file.py
@@ -69,7 +69,7 @@ class FileLogObserverTests(TestCase):
     def test_observeWritesEmpty(self) -> None:
         """
         L{FileLogObserver} does not write to the given file when it observes
-        events and C{formatEvent} returns C{u""}.
+        events and C{formatEvent} returns C{""}.
         """
         self._test_observeWrites("", 0)
 

--- a/src/twisted/logger/test/test_file.py
+++ b/src/twisted/logger/test/test_file.py
@@ -6,6 +6,8 @@ Test cases for L{twisted.logger._file}.
 """
 
 from io import StringIO
+from types import TracebackType
+from typing import Any, AnyStr, IO, Optional, Type, cast
 
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
@@ -13,9 +15,8 @@ from zope.interface.verify import verifyObject
 from twisted.trial.unittest import TestCase
 
 from twisted.python.failure import Failure
-from .._observer import ILogObserver
-from .._file import FileLogObserver
-from .._file import textFileLogObserver
+from .._file import FileLogObserver, textFileLogObserver
+from .._interfaces import ILogObserver
 
 
 class FileLogObserverTests(TestCase):
@@ -23,7 +24,7 @@ class FileLogObserverTests(TestCase):
     Tests for L{FileLogObserver}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{FileLogObserver} is an L{ILogObserver}.
         """
@@ -34,7 +35,7 @@ class FileLogObserverTests(TestCase):
             except BrokenMethodImplementation as e:
                 self.fail(e)
 
-    def test_observeWrites(self):
+    def test_observeWrites(self) -> None:
         """
         L{FileLogObserver} writes to the given file when it observes events.
         """
@@ -44,44 +45,41 @@ class FileLogObserverTests(TestCase):
             observer(event)
             self.assertEqual(fileHandle.getvalue(), str(event))
 
-    def _test_observeWrites(self, what, count):
+    def _test_observeWrites(self, what: Optional[str], count: int) -> None:
         """
         Verify that observer performs an expected number of writes when the
         formatter returns a given value.
 
         @param what: the value for the formatter to return.
-        @type what: L{unicode}
-
         @param count: the expected number of writes.
-        @type count: L{int}
         """
         with DummyFile() as fileHandle:
-            observer = FileLogObserver(fileHandle, lambda e: what)
+            observer = FileLogObserver(cast(IO[Any], fileHandle), lambda e: what)
             event = dict(x=1)
             observer(event)
             self.assertEqual(fileHandle.writes, count)
 
-    def test_observeWritesNone(self):
+    def test_observeWritesNone(self) -> None:
         """
         L{FileLogObserver} does not write to the given file when it observes
         events and C{formatEvent} returns L{None}.
         """
         self._test_observeWrites(None, 0)
 
-    def test_observeWritesEmpty(self):
+    def test_observeWritesEmpty(self) -> None:
         """
         L{FileLogObserver} does not write to the given file when it observes
         events and C{formatEvent} returns C{u""}.
         """
         self._test_observeWrites("", 0)
 
-    def test_observeFlushes(self):
+    def test_observeFlushes(self) -> None:
         """
         L{FileLogObserver} calles C{flush()} on the output file when it
         observes an event.
         """
         with DummyFile() as fileHandle:
-            observer = FileLogObserver(fileHandle, lambda e: str(e))
+            observer = FileLogObserver(cast(IO[Any], fileHandle), lambda e: str(e))
             event = dict(x=1)
             observer(event)
             self.assertEqual(fileHandle.flushes, 1)
@@ -92,7 +90,7 @@ class TextFileLogObserverTests(TestCase):
     Tests for L{textFileLogObserver}.
     """
 
-    def test_returnsFileLogObserver(self):
+    def test_returnsFileLogObserver(self) -> None:
         """
         L{textFileLogObserver} returns a L{FileLogObserver}.
         """
@@ -100,7 +98,7 @@ class TextFileLogObserverTests(TestCase):
             observer = textFileLogObserver(fileHandle)
             self.assertIsInstance(observer, FileLogObserver)
 
-    def test_outFile(self):
+    def test_outFile(self) -> None:
         """
         Returned L{FileLogObserver} has the correct outFile.
         """
@@ -108,7 +106,7 @@ class TextFileLogObserverTests(TestCase):
             observer = textFileLogObserver(fileHandle)
             self.assertIs(observer._outFile, fileHandle)
 
-    def test_timeFormat(self):
+    def test_timeFormat(self) -> None:
         """
         Returned L{FileLogObserver} has the correct outFile.
         """
@@ -117,7 +115,7 @@ class TextFileLogObserverTests(TestCase):
             observer(dict(log_format="XYZZY", log_time=112345.6))
             self.assertEqual(fileHandle.getvalue(), "600000 [-#-] XYZZY\n")
 
-    def test_observeFailure(self):
+    def test_observeFailure(self) -> None:
         """
         If the C{"log_failure"} key exists in an event, the observer appends
         the failure's traceback to the output.
@@ -137,7 +135,7 @@ class TextFileLogObserverTests(TestCase):
                 output.split("\n")[1].startswith("\tTraceback "), msg=repr(output)
             )
 
-    def test_observeFailureThatRaisesInGetTraceback(self):
+    def test_observeFailureThatRaisesInGetTraceback(self) -> None:
         """
         If the C{"log_failure"} key exists in an event, and contains an object
         that raises when you call its C{getTraceback()}, then the observer
@@ -157,27 +155,31 @@ class DummyFile:
     File that counts writes and flushes.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.writes = 0
         self.flushes = 0
 
-    def write(self, data):
+    def write(self, data: AnyStr) -> None:
         """
         Write data.
 
         @param data: data
-        @type data: L{unicode} or L{bytes}
         """
         self.writes += 1
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Flush buffers.
         """
         self.flushes += 1
 
-    def __enter__(self):
+    def __enter__(self) -> "DummyFile":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
         pass

--- a/src/twisted/logger/test/test_filter.py
+++ b/src/twisted/logger/test/test_filter.py
@@ -275,13 +275,6 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
                 predicate.logLevelForNamespace(default), predicate.defaultLogLevel
             )
             self.assertEqual(
-                predicate.logLevelForNamespace(""), predicate.defaultLogLevel
-            )
-            self.assertEqual(
-                predicate.logLevelForNamespace(cast(str, None)),
-                predicate.defaultLogLevel,
-            )
-            self.assertEqual(
                 predicate.logLevelForNamespace("rocker.cool.namespace"),
                 predicate.defaultLogLevel,
             )

--- a/src/twisted/logger/test/test_filter.py
+++ b/src/twisted/logger/test/test_filter.py
@@ -5,18 +5,25 @@
 Test cases for L{twisted.logger._filter}.
 """
 
+from typing import Iterable, List, Tuple, Union, cast
+
+from constantly import NamedConstant
+
+from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
 
 from twisted.trial import unittest
 
-from .._levels import InvalidLogLevelError
-from .._levels import LogLevel
-from .._observer import ILogObserver
-from .._observer import LogPublisher
-from .._filter import FilteringLogObserver
-from .._filter import PredicateResult
-from .._filter import LogLevelFilterPredicate
+from .._filter import (
+    FilteringLogObserver,
+    ILogFilterPredicate,
+    LogLevelFilterPredicate,
+    PredicateResult,
+)
+from .._interfaces import ILogObserver, LogEvent
+from .._levels import InvalidLogLevelError, LogLevel
+from .._observer import LogPublisher, bitbucketLogObserver
 
 
 class FilteringLogObserverTests(unittest.TestCase):
@@ -24,17 +31,19 @@ class FilteringLogObserverTests(unittest.TestCase):
     Tests for L{FilteringLogObserver}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{FilteringLogObserver} is an L{ILogObserver}.
         """
-        observer = FilteringLogObserver(lambda e: None, ())
+        observer = FilteringLogObserver(cast(ILogObserver, lambda e: None), ())
         try:
             verifyObject(ILogObserver, observer)
         except BrokenMethodImplementation as e:
             self.fail(e)
 
-    def filterWith(self, filters, other=False):
+    def filterWith(
+        self, filters: Iterable[str], other: bool = False
+    ) -> Union[List[int], Tuple[List[int], List[int]]]:
         """
         Apply a set of pre-defined filters on a known set of events and return
         the filtered list of event numbers.
@@ -43,40 +52,29 @@ class FilteringLogObserverTests(unittest.TestCase):
         C{0}, C{1}, C{2}, and C{3}.
 
         @param filters: names of the filters to apply.
-
             Options are:
-
                 - C{"twoMinus"} (count <=2),
-
                 - C{"twoPlus"} (count >= 2),
-
                 - C{"notTwo"} (count != 2),
-
                 - C{"no"} (False).
-
-        @type filters: iterable of str
-
         @param other: Whether to return a list of filtered events as well.
-        @type other: L{bool}
 
         @return: event numbers or 2-tuple of lists of event numbers.
-        @rtype: L{list} of L{int} or 2-L{tuple} of L{list} of L{int}
         """
         events = [
             dict(count=0),
             dict(count=1),
             dict(count=2),
             dict(count=3),
-        ]
+        ]  # type: List[LogEvent]
 
         class Filters:
             @staticmethod
-            def twoMinus(event):
+            def twoMinus(event: LogEvent) -> NamedConstant:
                 """
                 count <= 2
 
                 @param event: an event
-                @type event: dict
 
                 @return: L{PredicateResult.yes} if C{event["count"] <= 2},
                     otherwise L{PredicateResult.maybe}.
@@ -86,12 +84,11 @@ class FilteringLogObserverTests(unittest.TestCase):
                 return PredicateResult.maybe
 
             @staticmethod
-            def twoPlus(event):
+            def twoPlus(event: LogEvent) -> NamedConstant:
                 """
                 count >= 2
 
                 @param event: an event
-                @type event: dict
 
                 @return: L{PredicateResult.yes} if C{event["count"] >= 2},
                     otherwise L{PredicateResult.maybe}.
@@ -101,12 +98,11 @@ class FilteringLogObserverTests(unittest.TestCase):
                 return PredicateResult.maybe
 
             @staticmethod
-            def notTwo(event):
+            def notTwo(event: LogEvent) -> NamedConstant:
                 """
                 count != 2
 
                 @param event: an event
-                @type event: dict
 
                 @return: L{PredicateResult.yes} if C{event["count"] != 2},
                     otherwise L{PredicateResult.maybe}.
@@ -116,101 +112,106 @@ class FilteringLogObserverTests(unittest.TestCase):
                 return PredicateResult.maybe
 
             @staticmethod
-            def no(event):
+            def no(event: LogEvent) -> NamedConstant:
                 """
                 No way, man.
 
                 @param event: an event
-                @type event: dict
 
                 @return: L{PredicateResult.no}
                 """
                 return PredicateResult.no
 
             @staticmethod
-            def bogus(event):
+            def bogus(event: LogEvent) -> NamedConstant:
                 """
                 Bogus result.
 
                 @param event: an event
-                @type event: dict
 
                 @return: something other than a valid predicate result.
                 """
                 return None
 
         predicates = (getattr(Filters, f) for f in filters)
-        eventsSeen = []
-        eventsNotSeen = []
-        trackingObserver = eventsSeen.append
+        eventsSeen = []  # type: List[LogEvent]
+        eventsNotSeen = []  # type: List[LogEvent]
+        trackingObserver = cast(ILogObserver, eventsSeen.append)
+
         if other:
-            extra = [eventsNotSeen.append]
+            negativeObserver = cast(ILogObserver, eventsNotSeen.append)
         else:
-            extra = []
-        filteringObserver = FilteringLogObserver(trackingObserver, predicates, *extra)
+            negativeObserver = bitbucketLogObserver
+
+        filteringObserver = FilteringLogObserver(
+            trackingObserver, predicates, negativeObserver
+        )
+
         for e in events:
             filteringObserver(e)
 
-        if extra:
+        if other:
             return (
-                [e["count"] for e in eventsSeen],
-                [e["count"] for e in eventsNotSeen],
+                [cast(int, e["count"]) for e in eventsSeen],
+                [cast(int, e["count"]) for e in eventsNotSeen],
             )
-        return [e["count"] for e in eventsSeen]
+        else:
+            return [cast(int, e["count"]) for e in eventsSeen]
 
-    def test_shouldLogEventNoFilters(self):
+    def test_shouldLogEventNoFilters(self) -> None:
         """
         No filters: all events come through.
         """
         self.assertEqual(self.filterWith([]), [0, 1, 2, 3])
 
-    def test_shouldLogEventNoFilter(self):
+    def test_shouldLogEventNoFilter(self) -> None:
         """
         Filter with negative predicate result.
         """
         self.assertEqual(self.filterWith(["notTwo"]), [0, 1, 3])
 
-    def test_shouldLogEventOtherObserver(self):
+    def test_shouldLogEventOtherObserver(self) -> None:
         """
         Filtered results get sent to the other observer, if passed.
         """
         self.assertEqual(self.filterWith(["notTwo"], True), ([0, 1, 3], [2]))
 
-    def test_shouldLogEventYesFilter(self):
+    def test_shouldLogEventYesFilter(self) -> None:
         """
         Filter with positive predicate result.
         """
         self.assertEqual(self.filterWith(["twoPlus"]), [0, 1, 2, 3])
 
-    def test_shouldLogEventYesNoFilter(self):
+    def test_shouldLogEventYesNoFilter(self) -> None:
         """
         Series of filters with positive and negative predicate results.
         """
         self.assertEqual(self.filterWith(["twoPlus", "no"]), [2, 3])
 
-    def test_shouldLogEventYesYesNoFilter(self):
+    def test_shouldLogEventYesYesNoFilter(self) -> None:
         """
         Series of filters with positive, positive and negative predicate
         results.
         """
         self.assertEqual(self.filterWith(["twoPlus", "twoMinus", "no"]), [0, 1, 2, 3])
 
-    def test_shouldLogEventBadPredicateResult(self):
+    def test_shouldLogEventBadPredicateResult(self) -> None:
         """
         Filter with invalid predicate result.
         """
         self.assertRaises(TypeError, self.filterWith, ["bogus"])
 
-    def test_call(self):
+    def test_call(self) -> None:
         """
         Test filtering results from each predicate type.
         """
-        e = dict(obj=object())
+        e = dict(obj=object())  # type: LogEvent
 
-        def callWithPredicateResult(result):
-            seen = []
+        def callWithPredicateResult(result: NamedConstant) -> List[LogEvent]:
+            seen = []  # type: List[LogEvent]
             observer = FilteringLogObserver(
-                lambda e: seen.append(e), (lambda e: result,)
+                cast(ILogObserver, lambda e: seen.append(e)),
+                (cast(ILogFilterPredicate, lambda e: result),),
             )
             observer(e)
             return seen
@@ -219,16 +220,17 @@ class FilteringLogObserverTests(unittest.TestCase):
         self.assertIn(e, callWithPredicateResult(PredicateResult.maybe))
         self.assertNotIn(e, callWithPredicateResult(PredicateResult.no))
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         """
         Tracing keeps track of forwarding through the filtering observer.
         """
-        event = dict(log_trace=[])
+        event = dict(log_trace=[])  # type: LogEvent
 
-        oYes = lambda e: None
-        oNo = lambda e: None
+        oYes = cast(ILogObserver, lambda e: None)
+        oNo = cast(ILogObserver, lambda e: None)
 
-        def testObserver(e):
+        @implementer(ILogObserver)
+        def testObserver(e: LogEvent) -> None:
             self.assertIs(e, event)
             self.assertEqual(
                 event["log_trace"],
@@ -243,8 +245,12 @@ class FilteringLogObserverTests(unittest.TestCase):
 
         oTest = testObserver
 
-        yesFilter = FilteringLogObserver(oYes, (lambda e: PredicateResult.yes,))
-        noFilter = FilteringLogObserver(oNo, (lambda e: PredicateResult.no,))
+        yesFilter = FilteringLogObserver(
+            oYes, (cast(ILogFilterPredicate, lambda e: PredicateResult.yes),)
+        )
+        noFilter = FilteringLogObserver(
+            oNo, (cast(ILogFilterPredicate, lambda e: PredicateResult.no),)
+        )
 
         publisher = LogPublisher(yesFilter, noFilter, testObserver)
         publisher(event)
@@ -255,45 +261,65 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
     Tests for L{LogLevelFilterPredicate}.
     """
 
-    def test_defaultLogLevel(self):
+    def test_defaultLogLevel(self) -> None:
         """
         Default log level is used.
         """
         predicate = LogLevelFilterPredicate()
 
-        self.assertEqual(
-            predicate.logLevelForNamespace(None), predicate.defaultLogLevel
-        )
-        self.assertEqual(predicate.logLevelForNamespace(""), predicate.defaultLogLevel)
-        self.assertEqual(
-            predicate.logLevelForNamespace("rocker.cool.namespace"),
-            predicate.defaultLogLevel,
-        )
+        # Test using both "" and None as default namespace, because None was the
+        # documented default value in the past.
 
-    def test_setLogLevel(self):
+        for default in ("", cast(str, None)):
+            self.assertEqual(
+                predicate.logLevelForNamespace(default), predicate.defaultLogLevel
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace(""), predicate.defaultLogLevel
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace(cast(str, None)),
+                predicate.defaultLogLevel,
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace("rocker.cool.namespace"),
+                predicate.defaultLogLevel,
+            )
+
+    def test_setLogLevel(self) -> None:
         """
         Setting and retrieving log levels.
         """
         predicate = LogLevelFilterPredicate()
 
-        predicate.setLogLevelForNamespace(None, LogLevel.error)
-        predicate.setLogLevelForNamespace("twext.web2", LogLevel.debug)
-        predicate.setLogLevelForNamespace("twext.web2.dav", LogLevel.warn)
+        # Test using both "" and None as default namespace, because None was the
+        # documented default value in the past.
 
-        self.assertEqual(predicate.logLevelForNamespace(None), LogLevel.error)
-        self.assertEqual(predicate.logLevelForNamespace("twisted"), LogLevel.error)
-        self.assertEqual(predicate.logLevelForNamespace("twext.web2"), LogLevel.debug)
-        self.assertEqual(
-            predicate.logLevelForNamespace("twext.web2.dav"), LogLevel.warn
-        )
-        self.assertEqual(
-            predicate.logLevelForNamespace("twext.web2.dav.test"), LogLevel.warn
-        )
-        self.assertEqual(
-            predicate.logLevelForNamespace("twext.web2.dav.test1.test2"), LogLevel.warn
-        )
+        for default in ("", cast(str, None)):
+            predicate.setLogLevelForNamespace(default, LogLevel.error)
+            predicate.setLogLevelForNamespace("twext.web2", LogLevel.debug)
+            predicate.setLogLevelForNamespace("twext.web2.dav", LogLevel.warn)
 
-    def test_setInvalidLogLevel(self):
+            self.assertEqual(predicate.logLevelForNamespace(""), LogLevel.error)
+            self.assertEqual(
+                predicate.logLevelForNamespace(cast(str, None)), LogLevel.error
+            )
+            self.assertEqual(predicate.logLevelForNamespace("twisted"), LogLevel.error)
+            self.assertEqual(
+                predicate.logLevelForNamespace("twext.web2"), LogLevel.debug
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace("twext.web2.dav"), LogLevel.warn
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace("twext.web2.dav.test"), LogLevel.warn
+            )
+            self.assertEqual(
+                predicate.logLevelForNamespace("twext.web2.dav.test1.test2"),
+                LogLevel.warn,
+            )
+
+    def test_setInvalidLogLevel(self) -> None:
         """
         Can't pass invalid log levels to C{setLogLevelForNamespace()}.
         """
@@ -314,7 +340,7 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
             "debug",
         )
 
-    def test_clearLogLevels(self):
+    def test_clearLogLevels(self) -> None:
         """
         Clearing log levels.
         """
@@ -343,22 +369,26 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
             predicate.defaultLogLevel,
         )
 
-    def test_filtering(self):
+    def test_filtering(self) -> None:
         """
         Events are filtered based on log level/namespace.
         """
         predicate = LogLevelFilterPredicate()
 
-        predicate.setLogLevelForNamespace(None, LogLevel.error)
+        predicate.setLogLevelForNamespace("", LogLevel.error)
         predicate.setLogLevelForNamespace("twext.web2", LogLevel.debug)
         predicate.setLogLevelForNamespace("twext.web2.dav", LogLevel.warn)
 
-        def checkPredicate(namespace, level, expectedResult):
-            event = dict(log_namespace=namespace, log_level=level)
+        def checkPredicate(
+            namespace: str, level: NamedConstant, expectedResult: NamedConstant
+        ) -> None:
+            event = dict(log_namespace=namespace, log_level=level)  # type: LogEvent
             self.assertEqual(expectedResult, predicate(event))
 
         checkPredicate("", LogLevel.debug, PredicateResult.no)
-        checkPredicate("", LogLevel.error, PredicateResult.maybe)
+        checkPredicate(cast(str, None), LogLevel.debug, PredicateResult.no)
+        checkPredicate("", LogLevel.error, PredicateResult.no)
+        checkPredicate(cast(str, None), LogLevel.error, PredicateResult.no)
 
         checkPredicate("twext.web2", LogLevel.debug, PredicateResult.maybe)
         checkPredicate("twext.web2", LogLevel.error, PredicateResult.maybe)
@@ -366,5 +396,6 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
         checkPredicate("twext.web2.dav", LogLevel.debug, PredicateResult.no)
         checkPredicate("twext.web2.dav", LogLevel.error, PredicateResult.maybe)
 
-        checkPredicate(None, LogLevel.critical, PredicateResult.no)
+        checkPredicate("", LogLevel.critical, PredicateResult.no)
+        checkPredicate(cast(str, None), LogLevel.critical, PredicateResult.no)
         checkPredicate("twext.web2", None, PredicateResult.no)

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -164,12 +164,14 @@ class FlatFormattingTests(unittest.TestCase):
         self.assertEqual(keyFromFormat("{foo!s::}"), "foo!s::")
 
         sameFlattener = KeyFlattener()
-        ((
-            literalText,
-            fieldName,
-            formatSpec,
-            conversion,
-        ),) = aFormatter.parse("{x}")
+        (
+            (
+                literalText,
+                fieldName,
+                formatSpec,
+                conversion,
+            ),
+        ) = aFormatter.parse("{x}")
         assert fieldName is not None
 
         self.assertEqual(

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -8,6 +8,7 @@ Test cases for L{twisted.logger._format}.
 
 from itertools import count
 import json
+from typing import Any, Callable, Optional
 
 try:
     from time import tzset
@@ -16,8 +17,9 @@ except ImportError:
 
 from twisted.trial import unittest
 
-from .._format import formatEvent
 from .._flatten import flattenEvent, extractField, KeyFlattener, aFormatter
+from .._format import formatEvent
+from .._interfaces import LogEvent
 
 
 class FlatFormattingTests(unittest.TestCase):
@@ -25,7 +27,7 @@ class FlatFormattingTests(unittest.TestCase):
     Tests for flattened event formatting functions.
     """
 
-    def test_formatFlatEvent(self):
+    def test_formatFlatEvent(self) -> None:
         """
         L{flattenEvent} will "flatten" an event so that, if scrubbed of all but
         serializable objects, it will preserve all necessary data to be
@@ -71,7 +73,7 @@ class FlatFormattingTests(unittest.TestCase):
             ),
         )
 
-    def test_formatFlatEventBadFormat(self):
+    def test_formatFlatEventBadFormat(self) -> None:
         """
         If the format string is invalid, an error is produced.
         """
@@ -85,7 +87,7 @@ class FlatFormattingTests(unittest.TestCase):
 
         self.assertTrue(formatEvent(event2).startswith("Unable to format event"))
 
-    def test_formatFlatEventWithMutatedFields(self):
+    def test_formatFlatEventWithMutatedFields(self) -> None:
         """
         L{formatEvent} will prefer the stored C{str()} or C{repr()} value for
         an object, in case the other version.
@@ -98,7 +100,7 @@ class FlatFormattingTests(unittest.TestCase):
 
             destructed = False
 
-            def selfDestruct(self):
+            def selfDestruct(self) -> None:
                 """
                 Self destruct.
                 """
@@ -118,20 +120,22 @@ class FlatFormattingTests(unittest.TestCase):
 
         self.assertEqual(formatEvent(event1), "unpersistable: un-persistable")
 
-    def test_keyFlattening(self):
+    def test_keyFlattening(self) -> None:
         """
         Test that L{KeyFlattener.flatKey} returns the expected keys for format
         fields.
         """
 
-        def keyFromFormat(format):
+        def keyFromFormat(format: str) -> str:
             for (
                 literalText,
                 fieldName,
                 formatSpec,
                 conversion,
             ) in aFormatter.parse(format):
+                assert fieldName is not None
                 return KeyFlattener().flatKey(fieldName, formatSpec, conversion)
+            assert False, "Unable to derive key from format: {format}"
 
         # No name
         try:
@@ -158,13 +162,26 @@ class FlatFormattingTests(unittest.TestCase):
         self.assertEqual(keyFromFormat("{foo!s:%s}"), "foo!s:%s")
         self.assertEqual(keyFromFormat("{foo!s:!}"), "foo!s:!")
         self.assertEqual(keyFromFormat("{foo!s::}"), "foo!s::")
-        [keyPlusLiteral] = aFormatter.parse("{x}")
-        key = keyPlusLiteral[1:]
-        sameFlattener = KeyFlattener()
-        self.assertEqual(sameFlattener.flatKey(*key), "x!:")
-        self.assertEqual(sameFlattener.flatKey(*key), "x!:/2")
 
-    def _test_formatFlatEvent_fieldNamesSame(self, event=None):
+        sameFlattener = KeyFlattener()
+        ((
+            literalText,
+            fieldName,
+            formatSpec,
+            conversion,
+        ),) = aFormatter.parse("{x}")
+        assert fieldName is not None
+
+        self.assertEqual(
+            sameFlattener.flatKey(fieldName, formatSpec, conversion), "x!:"
+        )
+        self.assertEqual(
+            sameFlattener.flatKey(fieldName, formatSpec, conversion), "x!:/2"
+        )
+
+    def _test_formatFlatEvent_fieldNamesSame(
+        self, event: Optional[LogEvent] = None
+    ) -> LogEvent:
         """
         The same format field used twice in one event is rendered twice.
 
@@ -192,13 +209,13 @@ class FlatFormattingTests(unittest.TestCase):
 
         return event
 
-    def test_formatFlatEventFieldNamesSame(self):
+    def test_formatFlatEventFieldNamesSame(self) -> None:
         """
         The same format field used twice in one event is rendered twice.
         """
         self._test_formatFlatEvent_fieldNamesSame()
 
-    def test_formatFlatEventFieldNamesSameAgain(self):
+    def test_formatFlatEventFieldNamesSameAgain(self) -> None:
         """
         The same event flattened twice gives the same (already rendered)
         result.
@@ -206,7 +223,7 @@ class FlatFormattingTests(unittest.TestCase):
         event = self._test_formatFlatEvent_fieldNamesSame()
         self._test_formatFlatEvent_fieldNamesSame(event)
 
-    def test_formatEventFlatTrailingText(self):
+    def test_formatEventFlatTrailingText(self) -> None:
         """
         L{formatEvent} will handle a flattened event with tailing text after
         a replacement field.
@@ -221,7 +238,9 @@ class FlatFormattingTests(unittest.TestCase):
 
         self.assertEqual(result, "test value trailing")
 
-    def test_extractField(self, flattenFirst=lambda x: x):
+    def test_extractField(
+        self, flattenFirst: Callable[[LogEvent], LogEvent] = lambda x: x
+    ) -> None:
         """
         L{extractField} will extract a field used in the format string.
 
@@ -233,11 +252,11 @@ class FlatFormattingTests(unittest.TestCase):
                 return "repr"
 
         class Something:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.number = 7
                 self.object = ObjectWithRepr()
 
-            def __getstate__(self):
+            def __getstate__(self) -> None:
                 raise NotImplementedError("Just in case.")
 
         event = dict(
@@ -247,26 +266,26 @@ class FlatFormattingTests(unittest.TestCase):
 
         flattened = flattenFirst(event)
 
-        def extract(field):
+        def extract(field: str) -> Any:
             return extractField(field, flattened)
 
         self.assertEqual(extract("something.number"), 7)
         self.assertEqual(extract("something.number!s"), "7")
         self.assertEqual(extract("something.object!s"), "repr")
 
-    def test_extractFieldFlattenFirst(self):
+    def test_extractFieldFlattenFirst(self) -> None:
         """
         L{extractField} behaves identically if the event is explicitly
         flattened first.
         """
 
-        def flattened(evt):
-            flattenEvent(evt)
-            return evt
+        def flattened(event: LogEvent) -> LogEvent:
+            flattenEvent(event)
+            return event
 
         self.test_extractField(flattened)
 
-    def test_flattenEventWithoutFormat(self):
+    def test_flattenEventWithoutFormat(self) -> None:
         """
         L{flattenEvent} will do nothing to an event with no format string.
         """
@@ -274,7 +293,7 @@ class FlatFormattingTests(unittest.TestCase):
         flattenEvent(inputEvent)
         self.assertEqual(inputEvent, {"a": "b", "c": 1})
 
-    def test_flattenEventWithInertFormat(self):
+    def test_flattenEventWithInertFormat(self) -> None:
         """
         L{flattenEvent} will do nothing to an event with a format string that
         contains no format fields.
@@ -290,7 +309,7 @@ class FlatFormattingTests(unittest.TestCase):
             },
         )
 
-    def test_flattenEventWithNoneFormat(self):
+    def test_flattenEventWithNoneFormat(self) -> None:
         """
         L{flattenEvent} will do nothing to an event with log_format set to
         None.

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -6,7 +6,8 @@
 Test cases for L{twisted.logger._format}.
 """
 
-from twisted.python.test.test_tzhelper import mktime, addTZCleanup, setTZ
+from constantly import NamedConstant
+from typing import AnyStr, Optional, cast
 
 try:
     from time import tzset
@@ -16,10 +17,11 @@ try:
 except ImportError:
     tzset = None  # type: ignore[assignment,misc]
 
+from twisted.python.failure import Failure
+from twisted.python.test.test_tzhelper import mktime, addTZCleanup, setTZ
 from twisted.trial import unittest
 from twisted.trial.unittest import SkipTest
 
-from .._levels import LogLevel
 from .._format import (
     formatEvent,
     formatUnformattableEvent,
@@ -28,7 +30,8 @@ from .._format import (
     formatWithCall,
     eventAsText,
 )
-from twisted.python.failure import Failure
+from .._interfaces import LogEvent
+from .._levels import LogLevel
 
 
 class FormattingTests(unittest.TestCase):
@@ -36,7 +39,7 @@ class FormattingTests(unittest.TestCase):
     Tests for basic event formatting functions.
     """
 
-    def test_formatEvent(self):
+    def test_formatEvent(self) -> None:
         """
         L{formatEvent} will format an event according to several rules:
 
@@ -54,7 +57,7 @@ class FormattingTests(unittest.TestCase):
         always treat its format string as UTF-8 encoded.
         """
 
-        def format(logFormat, **event):
+        def format(logFormat: AnyStr, **event: object) -> str:
             event["log_format"] = logFormat
             result = formatEvent(event)
             self.assertIs(type(result), str)
@@ -68,15 +71,14 @@ class FormattingTests(unittest.TestCase):
             format("{not_called}, {called()}.", not_called="no", called=lambda: "yes"),
         )
         self.assertEqual("S\xe1nchez", format(b"S\xc3\xa1nchez"))
-        badResult = format(b"S\xe1nchez")
-        self.assertIn("Unable to format event", badResult)
+        self.assertIn("Unable to format event", format(b"S\xe1nchez"))
         maybeResult = format(b"S{a!s}nchez", a=b"\xe1")
         self.assertIn("Sb'\\xe1'nchez", maybeResult)
 
         xe1 = str(repr(b"\xe1"))
         self.assertIn("S" + xe1 + "nchez", format(b"S{a!r}nchez", a=b"\xe1"))
 
-    def test_formatEventNoFormat(self):
+    def test_formatEventNoFormat(self) -> None:
         """
         Formatting an event with no format.
         """
@@ -85,17 +87,17 @@ class FormattingTests(unittest.TestCase):
 
         self.assertEqual("", result)
 
-    def test_formatEventWeirdFormat(self):
+    def test_formatEventWeirdFormat(self) -> None:
         """
         Formatting an event with a bogus format.
         """
         event = dict(log_format=object(), foo=1, bar=2)
         result = formatEvent(event)
 
-        self.assertIn("Log format must be unicode or bytes", result)
+        self.assertIn("Log format must be str", result)
         self.assertIn(repr(event), result)
 
-    def test_formatUnformattableEvent(self):
+    def test_formatUnformattableEvent(self) -> None:
         """
         Formatting an event that's just plain out to get us.
         """
@@ -105,21 +107,21 @@ class FormattingTests(unittest.TestCase):
         self.assertIn("Unable to format event", result)
         self.assertIn(repr(event), result)
 
-    def test_formatUnformattableEventWithUnformattableKey(self):
+    def test_formatUnformattableEventWithUnformattableKey(self) -> None:
         """
         Formatting an unformattable event that has an unformattable key.
         """
         event = {
             "log_format": "{evil()}",
             "evil": lambda: 1 / 0,
-            Unformattable(): "gurk",
-        }
+            cast(str, Unformattable()): "gurk",
+        }  # type: LogEvent
         result = formatEvent(event)
         self.assertIn("MESSAGE LOST: unformattable object logged:", result)
         self.assertIn("Recoverable data:", result)
         self.assertIn("Exception during formatting:", result)
 
-    def test_formatUnformattableEventWithUnformattableValue(self):
+    def test_formatUnformattableEventWithUnformattableValue(self) -> None:
         """
         Formatting an unformattable event that has an unformattable value.
         """
@@ -133,7 +135,7 @@ class FormattingTests(unittest.TestCase):
         self.assertIn("Recoverable data:", result)
         self.assertIn("Exception during formatting:", result)
 
-    def test_formatUnformattableEventWithUnformattableErrorOMGWillItStop(self):
+    def test_formatUnformattableEventWithUnformattableErrorOMGWillItStop(self) -> None:
         """
         Formatting an unformattable event that has an unformattable value.
         """
@@ -143,7 +145,7 @@ class FormattingTests(unittest.TestCase):
             recoverable="okay",
         )
         # Call formatUnformattableEvent() directly with a bogus exception.
-        result = formatUnformattableEvent(event, Unformattable())
+        result = formatUnformattableEvent(event, cast(BaseException, Unformattable()))
         self.assertIn("MESSAGE LOST: unformattable object logged:", result)
         self.assertIn(repr("recoverable") + " = " + repr("okay"), result)
 
@@ -153,10 +155,10 @@ class TimeFormattingTests(unittest.TestCase):
     Tests for time formatting functions.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         addTZCleanup(self)
 
-    def test_formatTimeWithDefaultFormat(self):
+    def test_formatTimeWithDefaultFormat(self) -> None:
         """
         Default time stamp format is RFC 3339 and offset respects the timezone
         as set by the standard C{TZ} environment variable and L{tzset} API.
@@ -164,7 +166,7 @@ class TimeFormattingTests(unittest.TestCase):
         if tzset is None:
             raise SkipTest("Platform cannot change timezone; unable to verify offsets.")
 
-        def testForTimeZone(name, expectedDST, expectedSTD):
+        def testForTimeZone(name: str, expectedDST: str, expectedSTD: str) -> None:
             setTZ(name)
 
             localDST = mktime((2006, 6, 30, 0, 0, 0, 4, 181, 1))
@@ -201,14 +203,14 @@ class TimeFormattingTests(unittest.TestCase):
             "2007-01-31T00:00:00-0600",
         )
 
-    def test_formatTimeWithNoTime(self):
+    def test_formatTimeWithNoTime(self) -> None:
         """
         If C{when} argument is L{None}, we get the default output.
         """
         self.assertEqual(formatTime(None), "-")
         self.assertEqual(formatTime(None, default="!"), "!")
 
-    def test_formatTimeWithNoFormat(self):
+    def test_formatTimeWithNoFormat(self) -> None:
         """
         If C{timeFormat} argument is L{None}, we get the default output.
         """
@@ -216,14 +218,14 @@ class TimeFormattingTests(unittest.TestCase):
         self.assertEqual(formatTime(t, timeFormat=None), "-")
         self.assertEqual(formatTime(t, timeFormat=None, default="!"), "!")
 
-    def test_formatTimeWithAlternateTimeFormat(self):
+    def test_formatTimeWithAlternateTimeFormat(self) -> None:
         """
         Alternate time format in output.
         """
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
         self.assertEqual(formatTime(t, timeFormat="%Y/%W"), "2013/38")
 
-    def test_formatTimePercentF(self):
+    def test_formatTimePercentF(self) -> None:
         """
         "%f" supported in time format.
         """
@@ -235,7 +237,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
     Tests for classic text log event formatting functions.
     """
 
-    def test_formatTimeDefault(self):
+    def test_formatTimeDefault(self) -> None:
         """
         Time is first field.  Default time stamp format is RFC 3339 and offset
         respects the timezone as set by the standard C{TZ} environment variable
@@ -254,13 +256,13 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "2013-09-24T11:40:47+0000 [-\x23-] XYZZY\n",
         )
 
-    def test_formatTimeCustom(self):
+    def test_formatTimeCustom(self) -> None:
         """
         Time is first field.  Custom formatting function is an optional
         argument.
         """
 
-        def formatTime(t):
+        def formatTime(t: Optional[float]) -> str:
             return "__{0}__".format(t)
 
         event = dict(log_format="XYZZY", log_time=12345)
@@ -269,7 +271,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "__12345__ [-\x23-] XYZZY\n",
         )
 
-    def test_formatNamespace(self):
+    def test_formatNamespace(self) -> None:
         """
         Namespace is first part of second field.
         """
@@ -279,7 +281,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [my.namespace\x23-] XYZZY\n",
         )
 
-    def test_formatLevel(self):
+    def test_formatLevel(self) -> None:
         """
         Level is second part of second field.
         """
@@ -289,7 +291,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [-\x23warn] XYZZY\n",
         )
 
-    def test_formatSystem(self):
+    def test_formatSystem(self) -> None:
         """
         System is second field.
         """
@@ -299,7 +301,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [S.Y.S.T.E.M.] XYZZY\n",
         )
 
-    def test_formatSystemRulz(self):
+    def test_formatSystemRulz(self) -> None:
         """
         System is not supplanted by namespace and level.
         """
@@ -314,7 +316,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [S.Y.S.T.E.M.] XYZZY\n",
         )
 
-    def test_formatSystemUnformattable(self):
+    def test_formatSystemUnformattable(self) -> None:
         """
         System is not supplanted by namespace and level.
         """
@@ -324,7 +326,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [UNFORMATTABLE] XYZZY\n",
         )
 
-    def test_formatFormat(self):
+    def test_formatFormat(self) -> None:
         """
         Formatted event is last field.
         """
@@ -334,21 +336,21 @@ class ClassicLogFormattingTests(unittest.TestCase):
             "- [-\x23-] id:123\n",
         )
 
-    def test_formatNoFormat(self):
+    def test_formatNoFormat(self) -> None:
         """
         No format string.
         """
         event = dict(id="123")
         self.assertIs(formatEventAsClassicLogText(event), None)
 
-    def test_formatEmptyFormat(self):
+    def test_formatEmptyFormat(self) -> None:
         """
         Empty format string.
         """
         event = dict(log_format="", id="123")
         self.assertIs(formatEventAsClassicLogText(event), None)
 
-    def test_formatFormatMultiLine(self):
+    def test_formatFormatMultiLine(self) -> None:
         """
         If the formatted event has newlines, indent additional lines.
         """
@@ -364,7 +366,7 @@ class FormatFieldTests(unittest.TestCase):
     Tests for format field functions.
     """
 
-    def test_formatWithCall(self):
+    def test_formatWithCall(self) -> None:
         """
         L{formatWithCall} is an extended version of L{str.format} that
         will interpret a set of parentheses "C{()}" at the end of a format key
@@ -405,7 +407,7 @@ class EventAsTextTests(unittest.TestCase):
     returned type is UTF-8 decoded text.
     """
 
-    def test_eventWithTraceback(self):
+    def test_eventWithTraceback(self) -> None:
         """
         An event with a C{log_failure} key will have a traceback appended.
         """
@@ -414,13 +416,13 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}
+        event = {"log_format": "This is a test log message"}  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn(str(f.getTraceback()), eventText)
         self.assertIn("This is a test log message", eventText)
 
-    def test_formatEmptyEventWithTraceback(self):
+    def test_formatEmptyEventWithTraceback(self) -> None:
         """
         An event with an empty C{log_format} key appends a traceback from
         the accompanying failure.
@@ -429,13 +431,13 @@ class EventAsTextTests(unittest.TestCase):
             raise CapturedError("This is a fake error")
         except CapturedError:
             f = Failure()
-        event = {"log_format": ""}
+        event = {"log_format": ""}  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn(str(f.getTraceback()), eventText)
         self.assertIn("This is a fake error", eventText)
 
-    def test_formatUnformattableWithTraceback(self):
+    def test_formatUnformattableWithTraceback(self) -> None:
         """
         An event with an unformattable value in the C{log_format} key still
         has a traceback appended.
@@ -455,7 +457,7 @@ class EventAsTextTests(unittest.TestCase):
         self.assertIn(str(f.getTraceback()), eventText)
         self.assertIn("This is a fake error", eventText)
 
-    def test_formatUnformattableErrorWithTraceback(self):
+    def test_formatUnformattableErrorWithTraceback(self) -> None:
         """
         An event with an unformattable value in the C{log_format} key, that
         throws an exception when __repr__ is invoked still has a traceback
@@ -469,8 +471,8 @@ class EventAsTextTests(unittest.TestCase):
         event = {
             "log_format": "{evil()}",
             "evil": lambda: 1 / 0,
-            Unformattable(): "gurk",
-        }
+            cast(str, Unformattable()): "gurk",
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
@@ -478,27 +480,27 @@ class EventAsTextTests(unittest.TestCase):
         self.assertIn(str(f.getTraceback()), eventText)
         self.assertIn("This is a fake error", eventText)
 
-    def test_formatEventUnformattableTraceback(self):
+    def test_formatEventUnformattableTraceback(self) -> None:
         """
         If a traceback cannot be appended, a message indicating this is true
         is appended.
         """
-        event = {"log_format": ""}
+        event = {"log_format": ""}  # type: LogEvent
         event["log_failure"] = object()
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
         self.assertIn("(UNABLE TO OBTAIN TRACEBACK FROM EVENT)", eventText)
 
-    def test_formatEventNonCritical(self):
+    def test_formatEventNonCritical(self) -> None:
         """
         An event with no C{log_failure} key will not have a traceback appended.
         """
-        event = {"log_format": "This is a test log message"}
+        event = {"log_format": "This is a test log message"}  # type: LogEvent
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
         self.assertIn("This is a test log message", eventText)
 
-    def test_formatTracebackMultibyte(self):
+    def test_formatTracebackMultibyte(self) -> None:
         """
         An exception message with multibyte characters is properly handled.
         """
@@ -507,13 +509,13 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}
+        event = {"log_format": "This is a test log message"}  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn("€", eventText)
         self.assertIn("Traceback", eventText)
 
-    def test_formatTracebackHandlesUTF8DecodeFailure(self):
+    def test_formatTracebackHandlesUTF8DecodeFailure(self) -> None:
         """
         An error raised attempting to decode the UTF still produces a
         valid log message.
@@ -524,13 +526,13 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}
+        event = {"log_format": "This is a test log message"}  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn("Traceback", eventText)
         self.assertIn(r'CapturedError(b"\xff\xfet\x00e\x00s\x00t\x00")', eventText)
 
-    def test_eventAsTextSystemOnly(self):
+    def test_eventAsTextSystemOnly(self) -> None:
         """
         If includeSystem is specified as the only option no timestamp or
         traceback are printed.
@@ -545,7 +547,7 @@ class EventAsTextTests(unittest.TestCase):
             "log_format": "ABCD",
             "log_system": "fake_system",
             "log_time": t,
-        }
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -558,7 +560,7 @@ class EventAsTextTests(unittest.TestCase):
             "[fake_system] ABCD",
         )
 
-    def test_eventAsTextTimestampOnly(self):
+    def test_eventAsTextTimestampOnly(self) -> None:
         """
         If includeTimestamp is specified as the only option no system or
         traceback are printed.
@@ -579,7 +581,7 @@ class EventAsTextTests(unittest.TestCase):
             "log_format": "ABCD",
             "log_system": "fake_system",
             "log_time": t,
-        }
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -592,7 +594,7 @@ class EventAsTextTests(unittest.TestCase):
             "2013-09-24T11:40:47+0000 ABCD",
         )
 
-    def test_eventAsTextSystemMissing(self):
+    def test_eventAsTextSystemMissing(self) -> None:
         """
         If includeSystem is specified with a missing system [-#-]
         is used.
@@ -606,7 +608,7 @@ class EventAsTextTests(unittest.TestCase):
         event = {
             "log_format": "ABCD",
             "log_time": t,
-        }
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -619,7 +621,7 @@ class EventAsTextTests(unittest.TestCase):
             "[-\x23-] ABCD",
         )
 
-    def test_eventAsTextSystemMissingNamespaceAndLevel(self):
+    def test_eventAsTextSystemMissingNamespaceAndLevel(self) -> None:
         """
         If includeSystem is specified with a missing system but
         namespace and level are present they are used.
@@ -635,7 +637,7 @@ class EventAsTextTests(unittest.TestCase):
             "log_time": t,
             "log_level": LogLevel.info,
             "log_namespace": "test",
-        }
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -648,7 +650,7 @@ class EventAsTextTests(unittest.TestCase):
             "[test\x23info] ABCD",
         )
 
-    def test_eventAsTextSystemMissingLevelOnly(self):
+    def test_eventAsTextSystemMissingLevelOnly(self) -> None:
         """
         If includeSystem is specified with a missing system but
         level is present, level is included.
@@ -663,7 +665,7 @@ class EventAsTextTests(unittest.TestCase):
             "log_format": "ABCD",
             "log_time": t,
             "log_level": LogLevel.info,
-        }
+        }  # type: LogEvent
         event["log_failure"] = f
         eventText = eventAsText(
             event,

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -6,7 +6,6 @@
 Test cases for L{twisted.logger._format}.
 """
 
-from constantly import NamedConstant
 from typing import AnyStr, Optional, cast
 
 try:

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -5,34 +5,33 @@
 Test cases for L{twisted.logger._global}.
 """
 
-
 import io
+from typing import Any, IO, List, Optional, TextIO, Tuple, Type, cast
 
+from twisted.python.failure import Failure
 from twisted.trial import unittest
 
 from .._file import textFileLogObserver
-from .._observer import LogPublisher
-from .._logger import Logger
-from .._global import LogBeginner
-from .._global import MORE_THAN_ONCE_WARNING
+from .._global import LogBeginner, MORE_THAN_ONCE_WARNING
+from .._interfaces import ILogObserver, LogEvent
 from .._levels import LogLevel
+from .._logger import Logger
+from .._observer import LogPublisher
 from ..test.test_stdlib import nextLine
-from twisted.python.failure import Failure
 
 
-def compareEvents(test, actualEvents, expectedEvents):
+def compareEvents(
+    test: unittest.TestCase,
+    actualEvents: List[LogEvent],
+    expectedEvents: List[LogEvent],
+) -> None:
     """
     Compare two sequences of log events, examining only the the keys which are
     present in both.
 
     @param test: a test case doing the comparison
-    @type test: L{unittest.TestCase}
-
     @param actualEvents: A list of log events that were emitted by a logger.
-    @type actualEvents: L{list} of L{dict}
-
     @param expectedEvents: A list of log events that were expected by a test.
-    @type expected: L{list} of L{dict}
     """
     if len(actualEvents) != len(expectedEvents):
         test.assertEqual(actualEvents, expectedEvents)
@@ -41,7 +40,7 @@ def compareEvents(test, actualEvents, expectedEvents):
     for event in expectedEvents:
         allMergedKeys |= set(event.keys())
 
-    def simplify(event):
+    def simplify(event: LogEvent) -> LogEvent:
         copy = event.copy()
         for key in event.keys():
             if key not in allMergedKeys:
@@ -57,7 +56,7 @@ class LogBeginnerTests(unittest.TestCase):
     Tests for L{LogBeginner}.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.publisher = LogPublisher()
         self.errorStream = io.StringIO()
 
@@ -66,38 +65,35 @@ class LogBeginnerTests(unittest.TestCase):
             stderr = object()
 
         class NotWarnings:
-            def __init__(self):
-                self.warnings = []
+            def __init__(self) -> None:
+                self.warnings = (
+                    []
+                )  # type: List[Tuple[str, Type[Warning], str, int, Optional[IO[Any]], Optional[int]]]
 
             def showwarning(
-                self, message, category, filename, lineno, file=None, line=None
-            ):
+                self,
+                message: str,
+                category: Type[Warning],
+                filename: str,
+                lineno: int,
+                file: Optional[IO[Any]] = None,
+                line: Optional[int] = None,
+            ) -> None:
                 """
                 Emulate warnings.showwarning.
 
                 @param message: A warning message to emit.
-                @type message: L{str}
-
                 @param category: A warning category to associate with
                     C{message}.
-                @type category: L{warnings.Warning}
-
                 @param filename: A file name for the source code file issuing
                     the warning.
-                @type warning: L{str}
-
                 @param lineno: A line number in the source file where the
                     warning was issued.
-                @type lineno: L{int}
-
                 @param file: A file to write the warning message to.  If
                     L{None}, write to L{sys.stderr}.
-                @type file: file-like object
-
                 @param line: A line of source code to include with the warning
                     message. If L{None}, attempt to read the line from
                     C{filename} and C{lineno}.
-                @type line: L{str}
                 """
                 self.warnings.append((message, category, filename, lineno, file, line))
 
@@ -107,17 +103,17 @@ class LogBeginnerTests(unittest.TestCase):
             self.publisher, self.errorStream, self.sysModule, self.warningsModule
         )
 
-    def test_beginLoggingToAddObservers(self):
+    def test_beginLoggingToAddObservers(self) -> None:
         """
         Test that C{beginLoggingTo()} adds observers.
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []
-        events2 = []
+        events1 = []  # type: List[LogEvent]
+        events2 = []  # type: List[LogEvent]
 
-        o1 = lambda e: events1.append(e)
-        o2 = lambda e: events2.append(e)
+        o1 = cast(ILogObserver, lambda e: events1.append(e))
+        o2 = cast(ILogObserver, lambda e: events2.append(e))
 
         self.beginner.beginLoggingTo((o1, o2))
         self.publisher(event)
@@ -125,18 +121,18 @@ class LogBeginnerTests(unittest.TestCase):
         self.assertEqual([event], events1)
         self.assertEqual([event], events2)
 
-    def test_beginLoggingToBufferedEvents(self):
+    def test_beginLoggingToBufferedEvents(self) -> None:
         """
         Test that events are buffered until C{beginLoggingTo()} is
         called.
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []
-        events2 = []
+        events1 = []  # type: List[LogEvent]
+        events2 = []  # type: List[LogEvent]
 
-        o1 = lambda e: events1.append(e)
-        o2 = lambda e: events2.append(e)
+        o1 = cast(ILogObserver, lambda e: events1.append(e))
+        o2 = cast(ILogObserver, lambda e: events2.append(e))
 
         self.publisher(event)  # Before beginLoggingTo; this is buffered
         self.beginner.beginLoggingTo((o1, o2))
@@ -144,33 +140,28 @@ class LogBeginnerTests(unittest.TestCase):
         self.assertEqual([event], events1)
         self.assertEqual([event], events2)
 
-    def _bufferLimitTest(self, limit, beginner):
+    def _bufferLimitTest(self, limit: int, beginner: LogBeginner) -> None:
         """
         Verify that when more than C{limit} events are logged to L{LogBeginner},
         only the last C{limit} are replayed by L{LogBeginner.beginLoggingTo}.
 
         @param limit: The maximum number of events the log beginner should
             buffer.
-        @type limit: L{int}
-
         @param beginner: The L{LogBeginner} against which to verify.
-        @type beginner: L{LogBeginner}
 
         @raise: C{self.failureException} if the wrong events are replayed by
             C{beginner}.
-
-        @return: L{None}
         """
         for count in range(limit + 1):
             self.publisher(dict(count=count))
-        events = []
-        beginner.beginLoggingTo([events.append])
+        events = []  # type: List[LogEvent]
+        beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.assertEqual(
             list(range(1, limit + 1)),
             list(event["count"] for event in events),
         )
 
-    def test_defaultBufferLimit(self):
+    def test_defaultBufferLimit(self) -> None:
         """
         Up to C{LogBeginner._DEFAULT_BUFFER_SIZE} log events are buffered for
         replay by L{LogBeginner.beginLoggingTo}.
@@ -178,7 +169,7 @@ class LogBeginnerTests(unittest.TestCase):
         limit = LogBeginner._DEFAULT_BUFFER_SIZE
         self._bufferLimitTest(limit, self.beginner)
 
-    def test_overrideBufferLimit(self):
+    def test_overrideBufferLimit(self) -> None:
         """
         The size of the L{LogBeginner} event buffer can be overridden with the
         C{initialBufferSize} initilizer argument.
@@ -193,22 +184,22 @@ class LogBeginnerTests(unittest.TestCase):
         )
         self._bufferLimitTest(limit, beginner)
 
-    def test_beginLoggingToTwice(self):
+    def test_beginLoggingToTwice(self) -> None:
         """
         When invoked twice, L{LogBeginner.beginLoggingTo} will emit a log
         message warning the user that they previously began logging, and add
         the new log observers.
         """
-        events1 = []
-        events2 = []
+        events1 = []  # type: List[LogEvent]
+        events2 = []  # type: List[LogEvent]
         fileHandle = io.StringIO()
         textObserver = textFileLogObserver(fileHandle)
         self.publisher(dict(event="prebuffer"))
         firstFilename, firstLine = nextLine()
-        self.beginner.beginLoggingTo([events1.append, textObserver])
+        self.beginner.beginLoggingTo([cast(ILogObserver, events1.append), textObserver])
         self.publisher(dict(event="postbuffer"))
         secondFilename, secondLine = nextLine()
-        self.beginner.beginLoggingTo([events2.append, textObserver])
+        self.beginner.beginLoggingTo([cast(ILogObserver, events2.append), textObserver])
         self.publisher(dict(event="postwarn"))
         warning = dict(
             log_format=MORE_THAN_ONCE_WARNING,
@@ -219,6 +210,7 @@ class LogBeginnerTests(unittest.TestCase):
             lineThen=firstLine,
         )
 
+        self.maxDiff = None
         compareEvents(
             self,
             events1,
@@ -235,7 +227,7 @@ class LogBeginnerTests(unittest.TestCase):
         self.assertIn("<{0}:{1}>".format(firstFilename, firstLine), output)
         self.assertIn("<{0}:{1}>".format(secondFilename, secondLine), output)
 
-    def test_criticalLogging(self):
+    def test_criticalLogging(self) -> None:
         """
         Critical messages will be written as text to the error stream.
         """
@@ -244,7 +236,7 @@ class LogBeginnerTests(unittest.TestCase):
         log.critical("a critical {message}", message="message")
         self.assertEqual(self.errorStream.getvalue(), "a critical message\n")
 
-    def test_criticalLoggingStops(self):
+    def test_criticalLoggingStops(self) -> None:
         """
         Once logging has begun with C{beginLoggingTo}, critical messages are no
         longer written to the output stream.
@@ -254,21 +246,25 @@ class LogBeginnerTests(unittest.TestCase):
         log.critical("another critical message")
         self.assertEqual(self.errorStream.getvalue(), "")
 
-    def test_beginLoggingToRedirectStandardIO(self):
+    def test_beginLoggingToRedirectStandardIO(self) -> None:
         """
         L{LogBeginner.beginLoggingTo} will re-direct the standard output and
         error streams by setting the C{stdio} and C{stderr} attributes on its
         sys module object.
         """
-        x = []
-        self.beginner.beginLoggingTo([x.append])
-        print("Hello, world.", file=self.sysModule.stdout)
-        compareEvents(self, x, [dict(log_namespace="stdout", log_io="Hello, world.")])
-        del x[:]
-        print("Error, world.", file=self.sysModule.stderr)
-        compareEvents(self, x, [dict(log_namespace="stderr", log_io="Error, world.")])
+        events = []  # type: List[LogEvent]
+        self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
+        print("Hello, world.", file=cast(TextIO, self.sysModule.stdout))
+        compareEvents(
+            self, events, [dict(log_namespace="stdout", log_io="Hello, world.")]
+        )
+        del events[:]
+        print("Error, world.", file=cast(TextIO, self.sysModule.stderr))
+        compareEvents(
+            self, events, [dict(log_namespace="stderr", log_io="Error, world.")]
+        )
 
-    def test_beginLoggingToDontRedirect(self):
+    def test_beginLoggingToDontRedirect(self) -> None:
         """
         L{LogBeginner.beginLoggingTo} will leave the existing stdout/stderr in
         place if it has been told not to replace them.
@@ -279,7 +275,7 @@ class LogBeginnerTests(unittest.TestCase):
         self.assertIs(self.sysModule.stdout, oldOut)
         self.assertIs(self.sysModule.stderr, oldErr)
 
-    def test_beginLoggingToPreservesEncoding(self):
+    def test_beginLoggingToPreservesEncoding(self) -> None:
         """
         When L{LogBeginner.beginLoggingTo} redirects stdout/stderr streams, the
         replacement streams will preserve the encoding of the replaced streams,
@@ -292,23 +288,25 @@ class LogBeginnerTests(unittest.TestCase):
         self.sysModule.stdout = weird
         self.sysModule.stderr = weirderr
 
-        x = []
-        self.beginner.beginLoggingTo([x.append])
-        self.assertEqual(self.sysModule.stdout.encoding, "shift-JIS")
-        self.assertEqual(self.sysModule.stderr.encoding, "big5")
+        events = []  # type: List[LogEvent]
+        self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
+        stdout = cast(TextIO, self.sysModule.stdout)
+        stderr = cast(TextIO, self.sysModule.stderr)
+        self.assertEqual(stdout.encoding, "shift-JIS")
+        self.assertEqual(stderr.encoding, "big5")
 
-        self.sysModule.stdout.write(b"\x97\x9B\n")
-        self.sysModule.stderr.write(b"\xBC\xFC\n")
-        compareEvents(self, x, [dict(log_io="\u674e"), dict(log_io="\u7469")])
+        stdout.write(b"\x97\x9B\n")  # type: ignore[arg-type]
+        stderr.write(b"\xBC\xFC\n")  # type: ignore[arg-type]
+        compareEvents(self, events, [dict(log_io="\u674e"), dict(log_io="\u7469")])
 
-    def test_warningsModule(self):
+    def test_warningsModule(self) -> None:
         """
         L{LogBeginner.beginLoggingTo} will redirect the warnings of its
         warnings module into the logging system.
         """
         self.warningsModule.showwarning("a message", DeprecationWarning, __file__, 1)
-        x = []
-        self.beginner.beginLoggingTo([x.append])
+        events = []  # type: List[LogEvent]
+        self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.warningsModule.showwarning(
             "another message", DeprecationWarning, __file__, 2
         )
@@ -325,7 +323,7 @@ class LogBeginnerTests(unittest.TestCase):
         )
         compareEvents(
             self,
-            x,
+            events,
             [
                 dict(
                     warning="another message",
@@ -340,7 +338,7 @@ class LogBeginnerTests(unittest.TestCase):
             ],
         )
 
-    def test_failuresAppendTracebacks(self):
+    def test_failuresAppendTracebacks(self) -> None:
         """
         The string resulting from a logged failure contains a traceback.
         """

--- a/src/twisted/logger/test/test_io.py
+++ b/src/twisted/logger/test/test_io.py
@@ -5,15 +5,42 @@
 Test cases for L{twisted.logger._io}.
 """
 
-
 import sys
+from typing import List, Optional
+
+from constantly import NamedConstant
+
+from zope.interface import implementer
 
 from twisted.trial import unittest
 
+from .._interfaces import ILogObserver, LogEvent
+from .._io import LoggingFile
 from .._levels import LogLevel
 from .._logger import Logger
 from .._observer import LogPublisher
-from .._io import LoggingFile
+
+
+@implementer(ILogObserver)
+class TestLoggingFile(LoggingFile):
+    """
+    L{LoggingFile} that is also an observer which captures events and messages.
+    """
+
+    def __init__(
+        self,
+        logger: Logger,
+        level: NamedConstant = LogLevel.info,
+        encoding: Optional[str] = None,
+    ) -> None:
+        super().__init__(logger=logger, level=level, encoding=encoding)
+        self.events = []  # type: List[LogEvent]
+        self.messages = []  # type: List[str]
+
+    def __call__(self, event: LogEvent) -> None:
+        self.events.append(event)
+        if "log_io" in event:
+            self.messages.append(event["log_io"])
 
 
 class LoggingFileTests(unittest.TestCase):
@@ -21,20 +48,20 @@ class LoggingFileTests(unittest.TestCase):
     Tests for L{LoggingFile}.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         """
         Create a logger for test L{LoggingFile} instances to use.
         """
         self.publisher = LogPublisher()
         self.logger = Logger(observer=self.publisher)
 
-    def test_softspace(self):
+    def test_softspace(self) -> None:
         """
         L{LoggingFile.softspace} is 0.
         """
         self.assertEqual(LoggingFile.softspace, 0)
 
-    def test_readOnlyAttributes(self):
+    def test_readOnlyAttributes(self) -> None:
         """
         Some L{LoggingFile} attributes are read-only.
         """
@@ -46,7 +73,7 @@ class LoggingFileTests(unittest.TestCase):
         self.assertRaises(AttributeError, setattr, f, "newlines", ["\n"])
         self.assertRaises(AttributeError, setattr, f, "name", "foo")
 
-    def test_unsupportedMethods(self):
+    def test_unsupportedMethods(self) -> None:
         """
         Some L{LoggingFile} methods are unsupported.
         """
@@ -61,7 +88,7 @@ class LoggingFileTests(unittest.TestCase):
         self.assertRaises(IOError, f.tell)
         self.assertRaises(IOError, f.truncate)
 
-    def test_level(self):
+    def test_level(self) -> None:
         """
         Default level is L{LogLevel.info} if not set.
         """
@@ -71,7 +98,7 @@ class LoggingFileTests(unittest.TestCase):
         f = LoggingFile(self.logger, level=LogLevel.error)
         self.assertEqual(f.level, LogLevel.error)
 
-    def test_encoding(self):
+    def test_encoding(self) -> None:
         """
         Default encoding is C{sys.getdefaultencoding()} if not set.
         """
@@ -81,28 +108,28 @@ class LoggingFileTests(unittest.TestCase):
         f = LoggingFile(self.logger, encoding="utf-8")
         self.assertEqual(f.encoding, "utf-8")
 
-    def test_mode(self):
+    def test_mode(self) -> None:
         """
         Reported mode is C{"w"}.
         """
         f = LoggingFile(self.logger)
         self.assertEqual(f.mode, "w")
 
-    def test_newlines(self):
+    def test_newlines(self) -> None:
         """
         The C{newlines} attribute is L{None}.
         """
         f = LoggingFile(self.logger)
         self.assertIsNone(f.newlines)
 
-    def test_name(self):
+    def test_name(self) -> None:
         """
         The C{name} attribute is fixed.
         """
         f = LoggingFile(self.logger)
         self.assertEqual(f.name, "<LoggingFile twisted.logger.test.test_io#info>")
 
-    def test_close(self):
+    def test_close(self) -> None:
         """
         L{LoggingFile.close} closes the file.
         """
@@ -112,28 +139,28 @@ class LoggingFileTests(unittest.TestCase):
         self.assertTrue(f.closed)
         self.assertRaises(ValueError, f.write, "Hello")
 
-    def test_flush(self):
+    def test_flush(self) -> None:
         """
         L{LoggingFile.flush} does nothing.
         """
         f = LoggingFile(self.logger)
         f.flush()
 
-    def test_fileno(self):
+    def test_fileno(self) -> None:
         """
         L{LoggingFile.fileno} returns C{-1}.
         """
         f = LoggingFile(self.logger)
         self.assertEqual(f.fileno(), -1)
 
-    def test_isatty(self):
+    def test_isatty(self) -> None:
         """
         L{LoggingFile.isatty} returns C{False}.
         """
         f = LoggingFile(self.logger)
         self.assertFalse(f.isatty())
 
-    def test_writeBuffering(self):
+    def test_writeBuffering(self) -> None:
         """
         Writing buffers correctly.
         """
@@ -152,7 +179,7 @@ class LoggingFileTests(unittest.TestCase):
             ],
         )
 
-    def test_writeBytesDecoded(self):
+    def test_writeBytesDecoded(self) -> None:
         """
         Bytes are decoded to unicode.
         """
@@ -160,7 +187,7 @@ class LoggingFileTests(unittest.TestCase):
         f.write(b"Hello, Mr. S\xc3\xa1nchez\n")
         self.assertEqual(f.messages, ["Hello, Mr. S\xe1nchez"])
 
-    def test_writeUnicode(self):
+    def test_writeUnicode(self) -> None:
         """
         Unicode is unmodified.
         """
@@ -168,7 +195,7 @@ class LoggingFileTests(unittest.TestCase):
         f.write("Hello, Mr. S\xe1nchez\n")
         self.assertEqual(f.messages, ["Hello, Mr. S\xe1nchez"])
 
-    def test_writeLevel(self):
+    def test_writeLevel(self) -> None:
         """
         Log level is emitted properly.
         """
@@ -182,7 +209,7 @@ class LoggingFileTests(unittest.TestCase):
         self.assertEqual(len(f.events), 1)
         self.assertEqual(f.events[0]["log_level"], LogLevel.error)
 
-    def test_writeFormat(self):
+    def test_writeFormat(self) -> None:
         """
         Log format is C{u"{message}"}.
         """
@@ -191,7 +218,7 @@ class LoggingFileTests(unittest.TestCase):
         self.assertEqual(len(f.events), 1)
         self.assertEqual(f.events[0]["log_format"], "{log_io}")
 
-    def test_writelinesBuffering(self):
+    def test_writelinesBuffering(self) -> None:
         """
         C{writelines} does not add newlines.
         """
@@ -211,7 +238,7 @@ class LoggingFileTests(unittest.TestCase):
             ],
         )
 
-    def test_print(self):
+    def test_print(self) -> None:
         """
         L{LoggingFile} can replace L{sys.stdout}.
         """
@@ -223,28 +250,32 @@ class LoggingFileTests(unittest.TestCase):
 
         self.assertEqual(f.messages, ["Hello, world."])
 
-    def observedFile(self, **kwargs):
+    def observedFile(
+        self,
+        level: NamedConstant = LogLevel.info,
+        encoding: Optional[str] = None,
+    ) -> TestLoggingFile:
         """
         Construct a L{LoggingFile} with a built-in observer.
 
-        @param kwargs: keyword arguments for the L{LoggingFile}.
-        @type kwargs: L{dict}
+        @param level: C{level} argument to L{LoggingFile}
+        @param encoding: C{encoding} argument to L{LoggingFile}
 
-        @return: a L{LoggingFile} with an observer that appends received
+        @return: a L{TestLoggingFile} with an observer that appends received
             events into the file's C{events} attribute (a L{list}) and
             event messages into the file's C{messages} attribute (a L{list}).
-        @rtype: L{LoggingFile}
         """
+        # Logger takes an observer argument, for which we want to use the
+        # TestLoggingFile we will create, but that takes the Logger as an
+        # argument, so we'll use an array to indirectly reference the
+        # TestLoggingFile.
+        loggingFiles = []  # type: List[TestLoggingFile]
 
-        def observer(event):
-            f.events.append(event)
-            if "log_io" in event:
-                f.messages.append(event["log_io"])
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
+            loggingFiles[0](event)
 
         log = Logger(observer=observer)
+        loggingFiles.append(TestLoggingFile(logger=log, level=level, encoding=encoding))
 
-        f = LoggingFile(logger=log, **kwargs)
-        f.events = []
-        f.messages = []
-
-        return f
+        return loggingFiles[0]

--- a/src/twisted/logger/test/test_io.py
+++ b/src/twisted/logger/test/test_io.py
@@ -181,7 +181,7 @@ class LoggingFileTests(unittest.TestCase):
 
     def test_writeBytesDecoded(self) -> None:
         """
-        Bytes are decoded to unicode.
+        Bytes are decoded to text.
         """
         f = self.observedFile(encoding="utf-8")
         f.write(b"Hello, Mr. S\xc3\xa1nchez\n")

--- a/src/twisted/logger/test/test_io.py
+++ b/src/twisted/logger/test/test_io.py
@@ -211,7 +211,7 @@ class LoggingFileTests(unittest.TestCase):
 
     def test_writeFormat(self) -> None:
         """
-        Log format is C{u"{message}"}.
+        Log format is C{"{message}"}.
         """
         f = self.observedFile()
         f.write("Hello\n")

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -414,7 +414,7 @@ class LogFileReaderTests(TestCase):
         with BytesIO(b'\x1e{"x": "\xe2\x82\xac"}\n') as fileHandle:
             events = iter(eventsFromJSONLogFile(fileHandle, bufferSize=8))
 
-            self.assertEqual(next(events), {"x": "\u20ac"})  # Got unicode
+            self.assertEqual(next(events), {"x": "\u20ac"})  # Got text
             self.assertRaises(StopIteration, next, events)  # No more events
             self.assertEqual(len(self.errorEvents), 0)
 

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -6,21 +6,21 @@ Tests for L{twisted.logger._json}.
 """
 
 from io import StringIO, BytesIO
+from typing import Any, IO, List, Optional, Sequence, cast
 from unittest import skipIf
+
+from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
 
 from twisted.python.compat import _PYPY
-
+from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
 
-from twisted.python.failure import Failure
-
-from .._observer import ILogObserver, LogPublisher
-from .._format import formatEvent
-from .._levels import LogLevel
 from .._flatten import extractField
+from .._format import formatEvent
 from .._global import globalLogPublisher
+from .._interfaces import ILogObserver, LogEvent
 from .._json import (
     eventAsJSON,
     eventFromJSON,
@@ -28,21 +28,19 @@ from .._json import (
     eventsFromJSONLogFile,
     log as jsonLog,
 )
+from .._levels import LogLevel
 from .._logger import Logger
+from .._observer import LogPublisher
 
 
-def savedJSONInvariants(testCase, savedJSON):
+def savedJSONInvariants(testCase: TestCase, savedJSON: str) -> str:
     """
     Assert a few things about the result of L{eventAsJSON}, then return it.
 
     @param testCase: The L{TestCase} with which to perform the assertions.
-    @type testCase: L{TestCase}
-
     @param savedJSON: The result of L{eventAsJSON}.
-    @type savedJSON: L{str} (we hope)
 
     @return: C{savedJSON}
-    @rtype: L{str}
 
     @raise AssertionError: If any of the preconditions fail.
     """
@@ -56,25 +54,24 @@ class SaveLoadTests(TestCase):
     Tests for loading and saving log events.
     """
 
-    def savedEventJSON(self, event):
+    def savedEventJSON(self, event: LogEvent) -> str:
         """
         Serialize some an events, assert some things about it, and return the
         JSON.
 
         @param event: An event.
-        @type event: L{dict}
 
         @return: JSON.
         """
         return savedJSONInvariants(self, eventAsJSON(event))
 
-    def test_simpleSaveLoad(self):
+    def test_simpleSaveLoad(self) -> None:
         """
         Saving and loading an empty dictionary results in an empty dictionary.
         """
         self.assertEqual(eventFromJSON(self.savedEventJSON({})), {})
 
-    def test_saveLoad(self):
+    def test_saveLoad(self) -> None:
         """
         Saving and loading a dictionary with some simple values in it results
         in those same simple values in the output; according to JSON's rules,
@@ -82,10 +79,11 @@ class SaveLoadTests(TestCase):
         keys will be converted.
         """
         self.assertEqual(
-            eventFromJSON(self.savedEventJSON({1: 2, "3": "4"})), {"1": 2, "3": "4"}
+            eventFromJSON(self.savedEventJSON({1: 2, "3": "4"})),  # type: ignore[dict-item]
+            {"1": 2, "3": "4"},
         )
 
-    def test_saveUnPersistable(self):
+    def test_saveUnPersistable(self) -> None:
         """
         Saving and loading an object which cannot be represented in JSON will
         result in a placeholder.
@@ -95,7 +93,7 @@ class SaveLoadTests(TestCase):
             {"1": 2, "3": {"unpersistable": True}},
         )
 
-    def test_saveNonASCII(self):
+    def test_saveNonASCII(self) -> None:
         """
         Non-ASCII keys and values can be saved and loaded.
         """
@@ -105,7 +103,7 @@ class SaveLoadTests(TestCase):
         )
 
     @skipIf(_PYPY, "https://bitbucket.org/pypy/pypy/issues/3052/")
-    def test_saveBytes(self):
+    def test_saveBytes(self) -> None:
         """
         Any L{bytes} objects will be saved as if they are latin-1 so they can
         be faithfully re-loaded.
@@ -114,13 +112,13 @@ class SaveLoadTests(TestCase):
         # On Python 3, bytes keys will be skipped by the JSON encoder. Not
         # much we can do about that.  Let's make sure that we don't get an
         # error, though.
-        inputEvent.update({b"skipped": "okay"})
+        inputEvent.update({b"skipped": "okay"})  # type: ignore[dict-item]
         self.assertEqual(
             eventFromJSON(self.savedEventJSON(inputEvent)),
             {"hello": bytes(range(255)).decode("charmap")},
         )
 
-    def test_saveUnPersistableThenFormat(self):
+    def test_saveUnPersistableThenFormat(self) -> None:
         """
         Saving and loading an object which cannot be represented in JSON, but
         has a string representation which I{can} be saved as JSON, will result
@@ -129,7 +127,7 @@ class SaveLoadTests(TestCase):
         """
 
         class Reprable:
-            def __init__(self, value):
+            def __init__(self, value: object) -> None:
                 self.value = value
 
             def __repr__(self) -> str:
@@ -139,14 +137,14 @@ class SaveLoadTests(TestCase):
         outputEvent = eventFromJSON(self.savedEventJSON(inputEvent))
         self.assertEqual(formatEvent(outputEvent), "reprable 7")
 
-    def test_extractingFieldsPostLoad(self):
+    def test_extractingFieldsPostLoad(self) -> None:
         """
         L{extractField} can extract fields from an object that's been saved and
         loaded from JSON.
         """
 
         class Obj:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.value = 345
 
         inputEvent = dict(log_format="{object.value}", object=Obj())
@@ -159,13 +157,13 @@ class SaveLoadTests(TestCase):
         self.assertRaises(KeyError, extractField, "object", loadedEvent)
         self.assertRaises(KeyError, extractField, "object", inputEvent)
 
-    def test_failureStructurePreserved(self):
+    def test_failureStructurePreserved(self) -> None:
         """
         Round-tripping a failure through L{eventAsJSON} preserves its class and
         structure.
         """
-        events = []
-        log = Logger(observer=events.append)
+        events = []  # type: List[LogEvent]
+        log = Logger(observer=cast(ILogObserver, events.append))
         try:
             1 / 0
         except ZeroDivisionError:
@@ -177,7 +175,7 @@ class SaveLoadTests(TestCase):
         self.assertTrue(loaded.check(ZeroDivisionError))
         self.assertIsInstance(loaded.getTraceback(), str)
 
-    def test_saveLoadLevel(self):
+    def test_saveLoadLevel(self) -> None:
         """
         It's important that the C{log_level} key remain a
         L{constantly.NamedConstant} object.
@@ -186,7 +184,7 @@ class SaveLoadTests(TestCase):
         loadedEvent = eventFromJSON(self.savedEventJSON(inputEvent))
         self.assertIs(loadedEvent["log_level"], LogLevel.warn)
 
-    def test_saveLoadUnknownLevel(self):
+    def test_saveLoadUnknownLevel(self) -> None:
         """
         If a saved bit of JSON (let's say, from a future version of Twisted)
         were to persist a different log_level, it will resolve as None.
@@ -203,7 +201,7 @@ class FileLogObserverTests(TestCase):
     Tests for L{jsonFileLogObserver}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         A L{FileLogObserver} returned by L{jsonFileLogObserver} is an
         L{ILogObserver}.
@@ -215,29 +213,24 @@ class FileLogObserverTests(TestCase):
             except BrokenMethodImplementation as e:
                 self.fail(e)
 
-    def assertObserverWritesJSON(self, **kwargs):
+    def assertObserverWritesJSON(self, recordSeparator: str = "\x1e") -> None:
         """
         Asserts that an observer created by L{jsonFileLogObserver} with the
         given arguments writes events serialized as JSON text, using the given
         record separator.
 
-        @param recordSeparator: A record separator.
-        @type recordSeparator: L{str}
-
-        @param kwargs: Keyword arguments to pass to L{jsonFileLogObserver}.
-        @type kwargs: L{dict}
+        @param recordSeparator: C{recordSeparator} argument to
+            L{jsonFileLogObserver}
         """
-        recordSeparator = kwargs.get("recordSeparator", "\x1e")
-
         with StringIO() as fileHandle:
-            observer = jsonFileLogObserver(fileHandle, **kwargs)
+            observer = jsonFileLogObserver(fileHandle, recordSeparator)
             event = dict(x=1)
             observer(event)
             self.assertEqual(
                 fileHandle.getvalue(), '{0}{{"x": 1}}\n'.format(recordSeparator)
             )
 
-    def test_observeWritesDefaultRecordSeparator(self):
+    def test_observeWritesDefaultRecordSeparator(self) -> None:
         """
         A L{FileLogObserver} created by L{jsonFileLogObserver} writes events
         serialzed as JSON text to a file when it observes events.
@@ -245,7 +238,7 @@ class FileLogObserverTests(TestCase):
         """
         self.assertObserverWritesJSON()
 
-    def test_observeWritesEmptyRecordSeparator(self):
+    def test_observeWritesEmptyRecordSeparator(self) -> None:
         """
         A L{FileLogObserver} created by L{jsonFileLogObserver} writes events
         serialzed as JSON text to a file when it observes events.
@@ -253,15 +246,15 @@ class FileLogObserverTests(TestCase):
         """
         self.assertObserverWritesJSON(recordSeparator="")
 
-    def test_failureFormatting(self):
+    def test_failureFormatting(self) -> None:
         """
         A L{FileLogObserver} created by L{jsonFileLogObserver} writes failures
         serialized as JSON text to a file when it observes events.
         """
         io = StringIO()
         publisher = LogPublisher()
-        logged = []
-        publisher.addObserver(logged.append)
+        logged = []  # type: List[LogEvent]
+        publisher.addObserver(cast(ILogObserver, logged.append))
         publisher.addObserver(jsonFileLogObserver(io))
         logger = Logger(observer=publisher)
         try:
@@ -271,7 +264,7 @@ class FileLogObserverTests(TestCase):
         reader = StringIO(io.getvalue())
         deserialized = list(eventsFromJSONLogFile(reader))
 
-        def checkEvents(logEvents):
+        def checkEvents(logEvents: Sequence[LogEvent]) -> None:
             self.assertEqual(len(logEvents), 1)
             [failureEvent] = logEvents
             self.assertIn("log_failure", failureEvent)
@@ -292,10 +285,11 @@ class LogFileReaderTests(TestCase):
     Tests for L{eventsFromJSONLogFile}.
     """
 
-    def setUp(self):
-        self.errorEvents = []
+    def setUp(self) -> None:
+        self.errorEvents = []  # type: List[LogEvent]
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             if event["log_namespace"] == jsonLog.namespace and "record" in event:
                 self.errorEvents.append(event)
 
@@ -303,25 +297,31 @@ class LogFileReaderTests(TestCase):
 
         globalLogPublisher.addObserver(observer)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         globalLogPublisher.removeObserver(self.logObserver)
 
-    def _readEvents(self, fileHandle, **kwargs):
+    def _readEvents(
+        self,
+        inFile: IO[Any],
+        recordSeparator: Optional[str] = None,
+        bufferSize: int = 4096,
+    ) -> None:
         """
         Test that L{eventsFromJSONLogFile} reads two pre-defined events from a
         file: C{{u"x": 1}} and C{{u"y": 2}}.
 
-        @param fileHandle: The file to read from.
-
-        @param kwargs: Keyword arguments to pass to L{eventsFromJSONLogFile}.
+        @param inFile: C{inFile} argument to L{eventsFromJSONLogFile}
+        @param recordSeparator: C{recordSeparator} argument to
+            L{eventsFromJSONLogFile}
+        @param bufferSize: C{bufferSize} argument to L{eventsFromJSONLogFile}
         """
-        events = eventsFromJSONLogFile(fileHandle, **kwargs)
+        events = iter(eventsFromJSONLogFile(inFile, recordSeparator, bufferSize))
 
         self.assertEqual(next(events), {"x": 1})
         self.assertEqual(next(events), {"y": 2})
         self.assertRaises(StopIteration, next, events)  # No more events
 
-    def test_readEventsAutoWithRecordSeparator(self):
+    def test_readEventsAutoWithRecordSeparator(self) -> None:
         """
         L{eventsFromJSONLogFile} reads events from a file and automatically
         detects use of C{u"\\x1e"} as the record separator.
@@ -330,7 +330,7 @@ class LogFileReaderTests(TestCase):
             self._readEvents(fileHandle)
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readEventsAutoEmptyRecordSeparator(self):
+    def test_readEventsAutoEmptyRecordSeparator(self) -> None:
         """
         L{eventsFromJSONLogFile} reads events from a file and automatically
         detects use of C{u""} as the record separator.
@@ -339,7 +339,7 @@ class LogFileReaderTests(TestCase):
             self._readEvents(fileHandle)
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readEventsExplicitRecordSeparator(self):
+    def test_readEventsExplicitRecordSeparator(self) -> None:
         """
         L{eventsFromJSONLogFile} reads events from a file and is told to use
         a specific record separator.
@@ -349,7 +349,7 @@ class LogFileReaderTests(TestCase):
             self._readEvents(fileHandle, recordSeparator="\x08")
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readEventsPartialBuffer(self):
+    def test_readEventsPartialBuffer(self) -> None:
         """
         L{eventsFromJSONLogFile} handles buffering a partial event.
         """
@@ -358,12 +358,12 @@ class LogFileReaderTests(TestCase):
             self._readEvents(fileHandle, bufferSize=1)
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readTruncated(self):
+    def test_readTruncated(self) -> None:
         """
         If the JSON text for a record is truncated, skip it.
         """
         with StringIO('\x1e{"x": 1' '\x1e{"y": 2}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle)
+            events = iter(eventsFromJSONLogFile(fileHandle))
 
             self.assertEqual(next(events), {"y": 2})
             self.assertRaises(StopIteration, next, events)  # No more events
@@ -376,34 +376,34 @@ class LogFileReaderTests(TestCase):
             )
             self.assertEqual(self.errorEvents[0]["record"], b'{"x": 1')
 
-    def test_readUnicode(self):
+    def test_readUnicode(self) -> None:
         """
         If the file being read from vends L{str}, strings decode from JSON
         as-is.
         """
         # The Euro currency sign is u"\u20ac"
         with StringIO('\x1e{"currency": "\u20ac"}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle)
+            events = iter(eventsFromJSONLogFile(fileHandle))
 
             self.assertEqual(next(events), {"currency": "\u20ac"})
             self.assertRaises(StopIteration, next, events)  # No more events
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readUTF8Bytes(self):
+    def test_readUTF8Bytes(self) -> None:
         """
         If the file being read from vends L{bytes}, strings decode from JSON as
         UTF-8.
         """
         # The Euro currency sign is b"\xe2\x82\xac" in UTF-8
         with BytesIO(b'\x1e{"currency": "\xe2\x82\xac"}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle)
+            events = iter(eventsFromJSONLogFile(fileHandle))
 
             # The Euro currency sign is u"\u20ac"
             self.assertEqual(next(events), {"currency": "\u20ac"})
             self.assertRaises(StopIteration, next, events)  # No more events
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readTruncatedUTF8Bytes(self):
+    def test_readTruncatedUTF8Bytes(self) -> None:
         """
         If the JSON text for a record is truncated in the middle of a two-byte
         Unicode codepoint, we don't want to see a codec exception and the
@@ -412,20 +412,20 @@ class LogFileReaderTests(TestCase):
         # The Euro currency sign is u"\u20ac" and encodes in UTF-8 as three
         # bytes: b"\xe2\x82\xac".
         with BytesIO(b'\x1e{"x": "\xe2\x82\xac"}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle, bufferSize=8)
+            events = iter(eventsFromJSONLogFile(fileHandle, bufferSize=8))
 
             self.assertEqual(next(events), {"x": "\u20ac"})  # Got unicode
             self.assertRaises(StopIteration, next, events)  # No more events
             self.assertEqual(len(self.errorEvents), 0)
 
-    def test_readInvalidUTF8Bytes(self):
+    def test_readInvalidUTF8Bytes(self) -> None:
         """
         If the JSON text for a record contains invalid UTF-8 text, ignore that
         record.
         """
         # The string b"\xe2\xac" is bogus
         with BytesIO(b'\x1e{"x": "\xe2\xac"}\n' b'\x1e{"y": 2}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle)
+            events = iter(eventsFromJSONLogFile(fileHandle))
 
             self.assertEqual(next(events), {"y": 2})
             self.assertRaises(StopIteration, next, events)  # No more events
@@ -438,12 +438,12 @@ class LogFileReaderTests(TestCase):
             )
             self.assertEqual(self.errorEvents[0]["record"], b'{"x": "\xe2\xac"}\n')
 
-    def test_readInvalidJSON(self):
+    def test_readInvalidJSON(self) -> None:
         """
         If the JSON text for a record is invalid, skip it.
         """
         with StringIO('\x1e{"x": }\n' '\x1e{"y": 2}\n') as fileHandle:
-            events = eventsFromJSONLogFile(fileHandle)
+            events = iter(eventsFromJSONLogFile(fileHandle))
 
             self.assertEqual(next(events), {"y": 2})
             self.assertRaises(StopIteration, next, events)  # No more events
@@ -456,7 +456,7 @@ class LogFileReaderTests(TestCase):
             )
             self.assertEqual(self.errorEvents[0]["record"], b'{"x": }\n')
 
-    def test_readUnseparated(self):
+    def test_readUnseparated(self) -> None:
         """
         Multiple events without a record separator are skipped.
         """
@@ -473,7 +473,7 @@ class LogFileReaderTests(TestCase):
             )
             self.assertEqual(self.errorEvents[0]["record"], b'{"x": 1}\n{"y": 2}\n')
 
-    def test_roundTrip(self):
+    def test_roundTrip(self) -> None:
         """
         Data written by a L{FileLogObserver} returned by L{jsonFileLogObserver}
         and read by L{eventsFromJSONLogFile} is reconstructed properly.

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -234,7 +234,7 @@ class FileLogObserverTests(TestCase):
         """
         A L{FileLogObserver} created by L{jsonFileLogObserver} writes events
         serialzed as JSON text to a file when it observes events.
-        By default, the record separator is C{u"\\x1e"}.
+        By default, the record separator is C{"\\x1e"}.
         """
         self.assertObserverWritesJSON()
 
@@ -242,7 +242,7 @@ class FileLogObserverTests(TestCase):
         """
         A L{FileLogObserver} created by L{jsonFileLogObserver} writes events
         serialzed as JSON text to a file when it observes events.
-        This test sets the record separator to C{u""}.
+        This test sets the record separator to C{""}.
         """
         self.assertObserverWritesJSON(recordSeparator="")
 
@@ -308,7 +308,7 @@ class LogFileReaderTests(TestCase):
     ) -> None:
         """
         Test that L{eventsFromJSONLogFile} reads two pre-defined events from a
-        file: C{{u"x": 1}} and C{{u"y": 2}}.
+        file: C{{"x": 1}} and C{{"y": 2}}.
 
         @param inFile: C{inFile} argument to L{eventsFromJSONLogFile}
         @param recordSeparator: C{recordSeparator} argument to
@@ -324,7 +324,7 @@ class LogFileReaderTests(TestCase):
     def test_readEventsAutoWithRecordSeparator(self) -> None:
         """
         L{eventsFromJSONLogFile} reads events from a file and automatically
-        detects use of C{u"\\x1e"} as the record separator.
+        detects use of C{"\\x1e"} as the record separator.
         """
         with StringIO('\x1e{"x": 1}\n' '\x1e{"y": 2}\n') as fileHandle:
             self._readEvents(fileHandle)
@@ -333,7 +333,7 @@ class LogFileReaderTests(TestCase):
     def test_readEventsAutoEmptyRecordSeparator(self) -> None:
         """
         L{eventsFromJSONLogFile} reads events from a file and automatically
-        detects use of C{u""} as the record separator.
+        detects use of C{""} as the record separator.
         """
         with StringIO('{"x": 1}\n' '{"y": 2}\n') as fileHandle:
             self._readEvents(fileHandle)
@@ -344,7 +344,7 @@ class LogFileReaderTests(TestCase):
         L{eventsFromJSONLogFile} reads events from a file and is told to use
         a specific record separator.
         """
-        # Use u"\x08" (backspace)... because that seems weird enough.
+        # Use "\x08" (backspace)... because that seems weird enough.
         with StringIO('\x08{"x": 1}\n' '\x08{"y": 2}\n') as fileHandle:
             self._readEvents(fileHandle, recordSeparator="\x08")
             self.assertEqual(len(self.errorEvents), 0)
@@ -381,7 +381,7 @@ class LogFileReaderTests(TestCase):
         If the file being read from vends L{str}, strings decode from JSON
         as-is.
         """
-        # The Euro currency sign is u"\u20ac"
+        # The Euro currency sign is "\u20ac"
         with StringIO('\x1e{"currency": "\u20ac"}\n') as fileHandle:
             events = iter(eventsFromJSONLogFile(fileHandle))
 
@@ -398,7 +398,7 @@ class LogFileReaderTests(TestCase):
         with BytesIO(b'\x1e{"currency": "\xe2\x82\xac"}\n') as fileHandle:
             events = iter(eventsFromJSONLogFile(fileHandle))
 
-            # The Euro currency sign is u"\u20ac"
+            # The Euro currency sign is "\u20ac"
             self.assertEqual(next(events), {"currency": "\u20ac"})
             self.assertRaises(StopIteration, next, events)  # No more events
             self.assertEqual(len(self.errorEvents), 0)
@@ -409,7 +409,7 @@ class LogFileReaderTests(TestCase):
         Unicode codepoint, we don't want to see a codec exception and the
         stream is read properly when the additional data arrives.
         """
-        # The Euro currency sign is u"\u20ac" and encodes in UTF-8 as three
+        # The Euro currency sign is "\u20ac" and encodes in UTF-8 as three
         # bytes: b"\xe2\x82\xac".
         with BytesIO(b'\x1e{"x": "\xe2\x82\xac"}\n') as fileHandle:
             events = iter(eventsFromJSONLogFile(fileHandle, bufferSize=8))

--- a/src/twisted/logger/test/test_legacy.py
+++ b/src/twisted/logger/test/test_legacy.py
@@ -5,23 +5,23 @@
 Test cases for L{twisted.logger._legacy}.
 """
 
-from time import time
 import logging as py_logging
+from time import time
+from typing import List, cast
 
+from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
 
 from twisted.trial import unittest
 
-from twisted.python import context
-from twisted.python import log as legacyLog
+from twisted.python import context, log as legacyLog
 from twisted.python.failure import Failure
 
+from .._interfaces import ILogObserver, LogEvent
 from .._levels import LogLevel
-from .._observer import ILogObserver
 from .._format import formatEvent
-from .._legacy import LegacyLogObserverWrapper
-from .._legacy import publishToNewObserver
+from .._legacy import LegacyLogObserverWrapper, publishToNewObserver
 
 
 class LegacyLogObserverWrapperTests(unittest.TestCase):
@@ -29,59 +29,58 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
     Tests for L{LegacyLogObserverWrapper}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{LegacyLogObserverWrapper} is an L{ILogObserver}.
         """
-        legacyObserver = lambda e: None
+        legacyObserver = cast(legacyLog.ILogObserver, lambda e: None)
         observer = LegacyLogObserverWrapper(legacyObserver)
         try:
             verifyObject(ILogObserver, observer)
         except BrokenMethodImplementation as e:
             self.fail(e)
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """
         L{LegacyLogObserverWrapper} returns the expected string.
         """
 
+        @implementer(legacyLog.ILogObserver)
         class LegacyObserver:
             def __repr__(self) -> str:
                 return "<Legacy Observer>"
 
-            def __call__(self):
+            def __call__(self, eventDict: legacyLog.EventDict) -> None:
                 return
 
         observer = LegacyLogObserverWrapper(LegacyObserver())
 
         self.assertEqual(repr(observer), "LegacyLogObserverWrapper(<Legacy Observer>)")
 
-    def observe(self, event):
+    def observe(self, event: LogEvent) -> LogEvent:
         """
         Send an event to a wrapped legacy observer and capture the event as
         seen by that observer.
 
         @param event: an event
-        @type event: L{dict}
 
         @return: the event as observed by the legacy wrapper
         """
-        events = []
+        events = []  # type: List[LogEvent]
 
-        legacyObserver = lambda e: events.append(e)
+        legacyObserver = cast(legacyLog.ILogObserver, lambda e: events.append(e))
         observer = LegacyLogObserverWrapper(legacyObserver)
         observer(event)
         self.assertEqual(len(events), 1)
 
         return events[0]
 
-    def forwardAndVerify(self, event):
+    def forwardAndVerify(self, event: LogEvent) -> LogEvent:
         """
         Send an event to a wrapped legacy observer and verify that its data is
         preserved.
 
         @param event: an event
-        @type event: L{dict}
 
         @return: the event as observed by the legacy wrapper
         """
@@ -99,14 +98,14 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
 
         return observed
 
-    def test_forward(self):
+    def test_forward(self) -> None:
         """
         Basic forwarding: event keys as observed by a legacy observer are the
         same.
         """
         self.forwardAndVerify(dict(foo=1, bar=2))
 
-    def test_time(self):
+    def test_time(self) -> None:
         """
         The new-style C{"log_time"} key is copied to the old-style C{"time"}
         key.
@@ -115,7 +114,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_time=stamp))
         self.assertEqual(event["time"], stamp)
 
-    def test_timeAlreadySet(self):
+    def test_timeAlreadySet(self) -> None:
         """
         The new-style C{"log_time"} key does not step on a pre-existing
         old-style C{"time"} key.
@@ -124,7 +123,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_time=stamp + 1, time=stamp))
         self.assertEqual(event["time"], stamp)
 
-    def test_system(self):
+    def test_system(self) -> None:
         """
         The new-style C{"log_system"} key is copied to the old-style
         C{"system"} key.
@@ -132,7 +131,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_system="foo"))
         self.assertEqual(event["system"], "foo")
 
-    def test_systemAlreadySet(self):
+    def test_systemAlreadySet(self) -> None:
         """
         The new-style C{"log_system"} key does not step on a pre-existing
         old-style C{"system"} key.
@@ -140,7 +139,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_system="foo", system="bar"))
         self.assertEqual(event["system"], "bar")
 
-    def test_noSystem(self):
+    def test_noSystem(self) -> None:
         """
         If the new-style C{"log_system"} key is absent, the old-style
         C{"system"} key is set to C{"-"}.
@@ -150,7 +149,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         observed = self.observe(dict(event))
         self.assertEqual(observed["system"], "-")
 
-    def test_levelNotChange(self):
+    def test_levelNotChange(self) -> None:
         """
         If explicitly set, the C{isError} key will be preserved when forwarding
         from a new-style logging emitter to a legacy logging observer,
@@ -161,7 +160,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         self.forwardAndVerify(dict(log_level=LogLevel.error, isError=0))
         self.forwardAndVerify(dict(log_level=LogLevel.critical, isError=0))
 
-    def test_pythonLogLevelNotSet(self):
+    def test_pythonLogLevelNotSet(self) -> None:
         """
         The new-style C{"log_level"} key is not translated to the old-style
         C{"logLevel"} key.
@@ -173,7 +172,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_level=LogLevel.info))
         self.assertNotIn("logLevel", event)
 
-    def test_stringPythonLogLevel(self):
+    def test_stringPythonLogLevel(self) -> None:
         """
         If a stdlib log level was provided as a string (eg. C{"WARNING"}) in
         the legacy "logLevel" key, it does not get converted to a number.
@@ -187,7 +186,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         )
         self.assertEqual(event["logLevel"], "WARNING")
 
-    def test_message(self):
+    def test_message(self) -> None:
         """
         The old-style C{"message"} key is added, even if no new-style
         C{"log_format"} is given, as it is required, but may be empty.
@@ -195,14 +194,14 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict())
         self.assertEqual(event["message"], ())  # "message" is a tuple
 
-    def test_messageAlreadySet(self):
+    def test_messageAlreadySet(self) -> None:
         """
         The old-style C{"message"} key is not modified if it already exists.
         """
         event = self.forwardAndVerify(dict(message=("foo", "bar")))
         self.assertEqual(event["message"], ("foo", "bar"))
 
-    def test_format(self):
+    def test_format(self) -> None:
         """
         Formatting is translated such that text is rendered correctly, even
         though old-style logging doesn't use PEP 3101 formatting.
@@ -210,7 +209,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_format="Hello, {who}!", who="world"))
         self.assertEqual(legacyLog.textFromEventDict(event), "Hello, world!")
 
-    def test_formatMessage(self):
+    def test_formatMessage(self) -> None:
         """
         Using the message key, which is special in old-style, works for
         new-style formatting.
@@ -220,7 +219,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         )
         self.assertEqual(legacyLog.textFromEventDict(event), "Hello, world!")
 
-    def test_formatAlreadySet(self):
+    def test_formatAlreadySet(self) -> None:
         """
         Formatting is not altered if the old-style C{"format"} key already
         exists.
@@ -228,22 +227,20 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.forwardAndVerify(dict(log_format="Hello!", format="Howdy!"))
         self.assertEqual(legacyLog.textFromEventDict(event), "Howdy!")
 
-    def eventWithFailure(self, **values):
+    def eventWithFailure(self, **values: object) -> LogEvent:
         """
         Create a new-style event with a captured failure.
 
         @param values: Additional values to include in the event.
-        @type values: L{dict}
 
         @return: the new event
-        @rtype: L{dict}
         """
         failure = Failure(RuntimeError("nyargh!"))
         return self.forwardAndVerify(
             dict(log_failure=failure, log_format="oopsie...", **values)
         )
 
-    def test_failure(self):
+    def test_failure(self) -> None:
         """
         Captured failures in the new style set the old-style C{"failure"},
         C{"isError"}, and C{"why"} keys.
@@ -253,7 +250,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         self.assertTrue(event["isError"])
         self.assertEqual(event["why"], "oopsie...")
 
-    def test_failureAlreadySet(self):
+    def test_failureAlreadySet(self) -> None:
         """
         Captured failures in the new style do not step on a pre-existing
         old-style C{"failure"} key.
@@ -262,7 +259,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.eventWithFailure(failure=failure)
         self.assertIs(event["failure"], failure)
 
-    def test_isErrorAlreadySet(self):
+    def test_isErrorAlreadySet(self) -> None:
         """
         Captured failures in the new style do not step on a pre-existing
         old-style C{"isError"} key.
@@ -270,7 +267,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
         event = self.eventWithFailure(isError=0)
         self.assertEqual(event["isError"], 0)
 
-    def test_whyAlreadySet(self):
+    def test_whyAlreadySet(self) -> None:
         """
         Captured failures in the new style do not step on a pre-existing
         old-style C{"failure"} key.
@@ -284,19 +281,16 @@ class PublishToNewObserverTests(unittest.TestCase):
     Tests for L{publishToNewObserver}.
     """
 
-    def setUp(self):
-        self.events = []
-        self.observer = self.events.append
+    def setUp(self) -> None:
+        self.events = []  # type: List[LogEvent]
+        self.observer = cast(ILogObserver, self.events.append)
 
-    def legacyEvent(self, *message, **values):
+    def legacyEvent(self, *message: str, **values: object) -> legacyLog.EventDict:
         """
         Return a basic old-style event as would be created by L{legacyLog.msg}.
 
         @param message: a message event value in the legacy event format
-        @type message: L{tuple} of L{bytes}
-
         @param values: additional event values in the legacy event format
-        @type event: L{dict}
 
         @return: a legacy event
         """
@@ -308,7 +302,7 @@ class PublishToNewObserverTests(unittest.TestCase):
             event["isError"] = 0
         return event
 
-    def test_observed(self):
+    def test_observed(self) -> None:
         """
         The observer is called exactly once.
         """
@@ -317,7 +311,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(len(self.events), 1)
 
-    def test_time(self):
+    def test_time(self) -> None:
         """
         The old-style C{"time"} key is copied to the new-style C{"log_time"}
         key.
@@ -327,13 +321,13 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_time"], self.events[0]["time"])
 
-    def test_message(self):
+    def test_message(self) -> None:
         """
         A published old-style event should format as text in the same way as
         the given C{textFromEventDict} callable would format it.
         """
 
-        def textFromEventDict(event):
+        def textFromEventDict(event: LogEvent) -> str:
             return "".join(reversed(" ".join(event["message"])))
 
         event = self.legacyEvent("Hello,", "world!")
@@ -342,7 +336,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         publishToNewObserver(self.observer, event, textFromEventDict)
         self.assertEqual(formatEvent(self.events[0]), text)
 
-    def test_defaultLogLevel(self):
+    def test_defaultLogLevel(self) -> None:
         """
         Published event should have log level of L{LogLevel.info}.
         """
@@ -351,7 +345,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_level"], LogLevel.info)
 
-    def test_isError(self):
+    def test_isError(self) -> None:
         """
         If C{"isError"} is set to C{1} (true) on the legacy event, the
         C{"log_level"} key should get set to L{LogLevel.critical}.
@@ -361,7 +355,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_level"], LogLevel.critical)
 
-    def test_stdlibLogLevel(self):
+    def test_stdlibLogLevel(self) -> None:
         """
         If the old-style C{"logLevel"} key is set to a standard library logging
         level, using a predefined (L{int}) constant, the new-style
@@ -374,7 +368,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_level"], LogLevel.warn)
 
-    def test_stdlibLogLevelWithString(self):
+    def test_stdlibLogLevelWithString(self) -> None:
         """
         If the old-style C{"logLevel"} key is set to a standard library logging
         level, using a string value, the new-style C{"log_level"} key should
@@ -387,7 +381,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_level"], LogLevel.warn)
 
-    def test_stdlibLogLevelWithGarbage(self):
+    def test_stdlibLogLevelWithGarbage(self) -> None:
         """
         If the old-style C{"logLevel"} key is set to a standard library logging
         level, using an unknown value, the new-style C{"log_level"} key should
@@ -400,7 +394,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertNotIn("log_level", self.events[0])
 
-    def test_defaultNamespace(self):
+    def test_defaultNamespace(self) -> None:
         """
         Published event should have a namespace of C{"log_legacy"} to indicate
         that it was forwarded from legacy logging.
@@ -410,7 +404,7 @@ class PublishToNewObserverTests(unittest.TestCase):
         )
         self.assertEqual(self.events[0]["log_namespace"], "log_legacy")
 
-    def test_system(self):
+    def test_system(self) -> None:
         """
         The old-style C{"system"} key is copied to the new-style
         C{"log_system"} key.

--- a/src/twisted/logger/test/test_levels.py
+++ b/src/twisted/logger/test/test_levels.py
@@ -16,14 +16,14 @@ class LogLevelTests(unittest.TestCase):
     Tests for L{LogLevel}.
     """
 
-    def test_levelWithName(self):
+    def test_levelWithName(self) -> None:
         """
         Look up log level by name.
         """
         for level in LogLevel.iterconstants():
             self.assertIs(LogLevel.levelWithName(level.name), level)
 
-    def test_levelWithInvalidName(self):
+    def test_levelWithInvalidName(self) -> None:
         """
         You can't make up log level names.
         """

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -5,10 +5,16 @@
 Test cases for L{twisted.logger._logger}.
 """
 
+from typing import List, Optional, Type, cast
+
+from constantly import NamedConstant
+
+from zope.interface import implementer
+
 from twisted.trial import unittest
 
-from .._levels import InvalidLogLevelError
-from .._levels import LogLevel
+from .._interfaces import ILogObserver, LogEvent
+from .._levels import InvalidLogLevelError, LogLevel
 from .._format import formatEvent
 from .._logger import Logger
 from .._global import globalLogPublisher
@@ -20,8 +26,11 @@ class TestLogger(Logger):
     events.
     """
 
-    def emit(self, level, format=None, **kwargs):
-        def observer(event):
+    def emit(
+        self, level: NamedConstant, format: Optional[str] = None, **kwargs: object
+    ) -> None:
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             self.event = event
 
         globalLogPublisher.addObserver(observer)
@@ -44,7 +53,7 @@ class LogComposedObject:
 
     log = TestLogger()
 
-    def __init__(self, state=None):
+    def __init__(self, state: Optional[str] = None) -> None:
         self.state = state
 
     def __str__(self) -> str:
@@ -56,7 +65,7 @@ class LoggerTests(unittest.TestCase):
     Tests for L{Logger}.
     """
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """
         repr() on Logger
         """
@@ -64,20 +73,20 @@ class LoggerTests(unittest.TestCase):
         log = Logger(namespace)
         self.assertEqual(repr(log), "<Logger {0}>".format(repr(namespace)))
 
-    def test_namespaceDefault(self):
+    def test_namespaceDefault(self) -> None:
         """
         Default namespace is module name.
         """
         log = Logger()
         self.assertEqual(log.namespace, __name__)
 
-    def test_namespaceOMGItsTooHard(self):
+    def test_namespaceOMGItsTooHard(self) -> None:
         """
         Default namespace is C{"<unknown>"} when a logger is created from a
         context in which is can't be determined automatically and no namespace
         was specified.
         """
-        result = []
+        result = []  # type: List[Logger]
         exec(
             "result.append(Logger())",
             dict(Logger=Logger),
@@ -85,42 +94,48 @@ class LoggerTests(unittest.TestCase):
         )
         self.assertEqual(result[0].namespace, "<unknown>")
 
-    def test_namespaceAttribute(self):
+    def test_namespaceAttribute(self) -> None:
         """
         Default namespace for classes using L{Logger} as a descriptor is the
         class name they were retrieved from.
         """
         obj = LogComposedObject()
+
         expectedNamespace = "{0}.{1}".format(
             obj.__module__,
             obj.__class__.__name__,
         )
-        self.assertEqual(obj.log.namespace, expectedNamespace)
-        self.assertEqual(LogComposedObject.log.namespace, expectedNamespace)
-        self.assertIs(LogComposedObject.log.source, LogComposedObject)
-        self.assertIs(obj.log.source, obj)
+
+        self.assertEqual(cast(TestLogger, obj.log).namespace, expectedNamespace)
+        self.assertEqual(
+            cast(Type[TestLogger], LogComposedObject.log).namespace, expectedNamespace
+        )
+        self.assertIs(
+            cast(Type[TestLogger], LogComposedObject.log).source, LogComposedObject
+        )
+        self.assertIs(cast(TestLogger, obj.log).source, obj)
         self.assertIsNone(Logger().source)
 
-    def test_descriptorObserver(self):
+    def test_descriptorObserver(self) -> None:
         """
         When used as a descriptor, the observer is propagated.
         """
-        observed = []
+        observed = []  # type: List[LogEvent]
 
         class MyObject:
-            log = Logger(observer=observed.append)
+            log = Logger(observer=cast(ILogObserver, observed.append))
 
-        MyObject.log.info("hello")
+        cast(Logger, MyObject.log).info("hello")
         self.assertEqual(len(observed), 1)
         self.assertEqual(observed[0]["log_format"], "hello")
 
-    def test_sourceAvailableForFormatting(self):
+    def test_sourceAvailableForFormatting(self) -> None:
         """
         On instances that have a L{Logger} class attribute, the C{log_source}
         key is available to format strings.
         """
         obj = LogComposedObject("hello")
-        log = obj.log
+        log = cast(TestLogger, obj.log)
         log.error("Hello, {log_source}.")
 
         self.assertIn("log_source", log.event)
@@ -129,7 +144,7 @@ class LoggerTests(unittest.TestCase):
         stuff = formatEvent(log.event)
         self.assertIn("Hello, <LogComposedObject hello>.", stuff)
 
-    def test_basicLogger(self):
+    def test_basicLogger(self) -> None:
         """
         Test that log levels and messages are emitted correctly for
         Logger.
@@ -158,45 +173,48 @@ class LoggerTests(unittest.TestCase):
 
             self.assertEqual(formatEvent(log.event), message)
 
-    def test_sourceOnClass(self):
+    def test_sourceOnClass(self) -> None:
         """
         C{log_source} event key refers to the class.
         """
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             self.assertEqual(event["log_source"], Thingo)
 
         class Thingo:
             log = TestLogger(observer=observer)
 
-        Thingo.log.info()
+        cast(TestLogger, Thingo.log).info()
 
-    def test_sourceOnInstance(self):
+    def test_sourceOnInstance(self) -> None:
         """
         C{log_source} event key refers to the instance.
         """
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             self.assertEqual(event["log_source"], thingo)
 
         class Thingo:
             log = TestLogger(observer=observer)
 
         thingo = Thingo()
-        thingo.log.info()
+        cast(TestLogger, thingo.log).info()
 
-    def test_sourceUnbound(self):
+    def test_sourceUnbound(self) -> None:
         """
         C{log_source} event key is L{None}.
         """
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             self.assertIsNone(event["log_source"])
 
         log = TestLogger(observer=observer)
         log.info()
 
-    def test_defaultFailure(self):
+    def test_defaultFailure(self) -> None:
         """
         Test that log.failure() emits the right data.
         """
@@ -212,7 +230,7 @@ class LoggerTests(unittest.TestCase):
         self.assertEqual(log.emitted["level"], LogLevel.critical)
         self.assertEqual(log.emitted["format"], "Whoops")
 
-    def test_conflictingKwargs(self):
+    def test_conflictingKwargs(self) -> None:
         """
         Make sure that kwargs conflicting with args don't pass through.
         """
@@ -231,7 +249,7 @@ class LoggerTests(unittest.TestCase):
         self.assertEqual(log.event["log_namespace"], log.namespace)
         self.assertIsNone(log.event["log_source"])
 
-    def test_logInvalidLogLevel(self):
+    def test_logInvalidLogLevel(self) -> None:
         """
         Test passing in a bogus log level to C{emit()}.
         """
@@ -242,15 +260,17 @@ class LoggerTests(unittest.TestCase):
         errors = self.flushLoggedErrors(InvalidLogLevelError)
         self.assertEqual(len(errors), 1)
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         """
         Tracing keeps track of forwarding to the publisher.
         """
 
-        def publisher(event):
+        @implementer(ILogObserver)
+        def publisher(event: LogEvent) -> None:
             observer(event)
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             self.assertEqual(event["log_trace"], [(log, publisher)])
 
         log = TestLogger(observer=publisher)

--- a/src/twisted/logger/test/test_observer.py
+++ b/src/twisted/logger/test/test_observer.py
@@ -5,13 +5,16 @@
 Test cases for L{twisted.logger._observer}.
 """
 
+from typing import Dict, List, Tuple, cast
+
+from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
 
 from twisted.trial import unittest
 
+from .._interfaces import ILogObserver, LogEvent
 from .._logger import Logger
-from .._observer import ILogObserver
 from .._observer import LogPublisher
 
 
@@ -20,7 +23,7 @@ class LogPublisherTests(unittest.TestCase):
     Tests for L{LogPublisher}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{LogPublisher} is an L{ILogObserver}.
         """
@@ -30,29 +33,29 @@ class LogPublisherTests(unittest.TestCase):
         except BrokenMethodImplementation as e:
             self.fail(e)
 
-    def test_observers(self):
+    def test_observers(self) -> None:
         """
         L{LogPublisher.observers} returns the observers.
         """
-        o1 = lambda e: None
-        o2 = lambda e: None
+        o1 = cast(ILogObserver, lambda e: None)
+        o2 = cast(ILogObserver, lambda e: None)
 
         publisher = LogPublisher(o1, o2)
         self.assertEqual(set((o1, o2)), set(publisher._observers))
 
-    def test_addObserver(self):
+    def test_addObserver(self) -> None:
         """
         L{LogPublisher.addObserver} adds an observer.
         """
-        o1 = lambda e: None
-        o2 = lambda e: None
-        o3 = lambda e: None
+        o1 = cast(ILogObserver, lambda e: None)
+        o2 = cast(ILogObserver, lambda e: None)
+        o3 = cast(ILogObserver, lambda e: None)
 
         publisher = LogPublisher(o1, o2)
         publisher.addObserver(o3)
         self.assertEqual(set((o1, o2, o3)), set(publisher._observers))
 
-    def test_addObserverNotCallable(self):
+    def test_addObserverNotCallable(self) -> None:
         """
         L{LogPublisher.addObserver} refuses to add an observer that's
         not callable.
@@ -60,44 +63,44 @@ class LogPublisherTests(unittest.TestCase):
         publisher = LogPublisher()
         self.assertRaises(TypeError, publisher.addObserver, object())
 
-    def test_removeObserver(self):
+    def test_removeObserver(self) -> None:
         """
         L{LogPublisher.removeObserver} removes an observer.
         """
-        o1 = lambda e: None
-        o2 = lambda e: None
-        o3 = lambda e: None
+        o1 = cast(ILogObserver, lambda e: None)
+        o2 = cast(ILogObserver, lambda e: None)
+        o3 = cast(ILogObserver, lambda e: None)
 
         publisher = LogPublisher(o1, o2, o3)
         publisher.removeObserver(o2)
         self.assertEqual(set((o1, o3)), set(publisher._observers))
 
-    def test_removeObserverNotRegistered(self):
+    def test_removeObserverNotRegistered(self) -> None:
         """
         L{LogPublisher.removeObserver} removes an observer that is not
         registered.
         """
-        o1 = lambda e: None
-        o2 = lambda e: None
-        o3 = lambda e: None
+        o1 = cast(ILogObserver, lambda e: None)
+        o2 = cast(ILogObserver, lambda e: None)
+        o3 = cast(ILogObserver, lambda e: None)
 
         publisher = LogPublisher(o1, o2)
         publisher.removeObserver(o3)
         self.assertEqual(set((o1, o2)), set(publisher._observers))
 
-    def test_fanOut(self):
+    def test_fanOut(self) -> None:
         """
         L{LogPublisher} calls its observers.
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []
-        events2 = []
-        events3 = []
+        events1 = []  # type: List[LogEvent]
+        events2 = []  # type: List[LogEvent]
+        events3 = []  # type: List[LogEvent]
 
-        o1 = lambda e: events1.append(e)
-        o2 = lambda e: events2.append(e)
-        o3 = lambda e: events3.append(e)
+        o1 = cast(ILogObserver, events1.append)
+        o2 = cast(ILogObserver, events2.append)
+        o3 = cast(ILogObserver, events3.append)
 
         publisher = LogPublisher(o1, o2, o3)
         publisher(event)
@@ -105,7 +108,7 @@ class LogPublisherTests(unittest.TestCase):
         self.assertIn(event, events2)
         self.assertIn(event, events3)
 
-    def test_observerRaises(self):
+    def test_observerRaises(self) -> None:
         """
         Observer raises an exception during fan out: a failure is logged, but
         not re-raised.  Life goes on.
@@ -113,17 +116,18 @@ class LogPublisherTests(unittest.TestCase):
         event = dict(foo=1, bar=2)
         exception = RuntimeError("ARGH! EVIL DEATH!")
 
-        events = []
+        events = []  # type: List[LogEvent]
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             shouldRaise = not events
             events.append(event)
             if shouldRaise:
                 raise exception
 
-        collector = []
+        collector = []  # type: List[LogEvent]
 
-        publisher = LogPublisher(observer, collector.append)
+        publisher = LogPublisher(observer, cast(ILogObserver, collector.append))
         publisher(event)
 
         # Verify that the observer saw my event
@@ -136,7 +140,7 @@ class LogPublisherTests(unittest.TestCase):
         # Make sure the exceptional observer does not receive its own error.
         self.assertEqual(len(events), 1)
 
-    def test_observerRaisesAndLoggerHatesMe(self):
+    def test_observerRaisesAndLoggerHatesMe(self) -> None:
         """
         Observer raises an exception during fan out and the publisher's Logger
         pukes when the failure is reported.  The exception does not propagate
@@ -145,11 +149,12 @@ class LogPublisherTests(unittest.TestCase):
         event = dict(foo=1, bar=2)
         exception = RuntimeError("ARGH! EVIL DEATH!")
 
-        def observer(event):
+        @implementer(ILogObserver)
+        def observer(event: LogEvent) -> None:
             raise RuntimeError("Sad panda")
 
         class GurkLogger(Logger):
-            def failure(self, *args, **kwargs):
+            def failure(self, *args: object, **kwargs: object) -> None:
                 raise exception
 
         publisher = LogPublisher(observer)
@@ -158,18 +163,28 @@ class LogPublisherTests(unittest.TestCase):
 
         # Here, the lack of an exception thus far is a success, of sorts
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         """
         Tracing keeps track of forwarding to observers.
         """
         event = dict(foo=1, bar=2, log_trace=[])
 
-        traces = {}
+        traces = {}  # type: Dict[int, Tuple[Tuple[Logger, ILogObserver]]]
 
         # Copy trace to a tuple; otherwise, both observers will store the same
         # mutable list, and we won't be able to see o1's view distinctly.
-        o1 = lambda e: traces.setdefault(1, tuple(e["log_trace"]))
-        o2 = lambda e: traces.setdefault(2, tuple(e["log_trace"]))
+
+        @implementer(ILogObserver)
+        def o1(e: LogEvent) -> None:
+            traces.setdefault(
+                1, cast(Tuple[Tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
+            )
+
+        @implementer(ILogObserver)
+        def o2(e: LogEvent) -> None:
+            traces.setdefault(
+                2, cast(Tuple[Tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
+            )
 
         publisher = LogPublisher(o1, o2)
         publisher(event)

--- a/src/twisted/logger/test/test_stdlib.py
+++ b/src/twisted/logger/test/test_stdlib.py
@@ -5,10 +5,12 @@
 Test cases for L{twisted.logger._format}.
 """
 
-import sys
+from inspect import getsourcefile
 from io import BytesIO, TextIOWrapper
 import logging as py_logging
-from inspect import getsourcefile
+from logging import Formatter, LogRecord, StreamHandler, getLogger
+import sys
+from typing import List, Optional, Tuple
 
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
@@ -17,18 +19,17 @@ from twisted.python.compat import currentframe
 from twisted.python.failure import Failure
 from twisted.trial import unittest
 
+from .._interfaces import ILogObserver, LogEvent
 from .._levels import LogLevel
-from .._observer import ILogObserver
 from .._stdlib import STDLibLogObserver
 
 
-def nextLine():
+def nextLine() -> Tuple[Optional[str], int]:
     """
     Retrive the file name and line number immediately after where this function
     is called.
 
     @return: the file name and line number
-    @rtype: 2-L{tuple} of L{str}, L{int}
     """
     caller = currentframe(1)
     return (
@@ -37,12 +38,48 @@ def nextLine():
     )
 
 
+class StdlibLoggingContainer:
+    """
+    Continer for a test configuration of stdlib logging objects.
+    """
+
+    def __init__(self) -> None:
+        self.rootLogger = getLogger("")
+
+        self.originalLevel = self.rootLogger.getEffectiveLevel()
+        self.rootLogger.setLevel(py_logging.DEBUG)
+
+        self.bufferedHandler = BufferedHandler()
+        self.rootLogger.addHandler(self.bufferedHandler)
+
+        self.streamHandler, self.output = handlerAndBytesIO()
+        self.rootLogger.addHandler(self.streamHandler)
+
+    def close(self) -> None:
+        """
+        Close the logger.
+        """
+        self.rootLogger.setLevel(self.originalLevel)
+        self.rootLogger.removeHandler(self.bufferedHandler)
+        self.rootLogger.removeHandler(self.streamHandler)
+        self.streamHandler.close()
+        self.output.close()
+
+    def outputAsText(self) -> str:
+        """
+        Get the output to the underlying stream as text.
+
+        @return: the output text
+        """
+        return self.output.getvalue().decode("utf-8")
+
+
 class STDLibLogObserverTests(unittest.TestCase):
     """
     Tests for L{STDLibLogObserver}.
     """
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         L{STDLibLogObserver} is an L{ILogObserver}.
         """
@@ -52,28 +89,24 @@ class STDLibLogObserverTests(unittest.TestCase):
         except BrokenMethodImplementation as e:
             self.fail(e)
 
-    def py_logger(self):
+    def py_logger(self) -> StdlibLoggingContainer:
         """
         Create a logging object we can use to test with.
 
         @return: a stdlib-style logger
-        @rtype: L{StdlibLoggingContainer}
         """
         logger = StdlibLoggingContainer()
         self.addCleanup(logger.close)
         return logger
 
-    def logEvent(self, *events):
+    def logEvent(self, *events: LogEvent) -> Tuple[List[LogRecord], str]:
         """
-        Send one or more events to Python's logging module, and
-        capture the emitted L{logging.LogRecord}s and output stream as
-        a string.
+        Send one or more events to Python's logging module, and capture the
+        emitted L{LogRecord}s and output stream as a string.
 
         @param events: events
-        @type events: L{tuple} of L{dict}
 
         @return: a tuple: (records, output)
-        @rtype: 2-tuple of (L{list} of L{logging.LogRecord}, L{bytes}.)
         """
         pl = self.py_logger()
         observer = STDLibLogObserver(
@@ -82,11 +115,13 @@ class STDLibLogObserverTests(unittest.TestCase):
             stackDepth=STDLibLogObserver.defaultStackDepth
             + 1
         )
+
         for event in events:
             observer(event)
+
         return pl.bufferedHandler.records, pl.outputAsText()
 
-    def test_name(self):
+    def test_name(self) -> None:
         """
         Logger name.
         """
@@ -95,7 +130,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0].name, "twisted")
 
-    def test_levels(self):
+    def test_levels(self) -> None:
         """
         Log levels.
         """
@@ -130,7 +165,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         for i in range(len(records)):
             self.assertEqual(records[i].levelno, events[i]["py_levelno"])
 
-    def test_callerInfo(self):
+    def test_callerInfo(self) -> None:
         """
         C{pathname}, C{lineno}, C{exc_info}, C{func} is set properly on
         records.
@@ -147,7 +182,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         # documented.
         # self.assertEqual(records[0].func, "test_callerInfo")
 
-    def test_basicFormat(self):
+    def test_basicFormat(self) -> None:
         """
         Basic formattable event passes the format along correctly.
         """
@@ -158,7 +193,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         self.assertEqual(str(records[0].msg), "Hello, dude!")
         self.assertEqual(records[0].args, ())
 
-    def test_basicFormatRendered(self):
+    def test_basicFormatRendered(self) -> None:
         """
         Basic formattable event renders correctly.
         """
@@ -168,7 +203,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertTrue(output.endswith(":Hello, dude!\n"), repr(output))
 
-    def test_noFormat(self):
+    def test_noFormat(self) -> None:
         """
         Event with no format.
         """
@@ -177,99 +212,64 @@ class STDLibLogObserverTests(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(str(records[0].msg), "")
 
-    def test_failure(self):
+    def test_failure(self) -> None:
         """
         An event with a failure logs the failure details as well.
         """
 
-        def failing_func():
+        def failing_func() -> None:
             1 / 0
 
         try:
             failing_func()
         except ZeroDivisionError:
             failure = Failure()
+
         event = dict(log_format="Hi mom", who="me", log_failure=failure)
         records, output = self.logEvent(event)
+
         self.assertEqual(len(records), 1)
         self.assertIn("Hi mom", output)
         self.assertIn("in failing_func", output)
         self.assertIn("ZeroDivisionError", output)
 
-    def test_cleanedFailure(self):
+    def test_cleanedFailure(self) -> None:
         """
         A cleaned Failure object has a fake traceback object; make sure that
         logging such a failure still results in the exception details being
         logged.
         """
 
-        def failing_func():
+        def failing_func() -> None:
             1 / 0
 
         try:
             failing_func()
         except ZeroDivisionError:
             failure = Failure()
-        failure.cleanFailure()
+            failure.cleanFailure()
+
         event = dict(log_format="Hi mom", who="me", log_failure=failure)
         records, output = self.logEvent(event)
+
         self.assertEqual(len(records), 1)
         self.assertIn("Hi mom", output)
         self.assertIn("in failing_func", output)
         self.assertIn("ZeroDivisionError", output)
 
 
-class StdlibLoggingContainer:
-    """
-    Continer for a test configuration of stdlib logging objects.
-    """
-
-    def __init__(self):
-        self.rootLogger = py_logging.getLogger("")
-
-        self.originalLevel = self.rootLogger.getEffectiveLevel()
-        self.rootLogger.setLevel(py_logging.DEBUG)
-
-        self.bufferedHandler = BufferedHandler()
-        self.rootLogger.addHandler(self.bufferedHandler)
-
-        self.streamHandler, self.output = handlerAndBytesIO()
-        self.rootLogger.addHandler(self.streamHandler)
-
-    def close(self):
-        """
-        Close the logger.
-        """
-        self.rootLogger.setLevel(self.originalLevel)
-        self.rootLogger.removeHandler(self.bufferedHandler)
-        self.rootLogger.removeHandler(self.streamHandler)
-        self.streamHandler.close()
-        self.output.close()
-
-    def outputAsText(self):
-        """
-        Get the output to the underlying stream as text.
-
-        @return: the output text
-        @rtype: L{unicode}
-        """
-        return self.output.getvalue().decode("utf-8")
-
-
-def handlerAndBytesIO():
+def handlerAndBytesIO() -> Tuple[StreamHandler, BytesIO]:
     """
     Construct a 2-tuple of C{(StreamHandler, BytesIO)} for testing interaction
     with the 'logging' module.
 
     @return: handler and io object
-    @rtype: tuple of L{StreamHandler} and L{io.BytesIO}
     """
     output = BytesIO()
-    stream = output
     template = py_logging.BASIC_FORMAT
     stream = TextIOWrapper(output, encoding="utf-8", newline="\n")
-    formatter = py_logging.Formatter(template)
-    handler = py_logging.StreamHandler(stream)
+    formatter = Formatter(template)
+    handler = StreamHandler(stream)
     handler.setFormatter(formatter)
     return handler, output
 
@@ -279,14 +279,14 @@ class BufferedHandler(py_logging.Handler):
     A L{py_logging.Handler} that remembers all logged records in a list.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize this L{BufferedHandler}.
         """
         py_logging.Handler.__init__(self)
-        self.records = []
+        self.records = []  # type: List[LogRecord]
 
-    def emit(self, record):
+    def emit(self, record: LogRecord) -> None:
         """
         Remember the record.
         """

--- a/src/twisted/logger/test/test_util.py
+++ b/src/twisted/logger/test/test_util.py
@@ -7,6 +7,9 @@ Test cases for L{twisted.logger._util}.
 
 from twisted.trial import unittest
 
+from zope.interface import implementer
+
+from .._interfaces import ILogObserver, LogEvent
 from .._observer import LogPublisher
 from .._util import formatTrace
 
@@ -16,17 +19,20 @@ class UtilTests(unittest.TestCase):
     Utility tests.
     """
 
-    def test_trace(self):
+    def test_trace(self) -> None:
         """
         Tracing keeps track of forwarding done by the publisher.
         """
         publisher = LogPublisher()
 
-        event = dict(log_trace=[])
+        event = dict(log_trace=[])  # type: LogEvent
 
-        o1 = lambda e: None
+        @implementer(ILogObserver)
+        def o1(e: LogEvent) -> None:
+            pass
 
-        def o2(e):
+        @implementer(ILogObserver)
+        def o2(e: LogEvent) -> None:
             self.assertIs(e, event)
             self.assertEqual(
                 e["log_trace"],
@@ -37,7 +43,8 @@ class UtilTests(unittest.TestCase):
                 ],
             )
 
-        def o3(e):
+        @implementer(ILogObserver)
+        def o3(e: LogEvent) -> None:
             self.assertIs(e, event)
             self.assertEqual(
                 e["log_trace"],
@@ -53,24 +60,40 @@ class UtilTests(unittest.TestCase):
         publisher.addObserver(o3)
         publisher(event)
 
-    def test_formatTrace(self):
+    def test_formatTrace(self) -> None:
         """
         Format trace as string.
         """
-        event = dict(log_trace=[])
+        event = dict(log_trace=[])  # type: LogEvent
 
-        def noOp(e):
+        @implementer(ILogObserver)
+        def o1(e: LogEvent) -> None:
             pass
 
-        o1, o2, o3, o4, o5 = noOp, noOp, noOp, noOp, noOp
+        @implementer(ILogObserver)
+        def o2(e: LogEvent) -> None:
+            pass
 
-        o1.name = "root/o1"
+        @implementer(ILogObserver)
+        def o3(e: LogEvent) -> None:
+            pass
+
+        @implementer(ILogObserver)
+        def o4(e: LogEvent) -> None:
+            pass
+
+        @implementer(ILogObserver)
+        def o5(e: LogEvent) -> None:
+            pass
+
+        o1.name = "root/o1"  # type: ignore[attr-defined]
         o2.name = "root/p1/o2"
         o3.name = "root/p1/o3"
         o4.name = "root/p1/p2/o4"
         o5.name = "root/o5"
 
-        def testObserver(e):
+        @implementer(ILogObserver)
+        def testObserver(e: LogEvent) -> None:
             self.assertIs(e, event)
             trace = formatTrace(e["log_trace"])
             self.assertEqual(
@@ -103,9 +126,9 @@ class UtilTests(unittest.TestCase):
         p2 = LogPublisher(o4)
         p1 = LogPublisher(o2, o3, p2)
 
-        p2.name = "root/p1/p2/"
-        p1.name = "root/p1/"
+        p2.name = "root/p1/p2/"  # type: ignore[attr-defined]
+        p1.name = "root/p1/"  # type: ignore[attr-defined]
 
         root = LogPublisher(o1, p1, o5, oTest)
-        root.name = "root/"
+        root.name = "root/"  # type: ignore[attr-defined]
         root(event)

--- a/src/twisted/python/_tzhelper.py
+++ b/src/twisted/python/_tzhelper.py
@@ -63,7 +63,7 @@ class FixedOffsetTimeZone(TZInfo):
         return cls(TimeDelta(hours=hours, minutes=minutes), name)
 
     @classmethod
-    def fromLocalTimeStamp(cls, timeStamp: int) -> "FixedOffsetTimeZone":
+    def fromLocalTimeStamp(cls, timeStamp: float) -> "FixedOffsetTimeZone":
         """
         Create a time zone with a fixed offset corresponding to a time stamp in
         the system's locally configured time zone.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -647,7 +647,7 @@ class Failure(BaseException):
         self.printBriefTraceback(file=io)
         return io.getvalue()
 
-    def getTraceback(self, elideFrameworkCode=0, detail="default"):
+    def getTraceback(self, elideFrameworkCode: int = 0, detail: str = "default") -> str:
         io = StringIO()
         self.printTraceback(
             file=io, elideFrameworkCode=elideFrameworkCode, detail=detail

--- a/src/twisted/python/log.py
+++ b/src/twisted/python/log.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 import sys
 import time
-from typing import Dict, Optional
+from typing import Any, BinaryIO, Dict, Optional, cast
 import warnings
 
 from zope.interface import Interface
@@ -36,6 +36,9 @@ from twisted.logger._global import LogBeginner
 from twisted.logger._legacy import publishToNewObserver as _publishNew
 
 
+EventDict = Dict[str, Any]
+
+
 class ILogContext:
     """
     Actually, this interface is just a synonym for the dictionary interface,
@@ -53,11 +56,10 @@ class ILogObserver(Interface):
     explicitly declare provision of this interface.
     """
 
-    def __call__(eventDict):
+    def __call__(eventDict: EventDict) -> None:
         """
         Log an event.
 
-        @type eventDict: C{dict} with C{str} keys.
         @param eventDict: A dictionary with arbitrary keys.  However, these
             keys are often available:
               - C{message}: A C{tuple} of C{str} containing messages to be
@@ -177,7 +179,9 @@ class LogPublisher:
             # This default behavior is really only used for testing.
             beginnerPublisher = NewPublisher()
             beginnerPublisher.addObserver(observerPublisher)
-            logBeginner = LogBeginner(beginnerPublisher, NullFile(), sys, warnings)
+            logBeginner = LogBeginner(
+                beginnerPublisher, cast(BinaryIO, NullFile()), sys, warnings
+            )
         self._logBeginner = logBeginner
         self._warningsModule = warningsModule
         self._oldshowwarning = warningsModule.showwarning
@@ -267,7 +271,7 @@ class LogPublisher:
         >>> log.msg('Started', system='Foo')
 
         """
-        actualEventDict = (context.get(ILogContext) or {}).copy()
+        actualEventDict = cast(EventDict, (context.get(ILogContext) or {}).copy())
         actualEventDict.update(kw)
         actualEventDict["message"] = message
         actualEventDict["time"] = time.time()
@@ -354,7 +358,7 @@ if "theLogPublisher" not in globals():
         """
 
 
-def _safeFormat(fmtString, fmtDict):
+def _safeFormat(fmtString: str, fmtDict: Dict[str, Any]) -> str:
     """
     Try to format a string, swallowing all errors to always return a string.
 
@@ -363,11 +367,9 @@ def _safeFormat(fmtString, fmtDict):
         Python 3.
 
     @param fmtString: a C{%}-format string
-
     @param fmtDict: string formatting arguments for C{fmtString}
 
     @return: A native string, formatted from C{fmtString} and C{fmtDict}.
-    @rtype: L{str}
     """
     # There's a way we could make this if not safer at least more
     # informative: perhaps some sort of str/repr wrapper objects
@@ -397,14 +399,10 @@ def _safeFormat(fmtString, fmtDict):
                     "MESSAGE DETAILS, MESSAGE LOST"
                 )
 
-    # Return a native string
-    if isinstance(text, bytes):
-        text = text.decode("utf-8")
-
     return text
 
 
-def textFromEventDict(eventDict):
+def textFromEventDict(eventDict: EventDict) -> Optional[str]:
     """
     Extract text from an event dict passed to a log observer. If it cannot
     handle the dict, it returns None.
@@ -425,13 +423,13 @@ def textFromEventDict(eventDict):
     edm = eventDict["message"]
     if not edm:
         if eventDict["isError"] and "failure" in eventDict:
-            why = eventDict.get("why")
+            why = cast(str, eventDict.get("why"))
             if why:
                 why = reflect.safe_str(why)
             else:
                 why = "Unhandled Error"
             try:
-                traceback = eventDict["failure"].getTraceback()
+                traceback = cast(failure.Failure, eventDict["failure"]).getTraceback()
             except Exception as e:
                 traceback = "(unable to obtain traceback): " + str(e)
             text = why + "\n" + traceback
@@ -451,7 +449,7 @@ class _GlobalStartStopObserver(ABC):
     """
 
     @abstractmethod
-    def emit(self, eventDict: Dict[str, object]) -> None:
+    def emit(self, eventDict: EventDict) -> None:
         """
         Emit the given log event.
 
@@ -538,12 +536,11 @@ class FileLogObserver(_GlobalStartStopObserver):
             tzMin,
         )
 
-    def emit(self, eventDict: Dict[str, object]) -> None:
+    def emit(self, eventDict: EventDict) -> None:
         """
         Format the given log event as text and write it to the output file.
 
         @param eventDict: a log event
-        @type eventDict: L{dict} mapping L{str} (native string) to L{object}
         """
         text = textFromEventDict(eventDict)
         if text is None:
@@ -574,7 +571,7 @@ class PythonLoggingObserver(_GlobalStartStopObserver):
         """
         self._newObserver = NewSTDLibLogObserver(loggerName)
 
-    def emit(self, eventDict: Dict[str, object]) -> None:
+    def emit(self, eventDict: EventDict) -> None:
         """
         Receive a twisted log entry, format it and bridge it to python.
 
@@ -725,16 +722,16 @@ class DefaultObserver(_GlobalStartStopObserver):
 
     stderr = sys.stderr
 
-    def emit(self, eventDict: Dict[str, object]) -> None:
+    def emit(self, eventDict: EventDict) -> None:
         """
         Emit an event dict.
 
         @param eventDict: an event dict
-        @type eventDict: dict
         """
         if eventDict["isError"]:
             text = textFromEventDict(eventDict)
-            self.stderr.write(text)
+            if text is not None:
+                self.stderr.write(text)
             self.stderr.flush()
 
 


### PR DESCRIPTION
Add type hints for `twisted.logger`

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9995
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
