### PR TITLE
reactor.waker moved to be private as reactor._waker

### DIFF
--- a/src/twisted/internet/_threadedselect.py
+++ b/src/twisted/internet/_threadedselect.py
@@ -99,7 +99,7 @@ class ThreadedSelectReactor(posixbase.PosixReactorBase):
 
     def wakeUp(self):
         # we want to wake up from any thread
-        self.waker.wakeUp()
+        self._waker.wakeUp()
 
     def callLater(self, *args, **kw):
         tple = posixbase.PosixReactorBase.callLater(self, *args, **kw)

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -618,7 +618,7 @@ class ReactorBase(PluggableResolverMixin):
         # reactor internal readers, e.g. the waker.
         # Using Any as the type here… unable to find a suitable defined interface
         self._internalReaders = set()  # type: Set[Any]
-        self.waker = None  # type: Any
+        self._waker = None  # type: Any
 
         # Arrange for the running attribute to change to True at the right time
         # and let a subclass possibly do other things at that time (eg install
@@ -644,8 +644,8 @@ class ReactorBase(PluggableResolverMixin):
         """
         Wake up the event loop.
         """
-        if self.waker:
-            self.waker.wakeUp()
+        if self._waker:
+            self._waker.wakeUp()
         # if the waker isn't installed, the reactor isn't running, and
         # therefore doesn't need to be woken up
 

--- a/src/twisted/internet/cfreactor.py
+++ b/src/twisted/internet/cfreactor.py
@@ -140,10 +140,10 @@ class CFReactor(PosixReactorBase):
         Override C{installWaker} in order to use L{_WakerPlus}; otherwise this
         should be exactly the same as the parent implementation.
         """
-        if not self.waker:
-            self.waker = _WakerPlus(self)
-            self._internalReaders.add(self.waker)
-            self.addReader(self.waker)
+        if not self._waker:
+            self._waker = _WakerPlus(self)
+            self._internalReaders.add(self._waker)
+            self.addReader(self._waker)
 
     def _socketCallback(
         self, cfSocket, callbackType, ignoredAddress, ignoredData, context

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -326,10 +326,10 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin, ReactorB
         We use the self-pipe trick (http://cr.yp.to/docs/selfpipe.html) to wake
         the reactor. On Windows we use a pair of sockets.
         """
-        if not self.waker:
-            self.waker = self._wakerFactory(self)
-            self._internalReaders.add(self.waker)
-            self.addReader(self.waker)
+        if not self._waker:
+            self._waker = self._wakerFactory(self)
+            self._internalReaders.add(self._waker)
+            self.addReader(self._waker)
 
     _childWaker = None
 

--- a/src/twisted/internet/test/test_posixbase.py
+++ b/src/twisted/internet/test/test_posixbase.py
@@ -47,9 +47,9 @@ class PosixReactorBaseTests(TestCase):
     """
 
     def _checkWaker(self, reactor):
-        self.assertIsInstance(reactor.waker, _Waker)
-        self.assertIn(reactor.waker, reactor._internalReaders)
-        self.assertIn(reactor.waker, reactor._readers)
+        self.assertIsInstance(reactor._waker, _Waker)
+        self.assertIn(reactor._waker, reactor._internalReaders)
+        self.assertIn(reactor._waker, reactor._readers)
 
     def test_wakerIsInternalReader(self):
         """

--- a/src/twisted/newsfragments/10041.removal
+++ b/src/twisted/newsfragments/10041.removal
@@ -1,0 +1,1 @@
+`reactor.waker` moved to be private as `reactor._waker`.


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10041
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] ~~I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)~~
  - see CI runs
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
