### PR TITLE
use attr.s to make slotted classes

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -257,6 +257,7 @@ _x509names = {
 }
 
 
+@attr.s(slots=True)
 class DistinguishedName(dict):
     """
     Identify and describe an entity.
@@ -299,8 +300,6 @@ class DistinguishedName(dict):
         b'US'
 
     """
-
-    __slots__ = ()
 
     def __init__(self, **kw):
         for k, v in kw.items():

--- a/src/twisted/mail/test/test_mail.py
+++ b/src/twisted/mail/test/test_mail.py
@@ -19,7 +19,9 @@ import signal
 import time
 from hashlib import md5
 from unittest import skipIf
+from typing import Optional
 
+import attr
 from zope.interface.verify import verifyClass
 from zope.interface import Interface, implementer
 
@@ -1967,8 +1969,9 @@ class AddressAliasTests(TestCase):
         self.assertEqual(self.alias.resolve({}), None)
 
 
+@attr.s(slots=True)
 class DummyProcess:
-    __slots__ = ["onEnd"]
+    onEnd = attr.ib(type=Optional[defer.Deferred])
 
 
 class MockProcessAlias(mail.alias.ProcessAlias):

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -204,6 +204,7 @@ from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 import warnings
 
+import attr
 from zope.interface import Interface, implementer
 
 from twisted.internet.defer import Deferred, maybeDeferred, fail
@@ -608,15 +609,12 @@ class IncompatibleVersions(AmpError):
 PROTOCOL_ERRORS = {UNHANDLED_ERROR_CODE: UnhandledCommand}
 
 
+@attr.s(slots=True)
 class AmpBox(dict):
     """
     I am a packet in the AMP protocol, much like a
     regular bytes:bytes dictionary.
     """
-
-    # be like a regular dictionary don't magically
-    # acquire a __dict__...
-    __slots__ = []  # type: List[str]
 
     def __init__(self, *args, **kw):
         """
@@ -709,12 +707,11 @@ class AmpBox(dict):
 Box = AmpBox
 
 
+@attr.s(slots=True)
 class QuitBox(AmpBox):
     """
     I am an AmpBox that, upon being sent, terminates the connection.
     """
-
-    __slots__ = []  # type: List[str]
 
     def __repr__(self) -> str:
         return "QuitBox(**{})".format(super().__repr__())
@@ -727,13 +724,14 @@ class QuitBox(AmpBox):
         proto.transport.loseConnection()
 
 
+@attr.s(slots=True)
 class _SwitchBox(AmpBox):
     """
     Implementation detail of ProtocolSwitchCommand: I am an AmpBox which sets
     up state for the protocol to switch.
     """
 
-    # DON'T set __slots__ here; we do have an attribute.
+    innerProto = attr.ib()
 
     def __init__(self, innerProto, **kw):
         """
@@ -2038,12 +2036,11 @@ class _NoCertificate:
         return occo
 
 
+@attr.s(slots=True)
 class _TLSBox(AmpBox):
     """
     I am an AmpBox that, upon being sent, initiates a TLS connection.
     """
-
-    __slots__ = []  # type: List[str]
 
     def __init__(self):
         if ssl is None:

--- a/src/twisted/protocols/haproxy/_info.py
+++ b/src/twisted/protocols/haproxy/_info.py
@@ -7,11 +7,15 @@ IProxyInfo implementation.
 """
 
 from zope.interface import implementer
+import attr
+
+from twisted.internet.interfaces import IAddress
 
 from ._interfaces import IProxyInfo
 
 
 @implementer(IProxyInfo)
+@attr.s(slots=True)
 class ProxyInfo:
     """
     A data container for parsed PROXY protocol information.
@@ -24,13 +28,6 @@ class ProxyInfo:
     @type destination: L{twisted.internet.interfaces.IAddress}
     """
 
-    __slots__ = (
-        "header",
-        "source",
-        "destination",
-    )
-
-    def __init__(self, header, source, destination):
-        self.header = header
-        self.source = source
-        self.destination = destination
+    header = attr.ib(type=bytes)
+    source = attr.ib(type=IAddress)
+    destination = attr.ib(type=IAddress)

--- a/src/twisted/spread/test/test_jelly.py
+++ b/src/twisted/spread/test/test_jelly.py
@@ -10,6 +10,8 @@ import datetime
 import decimal
 from unittest import skipIf
 
+import attr
+
 from twisted.spread import banana, jelly, pb
 from twisted.trial import unittest
 from twisted.trial.unittest import TestCase
@@ -78,16 +80,14 @@ class D:
     """
 
 
+@attr.s(slots=True)
 class E:
     """
     Dummy new-style class with slots.
     """
 
-    __slots__ = ("x", "y")
-
-    def __init__(self, x=None, y=None):
-        self.x = x
-        self.y = y
+    x = attr.ib(default=None)
+    y = attr.ib(default=None)
 
     def __getstate__(self):
         return {"x": self.x, "y": self.y}

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -12,7 +12,9 @@ import itertools
 import datetime
 
 from unittest import skipIf
+from typing import Optional, List
 
+import attr
 from zope.interface import implementer
 from twisted.python.reflect import requireModule
 from twisted.test.test_twisted import SetAsideModule
@@ -2896,6 +2898,7 @@ class DiffieHellmanParametersTests(TestCase):
         self.assertEqual(self.filePath, params._dhFile)
 
 
+@attr.s(frozen=True, slots=True)
 class FakeLibState:
     """
     State for L{FakeLib}
@@ -2913,18 +2916,16 @@ class FakeLibState:
     @type ecdhValues: L{list} of L{boolean}s
     """
 
-    __slots__ = ("setECDHAutoRaises", "ecdhContexts", "ecdhValues")
-
-    def __init__(self, setECDHAutoRaises):
-        self.setECDHAutoRaises = setECDHAutoRaises
-        self.ecdhContexts = []
-        self.ecdhValues = []
+    setECDHAutoRaises = attr.ib(type=Optional[BaseException])
+    ecdhContexts = attr.ib(
+        type=List[SSL.Context], default=attr.Factory(list), init=False
+    )
+    ecdhValues = attr.ib(type=List[bool], default=attr.Factory(list), init=False)
 
 
 class FakeLib:
     """
     An introspectable fake of cryptography's lib object.
-
     @param state: A L{FakeLibState} instance that contains this fake's
         state.
     """
@@ -2987,6 +2988,7 @@ class FakeLibTests(TestCase):
         self.assertEqual(state.ecdhValues, [True])
 
 
+@attr.s(frozen=True, slots=True)
 class FakeCryptoState:
     """
     State for L{FakeCrypto}
@@ -3003,20 +3005,11 @@ class FakeCryptoState:
     @type getEllipticCurveCalls: L{list}
     """
 
-    __slots__ = (
-        "getEllipticCurveRaises",
-        "getEllipticCurveReturns",
-        "getEllipticCurveCalls",
+    getEllipticCurveRaises = attr.ib(type=Optional[BaseException])
+    getEllipticCurveReturns = attr.ib(type=Optional[str])
+    getEllipticCurveCalls = attr.ib(
+        type=List[str], default=attr.Factory(list), init=False
     )
-
-    def __init__(
-        self,
-        getEllipticCurveRaises,
-        getEllipticCurveReturns,
-    ):
-        self.getEllipticCurveRaises = getEllipticCurveRaises
-        self.getEllipticCurveReturns = getEllipticCurveReturns
-        self.getEllipticCurveCalls = []
 
 
 class FakeCrypto:


### PR DESCRIPTION
as often the __weakref__ attribute is forgotten and attr.s automatically
fills this in

## Contributor Checklist:

* [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
