### PR TITLE
Fix links to non-existing anchors in standard library documentation

### DIFF
--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -173,7 +173,7 @@ class StubSessionForStubAvatarWithEnv(StubSessionForStubAvatar):
     setting.
 
     End users would want to have the same class annotated with
-    @implementer(session.ISession, session.ISessionSetEnv). The interfaces
+    C{@implementer(session.ISession, session.ISessionSetEnv)}. The interfaces
     are split for backwards compatibility, so we split it here to test
     this compatibility too.
 

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -35,8 +35,8 @@ class AsyncioSelectorReactor(PosixReactorBase):
     On POSIX platforms, the default event loop is
     L{asyncio.SelectorEventLoop}.
     On Windows, the default event loop on Python 3.7 and older
-    is L{asyncio.WindowsSelectorEventLoop}, but on Python 3.8 and newer
-    the default event loop is L{asyncio.WindowsProactorEventLoop} which
+    is C{asyncio.WindowsSelectorEventLoop}, but on Python 3.8 and newer
+    the default event loop is C{asyncio.WindowsProactorEventLoop} which
     is incompatible with L{AsyncioSelectorReactor}.
     Applications that use L{AsyncioSelectorReactor} on Windows
     with Python 3.8+ must call

--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -319,7 +319,7 @@ class ProcessTerminated(ConnectionLost):
     def __init__(self, exitCode=None, signal=None, status=None):
         """
         @param exitCode: The exit status of the process.  This is roughly like
-            the value you might pass to L{os.exit}.  This is L{None} if the
+            the value you might pass to L{os._exit}.  This is L{None} if the
             process exited due to a signal.
         @type exitCode: L{int} or L{None}
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1037,10 +1037,10 @@ class IReactorProcess(Interface):
         L{unicode} may be encoded or decoded depending on the platform and the
         argument type given.  On UNIX systems (Linux, FreeBSD, macOS) and
         Python 2 on Windows, L{unicode} arguments will be encoded down to
-        L{bytes} using the encoding given by L{os.getfilesystemencoding}, to be
+        L{bytes} using the encoding given by L{sys.getfilesystemencoding}, to be
         used with the "narrow" OS APIs.  On Python 3 on Windows, L{bytes}
         arguments will be decoded up to L{unicode} using the encoding given by
-        L{os.getfilesystemencoding} (C{mbcs} before Python 3.6, C{utf8}
+        L{sys.getfilesystemencoding} (C{mbcs} before Python 3.6, C{utf8}
         thereafter) and given to Windows's native "wide" APIs.
 
         @param processProtocol: An object which will be notified of all events

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -1437,7 +1437,7 @@ class POP3Client(basic.LineOnlyReceiver):
     @type command: L{bytes}
     @ivar command: The command most recently sent to the server.
 
-    @type welcomeRe: L{RegexObject <re.RegexObject>}
+    @type welcomeRe: L{Pattern <re.Pattern.search>}
     @ivar welcomeRe: A regular expression which matches the APOP challenge in
         the server greeting.
 

--- a/src/twisted/mail/pop3client.py
+++ b/src/twisted/mail/pop3client.py
@@ -195,7 +195,7 @@ class POP3Client(basic.LineOnlyReceiver, policies.TimeoutMixin):
         so the first response to a capabilities command can be used for
         later lookups.
 
-    @type _challengeMagicRe: L{RegexObject <re.RegexObject>}
+    @type _challengeMagicRe: L{Pattern <re.Pattern.search>}
     @ivar _challengeMagicRe: A regular expression which matches the
         challenge in the server greeting.
 

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -2725,7 +2725,7 @@ class Message(tputil.FancyEqMixin):
 
         @return: An object which implements L{IRecord} or L{None} if none
             can be found for the given type.
-        @rtype: L{types.ClassType}
+        @rtype: C{Type[IRecord]}
         """
         return self._recordTypes.get(type, UnknownRecord)
 

--- a/src/twisted/persisted/aot.py
+++ b/src/twisted/persisted/aot.py
@@ -492,7 +492,7 @@ def _classOfMethod(methodObject):
     @type methodObject: L{types.MethodType}
 
     @return: a class
-    @rtype: L{types.ClassType} or L{type}
+    @rtype: L{type}
     """
     return methodObject.__self__.__class__
 

--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -37,7 +37,7 @@ def _methodFunction(classObject, methodName):
     it's on and a method name.
 
     @param classObject: A class to retrieve the method's function from.
-    @type classObject: L{type} or L{types.ClassType}
+    @type classObject: L{type}
 
     @param methodName: The name of the method whose function to retrieve.
     @type methodName: native L{str}
@@ -60,7 +60,7 @@ def unpickleMethod(im_name, im_self, im_class):
     @type im_self: L{object}
 
     @param im_class: The class where the method was declared.
-    @type im_class: L{types.ClassType} or L{type} or L{None}
+    @type im_class: L{type} or L{None}
     """
     if im_self is None:
         return getattr(im_class, im_name)

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -497,7 +497,7 @@ def _constructMethod(cls, name, self):
     Construct a bound method.
 
     @param cls: The class that the method should be bound to.
-    @type cls: L{types.ClassType} or L{type}.
+    @type cls: L{type}
 
     @param name: The name of the method.
     @type name: native L{str}

--- a/src/twisted/python/fakepwd.py
+++ b/src/twisted/python/fakepwd.py
@@ -13,8 +13,8 @@ __all__ = ["UserDatabase", "ShadowDatabase"]
 class _UserRecord:
     """
     L{_UserRecord} holds the user data for a single user in L{UserDatabase}.
-    It corresponds to L{pwd.struct_passwd}.  See that class for attribute
-    documentation.
+    It corresponds to the C{passwd} structure from the L{pwd} module.
+    See that module for attribute documentation.
     """
 
     def __init__(self, name, password, uid, gid, gecos, home, shell):

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -653,13 +653,6 @@ class FilePath(AbstractFilePath):
     Even if you pass me a relative path, I will convert that to an absolute
     path internally.
 
-    Note: although time-related methods do return floating-point results, they
-    may still be only second resolution depending on the platform and the last
-    value passed to L{os.stat_float_times}.  If you want greater-than-second
-    precision, call C{os.stat_float_times(True)}, or use Python 2.5.
-    Greater-than-second precision is only available in Windows on Python2.5 and
-    later.
-
     The type of C{path} when instantiating decides the mode of the L{FilePath}.
     That is, C{FilePath(b"/")} will return a L{bytes} mode L{FilePath}, and
     C{FilePath(u"/")} will return a L{unicode} mode L{FilePath}.

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -613,7 +613,7 @@ class PackageOrderingTests(packages.SysPathManglingTest):
         def sillySorter(s):
             # This has to work on fully-qualified class names and class
             # objects, which is silly, but it's the "spec", such as it is.
-            #             if isinstance(s, type) or isinstance(s, types.ClassType):
+            #             if isinstance(s, type):
             #                 return s.__module__+'.'+s.__name__
             n = runner.name(s)
             d = md5(n.encode("utf8")).hexdigest()


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10043
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

Note that the last commit technically doesn't belong in this PR, but it contains a 1-line fix for a docstring error that was recently merged.
