### PR TITLE
Bump python_requires to 3.5.3 for typing.Type and to 3.5.4 for the lowest avaiable python on GHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
+          python-version: ['3.5.3', 3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: ['3.5.3', 3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
+          python-version: ['3.5.4', 3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.2
+python_requires = >=3.5.3
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.3
+python_requires = >=3.5.4
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/src/twisted/newsfragments/10098.bugfix
+++ b/src/twisted/newsfragments/10098.bugfix
@@ -1,1 +1,1 @@
-When installing Twisted it now requires a minimum Python 3.5.3 version to match the version used with automated testing. This is the minimum Python version that we know that Twisted works with. 
+When installing Twisted it now requires a minimum Python 3.5.4 version to match the version used with automated testing. This is the minimum Python version that we know that Twisted works with. 

--- a/src/twisted/newsfragments/10098.bugfix
+++ b/src/twisted/newsfragments/10098.bugfix
@@ -1,1 +1,1 @@
-Bump python_requires to 3.5.3 for typing.Type
+When installing Twisted it now requires a minimum Python 3.5.3 version to match the version used with automated testing. This is the minimum Python version that we know that Twisted works with. 

--- a/src/twisted/newsfragments/10098.bugfix
+++ b/src/twisted/newsfragments/10098.bugfix
@@ -1,0 +1,1 @@
+Bump python_requires to 3.5.3 for typing.Type


### PR DESCRIPTION
## Scope and purpose

`typing.Type[str]` doesn't work on py3.5.2 fixed in python 3.5.3 ​https://github.com/python/typing/pull/267 

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10098#
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
