### PR TITLE
[10102] Add towncriertox env.

### DIFF
--- a/docs/core/development/policy/release-process.rst
+++ b/docs/core/development/policy/release-process.rst
@@ -95,7 +95,7 @@ Prepare the branch
 #. Run ``python -m incremental.update Twisted --rc``
 #. Commit the changes made by Incremental.
 #. Run ``tox -e towncrier``.
-#. Commit the changes made by towncrier - this automatically removes the NEWS newsfragments.
+#. Commit the changes made by towncrier - this automatically removes the newsfragment files.
 #. Bump copyright dates in ``LICENSE``, ``twisted/copyright.py``, and ``README.rst`` if required
 #. Push the changes up to GitHub and create a new release PR.
 #. The GitHub PR is dedicated to the final release and the same PR is used to release the candidate and final version.

--- a/tox.ini
+++ b/tox.ini
@@ -125,6 +125,18 @@ commands =
     newsfragment: python {toxinidir}/bin/admin/check-newsfragment "{toxinidir}"
 
 
+[testenv:towncrier]
+description = Create the release notes from the current fragment files found in the source tree.
+
+; towncrier needs Twisted install to get the version
+; and dev_release requires the towncrier package.
+extras =
+    dev_release
+
+commands =
+    towncrier --yes
+
+
 #
 # `narrativedocs` environment is designed to build the complete documentation HTML files.
 #


### PR DESCRIPTION
## Scope and purpose

This adds a towncrie tox env to make it a bit easier to create the news fragment.

Another option , is to update the release docs not to required using tox to call towncrier.



## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10102
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [NA] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
