### PR TITLE
[10014] Disable process tests that fail on Windows for py3.7 and 3.8.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,6 @@ Twisted
 =======
 
 |pypi|_
-|travis|_
 |circleci|_
 |mypy|_
 
@@ -115,9 +114,6 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/twisted.svg
 .. _pypi: https://pypi.python.org/pypi/twisted
-
-.. |travis| image:: https://travis-ci.org/twisted/twisted.svg?branch=trunk
-.. _travis: https://travis-ci.org/twisted/twisted
 
 .. |circleci| image:: https://circleci.com/gh/twisted/twisted.svg?style=svg
 .. _circleci: https://circleci.com/gh/twisted/twisted

--- a/azure-pipelines/tests_pipeline.yml
+++ b/azure-pipelines/tests_pipeline.yml
@@ -12,6 +12,7 @@ pr:
 variables:
   INFRASTRUCTURE: "AZUREPIPELINES"
   TRIAL_REPORTER: "verbose"
+  CI: "true"
 
 jobs:
 

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -550,6 +550,12 @@ class ProcessTests(unittest.TestCase):
         p.transport.closeStdin()
         return finished.addCallback(afterProcessEnd)
 
+    @skipIf(
+        os.environ.get("CI", "").lower() == "true"
+        and runtime.platform.getType() == "win32"
+        and sys.version_info[0:2] in [(3, 7), (3, 8)],
+        "See https://twistedmatrix.com/trac/ticket/10014",
+    )
     def test_process(self):
         """
         Test running a process: check its output, it exitCode, some property of

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -582,6 +582,12 @@ class ProcessTests(unittest.TestCase):
         d.addCallback(check)
         return d
 
+    @skipIf(
+        os.environ.get("CI", "").lower() == "true"
+        and runtime.platform.getType() == "win32"
+        and sys.version_info[0:2] in [(3, 7), (3, 8)],
+        "See https://twistedmatrix.com/trac/ticket/10014",
+    )
     def test_manyProcesses(self):
         def _check(results, protocols):
             for p in protocols:

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,8 @@ minversion=2.4
 skip_missing_interpreters=True
 toxworkdir=build/
 envlist=lint, mypy, black,
-    apidocs,narrativedocs,newsfragment,
+    apidocs, narrativedocs, newsfragment,
     manifest-checker, twine,
-    py36-alldeps-nocov
 
 [default]
 ; Files and directories that contain Python source for linting.

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ toxworkdir=build/
 envlist=lint, mypy, black,
     apidocs, narrativedocs, newsfragment,
     manifest-checker, twine,
+    py38-alldeps-nocov
 
 [default]
 ; Files and directories that contain Python source for linting.


### PR DESCRIPTION
# Why?

twisted.test.test_process.ProcessTests fails on both Azure and GitHub actions VMs on Windows for python 3.7 and 3.8 with iocp and select reactor.

It pass on linux or on Windows with pyhon 3.5 and 3.6

This PR just skips the test to have trunk green again.

I have executed the test on my Windows VM with 3.8 and it pass... so this is related to MS build env VMs.

2 tests were skipped:
* twisted.test.test_process.ProcessTests.test_process
* twisted.test.test_process.ProcessTests.test_manyProcesses


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10014
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
