### PR TITLE
Fix inlinecb test on pypy 3.7 and 3.8

### DIFF
--- a/src/twisted/internet/test/test_inlinecb.py
+++ b/src/twisted/internet/test/test_inlinecb.py
@@ -9,7 +9,7 @@ Some tests for inlineCallbacks are defined in L{twisted.test.test_defgen} as
 well.
 """
 
-
+from twisted.python.compat import _PYPY
 from twisted.trial.unittest import TestCase, SynchronousTestCase
 from twisted.internet.defer import (
     Deferred,
@@ -79,11 +79,15 @@ class NonLocalExitTests(TestCase):
         warnings = self.flushWarnings(offendingFunctions=[self.mistakenMethod])
         self.assertEqual(len(warnings), 1)
         self.assertEqual(warnings[0]["category"], DeprecationWarning)
+        if _PYPY:
+            contextVarMethod = "run"
+        else:
+            contextVarMethod = "inline"
         self.assertEqual(
             warnings[0]["message"],
-            "returnValue() in 'mistakenMethod' causing 'inline' to exit: "
+            "returnValue() in 'mistakenMethod' causing '{contextVarMethod}' to exit: "
             "returnValue should only be invoked by functions decorated with "
-            "inlineCallbacks",
+            "inlineCallbacks".format(contextVarMethod=contextVarMethod),
         )
 
     def test_returnValueNonLocalWarning(self):


### PR DESCRIPTION
## Scope and purpose

Fix test_inlinecb.py on pypy 3.7 and 3.8




## Contributor Checklist:

* [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10093
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [X] I have updated the automated tests.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
