### PR TITLE
 Convert parameters popped from **kwargs to keyword-only

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1177,7 +1177,12 @@ class ClientTLSOptions:
 
 
 def optionsForClientTLS(
-    hostname, trustRoot=None, clientCertificate=None, acceptableProtocols=None, **kw
+    hostname,
+    trustRoot=None,
+    clientCertificate=None,
+    acceptableProtocols=None,
+    *,
+    extraCertificateOptions=None
 ):
     """
     Create a L{client connection creator <IOpenSSLClientConnectionCreator>} for
@@ -1218,28 +1223,19 @@ def optionsForClientTLS(
         the list are preferred over those later in the list.
     @type acceptableProtocols: L{list} of L{bytes}
 
-    @keyword extraCertificateOptions: keyword-only argument; this is a dictionary
-        of additional keyword arguments to be presented to
-        L{CertificateOptions}. Please avoid using this unless you absolutely
-        need to; any time you need to pass an option here that is a bug in this
-        interface.
+    @param extraCertificateOptions: A dictionary of additional keyword arguments
+        to be presented to L{CertificateOptions}. Please avoid using this unless
+        you absolutely need to; any time you need to pass an option here that is
+        a bug in this interface.
     @type extraCertificateOptions: L{dict}
-
-    @param kw: (Backwards compatibility hack to allow keyword-only arguments on
-        Python 2. Please ignore; arbitrary keyword arguments will be errors.)
-    @type kw: L{dict}
 
     @return: A client connection creator.
     @rtype: L{IOpenSSLClientConnectionCreator}
     """
-    extraCertificateOptions = kw.pop("extraCertificateOptions", None) or {}
+    if extraCertificateOptions is None:
+        extraCertificateOptions = {}
     if trustRoot is None:
         trustRoot = platformTrust()
-    if kw:
-        raise TypeError(
-            "optionsForClientTLS() got an unexpected keyword argument"
-            " '{arg}'".format(arg=kw.popitem()[0])
-        )
     if not isinstance(hostname, str):
         raise TypeError(
             "optionsForClientTLS requires text for host names, not "

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -3574,7 +3574,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
                 ids.append(self._intOrRaise(parts[0], parts))
         return ids
 
-    def search(self, *queries, **kwarg):
+    def search(self, *queries, uid=False):
         """
         Search messages in the currently selected mailbox
 
@@ -3583,8 +3583,8 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         Any non-zero number of queries are accepted by this method, as returned
         by the C{Query}, C{Or}, and C{Not} functions.
 
-        @keyword uid: if true, the server is asked to return message UIDs instead
-            of message sequence numbers.  (This is a keyword-only argument.)
+        @param uid: if true, the server is asked to return message UIDs instead
+            of message sequence numbers.
         @type uid: L{bool}
 
         @rtype: L{Deferred}
@@ -3596,10 +3596,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
         # identifier is provided.  See #9201.
         queries = [query.encode("charmap") for query in queries]
 
-        if kwarg.get("uid"):
-            cmd = b"UID SEARCH"
-        else:
-            cmd = b"SEARCH"
+        cmd = b"UID SEARCH" if uid else b"SEARCH"
         args = b" ".join(queries)
         d = self.sendCommand(Command(cmd, args, wantResponse=(cmd,)))
         d.addCallback(self.__cbSearch)

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -2109,21 +2109,25 @@ class StartTLS(Command):
 
     responseType = _TLSBox
 
-    def __init__(self, **kw):
+    def __init__(self, *, tls_localCertificate=None, tls_verifyAuthorities=None, **kw):
         """
         Create a StartTLS command.  (This is private.  Use AMP.callRemote.)
 
-        @keyword tls_localCertificate: the PrivateCertificate object to use to
-        secure the connection.  If it's None, or unspecified, an ephemeral DH
+        @param tls_localCertificate: the PrivateCertificate object to use to
+        secure the connection.  If it's L{None}, or unspecified, an ephemeral DH
         key is used instead.
 
-        @keyword tls_verifyAuthorities: a list of Certificate objects which
+        @param tls_verifyAuthorities: a list of Certificate objects which
         represent root certificates to verify our peer with.
         """
         if ssl is None:
             raise RuntimeError("TLS not available.")
-        self.certificate = kw.pop("tls_localCertificate", _NoCertificate(True))
-        self.authorities = kw.pop("tls_verifyAuthorities", None)
+        self.certificate = (
+            _NoCertificate(True)
+            if tls_localCertificate is None
+            else tls_localCertificate
+        )
+        self.authorities = tls_verifyAuthorities
         Command.__init__(self, **kw)
 
     def _doCommand(self, proto):


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10025
* [x] I ran `tox -e black-reformat` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
