### PR TITLE
Fix incorrect fields in docstrings

### DIFF
--- a/src/twisted/_threads/_ithreads.py
+++ b/src/twisted/_threads/_ithreads.py
@@ -48,7 +48,7 @@ class IWorker(Interface):
         Free any resources associated with this L{IWorker} and cause it to
         reject all future work.
 
-        @raise: L{AlreadyQuit} if this method has already been called.
+        @raise AlreadyQuit: if this method has already been called.
         """
 
 

--- a/src/twisted/_threads/_pool.py
+++ b/src/twisted/_threads/_pool.py
@@ -40,9 +40,9 @@ def pool(currentLimit, threadFactory=Thread):
         created.
     @type currentLimit: 0-argument callable returning L{int}
 
-    @param reactor: If passed, the L{IReactorFromThreads} / L{IReactorCore} to
-        be used to coordinate actions on the L{Team} itself.  Otherwise, a
-        L{LockWorker} will be used.
+    @param threadFactory: Factory that, when given a C{target} keyword argument,
+        returns a L{threading.Thread} that will run that target.
+    @type threadFactory: callable returning a L{threading.Thread}
 
     @return: a new L{Team}.
     """

--- a/src/twisted/application/reactors.py
+++ b/src/twisted/application/reactors.py
@@ -75,7 +75,7 @@ def installReactor(shortName):
 
     @raise NoSuchReactor: If no reactor is found with a matching C{shortName}.
 
-    @raise: anything that the specified reactor can raise when installed.
+    @raise Exception: Anything that the specified reactor can raise when installed.
     """
     for installer in getReactorTypes():
         if installer.shortName == shortName:

--- a/src/twisted/conch/endpoints.py
+++ b/src/twisted/conch/endpoints.py
@@ -796,7 +796,7 @@ class _NewConnectionHelper:
 
         @return: A L{KnownHostsFile} instance pointed at the user's personal
             I{known hosts} file.
-        @type: L{KnownHostsFile}
+        @rtype: L{KnownHostsFile}
         """
         return KnownHostsFile.fromPath(FilePath(expanduser(cls._KNOWN_HOSTS)))
 

--- a/src/twisted/conch/insults/helper.py
+++ b/src/twisted/conch/insults/helper.py
@@ -73,7 +73,7 @@ class _FormattingState(_textattributes._FormattingStateMixin):
         """
         Add a character attribute to a copy of this formatting state.
 
-        @param **kw: An optional attribute name and value can be provided with
+        @param kw: An optional attribute name and value can be provided with
             a keyword argument.
 
         @return: A formatting state instance with the new attribute.

--- a/src/twisted/conch/ssh/connection.py
+++ b/src/twisted/conch/ssh/connection.py
@@ -411,7 +411,7 @@ class SSHConnection(service.SSHService):
         @type request:      L{bytes}
         @type data:         L{bytes}
         @type wantReply:    L{bool}
-        @rtype              C{Deferred}/L{None}
+        @rtype:             C{Deferred}/L{None}
         """
         self.transport.sendPacket(
             MSG_GLOBAL_REQUEST,
@@ -458,7 +458,7 @@ class SSHConnection(service.SSHService):
         @type requestType:  L{bytes}
         @type data:         L{bytes}
         @type wantReply:    L{bool}
-        @rtype              C{Deferred}/L{None}
+        @rtype:             C{Deferred}/L{None}
         """
         if channel.localClosed:
             return

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -856,7 +856,7 @@ class FileTransferClient(FileTransferBase):
         """
         Called when the client sends their version info.
 
-        @param otherVersion: an integer representing the version of the SFTP
+        @param serverVersion: an integer representing the version of the SFTP
         protocol they are claiming.
         @param extData: a dictionary of extended_name : extended_data items.
         These items are sent by the client to indicate additional features.

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -1582,7 +1582,7 @@ class Key:
         @type comment: L{bytes}
 
         @param passphrase: Passphrase for a private key.
-        @type comment: L{bytes}
+        @type passphrase: L{bytes}
 
         @rtype: L{bytes}
         """

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -1570,13 +1570,19 @@ class Key:
     def _toString_OPENSSH(self, subtype=None, comment=None, passphrase=None):
         """
         Return a public or private OpenSSH string.  See
-        _fromString_PUBLIC_OPENSSH and _fromPrivateOpenSSH_PEM for the
-        string formats.  If extra is present, it represents a comment for a
-        public key, or a passphrase for a private key.
+        L{_fromString_PUBLIC_OPENSSH} and L{_fromPrivateOpenSSH_PEM} for the
+        string formats.
 
-        @param extra: Comment for a public key or passphrase for a
-            private key
-        @type extra: L{bytes}
+        @param subtype: A subtype to emit.  Only supported for private keys,
+            for which the currently supported subtypes are C{'PEM'} and C{'v1'}.
+            If not given, an appropriate default is used.
+        @type subtype: L{str} or L{None}
+
+        @param comment: Comment for a public key.
+        @type comment: L{bytes}
+
+        @param passphrase: Passphrase for a private key.
+        @type comment: L{bytes}
 
         @rtype: L{bytes}
         """

--- a/src/twisted/cred/_digest.py
+++ b/src/twisted/cred/_digest.py
@@ -85,7 +85,7 @@ def calcHA2(algo, pszMethod, pszDigestUri, pszQop, pszHEntity):
     """
     Compute H(A2) from RFC 2617.
 
-    @param pszAlg: The name of the algorithm to use to calculate the digest.
+    @param algo: The name of the algorithm to use to calculate the digest.
         Currently supported are md5, md5-sess, and sha.
     @param pszMethod: The request method.
     @param pszDigestUri: The request URI.

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -266,9 +266,9 @@ class ConnectionPool:
             B{Note} that this function is B{not} run in the main thread: it
             must be threadsafe.
 
-        @param *args: positional arguments to be passed to func
+        @param args: positional arguments to be passed to func
 
-        @param **kw: keyword arguments to be passed to func
+        @param kw: keyword arguments to be passed to func
 
         @return: a L{Deferred} which will fire the return value of
             C{func(Transaction(...), *args, **kw)}, or a
@@ -311,10 +311,10 @@ class ConnectionPool:
         @param interaction: a callable object whose first argument is an
             L{adbapi.Transaction}.
 
-        @param *args: additional positional arguments to be passed to
+        @param args: additional positional arguments to be passed to
             interaction
 
-        @param **kw: keyword arguments to be passed to interaction
+        @param kw: keyword arguments to be passed to interaction
 
         @return: a Deferred which will fire the return value of
             C{interaction(Transaction(...), *args, **kw)}, or a

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -173,27 +173,27 @@ class ConnectionPool:
         @param dbapiName: an import string to use to obtain a DB-API compatible
             module (e.g. C{'pyPgSQL.PgSQL'})
 
-        @param cp_min: the minimum number of connections in pool (default 3)
+        @keyword cp_min: the minimum number of connections in pool (default 3)
 
-        @param cp_max: the maximum number of connections in pool (default 5)
+        @keyword cp_max: the maximum number of connections in pool (default 5)
 
-        @param cp_noisy: generate informational log messages during operation
+        @keyword cp_noisy: generate informational log messages during operation
             (default C{False})
 
-        @param cp_openfun: a callback invoked after every C{connect()} on the
+        @keyword cp_openfun: a callback invoked after every C{connect()} on the
             underlying DB-API object. The callback is passed a new DB-API
             connection object. This callback can setup per-connection state
             such as charset, timezone, etc.
 
-        @param cp_reconnect: detect connections which have failed and reconnect
+        @keyword cp_reconnect: detect connections which have failed and reconnect
             (default C{False}). Failed connections may result in
             L{ConnectionLost} exceptions, which indicate the query may need to
             be re-sent.
 
-        @param cp_good_sql: an sql query which should always succeed and change
+        @keyword cp_good_sql: an sql query which should always succeed and change
             no state (default C{'select 1'})
 
-        @param cp_reactor: use this reactor instead of the global reactor
+        @keyword cp_reactor: use this reactor instead of the global reactor
             (added in Twisted 10.2).
         @type cp_reactor: L{IReactorCore} provider
         """

--- a/src/twisted/internet/_glibbase.py
+++ b/src/twisted/internet/_glibbase.py
@@ -36,7 +36,7 @@ def ensureNotImported(moduleNames, errorMessage, preventImports=[]):
     @param errorMessage: Message to use when raising an C{ImportError}.
     @type errorMessage: C{str}
 
-    @raises: C{ImportError} with given error message if a given module name
+    @raise ImportError: with given error message if a given module name
         has already been imported.
     """
     for name in moduleNames:

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -477,7 +477,7 @@ class Certificate(CertBase):
 
         @rtype: C{Class}
 
-        @raise: L{CertificateError}, if the given transport does not have a peer
+        @raise CertificateError: if the given transport does not have a peer
             certificate.
         """
         return _handleattrhelper(Class, transport, "peer")
@@ -491,7 +491,7 @@ class Certificate(CertBase):
 
         @rtype: C{Class}
 
-        @raise: L{CertificateError}, if the given transport does not have a host
+        @raise CertificateError: if the given transport does not have a host
             certificate.
         """
         return _handleattrhelper(Class, transport, "host")

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1218,7 +1218,7 @@ def optionsForClientTLS(
         the list are preferred over those later in the list.
     @type acceptableProtocols: L{list} of L{bytes}
 
-    @param extraCertificateOptions: keyword-only argument; this is a dictionary
+    @keyword extraCertificateOptions: keyword-only argument; this is a dictionary
         of additional keyword arguments to be presented to
         L{CertificateOptions}. Please avoid using this unless you absolutely
         need to; any time you need to pass an option here that is a bug in this

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -422,8 +422,8 @@ class _ThreePhaseEvent:
         @param phase: One of C{'before'}, C{'during'}, or C{'after'}.
 
         @param callable: An object to be called when this event is triggered.
-        @param *args: Positional arguments to pass to C{callable}.
-        @param **kwargs: Keyword arguments to pass to C{callable}.
+        @param args: Positional arguments to pass to C{callable}.
+        @param kwargs: Keyword arguments to pass to C{callable}.
 
         @return: An opaque handle which may be passed to L{removeTrigger} to
             reverse the effects of calling this method.

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -727,7 +727,8 @@ class ReactorBase(PluggableResolverMixin):
         """
         Handle a SIGINT interrupt.
 
-        @param args: See handler specification in L{signal.signal}
+        @param number: See handler specification in L{signal.signal}
+        @param frame: See handler specification in L{signal.signal}
         """
         log.msg("Received SIGINT, shutting down.")
         self.callFromThread(self.stop)
@@ -737,7 +738,8 @@ class ReactorBase(PluggableResolverMixin):
         """
         Handle a SIGBREAK interrupt.
 
-        @param args: See handler specification in L{signal.signal}
+        @param number: See handler specification in L{signal.signal}
+        @param frame: See handler specification in L{signal.signal}
         """
         log.msg("Received SIGBREAK, shutting down.")
         self.callFromThread(self.stop)
@@ -747,7 +749,8 @@ class ReactorBase(PluggableResolverMixin):
         """
         Handle a SIGTERM interrupt.
 
-        @param args: See handler specification in L{signal.signal}
+        @param number: See handler specification in L{signal.signal}
+        @param frame: See handler specification in L{signal.signal}
         """
         log.msg("Received SIGTERM, shutting down.")
         self.callFromThread(self.stop)

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -920,7 +920,9 @@ def _cancelledToTimedOutError(value, timeout):
     @type timeout: L{int}
 
     @rtype: C{value}
-    @raise: L{TimeoutError}
+    @raise TimeoutError: If C{value} is a L{Failure} that is a L{CancelledError}.
+    @raise Exception: If C{value} is a L{Failure} that is not a L{CancelledError},
+        it is re-raised.
 
     @since: 16.5
     """

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -768,7 +768,7 @@ class Deferred:
 
     def asFuture(self, loop):
         """
-        Adapt a L{Deferred} into a L{asyncio.Future} which is bound to C{loop}.
+        Adapt this L{Deferred} into a L{asyncio.Future} which is bound to C{loop}.
 
         @note: converting a L{Deferred} to an L{asyncio.Future} consumes both
             its result and its errors, so this method implicitly converts
@@ -779,9 +779,6 @@ class Deferred:
 
         @param loop: The asyncio event loop to bind the L{asyncio.Future} to.
         @type loop: L{asyncio.AbstractEventLoop} or similar
-
-        @param deferred: The Deferred to adapt.
-        @type deferred: L{Deferred}
 
         @return: A Future which will fire when the Deferred fires.
         @rtype: L{asyncio.Future}

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -1985,15 +1985,14 @@ def _parseClientSSL(*args, **kwargs):
 
     Valid positional arguments to this function are host and port.
 
-    @param caCertsDir: The one parameter which is not part of
+    @keyword caCertsDir: The one parameter which is not part of
         L{IReactorSSL.connectSSL}'s signature, this is a path name used to
         construct a list of certificate authority certificates.  The directory
         will be scanned for files ending in C{.pem}, all of which will be
         considered valid certificate authorities for this connection.
-
     @type caCertsDir: L{str}
 
-    @param hostname: The hostname to use for validating the server's
+    @keyword hostname: The hostname to use for validating the server's
         certificate.
     @type hostname: L{unicode}
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1588,9 +1588,6 @@ class IFileDescriptor(ILoggingContext):
 
     def fileno() -> object:
         """
-        @raise: If the descriptor no longer has a valid file descriptor
-            number associated with it.
-
         @return: The platform-specified representation of a file descriptor
             number.  Or C{-1} if the descriptor no longer has a valid file
             descriptor number associated with it.  As long as the descriptor

--- a/src/twisted/internet/iocpreactor/interfaces.py
+++ b/src/twisted/internet/iocpreactor/interfaces.py
@@ -15,8 +15,8 @@ class IReadHandle(Interface):
         """
         Read into the given buffers from this handle.
 
-        @param buff: the buffers to read into
-        @type buff: list of objects implementing the read/write buffer protocol
+        @param bufflist: the buffers to read into
+        @type bufflist: list of objects implementing the read/write buffer protocol
 
         @param evt: an IOCP Event object
 

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -255,10 +255,10 @@ class ClientCreator:
         @param method: A callable which will actually start the connection
             attempt.  For example, C{reactor.connectTCP}.
 
-        @param *args: Positional arguments to pass to C{method}, excluding the
+        @param args: Positional arguments to pass to C{method}, excluding the
             factory.
 
-        @param **kwargs: Keyword arguments to pass to C{method}.
+        @param kwargs: Keyword arguments to pass to C{method}.
 
         @return: A L{Deferred} which fires with an instance of the protocol
             class passed to this L{ClientCreator}'s initializer or fails if the

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -822,9 +822,9 @@ def deferLater(clock, delay, callable=None, *args, **kw):
 
     @param callable: The object to call after the delay.
 
-    @param *args: The positional arguments to pass to C{callable}.
+    @param args: The positional arguments to pass to C{callable}.
 
-    @param **kw: The keyword arguments to pass to C{callable}.
+    @param kw: The keyword arguments to pass to C{callable}.
 
     @rtype: L{defer.Deferred}
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -913,8 +913,8 @@ class _IFileDescriptorReservation(Interface):
         because of C{EMFILE}, internal state is reset so that another
         reservation attempt can be made.
 
-        @raises: Any exception except an L{OSError} or L{IOError}
-            whose errno is L{EMFILE}.
+        @raises Exception: Any exception except an L{OSError} whose
+            errno is L{EMFILE}.
         """
 
     def __enter__():

--- a/src/twisted/internet/threads.py
+++ b/src/twisted/internet/threads.py
@@ -101,7 +101,7 @@ def blockingCallFromThread(reactor, f, *a, **kw):
     @return: the result of the L{Deferred} returned by C{f}, or the result
         of C{f} if it returns anything other than a L{Deferred}.
 
-    @raise: If C{f} raises a synchronous exception,
+    @raise Exception: If C{f} raises a synchronous exception,
         C{blockingCallFromThread} will raise that exception.  If C{f}
         returns a L{Deferred} which fires with a L{Failure},
         C{blockingCallFromThread} will raise that failure's exception (see

--- a/src/twisted/internet/threads.py
+++ b/src/twisted/internet/threads.py
@@ -29,8 +29,8 @@ def deferToThreadPool(reactor, threadpool, f, *args, **kwargs):
         method of C{twisted.python.threadpool.ThreadPool}.
 
     @param f: The function to call.
-    @param *args: positional arguments to pass to f.
-    @param **kwargs: keyword arguments to pass to f.
+    @param args: positional arguments to pass to f.
+    @param kwargs: keyword arguments to pass to f.
 
     @return: A Deferred which fires a callback with the result of f, or an
         errback with a L{twisted.python.failure.Failure} if f throws an
@@ -54,8 +54,8 @@ def deferToThread(f, *args, **kwargs):
     Run a function in a thread and return the result as a Deferred.
 
     @param f: The function to call.
-    @param *args: positional arguments to pass to f.
-    @param **kwargs: keyword arguments to pass to f.
+    @param args: positional arguments to pass to f.
+    @param kwargs: keyword arguments to pass to f.
 
     @return: A Deferred which fires a callback with the result of f,
     or an errback with a L{twisted.python.failure.Failure} if f throws

--- a/src/twisted/logger/_legacy.py
+++ b/src/twisted/logger/_legacy.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 @implementer(ILogObserver)
 class LegacyLogObserverWrapper:
     """
-    L{ILogObserver} that wraps a L{twisted.python.log.ILegacyLogObserver}.
+    L{ILogObserver} that wraps a L{twisted.python.log.ILogObserver}.
 
     Received (new-style) events are modified prior to forwarding to
     the legacy observer to ensure compatibility with observers that

--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -72,7 +72,7 @@ class STDLibLogObserver:
         self, name: str = "twisted", stackDepth: int = defaultStackDepth
     ) -> None:
         """
-        @param loggerName: logger identifier.
+        @param name: logger identifier.
         @param stackDepth: The depth of the stack to investigate for caller
             metadata.
         """

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -3409,8 +3409,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         @type mailbox: L{str}
         @param mailbox: The name of the mailbox to query
 
-        @type *names: L{bytes}
-        @param *names: The status names to query.  These may be any number of:
+        @type names: L{bytes}
+        @param names: The status names to query.  These may be any number of:
             C{'MESSAGES'}, C{'RECENT'}, C{'UIDNEXT'}, C{'UIDVALIDITY'}, and
             C{'UNSEEN'}.
 

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -3583,7 +3583,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         Any non-zero number of queries are accepted by this method, as returned
         by the C{Query}, C{Or}, and C{Not} functions.
 
-        @param uid: if true, the server is asked to return message UIDs instead
+        @keyword uid: if true, the server is asked to return message UIDs instead
             of message sequence numbers.  (This is a keyword-only argument.)
         @type uid: L{bool}
 

--- a/src/twisted/mail/maildir.py
+++ b/src/twisted/mail/maildir.py
@@ -689,10 +689,8 @@ class StringListMailbox:
         """
         Return an in-memory file-like object with the contents of a message.
 
-        @type i: L{int}
         @param i: The 0-based index of a message.
 
-        @rtype: L{IO[bytes]}
         @return: An in-memory file-like object containing the message.
 
         @raise IndexError: When the index does not correspond to a message in

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -770,7 +770,7 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
         send a successful response to the client.
 
         @type result: C{tuple}
-        @param interface_avatar_logout: The first item of the tuple is a
+        @param result: The first item of the tuple is a
             C{zope.interface.Interface} which is the interface
             supported by the avatar.  The second item of the tuple is a
             L{IMailbox} provider which is the mailbox for the

--- a/src/twisted/mail/pop3client.py
+++ b/src/twisted/mail/pop3client.py
@@ -61,7 +61,7 @@ class _ListSetter:
         Add the value at the specified position, padding out missing entries.
 
         @type itemAndValue: C{tuple}
-        @param item: A tuple of (item, value).  The I{item} is the 0-based
+        @param itemAndValue: A tuple of (item, value).  The I{item} is the 0-based
         index in the list at which the value should be placed.  The value is
         is an L{object} to put in the list.
         """

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -926,7 +926,7 @@ class MXCalculator:
         """
         @type resolver: L{IResolver <twisted.internet.interfaces.IResolver>}
             provider or L{None}
-        @param: A resolver.
+        @param resolver: A resolver.
 
         @type clock: L{IReactorTime <twisted.internet.interfaces.IReactorTime>}
             provider or L{None}

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -1173,7 +1173,7 @@ class SMTPClient(basic.LineReceiver, policies.TimeoutMixin):
 
         @param code: the code returned by the SMTP Server
         @param resp: The string response returned from the SMTP Server
-        @param numOK: the number of addresses accepted by the remote host.
+        @param numOk: the number of addresses accepted by the remote host.
         @param addresses: is a list of tuples (address, code, resp) listing
                           the response to each RCPT command.
         @param log: is the SMTP session log

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -81,7 +81,7 @@ class SerialNumber(FancyStrMixin):
 
         @param other: The foreign L{object} to be checked.
         @return: C{other} after compatibility checks and possible coercion.
-        @raises: L{TypeError} if C{other} is not compatible.
+        @raise TypeError: If C{other} is not compatible.
         """
         if not isinstance(other, SerialNumber):
             raise TypeError("cannot compare or combine %r and %r" % (self, other))
@@ -193,7 +193,7 @@ class SerialNumber(FancyStrMixin):
 
         @see: U{http://tools.ietf.org/html/rfc1982#section-3.1}
 
-        @raises: L{ArithmeticError} if C{other} is more than C{_maxAdd}
+        @raise ArithmeticError: If C{other} is more than C{_maxAdd}
             ie more than half the maximum value of this serial number.
         """
         try:

--- a/src/twisted/names/client.py
+++ b/src/twisted/names/client.py
@@ -258,7 +258,7 @@ class Resolver(common.ResolverBase):
         issue a query to it using C{*args}, and arrange for it to be
         disconnected from its transport after the query completes.
 
-        @param *args: Positional arguments to be passed to
+        @param args: Positional arguments to be passed to
             L{DNSDatagramProtocol.query}.
 
         @return: A L{Deferred} which will be called back with the result of the

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -741,7 +741,7 @@ class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin):
     ):
         """
         @type udpPayloadSize: L{int}
-        @param payload: The number of octets of the largest UDP
+        @param udpPayloadSize: The number of octets of the largest UDP
             payload that can be reassembled and delivered in the
             requestor's network stack.
 

--- a/src/twisted/names/secondary.py
+++ b/src/twisted/names/secondary.py
@@ -58,7 +58,8 @@ class SecondaryAuthorityService(service.Service):
             C{int} giving a port number.  Together, these define where zone
             transfers will be attempted from.
 
-        @param domain: A C{bytes} giving the domain to transfer.
+        @param domains: Domain names for which to perform zone transfers.
+        @type domains: sequence of L{bytes}
 
         @return: A new instance of L{SecondaryAuthorityService}.
         """

--- a/src/twisted/newsfragments/10021.doc
+++ b/src/twisted/newsfragments/10021.doc
@@ -1,0 +1,1 @@
+Fix many docstring mistakes flagged by new sanity checks in pydoctor.

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -351,7 +351,7 @@ class TuntapPort(abstract.FileDescriptor):
         """
         Write a datagram constructed from a L{list} of L{bytes}.
 
-        @param datagram: The data that will make up the complete datagram to be
+        @param seq: The data that will make up the complete datagram to be
             written.
         @type seq: L{list} of L{bytes}
         """

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -312,7 +312,7 @@ class Heading(Angle):
         @type angleValue: C{float}
         @param variationValue: The value of the variation of this heading.
         @type variationValue: C{float}
-        @return A C{Heading } with the given values.
+        @return: A L{Heading} with the given values.
         """
         variation = Angle(variationValue, Angles.VARIATION)
         return cls(angleValue, variation)

--- a/src/twisted/positioning/ipositioning.py
+++ b/src/twisted/positioning/ipositioning.py
@@ -29,8 +29,8 @@ class IPositioningReceiver(Interface):
         """
         Method called when position error is received.
 
-        @param positioningError: The position error.
-        @type positioningError: L{twisted.positioning.base.PositionError}
+        @param positionError: The position error.
+        @type positionError: L{twisted.positioning.base.PositionError}
         """
 
     def timeReceived(time):

--- a/src/twisted/positioning/nmea.py
+++ b/src/twisted/positioning/nmea.py
@@ -155,12 +155,12 @@ class NMEAProtocol(LineReceiver, _sentence._PositioningSentenceProducerMixin):
     @cvar _SENTENCE_CONTENTS: Has the field names in an NMEA sentence for each
         sentence type (in order, obviously).
     @type _SENTENCE_CONTENTS: C{dict} of bytestrings to C{list}s of C{str}
-    @param _receiver: A receiver for NMEAProtocol sentence objects.
-    @type _receiver: L{INMEAReceiver}
-    @param _sentenceCallback: A function that will be called with a new
+    @param receiver: A receiver for NMEAProtocol sentence objects.
+    @type receiver: L{INMEAReceiver}
+    @param sentenceCallback: A function that will be called with a new
         L{NMEASentence} when it is created. Useful for massaging data from
         particularly misbehaving NMEA receivers.
-    @type _sentenceCallback: unary callable
+    @type sentenceCallback: unary callable
     """
 
     def __init__(self, receiver, sentenceCallback=None):
@@ -865,9 +865,9 @@ class NMEAAdapter:
 
         If the adapter state has no beacon information, does nothing.
 
-        @param beaconInformation: The beacon information object that beacon
+        @param newBeaconInformation: The beacon information object that beacon
             information will be merged into (if necessary).
-        @type beaconInformation: L{twisted.positioning.base.BeaconInformation}
+        @type newBeaconInformation: L{twisted.positioning.base.BeaconInformation}
         """
         old = self._state.get("_partialBeaconInformation")
         if old is None:

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -2138,11 +2138,11 @@ class StartTLS(Command):
         """
         Create a StartTLS command.  (This is private.  Use AMP.callRemote.)
 
-        @param tls_localCertificate: the PrivateCertificate object to use to
+        @keyword tls_localCertificate: the PrivateCertificate object to use to
         secure the connection.  If it's None, or unspecified, an ephemeral DH
         key is used instead.
 
-        @param tls_verifyAuthorities: a list of Certificate objects which
+        @keyword tls_verifyAuthorities: a list of Certificate objects which
         represent root certificates to verify our peer with.
         """
         if ssl is None:

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1711,7 +1711,7 @@ class Descriptor(Integer):
 
         @return: A byte string which can be used by the receiver to reconstruct
             the file descriptor.
-        @type: C{str}
+        @rtype: C{bytes}
         """
         identifier = proto._sendFileDescriptor(inObject)
         outString = Integer.toStringProto(self, identifier, proto)

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1073,7 +1073,6 @@ class BoxDispatcher:
 
         Dispatch it to a local handler call it.
 
-        @param proto: an AMP instance.
         @param box: an AmpBox to be dispatched.
         """
         cmd = box[COMMAND]

--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -2928,10 +2928,10 @@ class FTPClient(FTPClientBasic):
         This method issues the I{RNFR}/I{RNTO} command sequence to rename
         C{pathFrom} to C{pathTo}.
 
-        @param: pathFrom: the absolute path to the file to be renamed
+        @param pathFrom: the absolute path to the file to be renamed
         @type pathFrom: C{str}
 
-        @param: pathTo: the absolute path to rename the file to.
+        @param pathTo: the absolute path to rename the file to.
         @type pathTo: C{str}
 
         @return: A L{Deferred} which fires when the rename operation has

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -384,7 +384,7 @@ class ZshArgumentsGenerator:
 
         @return: L{None}
 
-        @raises: ValueError: if C{Completer} with C{repeat=True} is found and
+        @raise ValueError: If C{Completer} with C{repeat=True} is found and
             is not the last item in the C{extraActions} list.
         """
         for i, action in enumerate(self.extraActions):
@@ -408,7 +408,7 @@ class ZshArgumentsGenerator:
         """
         Ensure that none of the option names given in the metadata are typoed
         @return: L{None}
-        @raise ValueError: Raised if unknown option names have been found.
+        @raise ValueError: If unknown option names have been found.
         """
 
         def err(name):

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -70,9 +70,9 @@ class ContextTracker:
 
         @param func: A callable which will be called.
 
-        @param *args: Any additional positional arguments to pass to C{func}.
+        @param args: Any additional positional arguments to pass to C{func}.
 
-        @param **kw: Any additional keyword arguments to pass to C{func}.
+        @param kw: Any additional keyword arguments to pass to C{func}.
 
         @return: Whatever is returned by C{func}
 

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -76,7 +76,7 @@ class ContextTracker:
 
         @return: Whatever is returned by C{func}
 
-        @raise: Whatever is raised by C{func}.
+        @raise Exception: Whatever is raised by C{func}.
         """
         self.contexts.append(newContext)
         try:

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -601,7 +601,7 @@ def warnAboutFunction(offender, warningString):
     from L{warnings.warn} in that it is not limited to deprecating the behavior
     of a function currently on the call stack.
 
-    @param function: The function that is being deprecated.
+    @param offender: The function that is being deprecated.
 
     @param warningString: The string that should be emitted by this warning.
     @type warningString: C{str}

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -439,7 +439,7 @@ class AbstractFilePath:
         @param ancestor: an instance of the same class as self, ostensibly an
         ancestor of self.
 
-        @raise: ValueError if the 'ancestor' parameter is not actually an
+        @raise ValueError: If the C{ancestor} parameter is not actually an
         ancestor, i.e. a path for /x/y/z is passed as an ancestor for /a/b/c/d.
 
         @return: a list of strs

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -1276,8 +1276,8 @@ class FilePath(AbstractFilePath):
             are relative to this L{FilePath}.
         @rtype: L{list}
 
-        @raise: Anything the platform L{os.listdir} implementation might raise
-            (typically L{OSError}).
+        @raise OSError: Any exception the platform L{os.listdir} implementation
+            may raise.
         """
         return listdir(self.path)
 

--- a/src/twisted/python/lockfile.py
+++ b/src/twisted/python/lockfile.py
@@ -152,8 +152,8 @@ class FilesystemLock:
         @rtype: C{bool}
         @return: True if the lock is acquired, false otherwise.
 
-        @raise: Any exception os.symlink() may raise, other than
-        EEXIST.
+        @raise OSError: Any exception L{os.symlink()} may raise,
+            other than L{errno.EEXIST}.
         """
         clean = True
         while True:
@@ -212,8 +212,8 @@ class FilesystemLock:
 
         This deletes the directory with the given name.
 
-        @raise: Any exception os.readlink() may raise, or
-        ValueError if the lock is not owned by this process.
+        @raise OSError: Any exception L{os.readlink()} may raise.
+        @raise ValueError: If the lock is not owned by this process.
         """
         pid = readlink(self.name)
         if int(pid) != os.getpid():

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -222,7 +222,7 @@ class _ModuleIteratorHelper:
 
         to retrieve this module.
 
-        @raise: KeyError if the module is not found.
+        @raise KeyError: if the module is not found.
 
         @return: a PythonModule.
         """

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -380,7 +380,7 @@ class PythonModule(_ModuleIteratorHelper):
 
         @return: a genuine python module.
 
-        @raise: any type of exception.  Importing modules is a risky business;
+        @raise Exception: Importing modules is a risky business;
         the erorrs of any code run at module scope may be raised from here, as
         well as ImportError if something bizarre happened to the system path
         between the discovery of this PythonModule object and the attempt to

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -777,8 +777,6 @@ def iterModules():
     """
     Iterate all modules and top-level packages on the global Python path, but
     do not descend into packages.
-
-    @param importPackages: Import packages as they are seen.
     """
     return theSystemPath.iterModules()
 

--- a/src/twisted/python/procutils.py
+++ b/src/twisted/python/procutils.py
@@ -28,7 +28,7 @@ def which(name, flags=os.X_OK):
     @param flags: Arguments to L{os.access}.
 
     @rtype: C{list}
-    @param: A list of the full paths to files found, in the order in which they
+    @return: A list of the full paths to files found, in the order in which they
     were found.
     """
     result = []

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -747,8 +747,7 @@ class SphinxBuilderTests(TestCase):
             C{fileDir}.
         @type fileName: L{str}
 
-        @raise: L{FailTest <twisted.trial.unittest.FailTest>} if
-            C{fileDir.child(fileName)}:
+        @raise FailTest: If C{fileDir.child(fileName)}:
 
                 1. Does not exist.
 

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -200,7 +200,7 @@ class URLPath:
 
         @param keepQuery: Whether to keep the query parameters on the returned
             L{URLPath}.
-        @type: keepQuery: L{bool}
+        @type keepQuery: L{bool}
 
         @return: a new L{URLPath}
         """
@@ -215,7 +215,7 @@ class URLPath:
 
         @param keepQuery: Whether to keep the query parameters on the returned
             L{URLPath}.
-        @type: keepQuery: L{bool}
+        @type keepQuery: L{bool}
 
         @return: a new L{URLPath}
         """
@@ -227,7 +227,7 @@ class URLPath:
 
         @param keepQuery: Whether to keep the query parameters on the returned
             L{URLPath}.
-        @type: keepQuery: L{bool}
+        @type keepQuery: L{bool}
 
         @return: a new L{URLPath}
         """
@@ -239,7 +239,7 @@ class URLPath:
 
         @param keepQuery: Whether to keep the query parameters on the returned
             L{URLPath}.
-        @type: keepQuery: L{bool}
+        @type keepQuery: L{bool}
 
         @return: a new L{URLPath}
         """

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -757,7 +757,7 @@ def untilConcludes(f, *a, **kw):
 
     @return: Whatever C{f} returns.
 
-    @raise: Whatever C{f} raises, except for C{IOError} or C{OSError} with
+    @raise Exception: Whatever C{f} raises, except for C{OSError} with
         C{errno} set to C{EINTR}.
     """
     while True:

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -751,9 +751,9 @@ def untilConcludes(f, *a, **kw):
 
     @param f: A function to call.
 
-    @param *a: Positional arguments to pass to C{f}.
+    @param a: Positional arguments to pass to C{f}.
 
-    @param **kw: Keyword arguments to pass to C{f}.
+    @param kw: Keyword arguments to pass to C{f}.
 
     @return: Whatever C{f} returns.
 
@@ -902,8 +902,8 @@ def runAsEffectiveUser(euid, egid, function, *args, **kwargs):
     @param function: the function run with the specific permission.
     @type function: any callable
 
-    @param *args: arguments passed to C{function}
-    @param **kwargs: keyword arguments passed to C{function}
+    @param args: arguments passed to C{function}
+    @param kwargs: keyword arguments passed to C{function}
     """
     uid, gid = os.geteuid(), os.getegid()
     if uid == euid and gid == egid:

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -68,7 +68,7 @@ def quoteArguments(arguments):
     a similar API.  This allows the list passed to C{reactor.spawnProcess} to
     match the child process's C{sys.argv} properly.
 
-    @param arglist: an iterable of C{str}, each unquoted.
+    @param arguments: an iterable of C{str}, each unquoted.
 
     @return: a single string, with the given sequence quoted as necessary.
     """

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -245,8 +245,7 @@ class ProcessMonitor(service.Service):
             The default of C{None} means inheriting the laucnhing process's
             working directory.
         @type env: C{dict}
-        @raises: C{KeyError} if a process with the given name already
-            exists
+        @raise KeyError: If a process with the given name already exists.
         """
         if name in self._processes:
             raise KeyError("remove %s first" % (name,))

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1085,7 +1085,7 @@ class SynchronousTestCase(_Assertions):
         C{TestCase} stores each error logged during the run of the test and
         reports them as errors during the cleanup phase (after C{tearDown}).
 
-        @param *errorTypes: If unspecified, flush all errors. Otherwise, only
+        @param errorTypes: If unspecified, flush all errors. Otherwise, only
         flush errors that match the given types.
 
         @return: A list of failures that have been removed.

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1252,7 +1252,7 @@ class SynchronousTestCase(_Assertions):
 
         @return: Whatever C{f} returns.
 
-        @raise: Whatever C{f} raises.  If any exception is
+        @raise Exception: Whatever C{f} raises.  If any exception is
             raised by C{f}, though, no assertions will be made about emitted
             deprecations.
 

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -454,7 +454,7 @@ class Reporter(TestResult):
         Safely write to the reporter's stream.
 
         @param format: A format string to write.
-        @param *args: The arguments for the format string.
+        @param args: The arguments for the format string.
         """
         s = str(format)
         assert isinstance(s, type(""))
@@ -470,7 +470,7 @@ class Reporter(TestResult):
         the format string.
 
         @param format: A format string to write.
-        @param *args: The arguments for the format string.
+        @param args: The arguments for the format string.
         """
         self._write(format, *args)
         self._write("\n")

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -564,7 +564,7 @@ class TestLoader:
         within the given package (and so on), otherwise, only inspect modules
         in the package itself.
 
-        @raise: TypeError if 'package' is not a package.
+        @raise TypeError: If C{package} is not a package.
 
         @return: a TestSuite created with my suiteFactory, containing all the
         tests.

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -401,7 +401,7 @@ class TestLoader:
         """
         Find and load tests, given C{name}.
 
-        @param name: The qualified name of the thing to load.
+        @param _name: The qualified name of the thing to load.
         @param recurse: A boolean. If True, inspect modules within packages
             within the given package (and so on), otherwise, only inspect
             modules in the package itself.

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -1075,7 +1075,7 @@ class H2Stream:
         @type reason: L{bytes}
 
         @param headers: The HTTP response headers.
-        @type: Any iterable of two-tuples of L{bytes}, representing header
+        @type headers: Any iterable of two-tuples of L{bytes}, representing header
             names and header values.
         """
         self._conn.writeHeaders(version, code, reason, headers, self.streamID)

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1069,7 +1069,7 @@ class _ContextFactoryWithContext:
         L{_DeprecatedToCurrentPolicyForHTTPS._webContextFactory}.
 
         @return: A context.
-        @rtype context: L{OpenSSL.SSL.Context}
+        @rtype: L{OpenSSL.SSL.Context}
         """
         return self._context
 

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -950,9 +950,6 @@ class BrowserLikePolicyForHTTPS:
         <twisted.internet.interfaces.IOpenSSLClientConnectionCreator>} for a
         given network location.
 
-        @param tls: The TLS protocol to create a connection for.
-        @type tls: L{twisted.protocols.tls.TLSMemoryBIOProtocol}
-
         @param hostname: The hostname part of the URI.
         @type hostname: L{bytes}
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1285,9 +1285,7 @@ class Request:
             U{https://tools.ietf.org/html/draft-west-first-party-cookies-07}
         @type sameSite: L{None}, L{bytes} or L{str}
 
-        @raises: L{DeprecationWarning} if an argument is not L{bytes} or
-            L{str}.
-            L{ValueError} if the value for C{sameSite} is not supported.
+        @raise ValueError: If the value for C{sameSite} is not supported.
         """
 
         def _ensureBytes(val):

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2652,9 +2652,6 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
         As described by HTTP standard we should be patient and accept the
         whole request from the client before sending a polite bad request
         response, even in the case when clients send tons of data.
-
-        @param transport: Transport handling connection to the client.
-        @type transport: L{interfaces.ITransport}
         """
         self.transport.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
         self.loseConnection()

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -214,7 +214,7 @@ class IRequest(Interface):
         @see: {twisted.web.server.Request.prepath}
 
         @return: An absolute URL.
-        @type: L{bytes}
+        @rtype: L{bytes}
         """
 
     def rememberRootURL():
@@ -228,7 +228,7 @@ class IRequest(Interface):
         Get a previously-remembered URL.
 
         @return: An absolute URL.
-        @type: L{bytes}
+        @rtype: L{bytes}
         """
 
     # Methods for outgoing response

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -824,7 +824,7 @@ class Site(http.HTTPFactory):
         @param uid: Unique ID of the session.
         @type uid: L{bytes}.
 
-        @raise: L{KeyError} if the session is not found.
+        @raise KeyError: If the session is not found.
         """
         return self.sessions[uid]
 

--- a/src/twisted/web/xmlrpc.py
+++ b/src/twisted/web/xmlrpc.py
@@ -317,8 +317,8 @@ def addIntrospection(xmlrpc):
     """
     Add Introspection support to an XMLRPC server.
 
-    @param parent: the XMLRPC server to add Introspection support to.
-    @type parent: L{XMLRPC}
+    @param xmlrpc: the XMLRPC server to add Introspection support to.
+    @type xmlrpc: L{XMLRPC}
     """
     xmlrpc.putSubHandler("system", XMLRPCIntrospection(xmlrpc))
 

--- a/src/twisted/words/im/basechat.py
+++ b/src/twisted/words/im/basechat.py
@@ -209,7 +209,7 @@ class GroupConversation:
         """
         Send text to the group.
 
-        @param: The text to be sent.
+        @param text: The text to be sent.
         @type text: C{str}
         """
         self.group.sendGroupMessage(text, None)
@@ -367,7 +367,7 @@ class ChatUI:
         @param person: The person whose conversation window we want to get.
 
         @type Class: L{IConversation<interfaces.IConversation>} implementor
-        @param: The kind of conversation window we want. If the conversation
+        @param Class: The kind of conversation window we want. If the conversation
             window for this person didn't already exist, create one of this type.
 
         @type stayHidden: C{bool}
@@ -396,7 +396,7 @@ class ChatUI:
         @param group: The group whose conversation window we want to get.
 
         @type Class: L{IConversation<interfaces.IConversation>} implementor
-        @param: The kind of conversation window we want. If the conversation
+        @param Class: The kind of conversation window we want. If the conversation
             window for this person didn't already exist, create one of this type.
 
         @type stayHidden: C{bool}

--- a/src/twisted/words/im/basechat.py
+++ b/src/twisted/words/im/basechat.py
@@ -331,7 +331,7 @@ class ChatUI:
         @type client: L{IClient<interfaces.IClient>} provider
         @param client: The client account for the person who has just signed on.
 
-        @rtype client: L{IClient<interfaces.IClient>} provider
+        @rtype: L{IClient<interfaces.IClient>} provider
         @return: The client, so that it may be used in a callback chain.
         """
         self.onlineClients.append(client)

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -885,7 +885,7 @@ class ServerSupportedFeatures(_CommandDispatcherMixin):
         @type param: C{str}
 
         @rtype: C{(str, list)}
-        @return C{(key, arguments)}
+        @return: C{(key, arguments)}
         """
         if "=" not in param:
             param += "="
@@ -2639,7 +2639,7 @@ class IRCClient(basic.LineReceiver):
         Get user modes that require parameters for correct parsing.
 
         @rtype: C{[str, str]}
-        @return C{[add, remove]}
+        @return: C{[add, remove]}
         """
         return ["", ""]
 
@@ -2648,7 +2648,7 @@ class IRCClient(basic.LineReceiver):
         Get channel modes that require parameters for correct parsing.
 
         @rtype: C{[str, str]}
-        @return C{[add, remove]}
+        @return: C{[add, remove]}
         """
         # PREFIX modes are treated as "type B" CHANMODES, they always take
         # parameter.

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -1320,7 +1320,7 @@ class IRCClient(basic.LineReceiver):
         Called with daemon information about the server, usually at logon.
 
         @type info: C{str}
-        @param when: A string describing what software the server is running, probably.
+        @param info: A string describing what software the server is running, probably.
         """
 
     def myInfo(self, servername, version, umodes, cmodes):


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10021
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
