### PR TITLE
Fix NoneType encode error when multipart body part does not include h…

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -980,6 +980,7 @@ class Request:
                                     for z in y
                                 ]
                                 for x, y in cgiArgs.items()
+                                if isinstance(x, str)
                             }
                         )
                     else:

--- a/src/twisted/web/newsfragments/10084.bugfix
+++ b/src/twisted/web/newsfragments/10084.bugfix
@@ -1,0 +1,1 @@
+Fixed an error where twisted.web.http.requestReceived() tries to encode a NoneType returned by cgi.parse_multipart when a multipart body does not contain a "content-disposition" definition.


### PR DESCRIPTION
…eaders

## Scope and purpose

Before commit ​https://github.com/python/cpython/commit/cc3fa204d357be5fafc10eb8c2a80fe0bca998f1 in cpython, cgi.parse_multipart ignored parts without a name defined in "content-disposition" (or parts without headers for that matter) but after 3.7+, to make it consistent with FieldStorage, the return of the function can now contain NoneType keys, which fail to encode.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10084
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard]
* [x] I have created a newsfragment in src/twisted/newsfragments/10084.bugfix
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
