### PR TITLE
[10068] Use latest pydoctor feature and pin dev deps.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,7 +216,6 @@ if os.environ.get("READTHEDOCS", "") == "True":
 _source_root = pathlib.Path(__file__).parent.parent / "src"
 pydoctor_args = [
     "--quiet",
-    "--make-html",
     f"--html-viewsource-base=https://github.com/twisted/twisted/tree/{_git_reference}/src",
     "--project-name=Twisted",
     "--project-url=https://twistedmatrix.com/",
@@ -237,6 +236,8 @@ pydoctor_args = [
     str(_source_root / "twisted"),
 ]
 
+pydoctor_url_path = "/en/{rtd_version}/api/"
+
 traclinks_base_url = "https://twistedmatrix.com/trac"
 
 # A dict mapping unique IDs (which can be used to disambiguate references) to a
@@ -245,7 +246,6 @@ traclinks_base_url = "https://twistedmatrix.com/trac"
 intersphinx_mapping = {
     "py3": ("https://docs.python.org/3", None),
     "zopeinterface": ("https://zopeinterface.readthedocs.io/en/latest", None),
-    "api": (api_base_url, "../apidocs/objects.inv"),
 }
 # How long to cache remote inventories. Positive is a number of days,
 # negative means infinite. The default is 5 days, which should be fine

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,10 @@ packages = find:
 ; This is list of minimum dependencies required to run the test.
 ; The plan is to remove the `test` extra requirement and skip tests that
 ; depend on then
+; To prevent trunk failures we should pin all dev dependencies to minor
+; versions.
+; We trust semantic versioning and auto-upgrading to a bugfix release
+; should be OK.
 test =
     cython-test-exception-raiser ~= 1.0
     PyHamcrest >= 1.9.0
@@ -49,18 +53,19 @@ test =
 ; List of dependencies required to build the documentation and test the
 ; release scripts and process.
 dev_release =
-    towncrier >= 17.4.0
-    pydoctor >= 20.12.1; python_version >= "3.6"
-    sphinx-rtd-theme~=0.5.0
+    towncrier ~= 19.2
+    pydoctor == 21.2; python_version >= "3.6"
+    sphinx-rtd-theme~=0.5
     readthedocs-sphinx-ext~=2.1
     sphinx~=3.3
 
 ; All the extra tools used to help with the development process.
 dev =
     %(dev_release)s
-    pyflakes >= 1.0.0
-    python-subunit
-    twistedchecker >= 0.7.2
+    pyflakes ~= 2.2
+    python-subunit ~= 1.4
+    twistedchecker ~= 0.7
+    coverage ~= 5.5
 
 tls =
     pyopenssl >= 16.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,10 +54,10 @@ test =
 ; release scripts and process.
 dev_release =
     towncrier ~= 19.2
-    pydoctor == 21.2; python_version >= "3.6"
-    sphinx-rtd-theme~=0.5
-    readthedocs-sphinx-ext~=2.1
-    sphinx~=3.3
+    pydoctor ~= 21.2; python_version >= "3.6"
+    sphinx-rtd-theme ~= 0.5
+    readthedocs-sphinx-ext ~= 2.1
+    sphinx ~= 3.3
 
 ; All the extra tools used to help with the development process.
 dev =

--- a/tox.ini
+++ b/tox.ini
@@ -137,8 +137,11 @@ commands =
 #
 # `narrativedocs` environment is designed to build the complete documentation HTML files.
 #
+# It tries to run as close as possible to the Read The Docs environment, as
+# that is the environment we use for the release.
+#
 [testenv:narrativedocs]
-description = Build the narrative documentation.
+description = Build the full documentation (narrative and apidocs).
 
 ; Documentation needs Twisted install to get the version.
 extras =
@@ -148,20 +151,20 @@ extras =
 allowlist_externals = sphinx-build
 
 setenv =
-    # Set this to `True` to run similar to Read the docs.
+    # Set this to `True` to run similar to Read The Docs.
     READTHEDOCS=False
     READTHEDOCS_LANGUAGE=en
     READTHEDOCS_VERSION=1.0.0.dev0
 
 commands =
-    # Create an intersphinx inventory before we run Sphinx.
-    # TODO: Replace this by moving the execution of the pydoctor extension
-    #       by Sphinx ahead of processing that requires the inventory.
-    pydoctor --quiet --make-intersphinx {toxinidir}/src/twisted
     sphinx-build -aW -b html -d {toxinidir}/docs/_build {toxinidir}/docs {toxinidir}/docs/_build/
+
 
 #
 # `apidocs` environment is designed to build only the API doc HTML files.
+#
+# This is here to help during the development process and debugging.
+# It is not used for the release.
 #
 # API docs build violation are visible to stdout.
 #

--- a/tox.ini
+++ b/tox.ini
@@ -60,14 +60,15 @@ extras =
 
     serial: serial
 
-    {withcov, coverage-prepare,codecov-publish}: dev
+    {withcov,coverage-prepare,codecov-publish}: dev
 
 ;; dependencies that are not specified as extras
 deps =
+    {codecov-push,codecov-publish}: codecov
+    
     coveralls-push: coveralls
     coveralls-push: PyYAML
 
-    {codecov-push,codecov-publish}: codecov
 
     lint: pre-commit
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,12 @@ extras =
 
 ;; dependencies that are not specified as extras
 deps =
-    {codecov-push,codecov-publish}: codecov
-    
+    ; We end up with a bit of deps duplication as we can't install
+    ; coverage deps via `extras` as we run them with `skip_install`.
+    {coverage-prepare,codecov-publish}: coverage ~= 5.5
+
+    {codecov-push,codecov-publish}: codecov ~= 2.1
+
     coveralls-push: coveralls
     coveralls-push: PyYAML
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ skip_missing_interpreters=True
 envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,
     release-prepare,
-    py38-alldeps-nocov
+    alldeps-nocov
 isolated_build=true
 
 
@@ -60,17 +60,14 @@ extras =
 
     serial: serial
 
+    {withcov, coverage-prepare,codecov-publish}: dev
+
 ;; dependencies that are not specified as extras
 deps =
-    {withcov}: coverage
-
-    {coverage-prepare,codecov-publish}: coverage
-
-    {codecov-push,codecov-publish}: codecov
-
     coveralls-push: coveralls
     coveralls-push: PyYAML
 
+    {codecov-push,codecov-publish}: codecov
 
     lint: pre-commit
 


### PR DESCRIPTION
## Scope and purpose

The initial target for this PR was to update pydoctor version... but that was already updated :)

So I have retargeted this PR for using the new features introduced in pydoctor and as a drive-by pin the dev deps so that we don't end up with similar failures in trunk.

It enabled creating the API doc inventory object as part of the Sphinx build process before the Sphinx HTML files are generated.
In this way Sphinx has access to the latest API inventory generated using the code from the branch.

## How to check

For pinned version. Check setup.cfg and tox.ini changes and see that they make sense.

I went with a "soft" pinning .. that is, bugfixes should still be auto-updated.
let me know if you want hard pinning.

------------

For the docs

The Read The Docs narrative docs should have links to API docs.

see the links to API docs like  twisted.internet.protocol.Protocol on RTD page

https://twisted--1530.org.readthedocs.build/en/1530/core/howto/servers.html

They should be the same as non RTD version:

https://twistedmatrix.com/documents/current/core/howto/servers.html


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10068
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
