### PR TITLE
Bump minimum Python version to 3.5.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.2
+python_requires = >=3.5.4
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/src/twisted/newsfragments/10099.removal
+++ b/src/twisted/newsfragments/10099.removal
@@ -1,0 +1,1 @@
+Python 3.5.4 is the minimum supported version of Python.


### PR DESCRIPTION
## Scope and purpose

From https://twistedmatrix.com/pipermail/twisted-python/2021-February/065465.html , suggested by @richvdh 

```
As it happens, it also fails (for an import of typing.Deque) on Python 
3.5.3, as used by Debian oldstable.

Craig, what is your intention here? I think it's ok to drop support for 
these ancient versions of Python 3.5, but please could you make sure 
that python_requires gets set to 3.5.10 if that's what's been tested 
against?
```

The minimum version we are testing against in CI is 3.5.4 on Azure.

So in the interest of getting this release out, I will bump the minimum version to 3.5.4


## Contributor Checklist:

* [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10099
* [X] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [X] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
