### PR TITLE
remove __metaclass__ py2 specific hacks

### DIFF
--- a/src/twisted/conch/client/options.py
+++ b/src/twisted/conch/client/options.py
@@ -39,13 +39,15 @@ class ConchOptions(usage.Options):
         optActions={
             "user": usage.CompleteUsernames(),
             "ciphers": usage.CompleteMultiList(
-                SSHCiphers.cipherMap.keys(), descr="ciphers to choose from"
+                [v.decode() for v in SSHCiphers.cipherMap.keys()],
+                descr="ciphers to choose from",
             ),
             "macs": usage.CompleteMultiList(
-                SSHCiphers.macMap.keys(), descr="macs to choose from"
+                [v.decode() for v in SSHCiphers.macMap.keys()],
+                descr="macs to choose from",
             ),
             "host-key-algorithms": usage.CompleteMultiList(
-                SSHClientTransport.supportedPublicKeys,
+                [v.decode() for v in SSHClientTransport.supportedPublicKeys],
                 descr="host key algorithms to choose from",
             ),
             # "user-authentications": usage.CompleteMultiList(?

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -259,8 +259,8 @@ class GeneralOptions(usage.Options):
     compData = usage.Completions(
         mutuallyExclusive=[("tty", "notty")],
         optActions={
-            "cipher": usage.CompleteList(_ciphers),
-            "macs": usage.CompleteList(_macs),
+            "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
+            "macs": usage.CompleteList([v.decode() for v in _macs]),
             "localforward": usage.Completer(descr="listen-port:host:port"),
             "remoteforward": usage.Completer(descr="listen-port:host:port"),
         },

--- a/src/twisted/newsfragments/10107.misc
+++ b/src/twisted/newsfragments/10107.misc
@@ -1,0 +1,1 @@
+use py3+ metaclass syntax

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -380,11 +380,11 @@ class DoNotFailTests(TestCase):
 pydoctor = requireModule("pydoctor")
 
 
-@skipIf(pydoctor is None, "Pydoctor is not present.")
 @skipIf(
-    pydoctor is not None and pydoctor.__version__ < Version("pydoctor", 20, 12, 1),
-    "Pydoctor 20.12.1 or later is required.",
+    sys.version_info <= (3, 5),
+    "Python version is too old to install pydoctor >= 20.12.1",
 )
+@skipIf(pydoctor is None, "Pydoctor is not present.")
 class APIBuilderTests(ExternalTempdirTestCase):
     """
     Tests for L{APIBuilder}.

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -38,7 +38,7 @@ class ZshScriptTestMeta(type):
         return type.__new__(cls, name, bases, attrs)
 
 
-class ZshScriptTestMixin:
+class ZshScriptTestMixin(metaclass=ZshScriptTestMeta):
     """
     Integration test helper to show that C{usage.Options} classes can have zsh
     completion functions generated for them without raising errors.
@@ -55,8 +55,6 @@ class ZshScriptTestMixin:
     subclass which also inherits from this mixin, and contains a C{generateFor}
     list appropriate for the scripts in that package.
     """
-
-    __metaclass__ = ZshScriptTestMeta
 
 
 def test_genZshFunction(self, cmdName, optionsFQPN):

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -532,13 +532,12 @@ class BrokenExceptionMetaclass(type):
         raise ValueError("You cannot make a string out of me.")
 
 
-class BrokenExceptionType(Exception):
+class BrokenExceptionType(Exception, metaclass=BrokenExceptionMetaclass):
+
     """
-    The aforementioned exception type which cnanot be presented as a string via
+    The aforementioned exception type which cannot be presented as a string via
     L{str}.
     """
-
-    __metaclass__ = BrokenExceptionMetaclass
 
 
 class GetTracebackTests(SynchronousTestCase):


### PR DESCRIPTION
## Scope and purpose

when doing the py3.6+ pyupgrade and com2ann fix I noticed that there were some py2 related `__metaclass__` hacks. We can use the py3 only syntax now

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10107
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
