### PR TITLE
[9972] inlineCallbacks async def

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1885,9 +1885,9 @@ def inlineCallbacks(
                 "inlineCallbacks requires %r to produce a generator; instead"
                 "caught returnValue being used in a non-generator" % (f,)
             )
-        if not isinstance(gen, GeneratorType):
+        if not isinstance(gen, GeneratorType) and not iscoroutine(gen):
             raise TypeError(
-                "inlineCallbacks requires %r to produce a generator; "
+                "inlineCallbacks requires %r to produce a generator or coroutine; "
                 "instead got %r" % (f, gen)
             )
         return _cancellableInlineCallbacks(gen)

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: twisted.test.test_defer -*-
+# -*- test-case-name: twisted.test.test_defer,twisted.test.test_defgen -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1829,62 +1829,51 @@ def inlineCallbacks(
     f: Callable[..., Generator[Deferred[object], object, _T]]
 ) -> Callable[..., Deferred[_T]]:
     """
-    L{inlineCallbacks} helps you write L{Deferred}-using code that looks like a
-    regular sequential function. For example::
+    L{inlineCallbacks} helps you write L{Deferred}-using code using coroutines.
+    For example::
+
+        @inlineCallbacks
+        async def thingummy():
+            thing = await makeSomeRequestResultingInADeferred()
+            return thing  # the result! hoorj!
+
+    When you call anything that results in a L{Deferred} or coroutine, you
+    can simply C{await} it; the function will resume when the C{await}ed thing
+    results in a value (which becomes the value of the C{await} expression) or
+    exception (which is raised at the point of the C{await} expression).  Any
+    object that isn't a L{Deferred} or coroutine will pass through C{await}, in
+    the matter of L{maybeDeferred}.
+
+    An L{inlineCallbacks}-decorated function always returns a L{Deferred}.
+    A C{return} statement callbacks the deferred. C{raise} errbacks it, as does
+    an unhandled exception. The deferred will callback with L{None} if it
+    executes without returning.
+
+    Cancelling the L{Deferred} returned by your L{inlineCallbacks}
+    function before it causes C{CancelledError} to be raised from the
+    C{await}ed L{Deferred} that has been cancelled if that C{Deferred} does not
+    otherwise suppress it.
+
+    For compatibility with code written before introduction of coroutine
+    function syntax (C{async def}) in Python 3.7, L{inlineCallbacks} can also
+    decorate generator functions. For example::
 
         @inlineCallbacks
         def thingummy():
             thing = yield makeSomeRequestResultingInDeferred()
-            print(thing)  # the result! hoorj!
+            return thing
 
-    When you call anything that results in a L{Deferred}, you can simply yield it;
-    your generator will automatically be resumed when the Deferred's result is
-    available. The generator will be sent the result of the L{Deferred} with the
-    'send' method on generators, or if the result was a failure, 'throw'.
+    This functions just like C{async def}, but you use C{yield} instead of
+    C{await}.
 
-    Things that are not L{Deferred}s may also be yielded, and your generator
-    will be resumed with the same object sent back. This means C{yield}
-    performs an operation roughly equivalent to L{maybeDeferred}.
-
-    Your inlineCallbacks-enabled generator will return a L{Deferred} object, which
-    will result in the return value of the generator (or will fail with a
-    failure object if your generator raises an unhandled exception). Note that
-    you can't use C{return result} to return a value; use C{returnValue(result)}
-    instead. Falling off the end of the generator, or simply using C{return}
-    will cause the L{Deferred} to have a result of L{None}.
-
-    Be aware that L{returnValue} will not accept a L{Deferred} as a parameter.
-    If you believe the thing you'd like to return could be a L{Deferred}, do
-    this::
-
-        result = yield result
-        returnValue(result)
-
-    The L{Deferred} returned from your deferred generator may errback if your
-    generator raised an exception::
-
-        @inlineCallbacks
-        def thingummy():
-            thing = yield makeSomeRequestResultingInDeferred()
-            if thing == 'I love Twisted':
-                # will become the result of the Deferred
-                returnValue('TWISTED IS GREAT!')
-            else:
-                # will trigger an errback
-                raise Exception('DESTROY ALL LIFE')
-
-    It is possible to use the C{return} statement instead of L{returnValue}::
+    For compatibility with code written before introduction of generator
+    return in Python 3.5, the L{returnValue} function may be used instead of
+    the C{return} statement::
 
         @inlineCallbacks
         def loadData(url):
             response = yield makeRequest(url)
-            return json.loads(response)
-
-    You can cancel the L{Deferred} returned from your L{inlineCallbacks}
-    generator before it is fired by your generator completing (either by
-    reaching its end, a C{return} statement, or by calling L{returnValue}).
-    A C{CancelledError} will be raised from the C{yield}ed L{Deferred} that
-    has been cancelled if that C{Deferred} does not otherwise suppress it.
+            returnValue(json.loads(response))
     """
 
     @wraps(f)

--- a/src/twisted/test/test_defgen.py
+++ b/src/twisted/test/test_defgen.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Tests for L{twisted.internet.defer.deferredGenerator} and related APIs.
+Tests for L{twisted.internet.defer.inlineCallbacks} and related APIs.
 """
 
 
@@ -272,6 +272,134 @@ class InlineCallbacksTests(BaseDefgenTests, unittest.TestCase):
     _genStackUsage2 = inlineCallbacks(_genStackUsage2)
 
     # Tests unique to inlineCallbacks
+
+    def testYieldNonDeferred(self):
+        """
+        Ensure that yielding a non-deferred passes it back as the
+        result of the yield expression.
+
+        @return: A L{twisted.internet.defer.Deferred}
+        @rtype: L{twisted.internet.defer.Deferred}
+        """
+
+        def _test():
+            yield 5
+            returnValue(5)
+
+        _test = inlineCallbacks(_test)
+
+        return _test().addCallback(self.assertEqual, 5)
+
+    def testReturnNoValue(self):
+        """Ensure a standard python return results in a None result."""
+
+        def _noReturn():
+            yield 5
+            return
+
+        _noReturn = inlineCallbacks(_noReturn)
+
+        return _noReturn().addCallback(self.assertEqual, None)
+
+    def testReturnValue(self):
+        """Ensure that returnValue works."""
+
+        def _return():
+            yield 5
+            returnValue(6)
+
+        _return = inlineCallbacks(_return)
+
+        return _return().addCallback(self.assertEqual, 6)
+
+    def test_nonGeneratorReturn(self):
+        """
+        Ensure that C{TypeError} with a message about L{inlineCallbacks} is
+        raised when a non-generator returns something other than a generator.
+        """
+
+        def _noYield():
+            return 5
+
+        _noYield = inlineCallbacks(_noYield)
+
+        self.assertIn("inlineCallbacks", str(self.assertRaises(TypeError, _noYield)))
+
+    def test_nonGeneratorReturnValue(self):
+        """
+        Ensure that C{TypeError} with a message about L{inlineCallbacks} is
+        raised when a non-generator calls L{returnValue}.
+        """
+
+        def _noYield():
+            returnValue(5)
+
+        _noYield = inlineCallbacks(_noYield)
+
+        self.assertIn("inlineCallbacks", str(self.assertRaises(TypeError, _noYield)))
+
+
+class InlineCallbacksCoroutineTests(BaseDefgenTests, unittest.TestCase):
+    """
+    Test L{twisted.internet.defer.inlineCallbacks} with coroutine functions.
+    """
+
+    # First provide all the generator impls necessary for BaseDefgenTests
+    # TODO: Skip this syntax on Python 3.5 and 3.6
+
+    @inlineCallbacks
+    async def _genBasics(self):
+
+        x = await getThing()
+
+        self.assertEqual(x, "hi")
+
+        try:
+            await getOwie()
+        except ZeroDivisionError as e:
+            self.assertEqual(str(e), "OMG")
+        return "WOOSH"
+
+    @inlineCallbacks
+    async def _genBuggy(self):
+        await getThing()
+        1 / 0
+
+    @inlineCallbacks
+    async def _genNothing(self):
+        if False:
+            await 1  # type: ignore[unreachable]
+
+    @inlineCallbacks
+    async def _genHandledTerminalFailure(self):
+        try:
+            await defer.fail(TerminalException("Handled Terminal Failure"))
+        except TerminalException:
+            pass
+
+    @inlineCallbacks
+    async def _genHandledTerminalAsyncFailure(self, d):
+        try:
+            await d
+        except TerminalException:
+            pass
+
+    @inlineCallbacks
+    async def _genStackUsage(self):
+        for x in range(5000):
+            # Test with yielding a deferred
+            await defer.succeed(1)
+        return 0
+
+    @inlineCallbacks
+    async def _genStackUsage2(self):
+        for x in range(5000):
+            # Test with yielding a random value
+            await 1
+        return 0
+
+    # Tests unique to inlineCallbacks with async def
+    # TODO update for async def
 
     def testYieldNonDeferred(self):
         """


### PR DESCRIPTION
## Scope and purpose

Add a few words about why this PR is needed and what is its scope.

Add mentions of things that are not covered here and are planed to be done
in separate PRs.

- [ ] Update description above
- [ ] Write migration documentation
- [ ] Skip tests on Python 3.6

Closes #1397.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9972
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
