### PR TITLE
Remove unused reactor attribute on wakers

### DIFF
--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -113,9 +113,8 @@ class _SocketWaker(log.Logger):
 
     disconnected = 0
 
-    def __init__(self, reactor):
+    def __init__(self):
         """Initialize."""
-        self.reactor = reactor
         # Following select_trigger (from asyncore)'s example;
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -172,9 +171,8 @@ class _FDWaker(log.Logger):
     i = None
     o = None
 
-    def __init__(self, reactor):
+    def __init__(self):
         """Initialize."""
-        self.reactor = reactor
         self.i, self.o = os.pipe()
         fdesc.setNonBlocking(self.i)
         fdesc._setCloseOnExec(self.i)
@@ -237,8 +235,8 @@ class _SIGCHLDWaker(_FDWaker):
     @see: L{twisted.internet._signals}
     """
 
-    def __init__(self, reactor):
-        _FDWaker.__init__(self, reactor)
+    def __init__(self):
+        _FDWaker.__init__(self)
 
     def install(self):
         """
@@ -324,7 +322,7 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin, ReactorB
         the reactor. On Windows we use a pair of sockets.
         """
         if not self.waker:
-            self.waker = self._wakerFactory(self)
+            self.waker = self._wakerFactory()
             self._internalReaders.add(self.waker)
             self.addReader(self.waker)
 
@@ -338,7 +336,7 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin, ReactorB
         _SignalReactorMixin._handleSignals(self)
         if platformType == "posix" and processEnabled:
             if not self._childWaker:
-                self._childWaker = _SIGCHLDWaker(self)
+                self._childWaker = _SIGCHLDWaker()
                 self._internalReaders.add(self._childWaker)
                 self.addReader(self._childWaker)
             self._childWaker.install()


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10019
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] ~~I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)~~
  - See CI runs.
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] ~~I have updated the automated tests.~~
  - No new feature nor bugfix, just cleanup.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
