### PR TITLE
Remove needs_sphinx from conf.py and only use setup.cfg for required Sphinx version.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,9 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration ------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.2"
+# See setup.cfg for the Sphinx version required to build the documentation.
+# needs_sphinx is not use to avoid duplication and getting these values
+# out of sync.
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
## Scope and purpose

This is an old ticket and I have just removed the sphinx version from conf.py so that we only define the required Sphinx once.



## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/6903
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [NA] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
