### PR TITLE
[10045] Don't skip test on empty string skip attribute.

### DIFF
--- a/src/twisted/newsfragments/10045.feature
+++ b/src/twisted/newsfragments/10045.feature
@@ -1,2 +1,2 @@
 Trial will now skip a test when the `skip` attribute is an empty string.
-In previous version the test was skipped only when the attribute was None.
+In previous versions the test was not skipped in this case.

--- a/src/twisted/newsfragments/10045.feature
+++ b/src/twisted/newsfragments/10045.feature
@@ -1,0 +1,2 @@
+Trial will now skip a test when the `skip` attribute is an empty string.
+In previous version the test was skipped only when the attribute was None.

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -980,7 +980,7 @@ class SynchronousTestCase(_Assertions):
         See L{TestCase} docstring for more details.
         """
         skipReason = util.acquireAttribute(self._parents, "skip", None)
-        doSkip = skipReason is not None
+        doSkip = skipReason not in [None, ""]
         if skipReason is None:
             doSkip = getattr(self, "__unittest_skip__", False)
             if doSkip:

--- a/src/twisted/trial/test/skipping.py
+++ b/src/twisted/trial/test/skipping.py
@@ -16,18 +16,51 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase, SkipTest, Fail
 
 
 class SkippingMixin:
+    """
+    Tests that are skipped at the method level.
+
+    Make sure the docstring of each tests will start with the skip reason,
+    as this is use in the test assertion.
+    """
+
+    def test_no_skip(self):
+        """
+        This is a test that is not skipped.
+        here to make sure that the whole class is not skipped.
+        """
+
     def test_skip1(self):
-        raise SkipTest("skip1")
+        """
+        The skip1 reason.
+
+        The test is skipped when SkipTest is raised inside.
+        """
+        raise SkipTest("The skip1 reason.")
 
     def test_skip2(self):
+        """
+        skip2-reason
+
+        If executed, this test will fail, but is skipped via the skip
+        attribute.
+        """
         raise RuntimeError("I should not get raised")
 
-    test_skip2.skip = "skip2"  # type: ignore[attr-defined]
+    test_skip2.skip = "skip2-reason"  # type: ignore[attr-defined]
 
-    def test_skip3(self):
-        self.fail("I should not fail")
+    def test_no_skip_empty_attribute(self):
+        """
+        This test is not skipepd as the skip attribute is the empty string.
+        """
 
-    test_skip3.skip = "skip3"  # type: ignore[attr-defined]
+    test_no_skip_empty_attribute.skip = ""
+
+    def test_no_skip_none_attribute(self):
+        """
+        This test is not skipepd as the skip attribute is None.
+        """
+
+    test_no_skip_empty_attribute.skip = None
 
 
 class SynchronousSkipping(SkippingMixin, SynchronousTestCase):

--- a/src/twisted/trial/test/skipping.py
+++ b/src/twisted/trial/test/skipping.py
@@ -53,14 +53,14 @@ class SkippingMixin:
         This test is not skipepd as the skip attribute is the empty string.
         """
 
-    test_no_skip_empty_attribute.skip = ""
+    test_no_skip_empty_attribute.skip = ""  # type: ignore[attr-defined]
 
     def test_no_skip_none_attribute(self):
         """
         This test is not skipepd as the skip attribute is None.
         """
 
-    test_no_skip_empty_attribute.skip = None
+    test_no_skip_empty_attribute.skip = None  # type: ignore[attr-defined]
 
 
 class SynchronousSkipping(SkippingMixin, SynchronousTestCase):

--- a/src/twisted/trial/test/test_skip.py
+++ b/src/twisted/trial/test/test_skip.py
@@ -90,3 +90,11 @@ class SkipAttributeOnMethods(TestCase):
 
     def test_shouldNotSkip(self):
         self.assertTrue(True, "Test should run and not be skipped")
+
+    def test_emptyStringNotSkip(self):
+        """
+        A skip attribute with empty string should not skip the tests.
+        """
+        self.assertTrue(True, "Test should run and not be skipped")
+
+    test_emptyStringNotSkip.skip = ""  # type: ignore[attr-defined]

--- a/src/twisted/trial/test/test_skipif.py
+++ b/src/twisted/trial/test/test_skipif.py
@@ -3,7 +3,9 @@
 #
 
 """
-Tests for L{twisted.trial.util}
+Tests for using the stdlib unittest skipIf decorator with trial TestCase.
+
+For other skip tests, check the `test_tests.py` and `skipping.py` files.
 """
 
 from twisted.trial.unittest import TestCase
@@ -61,40 +63,3 @@ class SkipDecoratorUsedOnMethods(TestCase):
     @skipIf(False, "")
     def test_shouldShouldRunWithSkipIfFalseEmptyReason(self):
         self.assertTrue(True, "Test should run and not be skipped")
-
-
-class SkipAttributeOnClass(TestCase):
-    """
-    All tests should be skipped because skip attribute is set on
-    this class.
-    """
-
-    skip = "'skip' attribute set on this class, so skip all tests"
-
-    def test_one(self):
-        raise Exception("Test should skip and never reach here")
-
-    def test_two(self):
-        raise Exception("Test should skip and never reach here")
-
-
-class SkipAttributeOnMethods(TestCase):
-    """
-    Only methods where @skipIf decorator is used should be skipped.
-    """
-
-    def test_one(self):
-        raise Exception("Should never reach here")
-
-    test_one.skip = "skip test, skip attribute set on method"  # type: ignore[attr-defined]
-
-    def test_shouldNotSkip(self):
-        self.assertTrue(True, "Test should run and not be skipped")
-
-    def test_emptyStringNotSkip(self):
-        """
-        A skip attribute with empty string should not skip the tests.
-        """
-        self.assertTrue(True, "Test should run and not be skipped")
-
-    test_emptyStringNotSkip.skip = ""  # type: ignore[attr-defined]

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -161,7 +161,7 @@ class SkipMethodsMixin(ResultsTestMixin):
         """
         Assert that there are three tests.
         """
-        self.assertCount(3)
+        self.assertCount(5)
 
     def test_results(self):
         """
@@ -174,8 +174,8 @@ class SkipMethodsMixin(ResultsTestMixin):
         self.assertTrue(self.reporter.wasSuccessful())
         self.assertEqual(self.reporter.errors, [])
         self.assertEqual(self.reporter.failures, [])
-        self.assertEqual(len(self.reporter.skips), 3)
-        self.assertEqual(self.reporter.successes, 0)
+        self.assertEqual(len(self.reporter.skips), 2)
+        self.assertEqual(self.reporter.successes, 3)
 
     def test_setUp(self):
         """
@@ -197,10 +197,8 @@ class SkipMethodsMixin(ResultsTestMixin):
         Test that reasons work
         """
         self.suite(self.reporter)
-        prefix = "test_"
-        # whiteboxing reporter
         for test, reason in self.reporter.skips:
-            self.assertEqual(test.shortDescription()[len(prefix) :], str(reason))
+            self.assertEqual(test.shortDescription(), str(reason))
 
     def test_deprecatedSkipWithoutReason(self):
         """


### PR DESCRIPTION
## Scope

This adds support in trial to not skip a test when the skip attribute is an empty string.

In previous version it was required to be None to be skipped.

I have created this since mypy is complaining about this code and wants Optional extra type hinting.

```
if non contextvars:
    contextvarsSkip = "contextvars is not available"
else:
    contextvarsSkip = None
```

Later I found out that mypy is happy with this syntax

```
if contextvars:
    contextvarsSkip = None
else:
    contextvarsSkip = "contextvars is not available"
```

When possible we should use the `@skipIf` decorator ...but the skip attribute is still supported and convenient for top level module skip.

I am pushing this since I have already created the implementation and the test.

Feel free to reject it.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10045
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
