### PR TITLE
[10064] Fix documentation GitHub Action build.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,10 @@ jobs:
 
     - name: Install dependencies
       run: |
+        echo "::group::Pre-deps "
         python -m pip install --upgrade pip tox
+        echo "::endgroup::"
+
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox virtualenv==20.2.1
+        python -m pip install --upgrade pip tox
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,14 +23,6 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
 
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
-          'setup.cfg', 'tox.ini') }}
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,10 +28,8 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:
-          ${{ runner.os }}-test-pip-${{ hashFiles('pyproject.toml', 'setup.py',
+          ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
           'setup.cfg', 'tox.ini') }}
-        restore-keys: |
-            ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox virtualenv==20.2.1
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:
-          ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
+          ${{ runner.os }}-test-pip-${{ hashFiles('pyproject.toml', 'setup.py',
           'setup.cfg', 'tox.ini') }}
         restore-keys: |
             ${{ runner.os }}-pip-

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade tox
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -23,9 +23,19 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
 
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
+          'setup.cfg', 'tox.ini') }}
+        restore-keys: |
+            ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade tox
+        python -m pip install --upgrade pip tox
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - dev
+        - dev_release

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier >= 17.4.0
-    pydoctor == 20.12.0; python_version >= "3.7"
+    pydoctor == 20.7.0; python_version >= "3.7"
     sphinx-rtd-theme~=0.5.0
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ dev_release =
 dev =
     %(dev_release)s
     pyflakes >= 1.0.0
-    twisted-dev-tools >= 0.0.2
     python-subunit
     twistedchecker >= 0.7.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier >= 17.4.0
-    pydoctor == 20.12.0
+    pydoctor == 20.12.0; python_version >= "3.7"
     sphinx-rtd-theme~=0.5.0
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier >= 17.4.0
-    pydoctor >= 20.7.0
+    pydoctor == 20.12.0
     sphinx-rtd-theme~=0.5.0
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -52,6 +52,9 @@ if sys.platform != "win32":
 else:
     skip = "Release toolchain only supported on POSIX."
 
+if sys.version_info[0:2] in [(3, 5)]:
+    skip = "Release toolchain not supported on this Python version."
+
 
 class ExternalTempdirTestCase(TestCase):
     """

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -52,9 +52,6 @@ if sys.platform != "win32":
 else:
     skip = "Release toolchain only supported on POSIX."
 
-if sys.version_info[0:2] in [(3, 5)]:
-    skip = "Release toolchain not supported on this Python version."
-
 
 class ExternalTempdirTestCase(TestCase):
     """

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -52,9 +52,6 @@ if sys.platform != "win32":
 else:
     skip = "Release toolchain only supported on POSIX."
 
-if sys.version_info[0:2] in [(3, 5), (3, 6), (3, 7)]:
-    skip = "Release toolchain not supported on this Python version."
-
 
 class ExternalTempdirTestCase(TestCase):
     """

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -52,6 +52,9 @@ if sys.platform != "win32":
 else:
     skip = "Release toolchain only supported on POSIX."
 
+if sys.version_info[0:2] in [(3, 5), (3, 6), (3, 7)]:
+    skip = "Release toolchain not supported on this Python version."
+
 
 class ExternalTempdirTestCase(TestCase):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,7 @@
 [tox]
 minversion=3.20.1
 requires=
-    virtualenv==20.2.1
-    pip==20.3
+    virtualenv>=20.0.35
     tox-wheel>=0.5.0
 skip_missing_interpreters=True
 envlist=lint, mypy,

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,6 @@ extras =
 
     serial: serial
 
-    ; Documentation needs Twisted install to get the version.
-    narrativedocs: dev
-
 ;; dependencies that are not specified as extras
 deps =
     {withcov}: coverage
@@ -126,13 +123,28 @@ commands =
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 
     apidocs: {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
-    narrativedocs: sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
 
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
 
+[testenv:narrativedocs]
+
+description = Build the narrative documentation.
+
+; Documentation needs Twisted install to get the version.
+extras:
+    dev
+
+command:
+    sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
+
+
 [testenv:apidocs]
+
+description = Build the API documentation.
+
 deps=https://github.com/twisted/pydoctor/archive/3f9c64829dfa040b334c9ae27c332c7078356e79.zip
+
 
 [testenv:mypy]
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,
     release-prepare,
     py38-alldeps-nocov
-install_command = python -m pip --use-deprecated=legacy-resolver install {opts} {packages}
 
 
 [default]
@@ -130,14 +129,13 @@ commands =
 
 
 [testenv:narrativedocs]
-
 description = Build the narrative documentation.
 
 ; Documentation needs Twisted install to get the version.
 extras:
-    dev
+    dev_release
 
-command:
+commands:
     sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -122,8 +122,6 @@ commands =
 
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 
-    apidocs: {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
-
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
 
@@ -139,10 +137,10 @@ commands:
 
 
 [testenv:apidocs]
-
 description = Build the API documentation.
 
-deps=https://github.com/twisted/pydoctor/archive/3f9c64829dfa040b334c9ae27c332c7078356e79.zip
+extras = dev_release
+commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
 
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ envlist=lint, mypy,
     release-prepare,
     py38-alldeps-nocov
 
-
 [default]
 ; Files and directories that contain Python source for linting.
 sources = setup.py src/ docs/conch/examples docs/mail/examples docs/names/examples docs/pair/examples docs/web/examples docs/words/examples

--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,16 @@
 [tox]
 minversion=3.20.1
 requires=
-    virtualenv>=20.0.35
+    virtualenv==20.2.1
+    pip==20.3
     tox-wheel>=0.5.0
 skip_missing_interpreters=True
 envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,
     release-prepare,
     py38-alldeps-nocov
+install_command = python -m pip --use-deprecated=legacy-resolver install {opts} {packages}
+
 
 [default]
 ; Files and directories that contain Python source for linting.


### PR DESCRIPTION
## Why we got the error

pip was updated to new resolver 

The issue was caused by `twisted-dev-tool`, depending on `treq` ... depending on  `twisted` back...and somehow `twisted[counch]` was triggered  and pip failed at `pyasn1`


## Changes

Use `dev_release` for docs as that is enough.

As a drive-by I have removed `twisted-dev-tools` as I don't think they are used anymore by dev team members.

As a drive-by I have created a separate section in tox for narrative docs.
It was making it easier to select narrativedocs only settings in tox, while debugging.

Also, as a drive by I added a group for GitHub actions logs as it is easier to debug and search the logs,

As a drive-by reactor release tests... the APIBuilder was kind of private ... and I merged it with the buildocs.

This PR tried to fix the code with latest pydoctor... but I had to pinned back to older pydoctor. I have still kept the changes for pydoctor CLI usage.


## Manual checks

-GHA build - https://github.com/twisted/twisted/pull/1492/checks?check_run_id=1518880477
- Read the docs - https://twisted--1492.org.readthedocs.build/en/1492/

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10064
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
