### PR TITLE
Fix invalid cross-references in docstrings

### DIFF
--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -11,6 +11,7 @@ import sys
 import binascii
 import errno
 from base64 import decodebytes
+from typing import BinaryIO, Callable, Iterator
 
 try:
     import pwd as _pwd
@@ -337,7 +338,9 @@ class IAuthorizedKeysDB(Interface):
         """
 
 
-def readAuthorizedKeyFile(fileobj, parseKey=keys.Key.fromString):
+def readAuthorizedKeyFile(
+    fileobj: BinaryIO, parseKey: Callable[[bytes], keys.Key] = keys.Key.fromString
+) -> Iterator[keys.Key]:
     """
     Reads keys from an authorized keys file.  Any non-comment line that cannot
     be parsed as a key will be ignored, although that particular line will
@@ -345,16 +348,10 @@ def readAuthorizedKeyFile(fileobj, parseKey=keys.Key.fromString):
 
     @param fileobj: something from which to read lines which can be parsed
         as keys
-    @type fileobj: L{file}-like object
-
-    @param parseKey: a callable that takes a string and returns a
+    @param parseKey: a callable that takes bytes and returns a
         L{twisted.conch.ssh.keys.Key}, mainly to be used for testing.  The
         default is L{twisted.conch.ssh.keys.Key.fromString}.
-    @type parseKey: L{callable}
-
     @return: an iterable of L{twisted.conch.ssh.keys.Key}
-    @rtype: iterable
-
     @since: 15.0
     """
     for line in fileobj:

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -1850,7 +1850,7 @@ class SSHClientTransport(SSHTransportBase):
         @param pubKey: the public key blob for the server's public key.
         @type pubKey: L{str}
         @param f: the server's Diffie-Hellman public key.
-        @type f: L{long}
+        @type f: L{int}
         @param signature: the server's signature, verifying that it has the
             correct private key.
         @type signature: L{str}
@@ -1910,7 +1910,7 @@ class SSHClientTransport(SSHTransportBase):
         @param pubKey: the public key blob for the server's public key.
         @type pubKey: L{str}
         @param f: the server's Diffie-Hellman public key.
-        @type f: L{long}
+        @type f: L{int}
         @param signature: the server's signature, verifying that it has the
             correct private key.
         @type signature: L{str}

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -456,7 +456,7 @@ class Queue:
         @type message: L{bytes}
         @param message: The base filename of a message.
 
-        @rtype: L{file}
+        @rtype: file
         @return: The envelope file for the message.
         """
         return open(os.path.join(self.directory, message + "-H"), "rb")
@@ -465,7 +465,7 @@ class Queue:
         """
         Create a new message in the queue.
 
-        @rtype: 2-L{tuple} of (0) L{file}, (1) L{FileMessage}
+        @rtype: 2-L{tuple} of (0) file, (1) L{FileMessage}
         @return: The envelope file and a message receiver for a new message in
             the queue.
         """

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -799,7 +799,7 @@ class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin):
         """
         Encode this L{_OPTHeader} instance to bytes.
 
-        @type strio: L{file}
+        @type strio: file
         @param strio: the byte representation of this L{_OPTHeader}
             will be written to this file.
 
@@ -825,7 +825,7 @@ class _OPTHeader(tputil.FancyStrMixin, tputil.FancyEqMixin):
         """
         Decode bytes into an L{_OPTHeader} instance.
 
-        @type strio: L{file}
+        @type strio: file
         @param strio: Bytes will be read from this file until the full
             L{_OPTHeader} is decoded.
 
@@ -909,7 +909,7 @@ class _OPTVariableOption(tputil.FancyStrMixin, tputil.FancyEqMixin):
         """
         Encode this L{_OPTVariableOption} to bytes.
 
-        @type strio: L{file}
+        @type strio: file
         @param strio: the byte representation of this
             L{_OPTVariableOption} will be written to this file.
 
@@ -924,7 +924,7 @@ class _OPTVariableOption(tputil.FancyStrMixin, tputil.FancyEqMixin):
         """
         Decode bytes into an L{_OPTVariableOption} instance.
 
-        @type strio: L{file}
+        @type strio: file
         @param strio: Bytes will be read from this file until the full
             L{_OPTVariableOption} is decoded.
 

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1936,7 +1936,7 @@ class Command:
         the behavior is undefined.
 
         @param methodfunc: A function which will later become a method, which
-        has a keyword signature compatible with this command's L{argument} list
+        has a keyword signature compatible with this command's L{arguments} list
         and returns a dictionary with a set of keys compatible with this
         command's L{response} list.
 

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -313,13 +313,7 @@ def ioType(fileIshObject, default=str):
 
             2. L{bytes}, if the file is unambiguously opened in binary mode.
 
-            3. L{basestring}, if we are on python 2 (the L{basestring} type
-               does not exist on python 3) and the file is opened in binary
-               mode, but has an encoding and can therefore accept both bytes
-               and text reliably for writing, but will return L{bytes} from
-               read methods.
-
-            4. The C{default} parameter, if the given type is not understood.
+            3. The C{default} parameter, if the given type is not understood.
 
     @rtype: L{type}
     """

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -20,7 +20,7 @@ from stat import S_ISREG, S_ISDIR, S_IMODE, S_ISBLK, S_ISSOCK
 from stat import S_IRUSR, S_IWUSR, S_IXUSR
 from stat import S_IRGRP, S_IWGRP, S_IXGRP
 from stat import S_IROTH, S_IWOTH, S_IXOTH
-from typing import Union
+from typing import IO, Union, cast
 
 from zope.interface import Interface, Attribute, implementer
 
@@ -667,12 +667,11 @@ class FilePath(AbstractFilePath):
     @ivar alwaysCreate: When opening this file, only succeed if the file does
         not already exist.
 
-    @type path: L{bytes} or L{unicode}
     @ivar path: The path from which 'downward' traversal is permitted.
     """
 
     _statinfo = None
-    path = None
+    path = None  # type: Union[bytes, str]
 
     def __init__(self, path, alwaysCreate=False):
         """
@@ -917,7 +916,7 @@ class FilePath(AbstractFilePath):
         """
         os.symlink(self.path, linkFilePath.path)
 
-    def open(self, mode="r"):
+    def open(self, mode: str = "r") -> IO[bytes]:
         """
         Open this file using C{mode} or for writing if C{alwaysCreate} is
         C{True}.
@@ -926,11 +925,9 @@ class FilePath(AbstractFilePath):
         to include C{"b"} in C{mode}.
 
         @param mode: The mode to open the file in.  Default is C{"r"}.
-        @type mode: L{str}
         @raises AssertionError: If C{"a"} is included in the mode and
             C{alwaysCreate} is C{True}.
-        @rtype: L{file}
-        @return: An open L{file} object.
+        @return: An open file-like object.
         """
         if self.alwaysCreate:
             assert "a" not in mode, (
@@ -1467,7 +1464,7 @@ class FilePath(AbstractFilePath):
         """
         self.alwaysCreate = val
 
-    def create(self):
+    def create(self) -> IO[bytes]:
         """
         Exclusively create a file, only if this file previously did not exist.
 
@@ -1479,7 +1476,7 @@ class FilePath(AbstractFilePath):
         # settable via fdopen, so this file is slightly less functional than the
         # one returned from 'open' by default.  send a patch to Python...
 
-        return os.fdopen(fdint, "w+b")
+        return cast(IO[bytes], os.fdopen(fdint, "w+b"))
 
     def temporarySibling(self, extension=b""):
         """

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -937,8 +937,7 @@ class FilePath(AbstractFilePath):
                 "Appending not supported when " "alwaysCreate == True"
             )
             return self.create()
-        # This hack is necessary because of a bug in Python 2.7 on Windows:
-        # http://bugs.python.org/issue7686
+        # Make sure we open with exactly one "b" in the mode.
         mode = mode.replace("b", "")
         return open(self.path, mode + "b")
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1062,7 +1062,7 @@ class Request:
         @rtype: C{bytes} or C{str} or L{None}
         @return: The value of the specified header, or L{None} if that header
             was not present in the request. The string type of the result
-            matches the type of L{key}.
+            matches the type of C{key}.
         """
         value = self.requestHeaders.getRawHeaders(key)
         if value is not None:

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -307,7 +307,7 @@ class IRequest(Interface):
 
         @param when: The last time the resource being returned was modified, in
             seconds since the epoch.
-        @type when: L{int}, L{long} or L{float}
+        @type when: L{int} or L{float}
 
         @return: If I am a C{If-Modified-Since} conditional request and the time
             given is not newer than the condition, I return


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10046
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
