### PR TITLE
Deprecate twisted.python.win32.WindowsError

### DIFF
--- a/src/twisted/newsfragments/10053.removal
+++ b/src/twisted/newsfragments/10053.removal
@@ -1,0 +1,1 @@
+twisted.python.win32.WindowsError and FakeWindowsError have been deprecated.

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -337,20 +337,7 @@ class AbstractFilePath:
             # code while the winerror attribute contains a Windows error code.
             # Windows error codes aren't the same as POSIX error codes,
             # so we need to handle them differently.
-
-            # Under Python 2.4 on Windows, WindowsError only has an errno
-            # attribute.  It is bound to the Windows error code.
-
-            # For simplicity of code and to keep the number of paths through
-            # this suite minimal, we grab the Windows error code under either
-            # version.
-
-            # Furthermore, attempting to use os.listdir on a non-existent path
-            # in Python 2.4 will result in a Windows error code of
-            # ERROR_PATH_NOT_FOUND.  However, in Python 2.5,
-            # ERROR_FILE_NOT_FOUND results instead. -exarkun
-            winerror = getattr(winErrObj, "winerror", winErrObj.errno)
-            if winerror not in (
+            if winErrObj.winerror not in (
                 ERROR_PATH_NOT_FOUND,
                 ERROR_FILE_NOT_FOUND,
                 ERROR_INVALID_NAME,

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -33,7 +33,6 @@ from twisted.python.runtime import platform
 from twisted.python.util import FancyEqMixin
 from twisted.python.win32 import ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND
 from twisted.python.win32 import ERROR_INVALID_NAME, ERROR_DIRECTORY, O_BINARY
-from twisted.python.win32 import WindowsError as _OSErrorOrFakeWindowsError
 
 
 _CREATE_FLAGS = os.O_EXCL | os.O_CREAT | os.O_RDWR | O_BINARY
@@ -224,11 +223,10 @@ class UnlistableError(OSError):
     This error will try to look as much like the original error as possible,
     while still being catchable as an independent type.
 
-    @ivar originalException: the actual original exception instance, either an
-        L{OSError} or a L{_OSErrorOrFakeWindowsError}.
+    @ivar originalException: the actual original exception instance.
     """
 
-    def __init__(self, originalException):
+    def __init__(self, originalException: OSError):
         """
         Create an UnlistableError exception.
 
@@ -236,17 +234,6 @@ class UnlistableError(OSError):
         """
         self.__dict__.update(originalException.__dict__)
         self.originalException = originalException
-
-
-class _WindowsUnlistableError(UnlistableError, _OSErrorOrFakeWindowsError):
-    """
-    This exception is raised on Windows, for compatibility with previous
-    releases of FilePath where unportable programs may have done "except
-    WindowsError:" around a call to children().
-
-    It is private because all application code may portably catch
-    L{UnlistableError} instead.
-    """
 
 
 def _secureEnoughString(path):
@@ -315,43 +302,30 @@ class AbstractFilePath:
         """
         try:
             subnames = self.listdir()
-        except _OSErrorOrFakeWindowsError as winErrObj:
+        except OSError as ose:
             # Under Python 3.3 and higher on Windows, WindowsError is an
             # alias for OSError.  OSError has a winerror attribute and an
             # errno attribute.
-
-            # Under Python 2, WindowsError is an OSError subclass.
-
-            # Under Python 2.5 and higher on Windows, WindowsError has a
-            # winerror attribute and an errno attribute.
-
+            #
             # The winerror attribute is bound to the Windows error code while
             # the errno attribute is bound to a translation of that code to a
             # perhaps equivalent POSIX error number.
             #
             # For further details, refer to:
             # https://docs.python.org/3/library/exceptions.html#OSError
-
-            # If not for this clause OSError would be handling all of these
-            # errors on Windows.  The errno attribute contains a POSIX error
-            # code while the winerror attribute contains a Windows error code.
-            # Windows error codes aren't the same as POSIX error codes,
-            # so we need to handle them differently.
-            if winErrObj.winerror not in (
+            if getattr(ose, "winerror", None) in (
                 ERROR_PATH_NOT_FOUND,
                 ERROR_FILE_NOT_FOUND,
                 ERROR_INVALID_NAME,
                 ERROR_DIRECTORY,
             ):
-                raise
-            raise _WindowsUnlistableError(winErrObj)
-        except OSError as ose:
-            if ose.errno not in (errno.ENOENT, errno.ENOTDIR):
-                # Other possible errors here, according to linux manpages:
-                # EACCES, EMIFLE, ENFILE, ENOMEM.  None of these seem like the
-                # sort of thing which should be handled normally. -glyph
-                raise
-            raise UnlistableError(ose)
+                raise UnlistableError(ose)
+            if ose.errno in (errno.ENOENT, errno.ENOTDIR):
+                raise UnlistableError(ose)
+            # Other possible errors here, according to linux manpages:
+            # EACCES, EMIFLE, ENFILE, ENOMEM.  None of these seem like the
+            # sort of thing which should be handled normally. -glyph
+            raise
         return [self.child(name) for name in subnames]
 
     def walk(self, descend=None):

--- a/src/twisted/python/test/test_win32.py
+++ b/src/twisted/python/test/test_win32.py
@@ -34,3 +34,41 @@ class CommandLineQuotingTests(unittest.TestCase):
         quoted empty string.
         """
         self.assertEqual(win32.cmdLineQuote(""), '""')
+
+
+class DeprecationTests(unittest.TestCase):
+    """
+    Tests for deprecated (Fake)WindowsError.
+    """
+
+    def test_deprecation_FakeWindowsError(self):
+        """Importing C{FakeWindowsError} should trigger a L{DeprecationWarning}."""
+
+        def import_FakeWindowsError():
+            from twisted.python.win32 import FakeWindowsError
+
+            FakeWindowsError  # pretend to use, for flake8
+
+        self.assertWarns(
+            DeprecationWarning,
+            "twisted.python.win32.FakeWindowsError was deprecated in Twisted NEXT: "
+            "Catch OSError and check presence of 'winerror' attribute.",
+            __file__,
+            import_FakeWindowsError,
+        )
+
+    def test_deprecation_WindowsError(self):
+        """Importing C{WindowsError} should trigger a L{DeprecationWarning}."""
+
+        def import_WindowsError():
+            from twisted.python.win32 import WindowsError
+
+            WindowsError  # pretend to use, for flake8
+
+        self.assertWarns(
+            DeprecationWarning,
+            "twisted.python.win32.WindowsError was deprecated in Twisted NEXT: "
+            "Catch OSError and check presence of 'winerror' attribute.",
+            __file__,
+            import_WindowsError,
+        )

--- a/src/twisted/python/test/test_win32.py
+++ b/src/twisted/python/test/test_win32.py
@@ -16,22 +16,22 @@ class CommandLineQuotingTests(unittest.TestCase):
 
     def test_argWithoutSpaces(self):
         """
-        Calling C{cmdLineQuote} with an argument with no spaces should
-        return the argument unchanged.
+        Calling C{cmdLineQuote} with an argument with no spaces returns
+        the argument unchanged.
         """
         self.assertEqual(win32.cmdLineQuote("an_argument"), "an_argument")
 
     def test_argWithSpaces(self):
         """
-        Calling C{cmdLineQuote} with an argument containing spaces should
-        return the argument surrounded by quotes.
+        Calling C{cmdLineQuote} with an argument containing spaces returns
+        the argument surrounded by quotes.
         """
         self.assertEqual(win32.cmdLineQuote("An Argument"), '"An Argument"')
 
     def test_emptyStringArg(self):
         """
-        Calling C{cmdLineQuote} with an empty string should return a
-        quoted empty string.
+        Calling C{cmdLineQuote} with an empty string returns a quoted empty
+        string.
         """
         self.assertEqual(win32.cmdLineQuote(""), '""')
 
@@ -42,7 +42,7 @@ class DeprecationTests(unittest.TestCase):
     """
 
     def test_deprecation_FakeWindowsError(self):
-        """Importing C{FakeWindowsError} should trigger a L{DeprecationWarning}."""
+        """Importing C{FakeWindowsError} triggers a L{DeprecationWarning}."""
 
         self.assertWarns(
             DeprecationWarning,
@@ -53,7 +53,7 @@ class DeprecationTests(unittest.TestCase):
         )
 
     def test_deprecation_WindowsError(self):
-        """Importing C{WindowsError} should trigger a L{DeprecationWarning}."""
+        """Importing C{WindowsError} triggers a L{DeprecationWarning}."""
 
         self.assertWarns(
             DeprecationWarning,

--- a/src/twisted/python/test/test_win32.py
+++ b/src/twisted/python/test/test_win32.py
@@ -6,7 +6,7 @@ Tests for L{twisted.python.win32}.
 """
 
 from twisted.trial import unittest
-from twisted.python import win32
+from twisted.python import reflect, win32
 
 
 class CommandLineQuotingTests(unittest.TestCase):
@@ -44,31 +44,21 @@ class DeprecationTests(unittest.TestCase):
     def test_deprecation_FakeWindowsError(self):
         """Importing C{FakeWindowsError} should trigger a L{DeprecationWarning}."""
 
-        def import_FakeWindowsError():
-            from twisted.python.win32 import FakeWindowsError
-
-            FakeWindowsError  # pretend to use, for flake8
-
         self.assertWarns(
             DeprecationWarning,
             "twisted.python.win32.FakeWindowsError was deprecated in Twisted NEXT: "
             "Catch OSError and check presence of 'winerror' attribute.",
-            __file__,
-            import_FakeWindowsError,
+            reflect.__file__,
+            lambda: reflect.namedAny("twisted.python.win32.FakeWindowsError"),
         )
 
     def test_deprecation_WindowsError(self):
         """Importing C{WindowsError} should trigger a L{DeprecationWarning}."""
 
-        def import_WindowsError():
-            from twisted.python.win32 import WindowsError
-
-            WindowsError  # pretend to use, for flake8
-
         self.assertWarns(
             DeprecationWarning,
             "twisted.python.win32.WindowsError was deprecated in Twisted NEXT: "
             "Catch OSError and check presence of 'winerror' attribute.",
-            __file__,
-            import_WindowsError,
+            reflect.__file__,
+            lambda: reflect.namedAny("twisted.python.win32.WindowsError"),
         )

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -16,7 +16,7 @@ import re
 import os
 
 
-# http://msdn.microsoft.com/library/default.asp?url=/library/en-us/debug/base/system_error_codes.asp
+# https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
 ERROR_FILE_NOT_FOUND = 2
 ERROR_PATH_NOT_FOUND = 3
 ERROR_INVALID_NAME = 123

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -15,6 +15,10 @@ See also twisted.python.shortcut.
 import re
 import os
 
+from incremental import Version
+
+from twisted.python.deprecate import deprecatedModuleAttribute
+
 
 # https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
 ERROR_FILE_NOT_FOUND = 2
@@ -32,10 +36,25 @@ class FakeWindowsError(OSError):
     """
 
 
+deprecatedModuleAttribute(
+    Version("Twisted", "NEXT", 0, 0),
+    "Catch OSError and check presence of 'winerror' attribute.",
+    "twisted.python.win32",
+    "FakeWindowsError",
+)
+
+
 try:
     WindowsError = WindowsError  # type: OSError
 except NameError:
     WindowsError = FakeWindowsError  # type: ignore[misc,assignment]
+
+deprecatedModuleAttribute(
+    Version("Twisted", "NEXT", 0, 0),
+    "Catch OSError and check presence of 'winerror' attribute.",
+    "twisted.python.win32",
+    "WindowsError",
+)
 
 
 _cmdLineQuoteRe = re.compile(r'(\\*)"')

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -14,7 +14,7 @@ import time
 from pprint import pformat
 from unittest import skipIf
 
-from twisted.python.win32 import WindowsError, ERROR_DIRECTORY
+from twisted.python.win32 import ERROR_DIRECTORY
 from twisted.python import filepath
 from twisted.python.runtime import platform
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10053
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
