### PR TITLE
Fix some more flake8 violations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -140,8 +140,6 @@ per-file-ignores =
         E712,
         # do not compare types, use 'isinstance()'
         E721,
-        # do not assign a lambda expression, use a def
-        E731,
         # ambiguous variable name 'l'
         E741,
         # ambiguous function definition 'l'

--- a/src/twisted/conch/test/test_endpoints.py
+++ b/src/twisted/conch/test/test_endpoints.py
@@ -647,7 +647,10 @@ class SSHCommandClientEndpointTestsMixin:
 
         recorder = []
         if noArgs:
-            f = lambda: recorder.append(None)
+
+            def f():
+                return recorder.append(None)
+
         else:
             f = recorder.append
 

--- a/src/twisted/conch/test/test_recvline.py
+++ b/src/twisted/conch/test/test_recvline.py
@@ -54,7 +54,10 @@ class ArrowsTests(TestCase):
         RIGHT_ARROW keystroke it moves the cursor left or right
         in the current line buffer, respectively.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
+
         for ch in iterbytes(b"xyz"):
             kR(ch)
 
@@ -92,7 +95,9 @@ class ArrowsTests(TestCase):
         When {HistoricRecvLine} receives a newline, it adds the current
         line buffer to the end of its history buffer.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz\nabc\n123\n"):
             kR(ch)
@@ -116,7 +121,9 @@ class ArrowsTests(TestCase):
         buffer up or down, and resets the current line buffer to the
         previous or next line in history, respectively for each.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz\nabc\n123\n"):
             kR(ch)
@@ -149,7 +156,9 @@ class ArrowsTests(TestCase):
         When L{HistoricRecvLine} receives a HOME keystroke it moves the
         cursor to the beginning of the current line buffer.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"hello, world"):
             kR(ch)
@@ -163,7 +172,9 @@ class ArrowsTests(TestCase):
         When L{HistoricRecvLine} receives an END keystroke it moves the cursor
         to the end of the current line buffer.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"hello, world"):
             kR(ch)
@@ -178,7 +189,9 @@ class ArrowsTests(TestCase):
         When L{HistoricRecvLine} receives a BACKSPACE keystroke it deletes
         the character immediately before the cursor.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz"):
             kR(ch)
@@ -199,7 +212,9 @@ class ArrowsTests(TestCase):
         When L{HistoricRecvLine} receives a DELETE keystroke, it
         delets the character immediately after the cursor.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz"):
             kR(ch)
@@ -228,7 +243,9 @@ class ArrowsTests(TestCase):
         When not in INSERT mode, L{HistoricRecvLine} inserts the typed
         character at the cursor before the next character.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz"):
             kR(ch)
@@ -248,7 +265,9 @@ class ArrowsTests(TestCase):
         the cursor with the typed character rather than inserting before.
         Ah, the ironies of INSERT mode.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
 
         for ch in iterbytes(b"xyz"):
             kR(ch)
@@ -268,7 +287,10 @@ class ArrowsTests(TestCase):
         When L{HistoricRecvLine} receives a keystroke for an unprintable
         function key with no assigned behavior, the line buffer is unmodified.
         """
-        kR = lambda ch: self.p.keystrokeReceived(ch, None)
+
+        def kR(ch):
+            return self.p.keystrokeReceived(ch, None)
+
         pt = self.pt
 
         for ch in (

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -856,7 +856,10 @@ class SSHFactoryTests(unittest.TestCase):
 
     def makeSSHFactory(self, primes=None):
         sshFactory = factory.SSHFactory()
-        gpk = lambda: {"ssh-rsa": keys.Key(None)}
+
+        def gpk():
+            return {"ssh-rsa": keys.Key(None)}
+
         sshFactory.getPrimes = lambda: primes
         sshFactory.getPublicKeys = sshFactory.getPrivateKeys = gpk
         sshFactory.startFactory()

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -293,7 +293,9 @@ class AsyncioSelectorReactor(PosixReactorBase):
         return dc
 
     def callFromThread(self, f, *args, **kwargs):
-        g = lambda: self.callLater(0, f, *args, **kwargs)
+        def g():
+            return self.callLater(0, f, *args, **kwargs)
+
         self._asyncioEventloop.call_soon_threadsafe(g)
 
 

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -320,7 +320,10 @@ class ConnectionTestsMixin:
         finished = []
 
         serverConnectionLostDeferred = Deferred()
-        protocol = lambda: ClosingLaterProtocol(serverConnectionLostDeferred)
+
+        def protocol():
+            return ClosingLaterProtocol(serverConnectionLostDeferred)
+
         portDeferred = self.endpoints.server(reactor).listen(
             ServerFactory.forProtocol(protocol)
         )
@@ -330,7 +333,10 @@ class ConnectionTestsMixin:
             endpoint = self.endpoints.client(reactor, port.getHost())
 
             lostConnectionDeferred = Deferred()
-            protocol = lambda: ClosingLaterProtocol(lostConnectionDeferred)
+
+            def protocol():
+                return ClosingLaterProtocol(lostConnectionDeferred)
+
             client = endpoint.connect(ClientFactory.forProtocol(protocol))
 
             def write(proto):

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -127,7 +127,10 @@ else:
     try:
         from twisted.internet.test import _posixifaces
     except ImportError:
-        getLinkLocalIPv6Addresses = lambda: []
+
+        def getLinkLocalIPv6Addresses():
+            return []
+
     else:
         getLinkLocalIPv6Addresses = _posixifaces.posixGetLinkLocalIPv6Addresses
 

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -267,4 +267,7 @@ class Logger:
 
 
 _log = Logger()
-_loggerFor = lambda obj: _log.__get__(obj, obj.__class__)
+
+
+def _loggerFor(obj):
+    return _log.__get__(obj, obj.__class__)

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -4705,7 +4705,9 @@ def collapseStrings(results):
     copy = []
     begun = None
 
-    pred = lambda e: isinstance(e, tuple)
+    def pred(e):
+        return isinstance(e, tuple)
+
     tran = {
         0: lambda e: splitQuoted(b"".join(e)),
         1: lambda e: [b"".join([i[0] for i in e])],
@@ -5656,35 +5658,51 @@ class _FetchParser:
         # reply-to and sender must not be None.  If not present in a message
         # they should be defaulted to the value of the from field.
         type = "envelope"
-        __str__ = lambda self: "envelope"
+
+        def __str__(self):
+            return "envelope"
 
     class Flags:
         type = "flags"
-        __str__ = lambda self: "flags"
+
+        def __str__(self):
+            return "flags"
 
     class InternalDate:
         type = "internaldate"
-        __str__ = lambda self: "internaldate"
+
+        def __str__(self):
+            return "internaldate"
 
     class RFC822Header:
         type = "rfc822header"
-        __str__ = lambda self: "rfc822.header"
+
+        def __str__(self):
+            return "rfc822.header"
 
     class RFC822Text:
         type = "rfc822text"
-        __str__ = lambda self: "rfc822.text"
+
+        def __str__(self):
+            return "rfc822.text"
 
     class RFC822Size:
         type = "rfc822size"
-        __str__ = lambda self: "rfc822.size"
+
+        def __str__(self):
+            return "rfc822.size"
 
     class RFC822:
         type = "rfc822"
-        __str__ = lambda self: "rfc822"
+
+        def __str__(self):
+            return "rfc822"
 
     class UID:
         type = "uid"
-        __str__ = lambda self: "uid"
+
+        def __str__(self):
+            return "uid"
 
     class Body:
         type = "body"
@@ -5725,7 +5743,9 @@ class _FetchParser:
 
     class BodyStructure:
         type = "bodystructure"
-        __str__ = lambda self: "bodystructure"
+
+        def __str__(self):
+            return "bodystructure"
 
     # These three aren't top-level, they don't need type indicators
     class Header:

--- a/src/twisted/mail/test/pop3testserver.py
+++ b/src/twisted/mail/test/pop3testserver.py
@@ -100,7 +100,9 @@ class POP3TestServer(basic.LineReceiver):
         """Error Conditions"""
 
         uline = line.upper()
-        find = lambda s: uline.find(s) != -1
+
+        def find(s):
+            return uline.find(s) != -1
 
         if TIMEOUT_RESPONSE:
             # Do not respond to clients request

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -804,7 +804,9 @@ class AdditionalProcessingTests(unittest.TestCase):
         # RRHeader instances aren't inherently ordered.  Impose an ordering
         # that's good enough for the purposes of these tests - in which we
         # never have more than one record of a particular type.
-        key = lambda rr: rr.type
+        def key(rr):
+            return rr.type
+
         self.assertEqual(sorted(expected, key=key), sorted(computed, key=key))
 
     def _additionalTest(self, method, makeRecord, addresses):

--- a/src/twisted/pair/testing.py
+++ b/src/twisted/pair/testing.py
@@ -542,9 +542,9 @@ class _FakePort:
             ether.addProto(0x800, ip)
             datagramReceived = ether.datagramReceived
         else:
-            datagramReceived = lambda data: ip.datagramReceived(
-                data, None, None, None, None
-            )
+
+            def datagramReceived(data):
+                return ip.datagramReceived(data, None, None, None, None)
 
         dataHasPI = not (mode & TunnelFlags.IFF_NO_PI.value)
 

--- a/src/twisted/persisted/test/test_styles.py
+++ b/src/twisted/persisted/test/test_styles.py
@@ -39,7 +39,8 @@ def sampleFunction():
     """
 
 
-lambdaExample = lambda x: x
+def lambdaExample(x):
+    return x
 
 
 class UniversalPicklingErrorTests(unittest.TestCase):

--- a/src/twisted/persisted/test/test_styles.py
+++ b/src/twisted/persisted/test/test_styles.py
@@ -39,10 +39,6 @@ def sampleFunction():
     """
 
 
-def lambdaExample(x):
-    return x
-
-
 class UniversalPicklingErrorTests(unittest.TestCase):
     """
     Tests the L{_UniversalPicklingError} exception.
@@ -126,4 +122,4 @@ class UnpickleMethodTests(unittest.TestCase):
         """
         Pickling a C{lambda} function ought to raise a L{pickle.PicklingError}.
         """
-        self.assertRaises(pickle.PicklingError, pickle.dumps, lambdaExample)
+        self.assertRaises(pickle.PicklingError, pickle.dumps, lambda x: x)

--- a/src/twisted/positioning/test/test_nmea.py
+++ b/src/twisted/positioning/test/test_nmea.py
@@ -737,7 +737,10 @@ class CoordinateFixerTests(FixerTestMixin, TestCase):
         when you pass nonexistent coordinate types (not latitude or
         longitude).
         """
-        getSign = lambda: self.adapter._getHemisphereSign("BOGUS_VALUE")
+
+        def getSign():
+            return self.adapter._getHemisphereSign("BOGUS_VALUE")
+
         self.assertRaises(ValueError, getSign)
 
 

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -602,7 +602,10 @@ class PythonPath:
         with sys.path to miss.
         """
         if sysPath is not None:
-            sysPathFactory = lambda: sysPath
+
+            def sysPathFactory():
+                return sysPath
+
         elif sysPathFactory is None:
             sysPathFactory = _defaultSysPathFactory
         self._sysPathFactory = sysPathFactory

--- a/src/twisted/python/test/test_components.py
+++ b/src/twisted/python/test/test_components.py
@@ -371,7 +371,10 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         class or interface and verify that the adapter can be looked up with
         L{components.getAdapterFactory}.
         """
-        adapter = lambda o: None
+
+        def adapter(o):
+            return None
+
         components.registerAdapter(adapter, original, ITest)
         self.assertIs(components.getAdapterFactory(original, ITest, None), adapter)
 
@@ -398,8 +401,13 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Verify that L{components.registerAdapter} raises L{ValueError} if the
         from-type/interface and to-interface pair is not unique.
         """
-        firstAdapter = lambda o: False
-        secondAdapter = lambda o: True
+
+        def firstAdapter(o):
+            return False
+
+        def secondAdapter(o):
+            return True
+
         components.registerAdapter(firstAdapter, original, ITest)
         self.assertRaises(
             ValueError, components.registerAdapter, secondAdapter, original, ITest
@@ -431,8 +439,12 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         adapter registrations for a particular from-type/interface and
         to-interface pair replace older registrations.
         """
-        firstAdapter = lambda o: False
-        secondAdapter = lambda o: True
+
+        def firstAdapter(o):
+            return False
+
+        def secondAdapter(o):
+            return True
 
         class TheInterface(Interface):
             pass
@@ -486,7 +498,10 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         Verify that an adapter can be registered for multiple to-interfaces at a
         time.
         """
-        adapter = lambda o: None
+
+        def adapter(o):
+            return None
+
         components.registerAdapter(adapter, original, ITest, ITest2)
         self.assertIs(components.getAdapterFactory(original, ITest, None), adapter)
         self.assertIs(components.getAdapterFactory(original, ITest2, None), adapter)
@@ -516,8 +531,12 @@ class RegistrationTests(RegistryUsingMixin, unittest.SynchronousTestCase):
         adapter registered to that interface and that the subclass adapter takes
         precedence over the base class adapter.
         """
-        firstAdapter = lambda o: True
-        secondAdapter = lambda o: False
+
+        def firstAdapter(o):
+            return True
+
+        def secondAdapter(o):
+            return False
 
         class TheSubclass(original):
             pass

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -70,7 +70,8 @@ relativeLinkTestsForRFC3986 = [
 ]
 
 
-_percentenc = lambda s: "".join("%%%02X" % ord(c) for c in s)
+def _percentenc(s):
+    return "".join("%%%02X" % ord(c) for c in s)
 
 
 class TestURL(SynchronousTestCase):

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -6,12 +6,19 @@
 L{URLPath}, a representation of a URL.
 """
 
-from typing import cast
+from typing import cast, TypeVar
 from urllib.parse import quote as urlquote, unquote as urlunquote, urlunsplit
 
 from hyperlink import URL as _URL
 
 _allascii = b"".join([chr(x).encode("ascii") for x in range(1, 128)])
+
+
+_T = TypeVar("_T")
+
+
+def _id(x: _T) -> _T:
+    return x
 
 
 def _rereconstituter(name):
@@ -119,17 +126,8 @@ class URLPath:
         @return: The components of C{self.path}
         @rtype: L{list} of L{bytes}
         """
-        segments = self._url.path
-
-        def mapper(x):
-            return x.encode("ascii")
-
-        if unquote:
-
-            def mapper(x, m=mapper):
-                return m(urlunquote(x))
-
-        return [b""] + [mapper(segment) for segment in segments]
+        mapper = urlunquote if unquote else _id
+        return [b""] + [mapper(segment).encode("ascii")) for segment in self._url.path]
 
     @classmethod
     def fromString(klass, url):

--- a/src/twisted/python/urlpath.py
+++ b/src/twisted/python/urlpath.py
@@ -120,9 +120,15 @@ class URLPath:
         @rtype: L{list} of L{bytes}
         """
         segments = self._url.path
-        mapper = lambda x: x.encode("ascii")
+
+        def mapper(x):
+            return x.encode("ascii")
+
         if unquote:
-            mapper = lambda x, m=mapper: m(urlunquote(x))
+
+            def mapper(x, m=mapper):
+                return m(urlunquote(x))
+
         return [b""] + [mapper(segment) for segment in segments]
 
     @classmethod

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -410,11 +410,15 @@ class Options(dict):
             # in parseOptions, as it makes all option-methods have the
             # same signature.
             if takesArg:
-                fn = lambda name, value, m=method: m(value)
+
+                def fn(name, value, m=method):
+                    return m(value)
+
             else:
                 # XXX: This won't raise a TypeError if it's called
                 # with a value when it shouldn't be.
-                fn = lambda name, value=None, m=method: m()
+                def fn(name, value=None, m=method):
+                    return m()
 
             dispatch[prettyName] = fn
 

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -417,7 +417,7 @@ class Options(dict):
             else:
                 # XXX: This won't raise a TypeError if it's called
                 # with a value when it shouldn't be.
-                def fn(name, value=None, m=method):
+                def fn(name, value=None, m=method):  # type: ignore[misc]
                     return m()
 
             dispatch[prettyName] = fn

--- a/src/twisted/test/test_task.py
+++ b/src/twisted/test/test_task.py
@@ -181,7 +181,9 @@ class ClockTests(unittest.TestCase):
         result = []
         expected = [("b", 2.0), ("a", 3.0)]
         clock = task.Clock()
-        logtime = lambda n: result.append((n, clock.seconds()))
+
+        def logtime(n):
+            return result.append((n, clock.seconds()))
 
         call_a = clock.callLater(1.0, logtime, "a")
         call_a.reset(3.0)
@@ -205,7 +207,9 @@ class ClockTests(unittest.TestCase):
         result = []
         expected = [("b", 2.0), ("a", 3.0)]
         clock = task.Clock()
-        logtime = lambda n: result.append((n, clock.seconds()))
+
+        def logtime(n):
+            return result.append((n, clock.seconds()))
 
         call_a = clock.callLater(1.0, logtime, "a")
         clock.callLater(2.0, logtime, "b")
@@ -224,7 +228,9 @@ class ClockTests(unittest.TestCase):
         result = []
         expected = [("c", 3.0), ("b", 4.0)]
         clock = task.Clock()
-        logtime = lambda n: result.append((n, clock.seconds()))
+
+        def logtime(n):
+            return result.append((n, clock.seconds()))
 
         call_b = clock.callLater(2.0, logtime, "b")
 

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -864,9 +864,14 @@ class TrialRunner:
                 result.stopTest(single)
         else:
             if self.mode == self.DEBUG:
-                run = lambda: self.debugger.runcall(suite.run, result)
+
+                def run():
+                    return self.debugger.runcall(suite.run, result)
+
             else:
-                run = lambda: suite.run(result)
+
+                def run():
+                    return suite.run(result)
 
             oldDir = self._setUpTestdir()
             try:

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -505,9 +505,9 @@ class HTTPClientParser(HTTPParser):
                     self._finished(self.clearLineBuffer())
                     transferDecoder = None
                 else:
-                    transferDecoder = lambda x, y: _IdentityTransferDecoder(
-                        contentLength, x, y
-                    )
+
+                    def transferDecoder(x, y):
+                        return _IdentityTransferDecoder(contentLength, x, y)
 
             if transferDecoder is None:
                 self.response._bodyDataFinished()

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -150,8 +150,11 @@ class HTTPPageGetter(http.HTTPClient):
     def handleStatus_200(self):
         pass
 
-    handleStatus_201 = lambda self: self.handleStatus_200()
-    handleStatus_202 = lambda self: self.handleStatus_200()
+    def handleStatus_201(self):
+        return self.handleStatus_200()
+
+    def handleStatus_202(self):
+        return self.handleStatus_200()
 
     def handleStatusDefault(self):
         self.failed = 1
@@ -825,7 +828,10 @@ def downloadPage(url, file, contextFactory=None, *args, **kwargs):
 
     See HTTPDownloader to see what extra args can be passed.
     """
-    factoryFactory = lambda url, *a, **kw: HTTPDownloader(url, file, *a, **kw)
+
+    def factoryFactory(url, *a, **kw):
+        return HTTPDownloader(url, file, *a, **kw)
+
     return _makeGetterFactory(
         url, factoryFactory, contextFactory=contextFactory, *args, **kwargs
     ).deferred
@@ -1392,7 +1398,10 @@ class HTTPConnectionPool:
             del self._timeouts[connection]
             if connection.state == "QUIESCENT":
                 if self.retryAutomatically:
-                    newConnection = lambda: self._newConnection(key, endpoint)
+
+                    def newConnection():
+                        return self._newConnection(key, endpoint)
+
                     connection = _RetryingHTTP11ClientProtocol(
                         connection, newConnection
                     )

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -736,7 +736,9 @@ class Element(Node):
         if self.tagName in BLOCKELEMENTS:
             begin = [newl, indent] + begin
         bext = begin.extend
-        writeattr = lambda _atr, _val: bext((" ", _atr, '="', escape(_val), '"'))
+
+        def writeattr(_atr, _val):
+            return bext((" ", _atr, '="', escape(_val), '"'))
 
         # Make a local for tracking what end tag will be used.  If namespace
         # prefixes are involved, this will be changed to account for that

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -839,7 +839,9 @@ class ServerSupportedFeatures(_CommandDispatcherMixin):
         @return: Sequence of C{(name, processedValue)}
         """
         if valueProcessor is None:
-            valueProcessor = lambda x: x
+
+            def valueProcessor(x):
+                return x
 
         def _parse():
             for param in params:

--- a/src/twisted/words/test/test_basesupport.py
+++ b/src/twisted/words/test/test_basesupport.py
@@ -85,7 +85,9 @@ class ClientMsgTests(unittest.TestCase):
                 not ui.clientRegistered, "Client shouldn't be registered in the UI"
             )
 
-        cb = lambda r: self.assertTrue(False, "Shouldn't get called back")
+        def cb(r):
+            return self.assertTrue(False, "Shouldn't get called back")
+
         d.addCallbacks(cb, err)
         return d
 

--- a/src/twisted/words/xish/utility.py
+++ b/src/twisted/words/xish/utility.py
@@ -293,11 +293,16 @@ class EventDispatcher:
         if event != None:
             # Named event
             observers = self._eventObservers
-            match = lambda query, obj: query == event
+
+            def match(query, obj):
+                return query == event
+
         else:
             # XPath event
             observers = self._xpathObservers
-            match = lambda query, obj: query.matches(obj)
+
+            def match(query, obj):
+                return query.matches(obj)
 
         priorities = list(observers.keys())
         priorities.sort()


### PR DESCRIPTION
this is particularly useful under mypy as lambdas cannot be type annotated 


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10040
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
