### PR TITLE
upgrade to mypy==0.800 and mypy-zope==0.2.10

### DIFF
--- a/src/twisted/__main__.py
+++ b/src/twisted/__main__.py
@@ -10,6 +10,4 @@ import sys
 from pkg_resources import load_entry_point
 
 if __name__ == "__main__":
-    sys.exit(
-        load_entry_point("Twisted", "console_scripts", "twist")()  # type: ignore[func-returns-value]
-    )
+    sys.exit(load_entry_point("Twisted", "console_scripts", "twist")())

--- a/src/twisted/conch/test/test_checkers.py
+++ b/src/twisted/conch/test/test_checkers.py
@@ -797,7 +797,7 @@ class UNIXAuthorizedKeysFilesTests(TestCase):
         self.assertEqual(self.expectedKeys, list(keydb.getAuthorizedKeys(b"alice")))
 
 
-_KeyDB = namedtuple("KeyDB", ["getAuthorizedKeys"])
+_KeyDB = namedtuple("_KeyDB", ["getAuthorizedKeys"])
 
 
 class _DummyException(Exception):

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1088,7 +1088,7 @@ class ReactorBase(PluggableResolverMixin):
                     arg = arg.encode(defaultEncoding)
                 except UnicodeEncodeError:
                     return None
-            if isinstance(arg, bytes) and b"\0" not in arg:  # type: ignore[unreachable]
+            if isinstance(arg, bytes) and b"\0" not in arg:
                 return arg
 
             return None

--- a/src/twisted/newsfragments/10090.misc
+++ b/src/twisted/newsfragments/10090.misc
@@ -1,0 +1,1 @@
+upgrade to mypy==0.800 and mypy-zope==0.2.10

--- a/src/twisted/trial/__main__.py
+++ b/src/twisted/trial/__main__.py
@@ -5,6 +5,4 @@ if __name__ == "__main__":
     from pkg_resources import load_entry_point
     import sys
 
-    sys.exit(
-        load_entry_point("Twisted", "console_scripts", "trial")()  # type: ignore[func-returns-value]
-    )
+    sys.exit(load_entry_point("Twisted", "console_scripts", "trial")())

--- a/tox.ini
+++ b/tox.ini
@@ -172,8 +172,8 @@ commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
 description = run Mypy (static type checker)
 
 deps =
-    mypy==0.790
-    mypy-zope==0.2.8
+    mypy==0.800
+    mypy-zope==0.2.10
 
 commands =
     mypy                                       \


### PR DESCRIPTION
## Scope and purpose

I tried running `tox -e mypy` with the old version and got:

> Found 120 errors in 36 files (checked 838 source files)

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10090
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
