### PR TITLE
delegate to stdlib parse qs

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -109,7 +109,7 @@ from io import BytesIO
 from urllib.parse import (
     ParseResultBytes,
     urlparse as _urlparse,
-    unquote_to_bytes as unquote,
+    parse_qs,
 )
 
 from zope.interface import Attribute, Interface, implementer, provider
@@ -259,31 +259,6 @@ def urlparse(url):
         query = query.encode("ascii")
         fragment = fragment.encode("ascii")
     return ParseResultBytes(scheme, netloc, path, params, query, fragment)
-
-
-def parse_qs(qs, keep_blank_values=0, strict_parsing=0):
-    """
-    Like C{cgi.parse_qs}, but with support for parsing byte strings on Python 3.
-
-    @type qs: C{bytes}
-    """
-    d = {}
-    items = [s2 for s1 in qs.split(b"&") for s2 in s1.split(b";")]
-    for item in items:
-        try:
-            k, v = item.split(b"=", 1)
-        except ValueError:
-            if strict_parsing:
-                raise
-            continue
-        if v or keep_blank_values:
-            k = unquote(k.replace(b"+", b" "))
-            v = unquote(v.replace(b"+", b" "))
-            if k in d:
-                d[k].append(v)
-            else:
-                d[k] = [v]
-    return d
 
 
 def datetimeToString(msSinceEpoch=None):

--- a/src/twisted/web/newsfragments/10096.bugfix
+++ b/src/twisted/web/newsfragments/10096.bugfix
@@ -1,0 +1,1 @@
+delegate to urllib.parse:parse_qs in twisted.web.http:parse_qs to avoid CVE-2021-23336 and the associated CI failures

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -19,7 +19,7 @@ import os
 import re
 from html import escape
 from typing import List, Optional
-from urllib.parse import quote as _quote
+from urllib.parse import quote as _quote, unquote_to_bytes as _unquote_to_bytes
 
 import zlib
 from binascii import hexlify
@@ -31,7 +31,6 @@ from twisted.spread.pb import Copyable, ViewPoint
 from twisted.internet import address, interfaces
 from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from twisted.web import iweb, http, util
-from twisted.web.http import unquote
 from twisted.python import reflect, failure, components
 from twisted import copyright
 from twisted.web import resource
@@ -213,7 +212,7 @@ class Request(Copyable, http.Request, components.Componentized):
 
         # Resource Identification
         self.prepath = []
-        self.postpath = list(map(unquote, self.path[1:].split(b"/")))
+        self.postpath = [_unquote_to_bytes(v) for v in self.path[1:].split(b"/")]
 
         # Short-circuit for requests whose path is '*'.
         if self.path == b"*":


### PR DESCRIPTION
## Scope and purpose
the stdlib parse_qs has changed behaviour with regard to splitting query parameters on `;`

    Python 3.6.13 (2021-02-16) fixed by commit 5c17dfc (branch 3.6) (2021-02-15)
    Python 3.7.10 (2021-02-16) fixed by commit d0d4d30 (branch 3.7) (2021-02-15)
    Python 3.8.8 (2021-02-19) fixed by commit e3110c3 (branch 3.8) (2021-02-15)
    Python 3.9.2 (2021-02-19) fixed by commit c9f0781 (branch 3.9) (2021-02-15)

this is causing CI to fail

## Remove this section

Please have a look at [our developer documentation](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch) before submitting your Pull Request.

Please note that the trac ticket, news fragment, and review submission portions of this process apply to *all* pull requests, no matter how small; if you don't do them, it's likely that nobody will even notice your PR needs a review.


## Contributor Checklist:

* [x] The associated ticket in Trac is here:https://twistedmatrix.com/trac/ticket/10096<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
