### PR TITLE
move _trial_temp to tox envtmpdir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,12 +121,12 @@ commands =
     posix: python -c "print('Running on POSIX (no special dependencies)')"
 
     ; Run tests without wrapping them using coverage.
-    nocov: python -m twisted.trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose}  {posargs:twisted}
+    nocov: python -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose}  {posargs:twisted}
 
     ; Run the tests wrapped using coverage.
     withcov: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth
     withcov: coverage erase
-    withcov: coverage run -p --rcfile={toxinidir}/.coveragerc -m twisted.trial --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {posargs:twisted}
+    withcov: coverage run -p --rcfile={toxinidir}/.coveragerc -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {posargs:twisted}
 
     ; Prepare coverage reports for publication.
     {coverage-prepare,codecov-publish}: coverage combine


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10036
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

More info here: https://freenode.logbot.info/twisted-dev/20201024#c5576741-c5577518

This helps enable a whole bunch of stuff:

* Running with `tox --parallel`
* avoiding problems like, pip failing with:

```
WARNING: Ignoring special file error '`/home/graingert/projects/twisted/_trial_temp/twisted.test.test_unix/DatagramUnixSocketTests/test_reprWithNewStyleProtocol/lk6x7h_1/temp` is a socket' encountered copying /home/graingert/projects/twisted/_trial_temp/twisted.test.test_unix/DatagramUnixSocketTests/test_reprWithNewStyleProtocol/lk6x7h_1/temp to /tmp/pip-req-build-1wyjs487/_trial_temp/twisted.test.test_unix/DatagramUnixSocketTests/test_reprWithNewStyleProtocol/lk6x7h_1/temp.
```