### PR TITLE
Stop using the deprecated int_from_bytes from cryptography.

### DIFF
--- a/src/twisted/conch/ssh/common.py
+++ b/src/twisted/conch/ssh/common.py
@@ -11,7 +11,7 @@ Maintainer: Paul Swartz
 
 import struct
 
-from cryptography.utils import int_from_bytes, int_to_bytes
+from cryptography.utils import int_to_bytes
 
 from twisted.python.deprecate import deprecated
 from twisted.python.versions import Version
@@ -63,7 +63,7 @@ def getMP(data, count=1):
     c = 0
     for i in range(count):
         (length,) = struct.unpack(">L", data[c : c + 4])
-        mp.append(int_from_bytes(data[c + 4 : c + 4 + length], "big"))
+        mp.append(int.from_bytes(data[c + 4 : c + 4 + length], "big"))
         c += 4 + length
     return tuple(mp) + (data[c:],)
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -31,7 +31,7 @@ from pyasn1.codec.ber import encoder as berEncoder
 from pyasn1.error import PyAsn1Error
 from pyasn1.type import univ
 from twisted.conch.ssh import common, sexpy
-from twisted.conch.ssh.common import int_from_bytes, int_to_bytes
+from twisted.conch.ssh.common import int_to_bytes
 from twisted.python import randbytes
 from twisted.python.compat import iterbytes, nativeString
 from twisted.python.constants import NamedConstant, Names
@@ -1803,8 +1803,8 @@ class Key:
             )
         elif keyType == "DSA":
             concatenatedSignature = common.getNS(signature)[0]
-            r = int_from_bytes(concatenatedSignature[:20], "big")
-            s = int_from_bytes(concatenatedSignature[20:], "big")
+            r = int.from_bytes(concatenatedSignature[:20], "big")
+            s = int.from_bytes(concatenatedSignature[20:], "big")
             signature = encode_dss_signature(r, s)
             k = self._keyObject
             if not self.isPublic():
@@ -1814,8 +1814,8 @@ class Key:
         elif keyType == "EC":  # Pragma: no branch
             concatenatedSignature = common.getNS(signature)[0]
             rstr, sstr, rest = common.getNS(concatenatedSignature, 2)
-            r = int_from_bytes(rstr, "big")
-            s = int_from_bytes(sstr, "big")
+            r = int.from_bytes(rstr, "big")
+            s = int.from_bytes(sstr, "big")
             signature = encode_dss_signature(r, s)
 
             k = self._keyObject

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -34,7 +34,7 @@ from twisted.logger import Logger
 # from twisted.python.compat import nativeString
 
 from twisted.conch.ssh import address, keys, _kex
-from twisted.conch.ssh.common import NS, getNS, MP, getMP, ffs, int_from_bytes
+from twisted.conch.ssh.common import NS, getNS, MP, getMP, ffs
 
 
 def _mpFromBytes(data):
@@ -48,7 +48,7 @@ def _mpFromBytes(data):
     @rtype: L{bytes}
     @return: The given data encoded as an SSH multiple-precision integer.
     """
-    return MP(int_from_bytes(data, "big"))
+    return MP(int.from_bytes(data, "big"))
 
 
 class _MACParams(tuple):


### PR DESCRIPTION
## Scope and purpose

cryptography 3.4.0 deprecated using `cryptography.utils.int_from_bytes` and suggests replacing it with `int.from_bytes` instead (which has the exact same signature). According to [the Python docs](https://docs.python.org/3/library/stdtypes.html#int.from_bytes) `int.from_bytes` has existed since Python 3.2, so should be safe to use in Twisted.

Looking at the deprecation PR (pyca/cryptography#5609) it was just passing through anyway, so this should just save an import and such and have no noticeable change.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10097
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles)) --> I put it in `src/twisted/conch/newsfragments/`, maybe that's not correct though.
* [x] I have updated the automated tests. --> Should be covered by the current conch tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
