### PR TITLE
Fix docs build and relase tests after latest pip and pydoctor releases.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,10 @@ jobs:
 
     - name: Install dependencies
       run: |
+        echo "::group::Pre-deps "
         python -m pip install --upgrade pip tox
+        echo "::endgroup::"
+
         tox --notest -e narrativedocs,apidocs
 
     - name: Check the narrative documentation

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - dev
+        - dev_release

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ dev_release =
 dev =
     %(dev_release)s
     pyflakes >= 1.0.0
-    twisted-dev-tools >= 0.0.2
     python-subunit
     twistedchecker >= 0.7.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier >= 17.4.0
-    pydoctor >= 20.7.0
+    pydoctor == 20.7.0
     sphinx-rtd-theme~=0.5.0
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,6 @@ extras =
 
     serial: serial
 
-    ; Documentation needs Twisted install to get the version.
-    narrativedocs: dev
-
 ;; dependencies that are not specified as extras
 deps =
     {withcov}: coverage
@@ -125,14 +122,26 @@ commands =
 
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 
-    apidocs: {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
-    narrativedocs: sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
-
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
 
+[testenv:narrativedocs]
+description = Build the narrative documentation.
+
+; Documentation needs Twisted install to get the version.
+extras:
+    dev_release
+
+commands:
+    sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
+
+
 [testenv:apidocs]
-deps=https://github.com/twisted/pydoctor/archive/3f9c64829dfa040b334c9ae27c332c7078356e79.zip
+description = Build the API documentation.
+
+extras = dev_release
+commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
+
 
 [testenv:mypy]
 

--- a/tox.ini
+++ b/tox.ini
@@ -129,10 +129,10 @@ commands =
 description = Build the narrative documentation.
 
 ; Documentation needs Twisted install to get the version.
-extras:
+extras =
     dev_release
 
-commands:
+commands =
     sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
 
 


### PR DESCRIPTION

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10064
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I ran additional checks listed at [Getting Your Patch Accepted](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#GettingYourPatchAccepted)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
