### PR TITLE
[10070] Fix passing str command arguments to spawProcess with None encoding.

### DIFF
--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1072,10 +1072,10 @@ class ReactorBase(PluggableResolverMixin):
             API or L{None}.
             If the given value is not allowable for some reason, L{None} is returned.
             """
-            if platform.isLinux():
-                return strToBytesChecker(arg)
+            if platform.isWindows():
+                return bytesToStrChecker(arg)
 
-            return bytesToStrChecker(arg)
+            return strToBytesChecker(arg)
 
         def strToBytesChecker(arg: Union[bytes, str]) -> Optional[bytes]:
             """

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1059,6 +1059,9 @@ class ReactorBase(PluggableResolverMixin):
         # are set before the Python interpreter runs, they will affect the
         # value of sys.stdout.encoding
         defaultEncoding = sys.stdout.encoding
+        if not defaultEncoding:
+            # Maybe we have a streaming stdout.
+            defaultEncoding = "utf-8"
 
         # Common check function
         def argChecker(arg: Union[bytes, str]) -> Optional[bytes]:
@@ -1102,7 +1105,7 @@ class ReactorBase(PluggableResolverMixin):
                     raise TypeError(
                         "Environment contains a "
                         "non-string key: {!r}, using encoding: {}".format(
-                            key, sys.stdout.encoding
+                            key, defaultEncoding
                         )
                     )
                 _val = argChecker(val)
@@ -1110,7 +1113,7 @@ class ReactorBase(PluggableResolverMixin):
                     raise TypeError(
                         "Environment contains a "
                         "non-string value: {!r}, using encoding {}".format(
-                            val, sys.stdout.encoding
+                            val, defaultEncoding
                         )
                     )
                 outputEnv[_key] = _val

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -60,7 +60,7 @@ from twisted.internet.interfaces import (
 from twisted.internet.protocol import ClientFactory
 from twisted.python import log, reflect
 from twisted.python.failure import Failure
-from twisted.python.runtime import seconds as runtimeSeconds, platform, platformType
+from twisted.python.runtime import seconds as runtimeSeconds, platform
 
 if TYPE_CHECKING:
     from twisted.internet.tcp import Client
@@ -1028,7 +1028,9 @@ class ReactorBase(PluggableResolverMixin):
 
     def _checkProcessArgs(
         self, args: List[Union[bytes, str]], env: Optional[Mapping[AnyStr, AnyStr]]
-    ) -> Tuple[List[bytes], Optional[Dict[bytes, bytes]]]:
+    ) -> Tuple[
+        List[Union[bytes, str]], Optional[Dict[Union[bytes, str], Union[bytes, str]]]
+    ]:
         """
         Check for valid arguments and environment to spawnProcess.
 
@@ -1070,12 +1072,12 @@ class ReactorBase(PluggableResolverMixin):
             API or L{None}.
             If the given value is not allowable for some reason, L{None} is returned.
             """
-            if platformType == "posix":
+            if platform.isLinux():
                 return strToBytesChecker(arg)
 
             return bytesToStrChecker(arg)
 
-        def strToBytesChecker(arg: Union[bytes, str]) -> Optional[Union[bytes, str]]:
+        def strToBytesChecker(arg: Union[bytes, str]) -> Optional[bytes]:
             """
             Return either L{bytes} or L{None}.  If the given value is not
             allowable for some reason, L{None} is returned.  Otherwise, a
@@ -1093,7 +1095,7 @@ class ReactorBase(PluggableResolverMixin):
 
             return None
 
-        def bytesToStrChecker(arg: Union[bytes, str]) -> Optional[Union[bytes, str]]:
+        def bytesToStrChecker(arg: Union[bytes, str]) -> Optional[str]:
             """
             Return either L{str} or L{None}.  If the given value is not
             allowable for some reason, L{None} is returned.  Otherwise, a

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: twisted.test.test_internet,twisted.internet.test.test_posixbase -*-
+# -*- test-case-name: twisted.test.test_internet,twisted.internet.test.test_posixbase,twisted.internet.test.test_process -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/src/twisted/newsfragments/10070.bugfix
+++ b/src/twisted/newsfragments/10070.bugfix
@@ -1,0 +1,2 @@
+twisted.internet.reactor.spawnProcess can now handle str arguments when
+standard output encoding is None (piped output).


### PR DESCRIPTION
## Scope and purpose

This tries to fix https://twistedmatrix.com/trac/ticket/10070

Default to utf-8 when encoding is None.

This is similar to https://github.com/twisted/towncrier/pull/300

I am not a Py 3 expert, but my understand is that a standard stream has encoding None, when it is piped.

This is other info I found https://stackoverflow.com/questions/492483/setting-the-correct-encoding-when-piping-stdout-in-python


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10070
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
