### PR TITLE
move extras to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,60 @@ zip_safe = False
 package_dir = =src
 packages = find:
 
+[options.extras_require]
+dev =
+    pyflakes >= 1.0.0
+    twisted-dev-tools >= 0.0.2
+    python-subunit
+    towncrier >= 17.4.0
+    twistedchecker >= 0.7.2
+    # force upgrades for rtd default packages: https://git.io/JU73V
+    alabaster~=0.7.12
+    commonmark~=0.9.1
+    docutils~=0.16.0
+    mock~=4.0
+    pillow~=7.2
+    readthedocs-sphinx-ext~=2.1
+    recommonmark~=0.6.0
+    sphinx~=3.2
+    sphinx-rtd-theme~=0.5.0
+tls =
+    pyopenssl >= 16.0.0
+    # service_identity 18.1.0 added support for validating IP addresses in
+    # certificate subjectAltNames
+    service_identity >= 18.1.0
+    idna >= 2.4
+conch =
+    pyasn1
+    cryptography >= 2.6
+    appdirs >= 1.4.0
+    bcrypt >= 3.0.0
+serial =
+    pyserial >= 3.0
+    pywin32 != 226; platform_system == "Windows"
+http2 =
+    h2 >= 3.0, < 4.0
+    priority >= 1.1.0, < 2.0
+contextvars =
+    contextvars >= 2.4, < 3; python_version < "3.7"
+all_non_platform =
+    cython-test-exception-raiser ~= 1.0
+    %(tls)s
+    %(conch)s
+    %(serial)s
+    %(http2)s
+    %(contextvars)s
+macos_platform =
+    pyobjc-core
+    pyobjc-framework-CFNetwork
+    pyobjc-framework-Cocoa
+    %(all_non_platform)s
+windows_platform =
+    pywin32 != 226
+    %(all_non_platform)s
+osx_platform =
+    %(macos_platform)s
+
 [options.packages.find]
 where = src
 

--- a/src/twisted/python/_setup.py
+++ b/src/twisted/python/_setup.py
@@ -11,22 +11,6 @@ This file must not import anything from Twisted, as it is loaded by C{exec} in
 C{setup.py}. If you need compatibility functions for this code, duplicate them
 here.
 
-@var _EXTRA_OPTIONS: These are the actual package names and versions that will
-    be used by C{extras_require}.  This is not passed to setup directly so that
-    combinations of the packages can be created without the need to copy
-    package names multiple times.
-
-@var _EXTRAS_REQUIRE: C{extras_require} is a dictionary of items that can be
-    passed to setup.py to install optional dependencies.  For example, to
-    install the optional dev dependencies one would type::
-
-        pip install -e ".[dev]"
-
-    This has been supported by setuptools since 0.5a4.
-
-@var _PLATFORM_INDEPENDENT: A list of all optional cross-platform dependencies,
-    as setuptools version specifiers, used to populate L{_EXTRAS_REQUIRE}.
-
 @var _EXTENSIONS: The list of L{ConditionalExtension} used by the setup
     process.
 """
@@ -41,69 +25,6 @@ from typing import Any, Dict, List, cast
 from distutils.command import build_ext
 from distutils.errors import CompileError
 from setuptools import Extension
-
-
-_dev = [
-    "pyflakes >= 1.0.0",
-    "twisted-dev-tools >= 0.0.2",
-    "python-subunit",
-    "towncrier >= 17.4.0",
-    "twistedchecker >= 0.7.2",
-    # force upgrades for rtd default packages: https://git.io/JU73V
-    "alabaster~=0.7.12",
-    "commonmark~=0.9.1",
-    "docutils~=0.16.0",
-    "mock~=4.0",
-    "pillow~=7.2",
-    "readthedocs-sphinx-ext~=2.1",
-    "recommonmark~=0.6.0",
-    "sphinx~=3.2",
-    "sphinx-rtd-theme~=0.5.0",
-]
-
-_EXTRA_OPTIONS = dict(
-    dev=_dev,
-    tls=[
-        "pyopenssl >= 16.0.0",
-        # service_identity 18.1.0 added support for validating IP addresses in
-        # certificate subjectAltNames
-        "service_identity >= 18.1.0",
-        "idna >= 2.4",
-    ],
-    conch=[
-        "pyasn1",
-        "cryptography >= 2.6",
-        "appdirs >= 1.4.0",
-        "bcrypt >= 3.0.0",
-    ],
-    serial=["pyserial >= 3.0", 'pywin32 != 226; platform_system == "Windows"'],
-    macos=["pyobjc-core", "pyobjc-framework-CFNetwork", "pyobjc-framework-Cocoa"],
-    windows=["pywin32 != 226"],
-    http2=["h2 >= 3.0, < 4.0", "priority >= 1.1.0, < 2.0"],
-    contextvars=['contextvars >= 2.4, < 3; python_version < "3.7"'],
-)
-
-_PLATFORM_INDEPENDENT = [
-    *_EXTRA_OPTIONS["tls"],
-    *_EXTRA_OPTIONS["conch"],
-    *_EXTRA_OPTIONS["serial"],
-    *_EXTRA_OPTIONS["http2"],
-    *_EXTRA_OPTIONS["contextvars"],
-    "cython-test-exception-raiser ~= 1.0",
-]
-
-_EXTRAS_REQUIRE = {
-    "dev": _EXTRA_OPTIONS["dev"],
-    "tls": _EXTRA_OPTIONS["tls"],
-    "conch": _EXTRA_OPTIONS["conch"],
-    "serial": _EXTRA_OPTIONS["serial"],
-    "http2": _EXTRA_OPTIONS["http2"],
-    "contextvars": _EXTRA_OPTIONS["contextvars"],
-    "all_non_platform": _PLATFORM_INDEPENDENT,
-    "macos_platform": (_EXTRA_OPTIONS["macos"] + _PLATFORM_INDEPENDENT),
-    "windows_platform": (_EXTRA_OPTIONS["windows"] + _PLATFORM_INDEPENDENT),
-}
-_EXTRAS_REQUIRE["osx_platform"] = _EXTRAS_REQUIRE["macos_platform"]
 
 
 class ConditionalExtension(Extension):
@@ -205,7 +126,6 @@ def getSetupArgs(
             readme.read_text(encoding="utf8"),
             flags=re.I,
         ),
-        "extras_require": _EXTRAS_REQUIRE,
         **_extension_kwargs(),
     }
 

--- a/src/twisted/python/test/test_setup.py
+++ b/src/twisted/python/test/test_setup.py
@@ -9,7 +9,6 @@ import os
 import pathlib
 import textwrap
 
-from pkg_resources import parse_requirements
 from setuptools.dist import Distribution
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -17,7 +16,6 @@ from twisted.python import _setup
 from twisted.python._setup import (
     getSetupArgs,
     ConditionalExtension,
-    _EXTRAS_REQUIRE,
 )
 
 
@@ -68,183 +66,6 @@ class SetupTests(SynchronousTestCase):
         self.patch(os, "name", "nt")
         builder.prepare_extensions()
         self.assertEqual(ext.define_macros, [("whatever", 2), ("WIN32", 1)])
-
-
-class OptionalDependenciesTests(SynchronousTestCase):
-    """
-    Tests for L{_EXTRAS_REQUIRE}
-    """
-
-    def test_distributeTakesExtrasRequire(self):
-        """
-        Setuptools' Distribution object parses and stores its C{extras_require}
-        argument as an attribute.
-
-        Requirements for install_requires/setup_requires can specified as:
-         * a single requirement as a string, such as:
-           {'im_an_extra_dependency': 'thing'}
-         * a series of requirements as a list, such as:
-           {'im_an_extra_dependency': ['thing']}
-         * a series of requirements as a multi-line string, such as:
-           {'im_an_extra_dependency': '''
-                                      thing
-                                      '''}
-
-        The extras need to be parsed with pkg_resources.parse_requirements(),
-        which returns a generator.
-        """
-        extras = dict(im_an_extra_dependency="thing")
-        attrs = dict(extras_require=extras)
-        distribution = Distribution(attrs)
-
-        def canonicalizeExtras(myExtras):
-            parsedExtras = {}
-            for name, val in myExtras.items():
-                parsedExtras[name] = list(parse_requirements(val))
-            return parsedExtras
-
-        self.assertEqual(
-            canonicalizeExtras(extras), canonicalizeExtras(distribution.extras_require)
-        )
-
-    def test_extrasRequireDictContainsKeys(self):
-        """
-        L{_EXTRAS_REQUIRE} contains options for all documented extras: C{dev},
-        C{tls}, C{conch}, C{soap}, C{serial}, C{all_non_platform},
-        C{macos_platform}, and C{windows_platform}.
-        """
-        self.assertIn("dev", _EXTRAS_REQUIRE)
-        self.assertIn("tls", _EXTRAS_REQUIRE)
-        self.assertIn("conch", _EXTRAS_REQUIRE)
-        self.assertIn("serial", _EXTRAS_REQUIRE)
-        self.assertIn("all_non_platform", _EXTRAS_REQUIRE)
-        self.assertIn("macos_platform", _EXTRAS_REQUIRE)
-        self.assertIn("osx_platform", _EXTRAS_REQUIRE)  # Compat for macOS
-        self.assertIn("windows_platform", _EXTRAS_REQUIRE)
-        self.assertIn("http2", _EXTRAS_REQUIRE)
-        self.assertIn("contextvars", _EXTRAS_REQUIRE)
-
-    def test_extrasRequiresDevDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{dev} extra contains setuptools requirements for
-        the tools required for Twisted development.
-        """
-        deps = _EXTRAS_REQUIRE["dev"]
-        self.assertIn("pyflakes >= 1.0.0", deps)
-        self.assertIn("twisted-dev-tools >= 0.0.2", deps)
-        self.assertIn("python-subunit", deps)
-        self.assertIn("sphinx~=3.2", deps)
-        self.assertIn("twistedchecker >= 0.7.2", deps)
-
-    def test_extrasRequiresTlsDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{tls} extra contains setuptools requirements for
-        the packages required to make Twisted's transport layer security fully
-        work for both clients and servers.
-        """
-        deps = _EXTRAS_REQUIRE["tls"]
-        self.assertIn("pyopenssl >= 16.0.0", deps)
-        self.assertIn("service_identity >= 18.1.0", deps)
-        self.assertIn("idna >= 2.4", deps)
-
-    def test_extrasRequiresConchDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{conch} extra contains setuptools requirements
-        for the packages required to make Twisted Conch's secure shell server
-        work.
-        """
-        deps = _EXTRAS_REQUIRE["conch"]
-        self.assertIn("pyasn1", deps)
-        self.assertIn("cryptography >= 2.6", deps)
-        self.assertIn("appdirs >= 1.4.0", deps)
-
-    def test_extrasRequiresSerialDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{serial} extra contains setuptools requirements
-        for the packages required to make Twisted's serial support work.
-        """
-        self.assertIn("pyserial >= 3.0", _EXTRAS_REQUIRE["serial"])
-
-    def test_extrasRequiresHttp2Deps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{http2} extra contains setuptools requirements
-        for the packages required to make Twisted HTTP/2 support work.
-        """
-        deps = _EXTRAS_REQUIRE["http2"]
-        self.assertIn("h2 >= 3.0, < 4.0", deps)
-        self.assertIn("priority >= 1.1.0, < 2.0", deps)
-
-    def test_extrasRequiresContextvarsDeps(self):
-        """
-        L{_EXTRAS_REQUIRES}'s C{contextvars} extra contains setuptools
-        requirements for the packages required to make Twisted contextvars
-        support work in Python versions less than 3.7 which do not contain
-        the contextvars library in the standard library.
-        """
-        deps = _EXTRAS_REQUIRE["contextvars"]
-        self.assertIn('contextvars >= 2.4, < 3; python_version < "3.7"', deps)
-
-    def test_extrasRequiresAllNonPlatformDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{all_non_platform} extra contains setuptools
-        requirements for all of Twisted's optional dependencies which work on
-        all supported operating systems.
-        """
-        deps = _EXTRAS_REQUIRE["all_non_platform"]
-        self.assertIn("pyopenssl >= 16.0.0", deps)
-        self.assertIn("service_identity >= 18.1.0", deps)
-        self.assertIn("idna >= 2.4", deps)
-        self.assertIn("pyasn1", deps)
-        self.assertIn("cryptography >= 2.6", deps)
-        self.assertIn("pyserial >= 3.0", deps)
-        self.assertIn("appdirs >= 1.4.0", deps)
-        self.assertIn("h2 >= 3.0, < 4.0", deps)
-        self.assertIn("priority >= 1.1.0, < 2.0", deps)
-        self.assertIn('contextvars >= 2.4, < 3; python_version < "3.7"', deps)
-
-    def test_extrasRequiresMacosPlatformDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{macos_platform} extra contains setuptools
-        requirements for all of Twisted's optional dependencies usable on the
-        macOS platform.
-        """
-        deps = _EXTRAS_REQUIRE["macos_platform"]
-        self.assertIn("pyopenssl >= 16.0.0", deps)
-        self.assertIn("service_identity >= 18.1.0", deps)
-        self.assertIn("idna >= 2.4", deps)
-        self.assertIn("pyasn1", deps)
-        self.assertIn("cryptography >= 2.6", deps)
-        self.assertIn("pyserial >= 3.0", deps)
-        self.assertIn("h2 >= 3.0, < 4.0", deps)
-        self.assertIn("priority >= 1.1.0, < 2.0", deps)
-        self.assertIn("pyobjc-core", deps)
-        self.assertIn('contextvars >= 2.4, < 3; python_version < "3.7"', deps)
-
-    def test_extrasRequireMacOSXPlatformDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{osx_platform} is an alias to C{macos_platform}.
-        """
-        self.assertEqual(
-            _EXTRAS_REQUIRE["macos_platform"], _EXTRAS_REQUIRE["osx_platform"]
-        )
-
-    def test_extrasRequiresWindowsPlatformDeps(self):
-        """
-        L{_EXTRAS_REQUIRE}'s C{windows_platform} extra contains setuptools
-        requirements for all of Twisted's optional dependencies usable on the
-        Microsoft Windows platform.
-        """
-        deps = _EXTRAS_REQUIRE["windows_platform"]
-        self.assertIn("pyopenssl >= 16.0.0", deps)
-        self.assertIn("service_identity >= 18.1.0", deps)
-        self.assertIn("idna >= 2.4", deps)
-        self.assertIn("pyasn1", deps)
-        self.assertIn("cryptography >= 2.6", deps)
-        self.assertIn("pyserial >= 3.0", deps)
-        self.assertIn("h2 >= 3.0, < 4.0", deps)
-        self.assertIn("priority >= 1.1.0, < 2.0", deps)
-        self.assertIn("pywin32 != 226", deps)
-        self.assertIn('contextvars >= 2.4, < 3; python_version < "3.7"', deps)
 
 
 class FakeModule:

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ sources = setup.py src/ docs/conch/examples docs/mail/examples docs/names/exampl
 ;   docs/core/examples
 
 [testenv]
-;; dependencies managed by extras in t.p._setup.py._EXTRAS_REQUIRE
+;; dependencies managed by extras in setup.cfg
 extras =
     alldeps: all_non_platform
 


### PR DESCRIPTION
Currently the twisted.python._setup is very complicated and has a lot of somewhat unusual tests.

This moves the extras config from that `twisted.python._setup` into the more modern setuptools declarative format enabling us to remove a fair amount of python code and tests.

This is part of a series of work to move to a more "hypermodern" pep517/pep518 pure python Twisted wheel

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10011
* [ ] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
