### PR TITLE
Use FS encoding and errors for unicode args

### DIFF
--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1063,7 +1063,8 @@ class ReactorBase(PluggableResolverMixin):
         # https://docs.python.org/3/library/sys.html#sys.getfilesystemencoding
         # and PEP 529 for the gory details.
         defaultEncoding = sys.getfilesystemencoding()
-        defaultErrors = sys.getfilesystemencodeerrors()
+        # https://github.com/python/typeshed/pull/4864
+        defaultErrors = sys.getfilesystemencodeerrors()  # type: ignore
 
         # Common check function
         def argChecker(arg: Union[bytes, str]) -> Optional[bytes]:


### PR DESCRIPTION
This partially reverts 85069b5ccdc92745809a8287ab24d6127c1a75da but should have the same effect.

## Scope and purpose

The error reported [Twisted #10070](https://twistedmatrix.com/trac/ticket/10070):

```pytb
Traceback (most recent call last):
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/defer.py", line 1445, in _inlineCallbacks
    result = current_context.run(g.send, result)
  File "/buildbot/buildbot-job/build/master/buildbot/test/unit/scripts/test_start.py", line 117, in test_start_timeout_number_string
    res = yield self.runStart(start_timeout='10')
  File "/buildbot/buildbot-job/build/master/buildbot/test/unit/scripts/test_start.py", line 87, in runStart
    return getProcessOutputAndValue(sys.executable, args=args, env=env)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/utils.py", line 174, in getProcessOutputAndValue
    return _callProtocolWithDeferred(
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/utils.py", line 28, in _callProtocolWithDeferred
    reactor.spawnProcess(p, executable, (executable,) + tuple(args), env, path)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/posixbase.py", line 386, in spawnProcess
    args, env = self._checkProcessArgs(args, env)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/base.py", line 1088, in _checkProcessArgs
    _arg = argChecker(arg)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/base.py", line 1074, in argChecker
    arg = arg.encode(defaultEncoding)
builtins.TypeError: encode() argument 'encoding' must be str, not None
```

This points at this code: ​https://github.com/twisted/twisted/blob/c8064075a207af1fc9ce19d8f885a986bc5ab00c/src/twisted/internet/base.py#L1055-L1074

It looks like `defaultEncoding` used to default to `sys.getfilesystemencoding()`: ​https://github.com/twisted/twisted/commit/85069b5ccdc92745809a8287ab24d6127c1a75da It's also [documented](https://docs.python.org/3/library/sys.html#sys.__stdin__) to be possible for `std.stdout` to be `None` on Windows so using `sys.stdout.encoding` seems broken in the general case.

It seems like just the environment variables added for #9858 should be sufficient to solve the problem there, as they activate UTF-8 mode on all supported Python versions. However it also looks off to me that we aren't using the system-configured encoding error handler (via the sublimely named `os.getfilesystemencodeerrors()`). That's what should allow non-text stuff to round-trip

I have no idea how to add tests for this, but I think that the additional coverage added in PR #1302 may be sufficient.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10070
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
