### PR TITLE
Add build date and version to HTML narrative documentation.

### DIFF
--- a/docs/_themes/twistedtrac/layout.html
+++ b/docs/_themes/twistedtrac/layout.html
@@ -260,6 +260,7 @@
 
 </div>
       <p class="left2">
+        Copyright</a> {{ copyright }}.<br />
         Site design<br />
         By <a href="http://huw.ugbox.net/">huw.wilkins.</a>
 

--- a/docs/_themes/twistedtrac/layout.html
+++ b/docs/_themes/twistedtrac/layout.html
@@ -260,7 +260,7 @@
 
 </div>
       <p class="left2">
-        Copyright</a> {{ copyright }}.<br />
+        Copyright {{ copyright }}.<br />
         Site design<br />
         By <a href="http://huw.ugbox.net/">huw.wilkins.</a>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ master_doc = "index"
 _today = date.today()
 # General information about the project.
 project = "Twisted"
-copyright = "{}, Twisted Matrix Labs. Ver {}. Build at {}".format(
+copyright = "{}, Twisted Matrix Labs. Ver {}. Built on {}".format(
     _today.year,
     twisted_version_object.public(),
     _today.isoformat(),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import subprocess
 from pprint import pprint
+from datetime import date
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -61,9 +62,14 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
+_today = date.today()
 # General information about the project.
 project = "Twisted"
-copyright = "2020, Twisted Matrix Labs"
+copyright = "{}, Twisted Matrix Labs. Ver {}. Build at {}".format(
+    _today.year,
+    twisted_version_object.public(),
+    _today.isoformat(),
+)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/src/twisted/newsfragments/3945.doc
+++ b/src/twisted/newsfragments/3945.doc
@@ -1,0 +1,2 @@
+The narrative docs now contains the associated Twisted version and the date
+when they were generated.


### PR DESCRIPTION
## Scope and purpose

This only looks for HTML rendering of the narrative docs.

For API docs there will be separate ticket. This should be fixed in pydoctor and get it in Twisted with an update of pydoctor.

The Trac theme already has the version visible
https://twistedmatrix.com/documents/current/

![image](https://user-images.githubusercontent.com/204609/107130892-e7b44b80-68c9-11eb-869c-82dcadf2f8dc.png)

And this was updated to add copyright and build date in the footer.

-------------

We are left with Read The Docs variant which now has the version and date in the footer.

This was implemented by hijacking the Copyright field... In this way we don't need to modify the RTD theme.

This can be tested with the RTD build for this PR.

Or see this screenshot

![image](https://user-images.githubusercontent.com/204609/107132942-72ea0d00-68db-11eb-9401-20ba5dc36b1e.png)


-------------

As a drive-by I have updated the copyright year to be automatically updated with the current year.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/3945
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [NA] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
