### PR TITLE
Fix or work around stricter pydoctor warnings about __all__ and __doc__

### DIFF
--- a/src/twisted/application/twist/_options.py
+++ b/src/twisted/application/twist/_options.py
@@ -37,6 +37,14 @@ from ..service import IServiceMaker
 openFile = open
 
 
+def _update_doc(opt: Callable[["TwistOptions", str], None], **kwargs: str) -> None:
+    """
+    Update the docstring of a method that implements an option.
+    The string is dedented and the given keyword arguments are substituted.
+    """
+    opt.__doc__ = dedent(opt.__doc__ or "").format(**kwargs)
+
+
 class TwistOptions(Options):
     """
     Command line options for C{twist}.
@@ -76,7 +84,8 @@ class TwistOptions(Options):
         else:
             self["reactorName"] = name
 
-    opt_reactor.__doc__ = dedent(opt_reactor.__doc__ or "").format(
+    _update_doc(
+        opt_reactor,
         options=", ".join('"{}"'.format(rt.shortName) for rt in getReactorTypes()),
     )
 
@@ -101,7 +110,8 @@ class TwistOptions(Options):
         except InvalidLogLevelError:
             raise UsageError("Invalid log level: {}".format(levelName))
 
-    opt_log_level.__doc__ = dedent(opt_log_level.__doc__ or "").format(
+    _update_doc(
+        opt_log_level,
         options=", ".join(
             '"{}"'.format(constant.name) for constant in LogLevel.iterconstants()
         ),
@@ -144,7 +154,7 @@ class TwistOptions(Options):
             raise UsageError("Invalid log format: {}".format(format))
         self["logFormat"] = format
 
-    opt_log_format.__doc__ = dedent(opt_log_format.__doc__ or "")
+    _update_doc(opt_log_format)
 
     def selectDefaultLogObserver(self) -> None:
         """

--- a/src/twisted/test/proto_helpers.py
+++ b/src/twisted/test/proto_helpers.py
@@ -10,7 +10,22 @@ instead.
 from twisted.internet import testing
 
 
-__all__ = testing.__all__
+__all__ = [
+    "AccumulatingProtocol",
+    "LineSendingProtocol",
+    "FakeDatagramTransport",
+    "StringTransport",
+    "StringTransportWithDisconnection",
+    "StringIOWithoutClosing",
+    "_FakeConnector",
+    "_FakePort",
+    "MemoryReactor",
+    "MemoryReactorClock",
+    "RaisingMemoryReactor",
+    "NonStreamingProducer",
+    "waitUntilAllDisconnected",
+    "EventLoggingObserver",
+]
 
 
 AccumulatingProtocol = testing.AccumulatingProtocol


### PR DESCRIPTION
## Scope and purpose

Fix warnings that will be reported when upgrading to the next pydoctor release. See ticket for details.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10080
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] ~I have updated the automated tests.~
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
