### PR TITLE
Correct port number in web example

### DIFF
--- a/docs/web/howto/web-in-60/static-content.rst
+++ b/docs/web/howto/web-in-60/static-content.rst
@@ -35,7 +35,7 @@ Then we create an instance of the Site factory with that resource::
 
 Now we glue that factory to a TCP port::
 
-    endpoint = endpoints.TCP4ServerEndpoint(reactor, 8888)
+    endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
     endpoint.listen(factory)
 
 Finally, we start the reactor so it can make the program work::

--- a/docs/web/howto/web-in-60/static-content.rst
+++ b/docs/web/howto/web-in-60/static-content.rst
@@ -50,7 +50,7 @@ And that's it. Here's the complete program::
 
     resource = File('/tmp')
     factory = Site(resource)
-    endpoint = endpoints.TCP4ServerEndpoint(reactor, 8888)
+    endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
     endpoint.listen(factory)
     reactor.run()
 


### PR DESCRIPTION
The Twisted Web in 60 Seconds example "Serving Static Content From a Directory" states that these are equivalent:

```
from twisted.web.server import Site
from twisted.web.static import File
from twisted.internet import reactor, endpoints

resource = File('/tmp')
factory = Site(resource)
endpoint = endpoints.TCP4ServerEndpoint(reactor, 8888)
endpoint.listen(factory)
reactor.run()
```

```
twistd -n web --path /tmp
```

However, they aren't because the default port for the web plugin is 8080 rather than 8888. They should match.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9659
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests. (N/A)
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
