### PR TITLE
Fix duplicate parameter documentation

### DIFF
--- a/src/twisted/_threads/_threadworker.py
+++ b/src/twisted/_threads/_threadworker.py
@@ -37,7 +37,7 @@ class ThreadWorker:
 
         @param queue: A L{Queue} to use to give tasks to the thread created by
             C{startThread}.
-        @param queue: L{Queue}
+        @type queue: L{Queue}
         """
         self._q = queue
         self._hasQuit = Quit()

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1870,7 +1870,7 @@ class _ChooseDiffieHellmanEllipticCurve:
     @see: L{OpenSSL.SSL.OPENSSL_VERSION_NUMBER}
 
     @param openSSLlib: The OpenSSL C{cffi} library module.
-    @param openSSLlib: The OpenSSL L{crypto} module.
+    @param openSSLcrypto: The OpenSSL L{crypto} module.
 
     @see: L{crypto}
     """

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -2266,7 +2266,7 @@ class ITLSTransport(ITCPTransport):
             For clients, use L{twisted.internet.ssl.optionsForClientTLS}; for
             servers, use L{twisted.internet.ssl.CertificateOptions}.
 
-        @param contextFactory: L{IOpenSSLClientConnectionCreator} or
+        @type contextFactory: L{IOpenSSLClientConnectionCreator} or
             L{IOpenSSLServerConnectionCreator}, depending on whether this
             L{ITLSTransport} is a server or not.  If the appropriate interface
             is not provided by the value given for C{contextFactory}, it must

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -138,7 +138,7 @@ class Port(base.BasePort):
 
         @param addressFamily: The address family (sometimes called I{domain}) of
             the existing socket.  For example, L{socket.AF_INET}.
-        @param addressFamily: L{int}
+        @type addressFamily: L{int}
 
         @param protocol: A C{DatagramProtocol} instance which will be
             connected to the C{port}.

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -222,18 +222,13 @@ def getDeprecationWarningString(callableThing, version, format=None, replacement
     @param callableThing: Callable object to be deprecated
 
     @type version: L{incremental.Version}
-    @param version: Version that C{callableThing} was deprecated in
+    @param version: Version that C{callableThing} was deprecated in.
 
     @type format: C{str}
     @param format: A user-provided format to interpolate warning values into,
         or L{DEPRECATION_WARNING_FORMAT
         <twisted.python.deprecate.DEPRECATION_WARNING_FORMAT>} if L{None} is
         given
-
-    @param callableThing: A callable to be deprecated.
-
-    @param version: The L{incremental.Version} that the callable
-        was deprecated in.
 
     @param replacement: what should be used in place of the callable. Either
         pass in a string, which will be inserted into the warning message,
@@ -283,9 +278,6 @@ def deprecated(version, replacement=None):
         with this version, having it set as its C{deprecatedVersion}
         attribute.
 
-    @param version: the version that the callable was deprecated in.
-    @type version: L{incremental.Version}
-
     @param replacement: what should be used in place of the callable. Either
         pass in a string, which will be inserted into the warning message,
         or a callable, which will be expanded to its full import path.
@@ -324,9 +316,6 @@ def deprecatedProperty(version, replacement=None):
         having been deprecated.  The decorated function will be annotated
         with this version, having it set as its C{deprecatedVersion}
         attribute.
-
-    @param version: the version that the callable was deprecated in.
-    @type version: L{incremental.Version}
 
     @param replacement: what should be used in place of the callable.
         Either pass in a string, which will be inserted into the warning

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -78,7 +78,7 @@ class LocalWorkerAMP(AMP):
 
         @param error: An C{Exception} instance.
 
-        @param error: The class name of the C{error} class.
+        @param errorClass: The class name of the C{error} class.
 
         @param frames: A flat list of strings representing the information need
             to approximatively rebuild C{Failure} frames.

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -63,7 +63,7 @@ def main(_fdopen=os.fdopen):
     Main function to be run if __name__ == "__main__".
 
     @param _fdopen: If specified, the function to use in place of C{os.fdopen}.
-    @param _fdopen: C{callable}
+    @type _fdopen: C{callable}
     """
     config = WorkerOptions()
     config.parseOptions()

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -126,7 +126,7 @@ class DigestMD5:
             challenge.
         @type username: C{unicode}
 
-        @param username: The authentication password to use to respond to a
+        @param password: The authentication password to use to respond to a
             challenge.
         @type password: C{unicode}
         """


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10060
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~~I have updated the automated tests.~~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
