### PR TITLE
Fix defaultEncoding in base.py, uncovered by Buildbot regression tests

### DIFF
--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1057,8 +1057,12 @@ class ReactorBase(PluggableResolverMixin):
         #  - PYTHONIOENCODING
         #
         # are set before the Python interpreter runs, they will affect the
-        # value of sys.stdout.encoding
-        defaultEncoding = sys.stdout.encoding
+        # value of sys.stdout.encoding.
+        # If a client application patches sys.stdout so that encoding is not
+        # set properly, try to fall back to sys.__stdout__.encoding.
+        defaultEncoding = sys.stdout.encoding or sys.__stdout__.encoding
+        if not defaultEncoding:
+            raise ValueError("sys.stdout does not have a valid encoding")
 
         # Common check function
         def argChecker(arg: Union[bytes, str]) -> Optional[bytes]:

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1028,7 +1028,10 @@ class ReactorBase(PluggableResolverMixin):
 
     def _checkProcessArgs(
         self, args: List[Union[bytes, str]], env: Optional[Mapping[AnyStr, AnyStr]]
-    ) -> Tuple[List[bytes], Optional[Dict[bytes, bytes]]]:
+    ) -> Union[
+        Tuple[List[bytes], Optional[Dict[bytes, bytes]]],
+        Tuple[List[Union[bytes, str]], Optional[Mapping[AnyStr, AnyStr]]],
+    ]:
         """
         Check for valid arguments and environment to spawnProcess.
 
@@ -1058,6 +1061,13 @@ class ReactorBase(PluggableResolverMixin):
         #
         # are set before the Python interpreter runs, they will affect the
         # value of sys.stdout.encoding.
+
+        # In certain cases, such as a Windows GUI Application which has no
+        # console, sys.stdout is None.  In this case,
+        # just return the args and env unmodified.
+        if not sys.stdout:
+            return args, env
+
         # If a client application patches sys.stdout so that encoding is not
         # set properly, try to fall back to sys.__stdout__.encoding.
         defaultEncoding = sys.stdout.encoding or sys.__stdout__.encoding

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -531,6 +531,16 @@ class ProcessTests(unittest.TestCase):
 
         return d.addCallback(processEnded)
 
+    def test_patchSysStdoutWithNone(self):
+        """
+        In some scenarious, such as Python running as part of a Windows
+        Windows GUI Application with no console, L{sys.stdout} is L{None}.
+        """
+        import sys
+
+        self.patch(sys, "stdout", None)
+        return self.test_stdio()
+
     def test_patchSysStdoutWithStringIO(self):
         """
         Some projects which use the Twisted reactor

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -531,6 +531,32 @@ class ProcessTests(unittest.TestCase):
 
         return d.addCallback(processEnded)
 
+    def test_patchSysStdoutWithStringIO(self):
+        """
+        Some projects which use the Twisted reactor
+        such as Buildbot patch L{sys.stdout} with L{io.StringIO}
+        before running their tests.
+        """
+        import sys
+        from io import StringIO
+
+        stdoutStringIO = StringIO()
+        self.patch(sys, "stdout", stdoutStringIO)
+        return self.test_stdio()
+
+    def test_patch_sys__stdout__WithStringIO(self):
+        """
+        If L{sys.stdout} and L{sys.__stdout__} are patched with L{io.StringIO},
+        we should get a L{ValueError}.
+        """
+        import sys
+        from io import StringIO
+
+        self.patch(sys, "stdout", StringIO())
+        self.patch(sys, "__stdout__", StringIO())
+        with self.assertRaises(ValueError):
+            return self.test_stdio()
+
     def test_unsetPid(self):
         """
         Test if pid is None/non-None before/after process termination.  This


### PR DESCRIPTION
## Scope and purpose

In ​https://github.com/buildbot/buildbot/pull/5591 , we found that Twisted trunk started breaking some of Buildbot's tests:

```
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/defer.py", line 1445, in _inlineCallbacks
    result = current_context.run(g.send, result)
  File "/buildbot/buildbot-job/build/master/buildbot/test/unit/scripts/test_start.py", line 117, in test_start_timeout_number_string
    res = yield self.runStart(start_timeout='10')
  File "/buildbot/buildbot-job/build/master/buildbot/test/unit/scripts/test_start.py", line 87, in runStart
    return getProcessOutputAndValue(sys.executable, args=args, env=env)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/utils.py", line 174, in getProcessOutputAndValue
    return _callProtocolWithDeferred(
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/utils.py", line 28, in _callProtocolWithDeferred
    reactor.spawnProcess(p, executable, (executable,) + tuple(args), env, path)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/posixbase.py", line 386, in spawnProcess
    args, env = self._checkProcessArgs(args, env)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/base.py", line 1088, in _checkProcessArgs
    _arg = argChecker(arg)
  File "/buildbot/buildbot-job/build/sandbox/lib/python3.8/site-packages/twisted/internet/base.py", line 1074, in argChecker
    arg = arg.encode(defaultEncoding)
builtins.TypeError: encode() argument 'encoding' must be str, not None
buildbot.test.unit.scripts.test_start.TestStart.test_start_timeout_number_string
-------------------------------------------------------------------------------
```

## Contributor Checklist:

* [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10069
* [X] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [X] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
