### PR TITLE
 Fix documentation of non-existing parameters

### DIFF
--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -571,6 +571,10 @@ class _ClientMachine:
     """
     State machine for maintaining a single outgoing connection to an endpoint.
 
+    @ivar _awaitingConnected: notifications to make when connection
+        succeeds, fails, or is cancelled
+    @type _awaitingConnected: list of (Deferred, count) tuples
+
     @see: L{ClientService}
     """
 
@@ -583,10 +587,6 @@ class _ClientMachine:
         @param log: The logger for the L{ClientService} instance this state
             machine is associated to.
         @type log: L{Logger}
-
-        @ivar _awaitingConnected: notifications to make when connection
-            succeeds, fails, or is cancelled
-        @type _awaitingConnected: list of (Deferred, count) tuples
         """
         self._endpoint = endpoint
         self._failedAttempts = 0

--- a/src/twisted/conch/ssh/userauth.py
+++ b/src/twisted/conch/ssh/userauth.py
@@ -692,7 +692,7 @@ class SSHUserAuthClient(service.SSHService):
         return the signature.
 
         @param privateKey: the private key object
-        @type publicKey: L{keys.Key}
+        @type privateKey: L{keys.Key}
         @param signData: the data to be signed by the private key.
         @type signData: L{bytes}
         @return: the signature

--- a/src/twisted/internet/_dumbwin32proc.py
+++ b/src/twisted/internet/_dumbwin32proc.py
@@ -284,7 +284,7 @@ class Process(_pollingfile._PollingTimer, BaseProcess):
         """
         Write data to the process' stdin.
 
-        @type data: C{list} of C{bytes}
+        @type seq: C{list} of C{bytes}
         """
         self.stdin.writeSequence(seq)
 

--- a/src/twisted/internet/_newtls.py
+++ b/src/twisted/internet/_newtls.py
@@ -106,7 +106,7 @@ def startTLS(transport, contextFactory, normal, bypass):
         as the underlying transport goes.  That is, if the SSL client will be
         the underlying client and the SSL server will be the underlying server.
         C{True} means it is the same, C{False} means they are switched.
-    @type param: L{bool}
+    @type normal: L{bool}
 
     @param bypass: A transport base class to call methods on to bypass the new
         SSL layer (so that the SSL layer itself can send its bytes).

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -142,7 +142,7 @@ class Port(base.BasePort):
 
         @param protocol: A C{DatagramProtocol} instance which will be
             connected to the C{port}.
-        @type proto: L{twisted.internet.protocol.DatagramProtocol}
+        @type protocol: L{twisted.internet.protocol.DatagramProtocol}
 
         @param maxPacketSize: The maximum packet size to accept.
         @type maxPacketSize: L{int}

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -245,8 +245,7 @@ class ESMTPManagedRelayerFactory(SMTPManagedRelayerFactory):
             (0) L{bytes}, (1), L{int}
         @param args: Positional arguments for L{SMTPClient.__init__}
 
-        @type pKwArgs: L{dict}
-        @param pKwArgs: Keyword arguments for L{SMTPClient.__init__}
+        @param kw: Keyword arguments for L{SMTPClient.__init__}
         """
         self.secret = secret
         self.contextFactory = contextFactory

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -2137,7 +2137,7 @@ def sendmail(
 
     @param to_addrs: A list of addresses to send this mail to.  A string will
         be treated as a list of one address.
-    @type to_addr: L{list} of L{bytes} or L{bytes}
+    @type to_addrs: L{list} of L{bytes} or L{bytes}
 
     @param msg: The message, including headers, either as a file or a string.
         File-like objects need to support read() and close(). Lines must be

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -432,7 +432,7 @@ class BindAuthority(FileAuthority):
         @type domain: bytes
 
         @param rdata:
-        @type rdate: bytes
+        @type rdata: bytes
         """
         record = getattr(dns, "Record_{}".format(nativeString(type)), None)
         if record:

--- a/src/twisted/plugins/cred_unix.py
+++ b/src/twisted/plugins/cred_unix.py
@@ -98,8 +98,8 @@ class UNIXChecker:
         and see if it it matches it matches C{password}.
 
         @param spwd: Module which provides functions which
-                    access to the Unix shadow password database.
-        @type pwd: C{module}
+                     access to the Unix shadow password database.
+        @type spwd: C{module}
         @param username: The user to look up in the Unix password database.
         @type username: L{unicode}/L{str} or L{bytes}
         @param password: The password to compare.

--- a/src/twisted/protocols/haproxy/_parser.py
+++ b/src/twisted/protocols/haproxy/_parser.py
@@ -27,7 +27,7 @@ def unparseEndpoint(args, kwargs):
 
     @param kwargs: C{:} and then C{=}-separated keyword arguments
 
-    @type arguments: L{tuple} of native L{str}
+    @type kwargs: L{tuple} of native L{str}
 
     @return: a string equivalent to the original format which this was parsed
         as.

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -846,9 +846,9 @@ def uidFromString(uidString):
     """
     Convert a user identifier, as a string, into an integer UID.
 
-    @type uid: C{str}
-    @param uid: A string giving the base-ten representation of a UID or the
-        name of a user which can be converted to a UID via L{pwd.getpwnam}.
+    @type uidString: C{str}
+    @param uidString: A string giving the base-ten representation of a UID or
+        the name of a user which can be converted to a UID via L{pwd.getpwnam}.
 
     @rtype: C{int}
     @return: The integer UID corresponding to the given string.
@@ -868,9 +868,9 @@ def gidFromString(gidString):
     """
     Convert a group identifier, as a string, into an integer GID.
 
-    @type uid: C{str}
-    @param uid: A string giving the base-ten representation of a GID or the
-        name of a group which can be converted to a GID via L{grp.getgrnam}.
+    @type gidString: C{str}
+    @param gidString: A string giving the base-ten representation of a GID or
+        the name of a group which can be converted to a GID via L{grp.getgrnam}.
 
     @rtype: C{int}
     @return: The integer GID corresponding to the given string.

--- a/src/twisted/trial/itrial.py
+++ b/src/twisted/trial/itrial.py
@@ -111,8 +111,8 @@ class IReporter(zi.Interface):
 
         @type test: L{unittest.TestCase}
         @param test: The test which this is about.
-        @type error: L{failure.Failure}
-        @param error: The error which this test failed with.
+        @type failure: L{failure.Failure}
+        @param failure: The error which this test failed with.
         @type todo: L{unittest.Todo}
         @param todo: The reason for the test's TODO status. If L{None}, a
             generic reason is used.

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1362,11 +1362,11 @@ class Request:
         Set an HTTP response header.  Overrides any previously set values for
         this header.
 
-        @type k: L{bytes} or L{str}
-        @param k: The name of the header for which to set the value.
+        @type name: L{bytes} or L{str}
+        @param name: The name of the header for which to set the value.
 
-        @type v: L{bytes} or L{str}
-        @param v: The value to set for the named header. A L{str} will be
+        @type value: L{bytes} or L{str}
+        @param value: The value to set for the named header. A L{str} will be
             UTF-8 encoded, which may not interoperable with other
             implementations. Avoid passing non-ASCII characters if possible.
         """
@@ -2484,7 +2484,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
         Write a list of strings to the HTTP response.
 
         @param iovec: A list of byte strings to write to the stream.
-        @type data: L{list} of L{bytes}
+        @type iovec: L{list} of L{bytes}
 
         @return: L{None}
         """

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -413,9 +413,9 @@ class ICredentialFactory(Interface):
         """
         Generate a new challenge to be sent to a client.
 
-        @type peer: L{twisted.web.http.Request}
-        @param peer: The request the response to which this challenge will be
-            included.
+        @type request: L{twisted.web.http.Request}
+        @param request: The request the response to which this challenge will
+            be included.
 
         @rtype: L{dict}
         @return: A mapping from L{str} challenge fields to associated L{str}

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -703,9 +703,9 @@ class IRCUser(irc.IRC):
         """
         Send a group of LIST response lines
 
-        @type channel: C{list} of C{(str, int, str)}
-        @param channel: Information about the channels being sent:
-        their name, the number of participants, and their topic.
+        @type channels: C{list} of C{(str, int, str)}
+        @param channels: Information about the channels being sent:
+            their name, the number of participants, and their topic.
         """
         for (name, size, topic) in channels:
             self.sendMessage(irc.RPL_LIST, name, str(size), ":" + topic)


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10059
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

---

Something I noticed while doing this is that `ITransport.writeSequence()` uses `data` as its argument name, but a lot of implementations use different names such as `seq` and `iovec`. I think these should be considered bugs, since these arguments can currently only be passed safely positionally, not via keywords. It will also cause problems once type annotations are added and mypy no longer ignores these methods.
