### PR TITLE
drop support for python3.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,10 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
+          # Run on the minimum micro Python version that we can get on CI.
+          # When updating the minimum Python version here, also update the
+          # `python_requires` from `setup.cfg`.
+          # Run on latest minor release of each major python version.
           python-version: ["3.6.7", 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: ['3.5.4', 3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
+          python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
+          python-version: ["3.6.7", 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       TOXENV: "alldeps-withcov-posix,coverage-prepare,codecov-push,coveralls-push"
     strategy:
       matrix:
-          python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+          python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,7 +6,7 @@ Installation Requirements
 
 To install Twisted, you need:
 
-- Python 3.5/3.6/3.7.
+- Python 3.6/3.7/3.8.
 
 - `setuptools <https://pypi.python.org/pypi/setuptools>`_
   (installed automatically if you use pip).

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,7 +6,7 @@ Installation Requirements
 
 To install Twisted, you need:
 
-- Python 3.5/3.6/3.7.
+- Python 3.6/3.7/3.8/3.9
 
 - `setuptools <https://pypi.python.org/pypi/setuptools>`_
   (installed automatically if you use pip).

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ For information on changes in this release, see the `NEWS <NEWS.rst>`_ file.
 What is this?
 -------------
 
-Twisted is an event-based framework for internet applications, supporting Python 3.5+.
+Twisted is an event-based framework for internet applications, supporting Python 3.6+.
 It includes modules for many different purposes, including the following:
 
 - ``twisted.web``: HTTP clients and servers, HTML templating, and a WSGI server

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -9,7 +9,6 @@ parameters:
 - name: pythonVersion
   type: string
   values:
-  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/azure-pipelines/tests_pipeline.yml
+++ b/azure-pipelines/tests_pipeline.yml
@@ -19,7 +19,6 @@ jobs:
 - template: 'macos_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"
@@ -28,7 +27,6 @@ jobs:
 - template: 'windows_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"
@@ -38,7 +36,6 @@ jobs:
 - template: 'windows_test_jobs.yml'
   parameters:
     pythonVersions:
-      py35: "3.5"
       py36: "3.6"
       py37: "3.7"
       py38: "3.8"

--- a/azure-pipelines/windows_test_jobs.yml
+++ b/azure-pipelines/windows_test_jobs.yml
@@ -21,7 +21,7 @@ jobs:
       # Set PYTHONUTF8 environment variable to force UTF-8 mode on Python 3.7+
       # on Windows.
       #
-      # Set PYTHONIOENCODING to force UTF-8 encoding on Python 3.5 and Python 3.6.
+      # Set PYTHONIOENCODING to force UTF-8 encoding on Python 3.6.
       # This allows people with non-ASCII characters in their names to file pull requests
       # and not trigger CI errors.
       PYTHONUTF8: 1

--- a/docs/core/development/policy/coding-standard.rst
+++ b/docs/core/development/policy/coding-standard.rst
@@ -617,11 +617,9 @@ An attribute (or function, method or class) should be considered private when on
 Python 3
 --------
 
-Twisted is being ported to Python 3, targeting Python 3.6+.
+Twisted was ported to Python 3.
 Please see :doc:`Porting to Python 3 </core/howto/python3>` for details.
 
-All new modules must be Python 3.6+ compatible, and all new code to ported modules must be 3.6+ compatible.
-New code in non-ported modules must be written in a 3.6+ compatible way (explicit bytes/unicode strings, new exception raising format, etc) as to prevent extra work when that module is eventually ported.
 
 
 Database

--- a/docs/core/development/policy/coding-standard.rst
+++ b/docs/core/development/policy/coding-standard.rst
@@ -617,12 +617,11 @@ An attribute (or function, method or class) should be considered private when on
 Python 3
 --------
 
-Twisted is being ported to Python 3, targeting Python 3.5+.
+Twisted is being ported to Python 3, targeting Python 3.6+.
 Please see :doc:`Porting to Python 3 </core/howto/python3>` for details.
 
-All new modules must be Python 2.7 & 3.5+ compatible, and all new code to ported modules must be Python 2.7 & 3.5+ compatible.
-New code in non-ported modules must be written in a 2.7 & 3.5+ compatible way (explicit bytes/unicode strings, new exception raising format, etc) as to prevent extra work when that module is eventually ported.
-Code targeting Python 3 specific features must gracefully fall-back on Python 2 as much as is reasonably possible (for example, Python 2 support for 'async/await' is not reasonably possible and would not be required, but code that uses a Python 3-specific module such as ipaddress should be able to use a backport to 2.7 if available).
+All new modules must be Python 3.6+ compatible, and all new code to ported modules must be 3.6+ compatible.
+New code in non-ported modules must be written in a 3.6+ compatible way (explicit bytes/unicode strings, new exception raising format, etc) as to prevent extra work when that module is eventually ported.
 
 
 Database
@@ -640,7 +639,7 @@ All SQL keywords should be in upper case.
 C Code
 ------
 
-C code must be optional, and work across multiple platforms (MSVC++9/10/14 for Pythons 2.7 and 3.5+ on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
+C code must be optional, and work across multiple platforms (MSVC++9/10/14 for 3.6+ on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
 
 C code should be kept in external bindings packages which Twisted depends on.
 If creating new C extension modules, using `cffi <https://cffi.readthedocs.io/en/latest/>`_ is highly encouraged, as it will perform well on PyPy and CPython, and be easier to use on Python 2 and 3.

--- a/docs/core/development/policy/coding-standard.rst
+++ b/docs/core/development/policy/coding-standard.rst
@@ -637,7 +637,7 @@ All SQL keywords should be in upper case.
 C Code
 ------
 
-C code must be optional, and work across multiple platforms (MSVC++9/10/14 for 3.6+ on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
+C code must be optional, and work across multiple platforms (MSVC++14 for Python 3 on Windows, as well as recent GCCs and Clangs for Linux, macOS, and FreeBSD).
 
 C code should be kept in external bindings packages which Twisted depends on.
 If creating new C extension modules, using `cffi <https://cffi.readthedocs.io/en/latest/>`_ is highly encouraged, as it will perform well on PyPy and CPython, and be easier to use on Python 2 and 3.

--- a/docs/core/howto/python3.rst
+++ b/docs/core/howto/python3.rst
@@ -4,7 +4,7 @@ Porting to Python 3
 Introduction
 ------------
 
-Twisted currently supports only Python 3.5+.
+Twisted currently supports only Python 3.6+.
 This document covers Twisted-specific issues in porting your code to Python 3.
 
 API Differences

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.6
+# When updating this value, make sure our CI matrix includes a matching minimum version.
+python_requires = >=3.6.7
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ license = MIT
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -24,7 +23,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.4
+python_requires = >=3.6
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1
@@ -50,7 +49,7 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier >= 17.4.0
-    pydoctor >= 20.12.1; python_version >= "3.6"
+    pydoctor >= 20.12.1
     sphinx-rtd-theme~=0.5.0
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ license = MIT
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -24,7 +23,7 @@ classifiers =
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.5.2
+python_requires = >=3.6.0
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/src/twisted/__init__.py
+++ b/src/twisted/__init__.py
@@ -12,7 +12,7 @@ from twisted._version import __version__ as version
 
 __version__ = version.short()
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
     raise Exception(
-        "This version of Twisted is not compatible with Python 3.4 " "or below."
+        "This version of Twisted is not compatible with Python 3.5 or below."
     )

--- a/src/twisted/__init__.py
+++ b/src/twisted/__init__.py
@@ -7,12 +7,6 @@
 Twisted: The Framework Of Your Internet.
 """
 
-import sys
 from twisted._version import __version__ as version
 
 __version__ = version.short()
-
-if sys.version_info < (3, 6):
-    raise Exception(
-        "This version of Twisted is not compatible with Python 3.5 or below."
-    )

--- a/src/twisted/newsfragments/9958.removal
+++ b/src/twisted/newsfragments/9958.removal
@@ -1,0 +1,1 @@
+Python 3.5 is no longer supported.

--- a/src/twisted/newsfragments/9958.removal
+++ b/src/twisted/newsfragments/9958.removal
@@ -1,0 +1,1 @@
+drop support for Python 3.5

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -381,10 +381,6 @@ pydoctor = requireModule("pydoctor")
 
 
 @skipIf(pydoctor is None, "Pydoctor is not present.")
-@skipIf(
-    pydoctor is not None and pydoctor.__version__ < Version("pydoctor", 20, 12, 1),
-    "Pydoctor 20.12.1 or later is required.",
-)
 class APIBuilderTests(ExternalTempdirTestCase):
     """
     Tests for L{APIBuilder}.

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -327,21 +327,13 @@ class ServerOptionsTests(TestCase):
             config.parseOptions,
             ["--logger", "twisted.test.test_twistd.FOOBAR"],
         )
-        if sys.version_info <= (3, 5):
-            self.assertTrue(
-                e.args[0].startswith(
-                    "Logger 'twisted.test.test_twistd.FOOBAR' could not be "
-                    "imported: 'module' object has no attribute 'FOOBAR'"
-                )
+        self.assertTrue(
+            e.args[0].startswith(
+                "Logger 'twisted.test.test_twistd.FOOBAR' could not be "
+                "imported: module 'twisted.test.test_twistd' "
+                "has no attribute 'FOOBAR'"
             )
-        else:
-            self.assertTrue(
-                e.args[0].startswith(
-                    "Logger 'twisted.test.test_twistd.FOOBAR' could not be "
-                    "imported: module 'twisted.test.test_twistd' "
-                    "has no attribute 'FOOBAR'"
-                )
-            )
+        )
         self.assertNotIn("\n", e.args[0])
 
     def test_version(self):

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2322,7 +2322,7 @@ ok
 class QueryArgumentsTests(unittest.TestCase):
     # FIXME: https://twistedmatrix.com/trac/ticket/10096
     # Re-enable once the implementation is updated.
-    @skipIf(sys.version_info >= (3, 6), "newer py3.6 parse_qs treat ; differently")
+    @skipIf(sys.version_info >= (3, 6, 13), "newer py3.6 parse_qs treat ; differently")
     def testParseqs(self):
         self.assertEqual(parse_qs(b"a=b&d=c;+=f"), http.parse_qs(b"a=b&d=c;+=f"))
         self.assertRaises(ValueError, http.parse_qs, b"blah", strict_parsing=True)


### PR DESCRIPTION
## Scope and purpose

Python 3.5 is EOL, this removes non-historical references to Python 3.5 and upgrades minimum python versions to py3.6 for various tools


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9958
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
