### PR TITLE
 update lint tooling target versions to py3.6+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.3
+    rev: v2.10.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -21,7 +21,7 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.7.3
     hooks:
       - id: pyupgrade
-        args: ["--py3-plus"]
+        args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/admin/check_tag_version_match.py
+++ b/admin/check_tag_version_match.py
@@ -21,14 +21,14 @@ branch_version = pep517.meta.load(".").version
 run_version = sys.argv[1]
 
 if not run_version.startswith(TAG_PREFIX):
-    print("Not a twisted release tag name '{}.".format(run_version))
+    print(f"Not a twisted release tag name '{run_version}.")
     sys.exit(1)
 
 run_version = run_version[len(TAG_PREFIX) :]
 
 if run_version != branch_version:
-    print("Branch is at '{}' while tag is '{}'".format(branch_version, run_version))
+    print(f"Branch is at '{branch_version}' while tag is '{run_version}'")
     exit(1)
 
-print("All good. Branch and tag versions match for '{}'.".format(branch_version))
+print(f"All good. Branch and tag versions match for '{branch_version}'.")
 sys.exit(0)

--- a/docs/conch/examples/demo_insults.tac
+++ b/docs/conch/examples/demo_insults.tac
@@ -211,7 +211,7 @@ class DemoProtocol(insults.TerminalProtocol):
         self.height = height
 
     def unhandledControlSequence(self, seq):
-        log.msg("Client sent something weird: {!r}".format(seq))
+        log.msg(f"Client sent something weird: {seq!r}")
 
     def keystrokeReceived(self, keyID, modifier):
         if keyID == "+":
@@ -223,7 +223,7 @@ class DemoProtocol(insults.TerminalProtocol):
         elif keyID == "/":
             self.rate *= 1.1
         else:
-            log.msg("Client sent: {!r}".format(keyID))
+            log.msg(f"Client sent: {keyID!r}")
             return
 
         self._call.stop()

--- a/docs/conch/examples/demo_scroll.tac
+++ b/docs/conch/examples/demo_scroll.tac
@@ -57,7 +57,7 @@ class DemoProtocol(insults.TerminalProtocol):
         self.terminal.write("> ")
 
     def unhandledControlSequence(self, seq):
-        log.msg("Client sent something weird: {!r}".format(seq))
+        log.msg(f"Client sent something weird: {seq!r}")
 
     def keystrokeReceived(self, keyID, modifier):
         if keyID == "\r":

--- a/docs/conch/examples/sshsimpleclient.py
+++ b/docs/conch/examples/sshsimpleclient.py
@@ -47,7 +47,7 @@ class SimpleTransport(transport.SSHClientTransport):
 
 class SimpleUserAuth(userauth.SSHUserAuthClient):
     def getPassword(self):
-        return defer.succeed(getpass.getpass("{}@{}'s password: ".format(USER, HOST)))
+        return defer.succeed(getpass.getpass(f"{USER}@{HOST}'s password: "))
 
     def getGenericAnswers(self, name, instruction, questions):
         print(name)

--- a/docs/conch/howto/listings/echoclient_ssh.py
+++ b/docs/conch/howto/listings/echoclient_ssh.py
@@ -75,7 +75,7 @@ def readKey(path):
     try:
         return Key.fromFile(path)
     except EncryptedKeyError:
-        passphrase = getpass.getpass("{!r} keyphrase: ".format(path))
+        passphrase = getpass.getpass(f"{path!r} keyphrase: ")
         return Key.fromFile(path, passphrase=passphrase)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,12 +182,12 @@ _git_reference = subprocess.run(
 ).stdout
 
 
-print("== Environment dump for {} ===".format(_git_reference))
+print(f"== Environment dump for {_git_reference} ===")
 pprint(dict(os.environ))
 print("======")
 
 # Base url for API docs
-api_base_url = "/documents/{}/api/".format(release)
+api_base_url = f"/documents/{release}/api/"
 if on_rtd:
     # For a PR the link is like:
     # https://twisted--1422.org.readthedocs.build/en/1422/

--- a/docs/core/benchmarks/netstringreceiver.py
+++ b/docs/core/benchmarks/netstringreceiver.py
@@ -206,7 +206,7 @@ class NetstringPerformanceTester(PerformanceTester):
     def receiveData(self, chunk, numberOfChunks, dataSize):
         dr = self.netstringReceiver.dataReceived
         now = time.time()
-        dr("{}:".format(dataSize).encode("ascii"))
+        dr(f"{dataSize}:".encode("ascii"))
         for idx in range(numberOfChunks):
             dr(chunk)
         dr(NETSTRING_POSTFIX)

--- a/docs/core/examples/ampserver.py
+++ b/docs/core/examples/ampserver.py
@@ -15,14 +15,14 @@ class Divide(amp.Command):
 class Math(amp.AMP):
     def sum(self, a, b):
         total = a + b
-        print("Did a sum: {} + {} = {}".format(a, b, total))
+        print(f"Did a sum: {a} + {b} = {total}")
         return {"total": total}
 
     Sum.responder(sum)
 
     def divide(self, numerator, denominator):
         result = float(numerator) / denominator
-        print("Divided: {} / {} = {}".format(numerator, denominator, result))
+        print(f"Divided: {numerator} / {denominator} = {result}")
         return {"result": result}
 
     Divide.responder(divide)

--- a/docs/core/examples/bananabench.py
+++ b/docs/core/examples/bananabench.py
@@ -53,14 +53,14 @@ class BananaBench:
         self.tearDown()
 
     def runTests(self, testData):
-        print("Test data is: {}".format(testData))
+        print(f"Test data is: {testData}")
         print("  Using Pure Python Banana:")
         self.performTest(self.testEncode, testData, banana.Banana)
         self.performTest(self.testDecode, testData, banana.Banana)
 
 
 bench = BananaBench()
-print("Doing {} iterations of each test.".format(iterationCount))
+print(f"Doing {iterationCount} iterations of each test.")
 print("")
 testData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 bench.runTests(testData)

--- a/docs/core/examples/courier.py
+++ b/docs/core/examples/courier.py
@@ -35,7 +35,7 @@ from syslog import syslog, openlog, LOG_MAIL
 def trace_dump():
     t, v, tb = sys.exc_info()
     openlog(FILTERNAME, 0, LOG_MAIL)
-    syslog("Unhandled exception: {} - {}".format(v, t))
+    syslog(f"Unhandled exception: {v} - {t}")
     while tb:
         syslog(
             "Trace: {}:{} {}".format(
@@ -73,7 +73,7 @@ class MailProcessor(basic.LineReceiver):
     delimiter = "\n"
 
     def connectionMade(self):
-        log.msg("Connection from {}".format(self.transport))
+        log.msg(f"Connection from {self.transport}")
         self.state = "connected"
         self.metaInfo = []
 
@@ -109,8 +109,8 @@ def main():
     # Listen on the UNIX socket
     f = Factory()
     f.protocol = MailProcessor
-    safe_del("{}/{}".format(ALLFILTERS, FILTERNAME))
-    reactor.listenUNIX("{}/{}".format(ALLFILTERS, FILTERNAME), f, 10)
+    safe_del(f"{ALLFILTERS}/{FILTERNAME}")
+    reactor.listenUNIX(f"{ALLFILTERS}/{FILTERNAME}", f, 10)
 
     # Once started, close fd 3 to let Courier know we're ready
     reactor.callLater(0, os.close, 3)

--- a/docs/core/examples/pbinterop.py
+++ b/docs/core/examples/pbinterop.py
@@ -51,11 +51,11 @@ class Interop(pb.Root):
     def remote_receive(self, obj):
         expected = [1, 1.5, "hi", "hi", {1: 2}]
         if obj != expected:
-            raise ValueError("{} != {}".format(obj, expected))
+            raise ValueError(f"{obj} != {expected}")
 
     def remote_self(self, obj):
         if obj != self:
-            raise ValueError("{} != {}".format(obj, self))
+            raise ValueError(f"{obj} != {self}")
 
     def remote_copy(self, x):
         o = flavors.Copyable()

--- a/docs/core/examples/recvfd.py
+++ b/docs/core/examples/recvfd.py
@@ -48,14 +48,14 @@ class ReceiveFDProtocol(LineOnlyReceiver):
 
     def lineReceived(self, line):
         if self.descriptor is None:
-            print("Received {} without receiving descriptor!".format(line))
+            print(f"Received {line} without receiving descriptor!")
         else:
             # Use the previously received descriptor, along with the newly
             # provided information about which file it is, to present some
             # information to the user.
             data = os.read(self.descriptor, 80)
-            print("Received {} from the server.".format(line))
-            print("First 80 bytes are:\n{}\n".format(data))
+            print(f"Received {line} from the server.")
+            print(f"First 80 bytes are:\n{data}\n")
         os.close(self.descriptor)
         self.transport.loseConnection()
 

--- a/docs/core/examples/rotatinglog.py
+++ b/docs/core/examples/rotatinglog.py
@@ -17,7 +17,7 @@ log.startLogging(f)
 
 # print a few message
 for i in range(10):
-    log.msg("this is a test of the logfile: {}".format(i))
+    log.msg(f"this is a test of the logfile: {i}")
 
 # rotate the logfile manually
 f.rotate()

--- a/docs/core/examples/streaming.py
+++ b/docs/core/examples/streaming.py
@@ -40,7 +40,7 @@ class Producer:
         likely), so set a flag that causes production to pause temporarily.
         """
         self._paused = True
-        print("Pausing connection from {}".format(self._proto.transport.getPeer()))
+        print(f"Pausing connection from {self._proto.transport.getPeer()}")
 
     def resumeProducing(self):
         """
@@ -54,7 +54,7 @@ class Producer:
 
         while not self._paused and self._produced < self._goal:
             next_int = randrange(0, 10000)
-            line = "{}".format(next_int)
+            line = f"{next_int}"
             self._proto.sendLine(line.encode("ascii"))
             self._produced += 1
 
@@ -79,7 +79,7 @@ class ServeRandom(LineReceiver):
         Once the connection is made we ask the client how many random integers
         the producer should return.
         """
-        print("Connection made from {}".format(self.transport.getPeer()))
+        print(f"Connection made from {self.transport.getPeer()}")
         self.sendLine(b"How many random integers do you want?")
 
     def lineReceived(self, line):
@@ -88,13 +88,13 @@ class ServeRandom(LineReceiver):
         tells the producer to start generating the data.
         """
         count = int(line.strip())
-        print("Client requested {} random integers!".format(count))
+        print(f"Client requested {count} random integers!")
         producer = Producer(self, count)
         self.transport.registerProducer(producer, True)
         producer.resumeProducing()
 
     def connectionLost(self, reason):
-        print("Connection lost from {}".format(self.transport.getPeer()))
+        print(f"Connection lost from {self.transport.getPeer()}")
 
 
 startLogging(stdout)

--- a/docs/core/examples/testlogging.py
+++ b/docs/core/examples/testlogging.py
@@ -16,10 +16,10 @@ import sys, warnings
 
 def test(i):
     print("printed", i)
-    log.msg("message {}".format(i))
-    warnings.warn("warning {}".format(i))
+    log.msg(f"message {i}")
+    warnings.warn(f"warning {i}")
     try:
-        raise RuntimeError("error {}".format(i))
+        raise RuntimeError(f"error {i}")
     except BaseException:
         log.err()
 

--- a/docs/core/examples/tls_alpn_npn_client.py
+++ b/docs/core/examples/tls_alpn_npn_client.py
@@ -80,7 +80,7 @@ def main(reactor):
             # the TLS handshake is over. This is generally *not* in the call to
             # connectionMade, but instead only when we've received some data
             # back.
-            print("Next protocol is: {}".format(self.transport.negotiatedProtocol))
+            print(f"Next protocol is: {self.transport.negotiatedProtocol}")
             self.transport.loseConnection()
 
             # If this is the first data write, we can tell the reactor we're
@@ -93,7 +93,7 @@ def main(reactor):
             # If we haven't received any data, an error occurred. Otherwise,
             # we lost the connection on purpose.
             if self.complete is not None:
-                print("Connection lost due to error {}".format(reason))
+                print(f"Connection lost due to error {reason}")
                 self.complete.callback(None)
             else:
                 print("Connection closed cleanly")

--- a/docs/core/examples/tls_alpn_npn_server.py
+++ b/docs/core/examples/tls_alpn_npn_server.py
@@ -80,7 +80,7 @@ class NPNPrinterProtocol(Protocol):
         if self.complete:
             print("Connection closed cleanly")
         else:
-            print("Connection lost due to error {}".format(reason))
+            print(f"Connection lost due to error {reason}")
 
 
 class ResponderFactory(Factory):

--- a/docs/core/examples/twistd-logging.tac
+++ b/docs/core/examples/twistd-logging.tac
@@ -18,7 +18,7 @@ logfile = open("twistd-logging.log", "a")
 def log(eventDict):
     # untilConcludes is necessary to retry the operation when the system call
     # has been interrupted.
-    untilConcludes(logfile.write, "Got a log! {}\n".format(eventDict))
+    untilConcludes(logfile.write, f"Got a log! {eventDict}\n")
     untilConcludes(logfile.flush)
 
 

--- a/docs/core/examples/udpbroadcast.py
+++ b/docs/core/examples/udpbroadcast.py
@@ -33,7 +33,7 @@ class PingPongProtocol(DatagramProtocol):
         self.transport.setBroadcastAllowed(True)
 
     def sendPing(self):
-        pingMsg = "PING {}".format(uuid4().hex)
+        pingMsg = f"PING {uuid4().hex}"
         pingMsg = pingMsg.encode("ascii")
         self.transport.write(pingMsg, ("<broadcast>", self.port))
         log.msg(b"SEND " + pingMsg)
@@ -41,7 +41,7 @@ class PingPongProtocol(DatagramProtocol):
     def datagramReceived(self, datagram, addr):
         if datagram[:4] == b"PING":
             uuid = datagram[5:]
-            pongMsg = "PONG {}".format(uuid)
+            pongMsg = f"PONG {uuid}"
             pongMsg = pongMsg.encode("ascii")
             self.transport.write(pongMsg, ("<broadcast>", self.port))
             log.msg(b"RECV " + datagram)

--- a/docs/core/howto/listings/pb/chatserver.py
+++ b/docs/core/howto/listings/pb/chatserver.py
@@ -61,7 +61,7 @@ class Group(pb.Viewable):
         if not self.allowMattress and "mattress" in message:
             raise ValueError("Don't say that word")
         for user in self.users:
-            user.send("<{}> says: {}".format(from_user.name, message))
+            user.send(f"<{from_user.name}> says: {message}")
 
 
 realm = ChatRealm()

--- a/docs/core/howto/listings/pb/pbAnonServer.py
+++ b/docs/core/howto/listings/pb/pbAnonServer.py
@@ -47,9 +47,7 @@ class MyPerspective(Avatar):
         Print a simple message which gives the argument this method was
         called with and this avatar's name.
         """
-        print(
-            "I am {}.  perspective_foo({}) called on {}.".format(self.name, arg, self)
-        )
+        print(f"I am {self.name}.  perspective_foo({arg}) called on {self}.")
 
 
 @implementer(IRealm)

--- a/docs/core/howto/listings/positioning/nmealogger.py
+++ b/docs/core/howto/listings/positioning/nmealogger.py
@@ -13,7 +13,7 @@ from twisted.python import log, usage
 
 class PositioningReceiver(base.BasePositioningReceiver):
     def positionReceived(self, latitude, longitude):
-        log.msg("I'm at {} lat, {} lon".format(latitude, longitude))
+        log.msg(f"I'm at {latitude} lat, {longitude} lon")
 
     def beaconInformationReceived(self, beaconInformation):
         template = "{0.seen} beacons seen, {0.used} beacons used"

--- a/docs/core/howto/listings/servers/chat.py
+++ b/docs/core/howto/listings/servers/chat.py
@@ -26,13 +26,13 @@ class Chat(LineReceiver):
         if name in self.users:
             self.sendLine("Name taken, please choose another.")
             return
-        self.sendLine("Welcome, {}!".format(name))
+        self.sendLine(f"Welcome, {name}!")
         self.name = name
         self.users[name] = self
         self.state = "CHAT"
 
     def handle_CHAT(self, message):
-        message = "<{}> {}".format(self.name, message)
+        message = f"<{self.name}> {message}"
         for name, protocol in self.users.iteritems():
             if protocol != self:
                 protocol.sendLine(message)

--- a/docs/core/howto/listings/trial/calculus/client_1.py
+++ b/docs/core/howto/listings/trial/calculus/client_1.py
@@ -15,7 +15,7 @@ class RemoteCalculationClient(basic.LineReceiver):
     def _sendOperation(self, op, a, b):
         d = defer.Deferred()
         self.results.append(d)
-        line = "{} {} {}".format(op, a, b).encode("utf-8")
+        line = f"{op} {a} {b}".encode("utf-8")
         self.sendLine(line)
         return d
 

--- a/docs/core/howto/listings/trial/calculus/client_2.py
+++ b/docs/core/howto/listings/trial/calculus/client_2.py
@@ -28,7 +28,7 @@ class RemoteCalculationClient(basic.LineReceiver):
         d = defer.Deferred()
         callID = self.callLater(self.timeOut, self._cancel, d)
         self.results.append((d, callID))
-        line = "{} {} {}".format(op, a, b).encode("utf-8")
+        line = f"{op} {a} {b}".encode("utf-8")
         self.sendLine(line)
         return d
 

--- a/docs/core/howto/listings/trial/calculus/client_3.py
+++ b/docs/core/howto/listings/trial/calculus/client_3.py
@@ -26,7 +26,7 @@ class RemoteCalculationClient(basic.LineReceiver, policies.TimeoutMixin):
     def _sendOperation(self, op, a, b):
         d = defer.Deferred()
         self.results.append(d)
-        line = "{} {} {}".format(op, a, b).encode("utf-8")
+        line = f"{op} {a} {b}".encode("utf-8")
         self.sendLine(line)
         self.setTimeout(self._timeOut)
         return d

--- a/docs/core/howto/listings/trial/calculus/remote_1.py
+++ b/docs/core/howto/listings/trial/calculus/remote_1.py
@@ -9,7 +9,7 @@ class CalculationProxy:
     def __init__(self):
         self.calc = Calculation()
         for m in ["add", "subtract", "multiply", "divide"]:
-            setattr(self, "remote_{}".format(m), getattr(self.calc, m))
+            setattr(self, f"remote_{m}", getattr(self.calc, m))
 
 
 class RemoteCalculationProtocol(basic.LineReceiver):
@@ -20,7 +20,7 @@ class RemoteCalculationProtocol(basic.LineReceiver):
         op, a, b = line.decode("utf-8").split()
         a = int(a)
         b = int(b)
-        op = getattr(self.proxy, "remote_{}".format(op))
+        op = getattr(self.proxy, f"remote_{op}")
         result = op(a, b)
         self.sendLine(str(result).encode("utf-8"))
 

--- a/docs/core/howto/listings/trial/calculus/remote_2.py
+++ b/docs/core/howto/listings/trial/calculus/remote_2.py
@@ -10,7 +10,7 @@ class CalculationProxy:
     def __init__(self):
         self.calc = Calculation()
         for m in ["add", "subtract", "multiply", "divide"]:
-            setattr(self, "remote_{}".format(m), getattr(self.calc, m))
+            setattr(self, f"remote_{m}", getattr(self.calc, m))
 
 
 class RemoteCalculationProtocol(basic.LineReceiver):

--- a/docs/core/howto/listings/trial/calculus/test/test_client_1.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_client_1.py
@@ -11,9 +11,7 @@ class ClientCalculationTestCase(unittest.TestCase):
 
     def _test(self, operation, a, b, expected):
         d = getattr(self.proto, operation)(a, b)
-        self.assertEqual(
-            self.tr.value(), "{} {} {}\r\n".format(operation, a, b).encode("utf-8")
-        )
+        self.assertEqual(self.tr.value(), f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.tr.clear()
         d.addCallback(self.assertEqual, expected)
         self.proto.dataReceived(

--- a/docs/core/howto/listings/trial/calculus/test/test_client_2.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_client_2.py
@@ -16,12 +16,10 @@ class ClientCalculationTestCase(unittest.TestCase):
 
     def _test(self, operation, a, b, expected):
         d = getattr(self.proto, operation)(a, b)
-        self.assertEqual(
-            self.tr.value(), "{} {} {}\r\n".format(operation, a, b).encode("utf-8")
-        )
+        self.assertEqual(self.tr.value(), f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.tr.clear()
         d.addCallback(self.assertEqual, expected)
-        self.proto.dataReceived("{}\r\n".format(expected).encode("utf-8"))
+        self.proto.dataReceived(f"{expected}\r\n".encode("utf-8"))
         return d
 
     def test_add(self):

--- a/docs/core/howto/listings/trial/calculus/test/test_client_3.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_client_3.py
@@ -16,12 +16,10 @@ class ClientCalculationTestCase(unittest.TestCase):
 
     def _test(self, operation, a, b, expected):
         d = getattr(self.proto, operation)(a, b)
-        self.assertEqual(
-            self.tr.value(), "{} {} {}\r\n".format(operation, a, b).encode("utf-8")
-        )
+        self.assertEqual(self.tr.value(), f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.tr.clear()
         d.addCallback(self.assertEqual, expected)
-        self.proto.dataReceived("{}\r\n".format(expected).encode("utf-8"))
+        self.proto.dataReceived(f"{expected}\r\n".encode("utf-8"))
         return d
 
     def test_add(self):

--- a/docs/core/howto/listings/trial/calculus/test/test_client_4.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_client_4.py
@@ -16,11 +16,9 @@ class ClientCalculationTestCase(unittest.TestCase):
 
     def _test(self, operation, a, b, expected):
         d = getattr(self.proto, operation)(a, b)
-        self.assertEqual(
-            self.tr.value(), "{} {} {}\r\n".format(operation, a, b).encode("utf-8")
-        )
+        self.assertEqual(self.tr.value(), f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.tr.clear()
-        self.proto.dataReceived("{}\r\n".format(expected).encode("utf-8"))
+        self.proto.dataReceived(f"{expected}\r\n".encode("utf-8"))
         self.assertEqual(expected, self.successResultOf(d))
 
     def test_add(self):

--- a/docs/core/howto/listings/trial/calculus/test/test_remote_1.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_remote_1.py
@@ -11,7 +11,7 @@ class RemoteCalculationTestCase(unittest.TestCase):
         self.proto.makeConnection(self.tr)
 
     def _test(self, operation, a, b, expected):
-        self.proto.dataReceived("{} {} {}\r\n".format(operation, a, b).encode("utf-8"))
+        self.proto.dataReceived(f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.assertEqual(int(self.tr.value()), expected)
 
     def test_add(self):

--- a/docs/core/howto/listings/trial/calculus/test/test_remote_3.py
+++ b/docs/core/howto/listings/trial/calculus/test/test_remote_3.py
@@ -11,7 +11,7 @@ class RemoteCalculationTestCase(unittest.TestCase):
         self.proto.makeConnection(self.tr)
 
     def _test(self, operation, a, b, expected):
-        self.proto.dataReceived("{} {} {}\r\n".format(operation, a, b).encode("utf-8"))
+        self.proto.dataReceived(f"{operation} {a} {b}\r\n".encode("utf-8"))
         self.assertEqual(int(self.tr.value()), expected)
 
     def test_add(self):

--- a/docs/core/howto/listings/udp/adopt_datagram_port.py
+++ b/docs/core/howto/listings/udp/adopt_datagram_port.py
@@ -6,7 +6,7 @@ from twisted.internet import reactor
 
 class Echo(DatagramProtocol):
     def datagramReceived(self, data, addr):
-        print("received {!r} from {}".format(data, addr))
+        print(f"received {data!r} from {addr}")
         self.transport.write(data, addr)
 
 

--- a/docs/core/howto/listings/udp/basic_example.py
+++ b/docs/core/howto/listings/udp/basic_example.py
@@ -4,7 +4,7 @@ from twisted.internet import reactor
 
 class Echo(DatagramProtocol):
     def datagramReceived(self, data, addr):
-        print("received {!r} from {}".format(data, addr))
+        print(f"received {data!r} from {addr}")
         self.transport.write(data, addr)
 
 

--- a/docs/core/howto/listings/udp/connected_udp.py
+++ b/docs/core/howto/listings/udp/connected_udp.py
@@ -12,7 +12,7 @@ class Helloer(DatagramProtocol):
         self.transport.write(b"hello")  # no need for address
 
     def datagramReceived(self, data, addr):
-        print("received {!r} from {}".format(data, addr))
+        print(f"received {data!r} from {addr}")
 
     # Possibly invoked if there is no server listening on the
     # address to which we are sending.

--- a/docs/core/howto/listings/udp/ipv6_listen.py
+++ b/docs/core/howto/listings/udp/ipv6_listen.py
@@ -4,7 +4,7 @@ from twisted.internet import reactor
 
 class Echo(DatagramProtocol):
     def datagramReceived(self, data, addr):
-        print("received {!r} from {}".format(data, addr))
+        print(f"received {data!r} from {addr}")
         self.transport.write(data, addr)
 
 

--- a/docs/core/howto/tutorial/listings/finger/finger/finger.py
+++ b/docs/core/howto/tutorial/listings/finger/finger/finger.py
@@ -124,7 +124,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg)
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -195,7 +195,7 @@ class UserStatusTree(resource.Resource):
                     "users": "".join(
                         [
                             # Name should be quoted properly these uses.
-                            '<li><a href="{}">{}</a></li>'.format(name, name)
+                            f'<li><a href="{name}">{name}</a></li>'
                             for name in users
                         ]
                     )

--- a/docs/core/howto/tutorial/listings/finger/finger15.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger15.tac
@@ -41,9 +41,9 @@ class FingerResource(resource.Resource):
         username = cgi.escape(username)
         if messagevalue is not None:
             messagevalue = cgi.escape(messagevalue)
-            text = "<h1>{}</h1><p>{}</p>".format(username, messagevalue)
+            text = f"<h1>{username}</h1><p>{messagevalue}</p>"
         else:
-            text = "<h1>{}</h1><p>No such user</p>".format(username)
+            text = f"<h1>{username}</h1><p>No such user</p>"
         text = text.encode("ascii")
         return static.Data(text, "text/html")
 

--- a/docs/core/howto/tutorial/listings/finger/finger16.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger16.tac
@@ -75,7 +75,7 @@ class FingerService(service.Service):
             user = self.users.get(path, b"No such users <p/> usage: site/user")
             path = path.decode("ascii")
             user = user.decode("ascii")
-            text = "<h1>{}</h1><p>{}</p>".format(path, user)
+            text = f"<h1>{path}</h1><p>{user}</p>"
             text = text.encode("ascii")
             return static.Data(text, "text/html")
 

--- a/docs/core/howto/tutorial/listings/finger/finger17.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger17.tac
@@ -74,7 +74,7 @@ class FingerService(service.Service):
             user = self.users.get(path, b"No such user <p/> usage: site/user")
             path = path.decode("ascii")
             user = user.decode("ascii")
-            text = "<h1>{}</h1><p>{}</p>".format(path, user)
+            text = f"<h1>{path}</h1><p>{user}</p>"
             text = text.encode("ascii")
             return static.Data(text, "text/html")
 

--- a/docs/core/howto/tutorial/listings/finger/finger18.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger18.tac
@@ -33,7 +33,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg.encode("ascii"))
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -46,7 +46,7 @@ class UserStatusTree(resource.Resource):
         d = self.service.getUsers()
 
         def formatUsers(users):
-            l = ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            l = [f'<li><a href="{user}">{user}</a></li>' for user in users]
             return "<ul>" + "".join(l) + "</ul>"
 
         d.addCallback(formatUsers)

--- a/docs/core/howto/tutorial/listings/finger/finger19.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger19.tac
@@ -122,7 +122,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg.encode("ascii"))
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -170,7 +170,7 @@ class UserStatusTree(resource.Resource):
         d = self.service.getUsers()
 
         def formatUsers(users):
-            l = ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            l = [f'<li><a href="{user}">{user}</a></li>' for user in users]
             return "<ul>" + "".join(l) + "</ul>"
 
         d.addCallback(formatUsers)

--- a/docs/core/howto/tutorial/listings/finger/finger19a.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger19a.tac
@@ -106,7 +106,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg)
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -151,7 +151,7 @@ class UserStatusTree(resource.Resource):
         d = self.service.getUsers()
 
         def formatUsers(users):
-            l = ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            l = [f'<li><a href="{user}">{user}</a></li>' for user in users]
             return "<ul>" + "".join(l) + "</ul>"
 
         d.addCallback(formatUsers)

--- a/docs/core/howto/tutorial/listings/finger/finger19b.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger19b.tac
@@ -128,7 +128,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg)
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -177,7 +177,7 @@ class UserStatusTree(resource.Resource):
         d = self.service.getUsers()
 
         def formatUsers(users):
-            l = ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            l = [f'<li><a href="{user}">{user}</a></li>' for user in users]
             return "<ul>" + "".join(l) + "</ul>"
 
         d.addCallback(formatUsers)

--- a/docs/core/howto/tutorial/listings/finger/finger19c.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger19c.tac
@@ -131,7 +131,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg)
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -181,7 +181,7 @@ class UserStatusTree(resource.Resource):
         d = self.service.getUsers()
 
         def formatUsers(users):
-            l = ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            l = [f'<li><a href="{user}">{user}</a></li>' for user in users]
             return "<ul>" + "".join(l) + "</ul>"
 
         d.addCallback(formatUsers)

--- a/docs/core/howto/tutorial/listings/finger/finger20.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger20.tac
@@ -122,7 +122,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg)
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -174,7 +174,7 @@ class UserStatusTree(resource.Resource):
 
     def _cb_render_GET(self, users, request):
         userOutput = "".join(
-            ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            [f'<li><a href="{user}">{user}</a></li>' for user in users]
         )
         request.write(
             """

--- a/docs/core/howto/tutorial/listings/finger/finger21.tac
+++ b/docs/core/howto/tutorial/listings/finger/finger21.tac
@@ -123,7 +123,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg.encode("ascii"))
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -175,7 +175,7 @@ class UserStatusTree(resource.Resource):
 
     def _cb_render_GET(self, users, request):
         userOutput = "".join(
-            ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            [f'<li><a href="{user}">{user}</a></li>' for user in users]
         )
         request.write(
             """

--- a/docs/core/howto/tutorial/listings/finger/finger22.py
+++ b/docs/core/howto/tutorial/listings/finger/finger22.py
@@ -124,7 +124,7 @@ class IRCReplyBot(irc.IRCClient):
         if self.nickname.lower() == channel.lower():
             d = self.factory.getUser(msg.encode("ascii"))
             d.addErrback(catchError)
-            d.addCallback(lambda m: "Status of {}: {}".format(msg, m))
+            d.addCallback(lambda m: f"Status of {msg}: {m}")
             d.addCallback(lambda m: self.msg(user, m))
 
 
@@ -176,7 +176,7 @@ class UserStatusTree(resource.Resource):
 
     def _cb_render_GET(self, users, request):
         userOutput = "".join(
-            ['<li><a href="{}">{}</a></li>'.format(user, user) for user in users]
+            [f'<li><a href="{user}">{user}</a></li>' for user in users]
         )
         request.write(
             """

--- a/docs/historic/2003/pycon/applications/applications
+++ b/docs/historic/2003/pycon/applications/applications
@@ -8,7 +8,7 @@ class PythonSource:
         self.content = content
 
     def toHTML(self):
-        return '<pre class="python">{}</pre>'.format(self.content)
+        return f'<pre class="python">{self.content}</pre>'
 
 
 class Raw:

--- a/docs/names/examples/dns-service.py
+++ b/docs/names/examples/dns-service.py
@@ -44,9 +44,7 @@ def printResult(records, domainname):
             domainname + " IN \n " + "\n ".join(str(x.payload) for x in answers) + "\n"
         )
     else:
-        sys.stderr.write(
-            "ERROR: No SRV records found for name {!r}\n".format(domainname)
-        )
+        sys.stderr.write(f"ERROR: No SRV records found for name {domainname!r}\n")
 
 
 def printError(failure, domainname):
@@ -55,7 +53,7 @@ def printError(failure, domainname):
     resolved.
     """
     failure.trap(error.DNSNameError)
-    sys.stderr.write("ERROR: domain name not found {!r}\n".format(domainname))
+    sys.stderr.write(f"ERROR: domain name not found {domainname!r}\n")
 
 
 def main(reactor, *argv):
@@ -64,7 +62,7 @@ def main(reactor, *argv):
         options.parseOptions(argv)
     except usage.UsageError as errortext:
         sys.stderr.write(str(options) + "\n")
-        sys.stderr.write("ERROR: {}\n".format(errortext))
+        sys.stderr.write(f"ERROR: {errortext}\n")
         raise SystemExit(1)
 
     resolver = client.Resolver("/etc/resolv.conf")

--- a/docs/names/examples/gethostbyname.py
+++ b/docs/names/examples/gethostbyname.py
@@ -38,9 +38,7 @@ def printResult(address, hostname):
     if address:
         sys.stdout.write(address + "\n")
     else:
-        sys.stderr.write(
-            "ERROR: No IP addresses found for name {!r}\n".format(hostname)
-        )
+        sys.stderr.write(f"ERROR: No IP addresses found for name {hostname!r}\n")
 
 
 def printError(failure, hostname):
@@ -49,7 +47,7 @@ def printError(failure, hostname):
     resolved.
     """
     failure.trap(error.DNSNameError)
-    sys.stderr.write("ERROR: hostname not found {!r}\n".format(hostname))
+    sys.stderr.write(f"ERROR: hostname not found {hostname!r}\n")
 
 
 def main(reactor, *argv):
@@ -58,7 +56,7 @@ def main(reactor, *argv):
         options.parseOptions(argv)
     except usage.UsageError as errortext:
         sys.stderr.write(str(options) + "\n")
-        sys.stderr.write("ERROR: {}\n".format(errortext))
+        sys.stderr.write(f"ERROR: {errortext}\n")
         raise SystemExit(1)
 
     hostname = options["hostname"]

--- a/docs/names/examples/multi_reverse_lookup.py
+++ b/docs/names/examples/multi_reverse_lookup.py
@@ -66,7 +66,7 @@ def printResult(result):
     answers, authority, additional = result
     if answers:
         sys.stdout.write(
-            ", ".join("{} IN {}".format(a.name.name, a.payload) for a in answers) + "\n"
+            ", ".join(f"{a.name.name} IN {a.payload}" for a in answers) + "\n"
         )
 
 
@@ -86,7 +86,7 @@ def main(reactor, *argv):
         options.parseOptions(argv)
     except usage.UsageError as errortext:
         sys.stderr.write(str(options) + "\n")
-        sys.stderr.write("ERROR: {}\n".format(errortext))
+        sys.stderr.write(f"ERROR: {errortext}\n")
         raise SystemExit(1)
 
     pending = []

--- a/docs/names/examples/testdns.py
+++ b/docs/names/examples/testdns.py
@@ -48,7 +48,7 @@ def printResults(results, domainname):
     """
     Print the formatted results for each DNS record type.
     """
-    sys.stdout.write("# Domain Summary for {!r}\n".format(domainname))
+    sys.stdout.write(f"# Domain Summary for {domainname!r}\n")
     sys.stdout.write("\n\n".join(results) + "\n")
 
 
@@ -60,7 +60,7 @@ def printError(failure, domainname):
     failure.trap(defer.FirstError)
     failure = failure.value.subFailure
     failure.trap(error.DNSNameError)
-    sys.stderr.write("ERROR: domain name not found {!r}\n".format(domainname))
+    sys.stderr.write(f"ERROR: domain name not found {domainname!r}\n")
 
 
 def main(reactor, *argv):
@@ -69,7 +69,7 @@ def main(reactor, *argv):
         options.parseOptions(argv)
     except usage.UsageError as errortext:
         sys.stderr.write(str(options) + "\n")
-        sys.stderr.write("ERROR: {}\n".format(errortext))
+        sys.stderr.write(f"ERROR: {errortext}\n")
         raise SystemExit(1)
 
     domainname = options["domainname"]

--- a/docs/names/howto/listings/names/reverse_lookup.py
+++ b/docs/names/howto/listings/names/reverse_lookup.py
@@ -12,7 +12,7 @@ def printResult(result):
     answers, authority, additional = result
     if answers:
         a = answers[0]
-        print("{} IN {}".format(a.name.name, a.payload))
+        print(f"{a.name.name} IN {a.payload}")
 
 
 def main(reactor, address):

--- a/docs/web/examples/httpclient.py
+++ b/docs/web/examples/httpclient.py
@@ -47,7 +47,7 @@ def main(reactor, url):
     We create a custom UserAgent and send a GET request to a web server.
     """
     url = url.encode("ascii")
-    userAgent = "Twisted/{} (httpclient.py)".format(version.short()).encode("ascii")
+    userAgent = f"Twisted/{version.short()} (httpclient.py)".encode("ascii")
     agent = Agent(reactor)
     d = agent.request(b"GET", url, Headers({b"user-agent": [userAgent]}))
 

--- a/docs/words/examples/ircLogBot.py
+++ b/docs/words/examples/ircLogBot.py
@@ -48,7 +48,7 @@ class MessageLogger:
     def log(self, message):
         """Write a message to the file."""
         timestamp = time.strftime("[%H:%M:%S]", time.localtime(time.time()))
-        self.file.write("{} {}\n".format(timestamp, message))
+        self.file.write(f"{timestamp} {message}\n")
         self.file.flush()
 
     def close(self):
@@ -85,7 +85,7 @@ class LogBot(irc.IRCClient):
     def privmsg(self, user, channel, msg):
         """This will get called when the bot receives a message."""
         user = user.split("!", 1)[0]
-        self.logger.log("<{}> {}".format(user, msg))
+        self.logger.log(f"<{user}> {msg}")
 
         # Check to see if they're sending me a private message
         if channel == self.nickname:
@@ -97,12 +97,12 @@ class LogBot(irc.IRCClient):
         if msg.startswith(self.nickname + ":"):
             msg = "%s: I am a log bot" % user
             self.msg(channel, msg)
-            self.logger.log("<{}> {}".format(self.nickname, msg))
+            self.logger.log(f"<{self.nickname}> {msg}")
 
     def action(self, user, channel, msg):
         """This will get called when the bot sees someone do an action."""
         user = user.split("!", 1)[0]
-        self.logger.log("* {} {}".format(user, msg))
+        self.logger.log(f"* {user} {msg}")
 
     # irc callbacks
 
@@ -110,7 +110,7 @@ class LogBot(irc.IRCClient):
         """Called when an IRC user changes their nickname."""
         old_nick = prefix.split("!")[0]
         new_nick = params[0]
-        self.logger.log("{} is now known as {}".format(old_nick, new_nick))
+        self.logger.log(f"{old_nick} is now known as {new_nick}")
 
     # For fun, override the method that determines how a nickname is changed on
     # collisions. The default method appends an underscore.

--- a/docs/words/examples/minchat.py
+++ b/docs/words/examples/minchat.py
@@ -69,11 +69,11 @@ class MinConversation(basechat.Conversation):
         pass
 
     def showMessage(self, text, metadata=None):
-        print("<{}> {}".format(self.person.name, text))
+        print(f"<{self.person.name}> {text}")
 
     def contactChangedNick(self, person, newnick):
         basechat.Conversation.contactChangedNick(self, person, newnick)
-        print("-!- {} is now known as {}".format(person.name, newnick))
+        print(f"-!- {person.name} is now known as {newnick}")
 
 
 class MinGroupConversation(basechat.GroupConversation):
@@ -96,26 +96,22 @@ class MinGroupConversation(basechat.GroupConversation):
         pass
 
     def showGroupMessage(self, sender, text, metadata=None):
-        print("<{}/{}> {}".format(sender, self.group.name, text))
+        print(f"<{sender}/{self.group.name}> {text}")
 
     def setTopic(self, topic, author):
-        print(
-            "-!- {} set the topic of {} to: {}".format(author, self.group.name, topic)
-        )
+        print(f"-!- {author} set the topic of {self.group.name} to: {topic}")
 
     def memberJoined(self, member):
         basechat.GroupConversation.memberJoined(self, member)
-        print("-!- {} joined {}".format(member, self.group.name))
+        print(f"-!- {member} joined {self.group.name}")
 
     def memberChangedNick(self, oldnick, newnick):
         basechat.GroupConversation.memberChangedNick(self, oldnick, newnick)
-        print(
-            "-!- {} is now known as {} in {}".format(oldnick, newnick, self.group.name)
-        )
+        print(f"-!- {oldnick} is now known as {newnick} in {self.group.name}")
 
     def memberLeft(self, member):
         basechat.GroupConversation.memberLeft(self, member)
-        print("-!- {} left {}".format(member, self.group.name))
+        print(f"-!- {member} left {self.group.name}")
 
 
 class MinChat(basechat.ChatUI):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "setuptools.build_meta"
         showcontent = false
 
 [tool.black]
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']
 
 [tool.isort]
 line_length = 88

--- a/src/twisted/application/app.py
+++ b/src/twisted/application/app.py
@@ -46,7 +46,7 @@ class _BasicProfiler:
         has to be explicit because some of these modules are removed by
         distributions due to them being non-free.
         """
-        s = "Failed to import module {}: {}".format(module, e)
+        s = f"Failed to import module {module}: {e}"
         s += """
 This is most likely caused by your operating system not including
 the module due to it being non-free. Either do not use the option
@@ -129,7 +129,7 @@ class AppProfiler:
             profiler = self.profilers[self.profiler](profileOutput, saveStats)
             self.run = profiler.run
         else:
-            raise SystemExit("Unsupported profiler name: {}".format(self.profiler))
+            raise SystemExit(f"Unsupported profiler name: {self.profiler}")
 
 
 class AppLogger:
@@ -491,9 +491,7 @@ class ReactorSelectionMixin:
         for r in rcts:
             try:
                 namedModule(r.moduleName)
-                self.messageOutput.write(
-                    "    {:<4}\t{}\n".format(r.shortName, r.description)
-                )
+                self.messageOutput.write(f"    {r.shortName:<4}\t{r.description}\n")
             except ImportError as e:
                 notWorkingReactors += "    !{:<4}\t{} ({})\n".format(
                     r.shortName,
@@ -673,7 +671,7 @@ def run(runApp, ServerOptions):
     except usage.error as ue:
         commstr = " ".join(sys.argv[0:2])
         print(config)
-        print("{}: {}".format(commstr, ue))
+        print(f"{commstr}: {ue}")
     else:
         runApp(config)
 

--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -191,9 +191,9 @@ class _AbstractClient(_VolatileDataService):
         @return: the port object returned by the connect method.
         @rtype: an object providing L{twisted.internet.interfaces.IConnector}.
         """
-        return getattr(
-            _maybeGlobalReactor(self.reactor), "connect{}".format(self.method)
-        )(*self.args, **self.kwargs)
+        return getattr(_maybeGlobalReactor(self.reactor), f"connect{self.method}")(
+            *self.args, **self.kwargs
+        )
 
 
 _clientDoc = """Connect to {tran}
@@ -470,7 +470,7 @@ class _ReconnectingProtocolProxy:
         return getattr(self._protocol, item)
 
     def __repr__(self) -> str:
-        return "<{} wrapping {!r}>".format(self.__class__.__name__, self._protocol)
+        return f"<{self.__class__.__name__} wrapping {self._protocol!r}>"
 
 
 class _DisconnectFactory:

--- a/src/twisted/application/runner/_pidfile.py
+++ b/src/twisted/application/runner/_pidfile.py
@@ -127,7 +127,7 @@ class PIDFile:
             return int(pidString)
         except ValueError:
             raise InvalidPIDFileError(
-                "non-integer PID value in PID file: {!r}".format(pidString)
+                f"non-integer PID value in PID file: {pidString!r}"
             )
 
     def _write(self, pid: int) -> None:
@@ -155,9 +155,7 @@ class PIDFile:
         if SYSTEM_NAME == "posix":
             return self._pidIsRunningPOSIX(pid)
         else:
-            raise NotImplementedError(
-                "isRunning is not implemented on {}".format(SYSTEM_NAME)
-            )
+            raise NotImplementedError(f"isRunning is not implemented on {SYSTEM_NAME}")
 
     @staticmethod
     def _pidIsRunningPOSIX(pid: int) -> bool:

--- a/src/twisted/application/runner/test/test_pidfile.py
+++ b/src/twisted/application/runner/test/test_pidfile.py
@@ -111,9 +111,7 @@ class PIDFileTests(twisted.trial.unittest.TestCase):
         pidFile = PIDFile(self.filePath(b""))
 
         e = self.assertRaises(InvalidPIDFileError, pidFile.read)
-        self.assertEqual(
-            str(e), "non-integer PID value in PID file: {!r}".format(pidValue)
-        )
+        self.assertEqual(str(e), f"non-integer PID value in PID file: {pidValue!r}")
 
     def test_readWithBogusPID(self) -> None:
         """
@@ -124,9 +122,7 @@ class PIDFileTests(twisted.trial.unittest.TestCase):
         pidFile = PIDFile(self.filePath(pidValue))
 
         e = self.assertRaises(InvalidPIDFileError, pidFile.read)
-        self.assertEqual(
-            str(e), "non-integer PID value in PID file: {!r}".format(pidValue)
-        )
+        self.assertEqual(str(e), f"non-integer PID value in PID file: {pidValue!r}")
 
     def test_readDoesntExist(self) -> None:
         """

--- a/src/twisted/application/runner/test/test_runner.py
+++ b/src/twisted/application/runner/test/test_runner.py
@@ -57,7 +57,7 @@ class RunnerTests(twisted.trial.unittest.TestCase):
         # Patch getpid so we get a known result
 
         self.pid = 1337
-        self.pidFileContent = "{}\n".format(self.pid).encode("utf-8")
+        self.pidFileContent = f"{self.pid}\n".encode("utf-8")
 
         # Patch globalLogBeginner so that we aren't trying to install multiple
         # global log observers.
@@ -338,7 +338,7 @@ class RunnerTests(twisted.trial.unittest.TestCase):
 
         runnerArguments = {
             methodName: hook,
-            "{}Arguments".format(methodName): arguments.copy(),
+            f"{methodName}Arguments": arguments.copy(),
         }
         runner = Runner(
             reactor=MemoryReactor(), **runnerArguments  # type: ignore[arg-type]

--- a/src/twisted/application/twist/_options.py
+++ b/src/twisted/application/twist/_options.py
@@ -67,7 +67,7 @@ class TwistOptions(Options):
         """
         Print version and exit.
         """
-        exit(ExitStatus.EX_OK, "{}".format(version))
+        exit(ExitStatus.EX_OK, f"{version}")
 
     def opt_reactor(self, name: str) -> None:
         """
@@ -80,13 +80,13 @@ class TwistOptions(Options):
         try:
             self["reactor"] = self.installReactor(name)
         except NoSuchReactor:
-            raise UsageError("Unknown reactor: {}".format(name))
+            raise UsageError(f"Unknown reactor: {name}")
         else:
             self["reactorName"] = name
 
     _update_doc(
         opt_reactor,
-        options=", ".join('"{}"'.format(rt.shortName) for rt in getReactorTypes()),
+        options=", ".join(f'"{rt.shortName}"' for rt in getReactorTypes()),
     )
 
     def installReactor(self, name: str) -> IReactorCore:
@@ -108,12 +108,12 @@ class TwistOptions(Options):
         try:
             self["logLevel"] = LogLevel.levelWithName(levelName)
         except InvalidLogLevelError:
-            raise UsageError("Invalid log level: {}".format(levelName))
+            raise UsageError(f"Invalid log level: {levelName}")
 
     _update_doc(
         opt_log_level,
         options=", ".join(
-            '"{}"'.format(constant.name) for constant in LogLevel.iterconstants()
+            f'"{constant.name}"' for constant in LogLevel.iterconstants()
         ),
         default=defaultLogLevel.name,
     )
@@ -135,7 +135,7 @@ class TwistOptions(Options):
         except OSError as e:
             exit(
                 ExitStatus.EX_IOERR,
-                "Unable to open log file {!r}: {}".format(fileName, e),
+                f"Unable to open log file {fileName!r}: {e}",
             )
 
     def opt_log_format(self, format: str) -> None:
@@ -151,7 +151,7 @@ class TwistOptions(Options):
         elif format == "json":
             self["fileLogObserverFactory"] = jsonFileLogObserver
         else:
-            raise UsageError("Invalid log format: {}".format(format))
+            raise UsageError(f"Invalid log format: {format}")
         self["logFormat"] = format
 
     _update_doc(opt_log_format)

--- a/src/twisted/application/twist/_twist.py
+++ b/src/twisted/application/twist/_twist.py
@@ -37,7 +37,7 @@ class Twist:
         try:
             options.parseOptions(argv[1:])
         except UsageError as e:
-            exit(ExitStatus.EX_USAGE, "Error: {}\n\n{}".format(e, options))
+            exit(ExitStatus.EX_USAGE, f"Error: {e}\n\n{options}")
 
         return options
 

--- a/src/twisted/application/twist/test/test_twist.py
+++ b/src/twisted/application/twist/test/test_twist.py
@@ -88,7 +88,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
         )
         self.assertTrue(
             self.exit.message.endswith(  # type: ignore[union-attr]
-                "\n\n{}".format(TwistOptions())
+                f"\n\n{TwistOptions()}"
             )
         )
 

--- a/src/twisted/conch/scripts/cftp.py
+++ b/src/twisted/conch/scripts/cftp.py
@@ -420,7 +420,7 @@ class StdioClient(basic.LineReceiver):
         lf.close()
         if self.useProgressBar:
             self._writeToTransport("\n")
-        return "Transferred {} to {}".format(rf.name, lf.name)
+        return f"Transferred {rf.name} to {lf.name}"
 
     def cmd_PUT(self, rest):
         """
@@ -590,7 +590,7 @@ class StdioClient(basic.LineReceiver):
         rf.close()
         if self.useProgressBar:
             self._writeToTransport("\n")
-        return "Transferred {} to {}".format(lf.name, rf.name)
+        return f"Transferred {lf.name} to {rf.name}"
 
     def cmd_LCD(self, path):
         os.chdir(path)
@@ -845,7 +845,7 @@ version                         Print the SFTP version.
             self._abbrevTime(timeLeft),
         )
         spaces = (winSize[1] - (len(front) + len(back) + 1)) * " "
-        command = "\r{}{}{}".format(front, spaces, back)
+        command = f"\r{front}{spaces}{back}"
         self._writeToTransport(command)
 
     def _getFilename(self, line):

--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -240,9 +240,9 @@ def changePassPhrase(options):
         except keys.BadKeyError:
             sys.exit("Could not change passphrase: old passphrase error")
         except keys.EncryptedKeyError as e:
-            sys.exit("Could not change passphrase: {}".format(e))
+            sys.exit(f"Could not change passphrase: {e}")
     except keys.BadKeyError as e:
-        sys.exit("Could not change passphrase: {}".format(e))
+        sys.exit(f"Could not change passphrase: {e}")
 
     if not options.get("newpass"):
         while 1:
@@ -263,12 +263,12 @@ def changePassPhrase(options):
             passphrase=options["newpass"],
         )
     except Exception as e:
-        sys.exit("Could not change passphrase: {}".format(e))
+        sys.exit(f"Could not change passphrase: {e}")
 
     try:
         keys.Key.fromString(newkeydata, passphrase=options["newpass"])
     except (keys.EncryptedKeyError, keys.BadKeyError) as e:
-        sys.exit("Could not change passphrase: {}".format(e))
+        sys.exit(f"Could not change passphrase: {e}")
 
     with open(options["filename"], "wb") as fd:
         fd.write(newkeydata)
@@ -312,9 +312,9 @@ def _saveKey(key, options):
     KeyTypeMapping = {"EC": "ecdsa", "Ed25519": "ed25519", "RSA": "rsa", "DSA": "dsa"}
     keyTypeName = KeyTypeMapping[key.type()]
     if not options["filename"]:
-        defaultPath = os.path.expanduser("~/.ssh/id_{}".format(keyTypeName))
+        defaultPath = os.path.expanduser(f"~/.ssh/id_{keyTypeName}")
         newPath = _inputSaveFile(
-            "Enter file in which to save the key ({}): ".format(defaultPath)
+            f"Enter file in which to save the key ({defaultPath}): "
         )
 
         options["filename"] = newPath.strip() or defaultPath
@@ -339,7 +339,7 @@ def _saveKey(key, options):
     if options.get("private-key-subtype") is None:
         options["private-key-subtype"] = _defaultPrivateKeySubtype(key.type())
 
-    comment = "{}@{}".format(getpass.getuser(), socket.gethostname())
+    comment = f"{getpass.getuser()}@{socket.gethostname()}"
 
     filepath.FilePath(options["filename"]).setContent(
         key.toString(

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -89,7 +89,7 @@ class ClientOptions(ConchOptions):
         elif len(esc) == 1:
             self["escape"] = esc
         else:
-            sys.exit("Bad escape character '{}'.".format(esc))
+            sys.exit(f"Bad escape character '{esc}'.")
 
     def opt_localforward(self, f):
         """
@@ -141,7 +141,7 @@ def run():
     try:
         options.parseOptions(args)
     except usage.UsageError as u:
-        print("ERROR: {}".format(u))
+        print(f"ERROR: {u}")
         options.opt_help()
         sys.exit(1)
     if options["log"]:
@@ -223,7 +223,7 @@ def doConnect():
 
 def _ebExit(f):
     global exitStatus
-    exitStatus = "conch: exiting with error {}".format(f)
+    exitStatus = f"conch: exiting with error {f}"
     reactor.callLater(0.1, _stopReactor)
 
 
@@ -244,9 +244,7 @@ def onConnect():
             conn.localForwards.append(s)
     if options.remoteForwards:
         for remotePort, hostport in options.remoteForwards:
-            log.msg(
-                "asking for remote forwarding for {}:{}".format(remotePort, hostport)
-            )
+            log.msg(f"asking for remote forwarding for {remotePort}:{hostport}")
             conn.requestRemoteForwarding(remotePort, hostport)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
@@ -273,7 +271,7 @@ def reConnect():
 def beforeShutdown():
     remoteForwards = options.remoteForwards
     for remotePort, hostport in remoteForwards:
-        log.msg("cancelling {}:{}".format(remotePort, hostport))
+        log.msg(f"cancelling {remotePort}:{hostport}")
         conn.cancelRemoteForwarding(remotePort)
 
 
@@ -325,23 +323,23 @@ class SSHConnection(connection.SSHConnection):
     def requestRemoteForwarding(self, remotePort, hostport):
         data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
-        log.msg("requesting remote forwarding {}:{}".format(remotePort, hostport))
+        log.msg(f"requesting remote forwarding {remotePort}:{hostport}")
         d.addCallback(self._cbRemoteForwarding, remotePort, hostport)
         d.addErrback(self._ebRemoteForwarding, remotePort, hostport)
 
     def _cbRemoteForwarding(self, result, remotePort, hostport):
-        log.msg("accepted remote forwarding {}:{}".format(remotePort, hostport))
+        log.msg(f"accepted remote forwarding {remotePort}:{hostport}")
         self.remoteForwards[remotePort] = hostport
         log.msg(repr(self.remoteForwards))
 
     def _ebRemoteForwarding(self, f, remotePort, hostport):
-        log.msg("remote forwarding {}:{} failed".format(remotePort, hostport))
+        log.msg(f"remote forwarding {remotePort}:{hostport} failed")
         log.msg(f)
 
     def cancelRemoteForwarding(self, remotePort):
         data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
-        log.msg("cancelling remote forwarding {}".format(remotePort))
+        log.msg(f"cancelling remote forwarding {remotePort}")
         try:
             del self.remoteForwards[remotePort]
         except Exception:
@@ -349,13 +347,13 @@ class SSHConnection(connection.SSHConnection):
         log.msg(repr(self.remoteForwards))
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
-        log.msg("FTCP {!r}".format(data))
+        log.msg(f"FTCP {data!r}")
         remoteHP, origHP = forwarding.unpackOpen_forwarded_tcpip(data)
         log.msg(self.remoteForwards)
         log.msg(remoteHP)
         if remoteHP[1] in self.remoteForwards:
             connectHP = self.remoteForwards[remoteHP[1]]
-            log.msg("connect forwarding {}".format(connectHP))
+            log.msg(f"connect forwarding {connectHP}")
             return SSHConnectForwardingChannel(
                 connectHP, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
             )
@@ -365,7 +363,7 @@ class SSHConnection(connection.SSHConnection):
             )
 
     def channelClosed(self, channel):
-        log.msg("connection closing {}".format(channel))
+        log.msg(f"connection closing {channel}")
         log.msg(self.channels)
         if len(self.channels) == 1:  # Just us left
             log.msg("stopping connection")
@@ -380,7 +378,7 @@ class SSHSession(channel.SSHChannel):
     name = b"session"
 
     def channelOpen(self, foo):
-        log.msg("session {} open".format(self.id))
+        log.msg(f"session {self.id} open")
         if options["agent"]:
             d = self.conn.sendRequest(
                 self, b"auth-agent-req@openssh.com", b"", wantReply=1
@@ -483,18 +481,18 @@ class SSHSession(channel.SSHChannel):
         self.stdio.loseWriteConnection()
 
     def closeReceived(self):
-        log.msg("remote side closed {}".format(self))
+        log.msg(f"remote side closed {self}")
         self.conn.sendClose(self)
 
     def closed(self):
         global old
-        log.msg("closed {}".format(self))
+        log.msg(f"closed {self}")
         log.msg(repr(self.conn.channels))
 
     def request_exit_status(self, data):
         global exitStatus
         exitStatus = int(struct.unpack(">L", data)[0])
-        log.msg("exit status: {}".format(exitStatus))
+        log.msg(f"exit status: {exitStatus}")
 
     def sendEOF(self):
         self.conn.sendEOF(self)

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -135,9 +135,9 @@ class TkConchMenu(Tkinter.Frame):
         host = self.forwardHost.get()
         self.forwardHost.delete(0, Tkinter.END)
         if self.localRemoteVar.get() == "local":
-            self.forwards.insert(Tkinter.END, "L:{}:{}".format(port, host))
+            self.forwards.insert(Tkinter.END, f"L:{port}:{host}")
         else:
-            self.forwards.insert(Tkinter.END, "R:{}:{}".format(port, host))
+            self.forwards.insert(Tkinter.END, f"R:{port}:{host}")
 
     def removeForward(self):
         cur = self.forwards.curselection()
@@ -372,10 +372,10 @@ def run():
         if v and hasattr(menu, k):
             getattr(menu, k).insert(Tkinter.END, v)
     for (p, (rh, rp)) in options.localForwards:
-        menu.forwards.insert(Tkinter.END, "L:{}:{}:{}".format(p, rh, rp))
+        menu.forwards.insert(Tkinter.END, f"L:{p}:{rh}:{rp}")
     options.localForwards = []
     for (p, (rh, rp)) in options.remoteForwards:
-        menu.forwards.insert(Tkinter.END, "R:{}:{}:{}".format(p, rh, rp))
+        menu.forwards.insert(Tkinter.END, f"R:{p}:{rh}:{rp}")
     options.remoteForwards = []
     frame = tkvt100.VT100Frame(root, callback=None)
     root.geometry(
@@ -415,7 +415,7 @@ class SSHClientFactory(protocol.ClientFactory):
     def clientConnectionFailed(self, connector, reason):
         tkMessageBox.showwarning(
             "TkConch",
-            "Connection Failed, Reason:\n {}: {}".format(reason.type, reason.value),
+            f"Connection Failed, Reason:\n {reason.type}: {reason.value}",
         )
 
 
@@ -485,7 +485,7 @@ class SSHClientTransport(transport.SSHClientTransport):
             )
             with open(os.path.expanduser("~/.ssh/known_hosts"), "a") as known_hosts:
                 encodedKey = base64.b64encode(pubKey)
-                known_hosts.write("\n{} {} {}".format(khHost, keyType, encodedKey))
+                known_hosts.write(f"\n{khHost} {keyType} {encodedKey}")
         except BaseException:
             log.deferr()
             raise error.ConchError

--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -195,9 +195,7 @@ def getKex(kexAlgorithm):
     @raises ConchError: if the key exchange algorithm is not found.
     """
     if kexAlgorithm not in _kexAlgorithms:
-        raise error.ConchError(
-            "Unsupported key exchange algorithm: {}".format(kexAlgorithm)
-        )
+        raise error.ConchError(f"Unsupported key exchange algorithm: {kexAlgorithm}")
     return _kexAlgorithms[kexAlgorithm]
 
 

--- a/src/twisted/conch/ssh/address.py
+++ b/src/twisted/conch/ssh/address.py
@@ -37,7 +37,7 @@ class SSHTransportAddress(util.FancyEqMixin):
         self.address = address
 
     def __repr__(self) -> str:
-        return "SSHTransportAddress({!r})".format(self.address)
+        return f"SSHTransportAddress({self.address!r})"
 
     def __hash__(self):
         return hash(("SSH", self.address))

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -104,7 +104,7 @@ class SSHChannel(log.Logger):
             name = self.name.decode("ascii")
         else:
             name = "None"
-        return "SSHChannel {} ({}) on {}".format(name, id, self.conn.logPrefix())
+        return f"SSHChannel {name} ({id}) on {self.conn.logPrefix()}"
 
     def channelOpen(self, specificData):
         """

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -44,7 +44,7 @@ class FileTransferBase(protocol.Protocol):
             if not packetType:
                 self._log.info("no packet type for {kind}", kind=kind)
                 continue
-            f = getattr(self, "packet_{}".format(packetType), None)
+            f = getattr(self, f"packet_{packetType}", None)
             if not f:
                 self._log.info(
                     "not implemented: {packetType} data={data!r}",
@@ -53,7 +53,7 @@ class FileTransferBase(protocol.Protocol):
                 )
                 (reqId,) = struct.unpack("!L", data[:4])
                 self._sendStatus(
-                    reqId, FX_OP_UNSUPPORTED, "don't understand {}".format(packetType)
+                    reqId, FX_OP_UNSUPPORTED, f"don't understand {packetType}"
                 )
                 # XXX not implemented
                 continue
@@ -162,7 +162,7 @@ class FileTransferServer(FileTransferBase):
         (flags,) = struct.unpack("!L", data[:4])
         data = data[4:]
         attrs, data = self._parseAttributes(data)
-        assert data == b"", "still have data in OPEN: {!r}".format(data)
+        assert data == b"", f"still have data in OPEN: {data!r}"
         d = defer.maybeDeferred(self.client.openFile, filename, flags, attrs)
         d.addCallback(self._cbOpenFile, requestId)
         d.addErrback(self._ebStatus, requestId, b"open failed")
@@ -178,7 +178,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         handle, data = getNS(data)
-        assert data == b"", "still have data in CLOSE: {!r}".format(data)
+        assert data == b"", f"still have data in CLOSE: {data!r}"
         if handle in self.openFiles:
             fileObj = self.openFiles[handle]
             d = defer.maybeDeferred(fileObj.close)
@@ -204,7 +204,7 @@ class FileTransferServer(FileTransferBase):
         data = data[4:]
         handle, data = getNS(data)
         (offset, length), data = struct.unpack("!QL", data[:12]), data[12:]
-        assert data == b"", "still have data in READ: {!r}".format(data)
+        assert data == b"", f"still have data in READ: {data!r}"
         if handle not in self.openFiles:
             self._ebRead(failure.Failure(KeyError()), requestId)
         else:
@@ -225,7 +225,7 @@ class FileTransferServer(FileTransferBase):
         (offset,) = struct.unpack("!Q", data[:8])
         data = data[8:]
         writeData, data = getNS(data)
-        assert data == b"", "still have data in WRITE: {!r}".format(data)
+        assert data == b"", f"still have data in WRITE: {data!r}"
         if handle not in self.openFiles:
             self._ebWrite(failure.Failure(KeyError()), requestId)
         else:
@@ -238,7 +238,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         filename, data = getNS(data)
-        assert data == b"", "still have data in REMOVE: {!r}".format(data)
+        assert data == b"", f"still have data in REMOVE: {data!r}"
         d = defer.maybeDeferred(self.client.removeFile, filename)
         d.addCallback(self._cbStatus, requestId, b"remove succeeded")
         d.addErrback(self._ebStatus, requestId, b"remove failed")
@@ -248,7 +248,7 @@ class FileTransferServer(FileTransferBase):
         data = data[4:]
         oldPath, data = getNS(data)
         newPath, data = getNS(data)
-        assert data == b"", "still have data in RENAME: {!r}".format(data)
+        assert data == b"", f"still have data in RENAME: {data!r}"
         d = defer.maybeDeferred(self.client.renameFile, oldPath, newPath)
         d.addCallback(self._cbStatus, requestId, b"rename succeeded")
         d.addErrback(self._ebStatus, requestId, b"rename failed")
@@ -258,7 +258,7 @@ class FileTransferServer(FileTransferBase):
         data = data[4:]
         path, data = getNS(data)
         attrs, data = self._parseAttributes(data)
-        assert data == b"", "still have data in MKDIR: {!r}".format(data)
+        assert data == b"", f"still have data in MKDIR: {data!r}"
         d = defer.maybeDeferred(self.client.makeDirectory, path, attrs)
         d.addCallback(self._cbStatus, requestId, b"mkdir succeeded")
         d.addErrback(self._ebStatus, requestId, b"mkdir failed")
@@ -267,7 +267,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         path, data = getNS(data)
-        assert data == b"", "still have data in RMDIR: {!r}".format(data)
+        assert data == b"", f"still have data in RMDIR: {data!r}"
         d = defer.maybeDeferred(self.client.removeDirectory, path)
         d.addCallback(self._cbStatus, requestId, b"rmdir succeeded")
         d.addErrback(self._ebStatus, requestId, b"rmdir failed")
@@ -276,7 +276,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         path, data = getNS(data)
-        assert data == b"", "still have data in OPENDIR: {!r}".format(data)
+        assert data == b"", f"still have data in OPENDIR: {data!r}"
         d = defer.maybeDeferred(self.client.openDirectory, path)
         d.addCallback(self._cbOpenDirectory, requestId)
         d.addErrback(self._ebStatus, requestId, b"opendir failed")
@@ -292,7 +292,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         handle, data = getNS(data)
-        assert data == b"", "still have data in READDIR: {!r}".format(data)
+        assert data == b"", f"still have data in READDIR: {data!r}"
         if handle not in self.openDirs:
             self._ebStatus(failure.Failure(KeyError()), requestId)
         else:
@@ -332,7 +332,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         path, data = getNS(data)
-        assert data == b"", "still have data in STAT/LSTAT: {!r}".format(data)
+        assert data == b"", f"still have data in STAT/LSTAT: {data!r}"
         d = defer.maybeDeferred(self.client.getAttrs, path, followLinks)
         d.addCallback(self._cbStat, requestId)
         d.addErrback(self._ebStatus, requestId, b"stat/lstat failed")
@@ -344,10 +344,10 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         handle, data = getNS(data)
-        assert data == b"", "still have data in FSTAT: {!r}".format(data)
+        assert data == b"", f"still have data in FSTAT: {data!r}"
         if handle not in self.openFiles:
             self._ebStatus(
-                failure.Failure(KeyError("{} not in self.openFiles".format(handle))),
+                failure.Failure(KeyError(f"{handle} not in self.openFiles")),
                 requestId,
             )
         else:
@@ -376,7 +376,7 @@ class FileTransferServer(FileTransferBase):
         data = data[4:]
         handle, data = getNS(data)
         attrs, data = self._parseAttributes(data)
-        assert data == b"", "still have data in FSETSTAT: {!r}".format(data)
+        assert data == b"", f"still have data in FSETSTAT: {data!r}"
         if handle not in self.openFiles:
             self._ebStatus(failure.Failure(KeyError()), requestId)
         else:
@@ -389,7 +389,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         path, data = getNS(data)
-        assert data == b"", "still have data in READLINK: {!r}".format(data)
+        assert data == b"", f"still have data in READLINK: {data!r}"
         d = defer.maybeDeferred(self.client.readLink, path)
         d.addCallback(self._cbReadLink, requestId)
         d.addErrback(self._ebStatus, requestId, b"readlink failed")
@@ -410,7 +410,7 @@ class FileTransferServer(FileTransferBase):
         requestId = data[:4]
         data = data[4:]
         path, data = getNS(data)
-        assert data == b"", "still have data in REALPATH: {!r}".format(data)
+        assert data == b"", f"still have data in REALPATH: {data!r}"
         d = defer.maybeDeferred(self.client.realPath, path)
         d.addCallback(self._cbReadLink, requestId)  # Same return format
         d.addErrback(self._ebStatus, requestId, b"realpath failed")
@@ -956,7 +956,7 @@ class SFTPError(Exception):
         return self._message
 
     def __str__(self) -> str:
-        return "SFTPError {}: {}".format(self.code, self.message)
+        return f"SFTPError {self.code}: {self.message}"
 
 
 FXP_INIT = 1

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -199,10 +199,10 @@ class Key:
         if type is None:
             type = cls._guessStringType(data)
         if type is None:
-            raise BadKeyError("cannot guess the type of {!r}".format(data))
-        method = getattr(cls, "_fromString_{}".format(type.upper()), None)
+            raise BadKeyError(f"cannot guess the type of {data!r}")
+        method = getattr(cls, f"_fromString_{type.upper()}", None)
         if method is None:
-            raise BadKeyError("no _fromString method for {}".format(type))
+            raise BadKeyError(f"no _fromString method for {type}")
         if method.__code__.co_argcount == 2:  # No passphrase
             if passphrase:
                 raise BadKeyError("key not encrypted")
@@ -265,7 +265,7 @@ class Key:
             a, rest = common.getNS(rest)
             return cls._fromEd25519Components(a)
         else:
-            raise BadKeyError("unknown blob type: {}".format(keyType))
+            raise BadKeyError(f"unknown blob type: {keyType}")
 
     @classmethod
     def _fromString_PRIVATE_BLOB(cls, blob):
@@ -340,7 +340,7 @@ class Key:
             k = combined[:32]
             return cls._fromEd25519Components(a, k=k)
         else:
-            raise BadKeyError("unknown blob type: {}".format(keyType))
+            raise BadKeyError(f"unknown blob type: {keyType}")
 
     @classmethod
     def _fromString_PUBLIC_OPENSSH(cls, data):
@@ -418,7 +418,7 @@ class Key:
                 keySize = int(cipher[3:6]) // 8
                 ivSize = blockSize
             else:
-                raise BadKeyError("unknown encryption type {!r}".format(cipher))
+                raise BadKeyError(f"unknown encryption type {cipher!r}")
             if kdf == b"bcrypt":
                 salt, rest = common.getNS(kdfOptions)
                 rounds = struct.unpack("!L", rest[:4])[0]
@@ -431,7 +431,7 @@ class Key:
                     ignore_few_rounds=True,
                 )
             else:
-                raise BadKeyError("unknown KDF type {!r}".format(kdf))
+                raise BadKeyError(f"unknown KDF type {kdf!r}")
             if (len(encPrivKeyList) % blockSize) != 0:
                 raise BadKeyError("bad padding")
             decryptor = Cipher(
@@ -515,7 +515,7 @@ class Key:
                 if len(ivdata) != 16:
                     raise BadKeyError("DES encrypted key with a bad IV")
             else:
-                raise BadKeyError("unknown encryption type {!r}".format(cipher))
+                raise BadKeyError(f"unknown encryption type {cipher!r}")
 
             # Extract keyData for decoding
             iv = bytes(
@@ -542,9 +542,7 @@ class Key:
         try:
             decodedKey = berDecoder.decode(keyData)[0]
         except PyAsn1Error as asn1Error:
-            raise BadKeyError(
-                "Failed to decode key (Bad Passphrase?): {}".format(asn1Error)
-            )
+            raise BadKeyError(f"Failed to decode key (Bad Passphrase?): {asn1Error}")
 
         if kind == b"EC":
             return cls(load_pem_private_key(data, passphrase, default_backend()))
@@ -580,7 +578,7 @@ class Key:
                 ).private_key(backend=default_backend())
             )
         else:
-            raise BadKeyError("unknown key type {}".format(kind))
+            raise BadKeyError(f"unknown key type {kind}")
 
     @classmethod
     def _fromString_PRIVATE_OPENSSH(cls, data, passphrase):
@@ -728,7 +726,7 @@ class Key:
             q, data = common.getMP(data)
             return cls._fromRSAComponents(n=n, e=e, d=d, p=p, q=q, u=u)
         else:
-            raise BadKeyError("unknown key type {}".format(keyType))
+            raise BadKeyError(f"unknown key type {keyType}")
 
     @classmethod
     def _guessStringType(cls, data):
@@ -956,9 +954,9 @@ class Key:
 
             for k, v in sorted(data.items()):
                 if k == "curve":
-                    out += "\ncurve:\n\t{}".format(name)
+                    out += f"\ncurve:\n\t{name}"
                 else:
-                    out += "\n{}:\n\t{}".format(k, v)
+                    out += f"\n{k}:\n\t{v}"
 
             return out + ">\n"
         else:
@@ -971,7 +969,7 @@ class Key:
                 )
             ]
             for k, v in sorted(self.data().items()):
-                lines.append("attr {}:".format(k))
+                lines.append(f"attr {k}:")
                 by = v if self.type() == "Ed25519" else common.MP(v)[4:]
                 while by:
                     m = by[:15]
@@ -1053,9 +1051,7 @@ class Key:
                 )
             )
         else:
-            raise BadFingerPrintFormat(
-                "Unsupported fingerprint format: {}".format(format)
-            )
+            raise BadFingerPrintFormat(f"Unsupported fingerprint format: {format}")
 
     def type(self):
         """
@@ -1078,7 +1074,7 @@ class Key:
         ):
             return "Ed25519"
         else:
-            raise RuntimeError("unknown type of object: {!r}".format(self._keyObject))
+            raise RuntimeError(f"unknown type of object: {self._keyObject!r}")
 
     def sshType(self):
         """
@@ -1191,7 +1187,7 @@ class Key:
             }
 
         else:
-            raise RuntimeError("Unexpected key type: {}".format(self._keyObject))
+            raise RuntimeError(f"Unexpected key type: {self._keyObject}")
 
     def blob(self):
         """
@@ -1251,7 +1247,7 @@ class Key:
         elif type == "Ed25519":
             return common.NS(b"ssh-ed25519") + common.NS(data["a"])
         else:
-            raise BadKeyError("unknown key type: {}".format(type))
+            raise BadKeyError(f"unknown key type: {type}")
 
     def privateBlob(self):
         """
@@ -1334,7 +1330,7 @@ class Key:
                 + common.NS(data["k"] + data["a"])
             )
         else:
-            raise BadKeyError("unknown key type: {}".format(type))
+            raise BadKeyError(f"unknown key type: {type}")
 
     @_mutuallyExclusiveArguments(
         [
@@ -1397,9 +1393,9 @@ class Key:
         if isinstance(comment, str):
             comment = comment.encode("utf-8")
         passphrase = _normalizePassphrase(passphrase)
-        method = getattr(self, "_toString_{}".format(type.upper()), None)
+        method = getattr(self, f"_toString_{type.upper()}", None)
         if method is None:
-            raise BadKeyError("unknown key type: {}".format(type))
+            raise BadKeyError(f"unknown key type: {type}")
         return method(subtype=subtype, comment=comment, passphrase=passphrase)
 
     def _toPublicOpenSSH(self, comment=None):
@@ -1596,7 +1592,7 @@ class Key:
         elif subtype is None or subtype == "PEM":
             return self._toPrivateOpenSSH_PEM(passphrase=passphrase)
         else:
-            raise ValueError("unknown subtype {}".format(subtype))
+            raise ValueError(f"unknown subtype {subtype}")
 
     def _toString_LSH(self, **kwargs):
         """
@@ -1637,7 +1633,7 @@ class Key:
                     ]
                 )
             else:
-                raise BadKeyError("unknown key type {}".format(type))
+                raise BadKeyError(f"unknown key type {type}")
             return b"{" + encodebytes(keyData).replace(b"\n", b"") + b"}"
         else:
             if type == "RSA":
@@ -1678,7 +1674,7 @@ class Key:
                     ]
                 )
             else:
-                raise BadKeyError("unknown key type {}'".format(type))
+                raise BadKeyError(f"unknown key type {type}'")
 
     def _toString_AGENTV3(self, **kwargs):
         """

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -631,7 +631,7 @@ class SSHTransportBase(protocol.Protocol):
         if packetLen > 1048576:  # 1024 ** 2
             self.sendDisconnect(
                 DISCONNECT_PROTOCOL_ERROR,
-                networkString("bad packet length {}".format(packetLen)),
+                networkString(f"bad packet length {packetLen}"),
             )
             return
         if len(self.buf) < packetLen + 4 + ms:
@@ -733,7 +733,7 @@ class SSHTransportBase(protocol.Protocol):
         """
         if messageNum < 50 and messageNum in messages:
             messageType = messages[messageNum][4:]
-            f = getattr(self, "ssh_{}".format(messageType), None)
+            f = getattr(self, f"ssh_{messageType}", None)
             if f is not None:
                 f(payload)
             else:
@@ -1292,7 +1292,7 @@ class SSHTransportBase(protocol.Protocol):
             )
         else:
             raise UnsupportedAlgorithm(
-                "Cannot encode elliptic curve public key for {!r}".format(self.kexAlg)
+                f"Cannot encode elliptic curve public key for {self.kexAlg!r}"
             )
 
     def _generateECSharedSecret(self, ecPriv, theirECPubBytes):

--- a/src/twisted/conch/ssh/userauth.py
+++ b/src/twisted/conch/ssh/userauth.py
@@ -143,18 +143,16 @@ class SSHUserAuthServer(service.SSHService):
         if kind not in self.supportedAuthentications:
             return defer.fail(error.ConchError("unsupported authentication, failing"))
         kind = nativeString(kind.replace(b"-", b"_"))
-        f = getattr(self, "auth_{}".format(kind), None)
+        f = getattr(self, f"auth_{kind}", None)
         if f:
             ret = f(data)
             if not ret:
                 return defer.fail(
-                    error.ConchError(
-                        "{} return None instead of a Deferred".format(kind)
-                    )
+                    error.ConchError(f"{kind} return None instead of a Deferred")
                 )
             else:
                 return ret
-        return defer.fail(error.ConchError("bad auth type: {}".format(kind)))
+        return defer.fail(error.ConchError(f"bad auth type: {kind}"))
 
     def ssh_USERAUTH_REQUEST(self, packet):
         """
@@ -192,9 +190,7 @@ class SSHUserAuthServer(service.SSHService):
         self.transport.logoutFunction = logout
         service = self.transport.factory.getService(self.transport, self.nextService)
         if not service:
-            raise error.ConchError(
-                "could not get next service: {}".format(self.nextService)
-            )
+            raise error.ConchError(f"could not get next service: {self.nextService}")
         self._log.debug(
             "{user!r} authenticated with {method!r}", user=self.user, method=self.method
         )

--- a/src/twisted/conch/telnet.py
+++ b/src/twisted/conch/telnet.py
@@ -434,7 +434,7 @@ class Telnet(protocol.Protocol):
             self.him = self._Perspective()
 
         def __repr__(self) -> str:
-            return "<_OptionState us={} him={}>".format(self.us, self.him)
+            return f"<_OptionState us={self.us} him={self.him}>"
 
     def getOptionState(self, opt):
         return self.options.setdefault(opt, self._OptionState())
@@ -831,7 +831,7 @@ class Telnet(protocol.Protocol):
         @raise NotImplementedError: Always raised.
         """
         raise NotImplementedError(
-            "Don't know how to disable local telnet option {!r}".format(option)
+            f"Don't know how to disable local telnet option {option!r}"
         )
 
     def disableRemote(self, option):
@@ -846,7 +846,7 @@ class Telnet(protocol.Protocol):
         @raise NotImplementedError: Always raised.
         """
         raise NotImplementedError(
-            "Don't know how to disable remote telnet option {!r}".format(option)
+            f"Don't know how to disable remote telnet option {option!r}"
         )
 
 

--- a/src/twisted/conch/test/loopback.py
+++ b/src/twisted/conch/test/loopback.py
@@ -12,7 +12,7 @@ class LoopbackRelay(loopback.LoopbackRelay):
     clearCall = None
 
     def logPrefix(self):
-        return "LoopbackRelay({!r})".format(self.target.__class__.__name__)
+        return f"LoopbackRelay({self.target.__class__.__name__!r})"
 
     def write(self, data):
         loopback.LoopbackRelay.write(self, data)

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -584,8 +584,8 @@ class StdioClientTests(TestCase):
             # ends with the final message informing that file was transferred.
             expectedTransfer = []
             for line in expected:
-                expectedTransfer.append("{} {}".format(local, line))
-            expectedTransfer.append("Transferred {} to {}".format(local, remote))
+                expectedTransfer.append(f"{local} {line}")
+            expectedTransfer.append(f"Transferred {local} to {remote}")
             expectedOutput.append(expectedTransfer)
 
             progressParts = output.pop(0).strip("\r").split("\r")
@@ -659,7 +659,7 @@ class StdioClientTests(TestCase):
         remoteFile = InMemoryRemoteFile(remoteName)
         self.fakeFilesystem.put(remoteName, flags, defer.succeed(remoteFile))
 
-        deferred = self.client.cmd_PUT("{} {} ignored".format(localPath, remoteName))
+        deferred = self.client.cmd_PUT(f"{localPath} {remoteName} ignored")
         self.successResultOf(deferred)
 
         self.checkPutMessage([(localPath, remoteName, ["100% 0.0B"])])
@@ -677,8 +677,8 @@ class StdioClientTests(TestCase):
         parent = os.path.dirname(first)
         second = self.makeFile(path=os.path.join(parent, secondName))
         flags = filetransfer.FXF_WRITE | filetransfer.FXF_CREAT | filetransfer.FXF_TRUNC
-        firstRemotePath = "/{}".format(firstName)
-        secondRemotePath = "/{}".format(secondName)
+        firstRemotePath = f"/{firstName}"
+        secondRemotePath = f"/{secondName}"
         firstRemoteFile = InMemoryRemoteFile(firstRemotePath)
         secondRemoteFile = InMemoryRemoteFile(secondRemotePath)
         self.fakeFilesystem.put(firstRemotePath, flags, defer.succeed(firstRemoteFile))
@@ -716,8 +716,8 @@ class StdioClientTests(TestCase):
         flags = filetransfer.FXF_WRITE | filetransfer.FXF_CREAT | filetransfer.FXF_TRUNC
         firstRemoteFile = InMemoryRemoteFile(firstName)
         secondRemoteFile = InMemoryRemoteFile(secondName)
-        firstRemotePath = "/remote/{}".format(firstName)
-        secondRemotePath = "/remote/{}".format(secondName)
+        firstRemotePath = f"/remote/{firstName}"
+        secondRemotePath = f"/remote/{secondName}"
         self.fakeFilesystem.put(firstRemotePath, flags, defer.succeed(firstRemoteFile))
         self.fakeFilesystem.put(
             secondRemotePath, flags, defer.succeed(secondRemoteFile)
@@ -936,7 +936,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
         )
         port = self.server.getHost().port
         cmds = test_conch._makeArgs((cmds % port).split(), mod="cftp")
-        log.msg("running {} {}".format(sys.executable, cmds))
+        log.msg(f"running {sys.executable} {cmds}")
         d = defer.Deferred()
         self.processProtocol = SFTPTestProcess(d)
         d.addCallback(lambda _: self.processProtocol.clearBuffer())
@@ -1110,7 +1110,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
             )
             return self.runCommand('rm "test file2"')
 
-        d = self.runCommand('get testfile1 "{}/test file2"'.format(self.testDir.path))
+        d = self.runCommand(f'get testfile1 "{self.testDir.path}/test file2"')
         d.addCallback(_checkGet)
         d.addCallback(
             lambda _: self.assertFalse(self.testDir.child("test file2").exists())
@@ -1158,7 +1158,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
             self.assertTrue(result.endswith(expectedOutput))
             return self.runCommand('rm "test\\"file2"')
 
-        d = self.runCommand('put {}/testfile1 "test\\"file2"'.format(self.testDir.path))
+        d = self.runCommand(f'put {self.testDir.path}/testfile1 "test\\"file2"')
         d.addCallback(_checkPut)
         d.addCallback(
             lambda _: self.assertFalse(self.testDir.child('test"file2').exists())
@@ -1181,7 +1181,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
                 self.testDir.child("shorterFile"), self.testDir.child("longerFile")
             )
 
-        d = self.runCommand("put {}/shorterFile longerFile".format(self.testDir.path))
+        d = self.runCommand(f"put {self.testDir.path}/shorterFile longerFile")
         d.addCallback(_checkPut)
         return d
 
@@ -1201,7 +1201,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
         def _checkPut(result):
             self.assertFilesEqual(someDir.child("file"), self.testDir.child("file"))
 
-        d = self.runCommand("put {}/dir/*".format(self.testDir.path))
+        d = self.runCommand(f"put {self.testDir.path}/dir/*")
         d.addCallback(_checkPut)
         return d
 
@@ -1229,7 +1229,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
 
         d = self.runScript(
             "cd ..",
-            "put {}/testR*".format(self.testDir.path),
+            f"put {self.testDir.path}/testR*",
             "cd %s" % self.testDir.basename(),
         )
         d.addCallback(check)
@@ -1287,7 +1287,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
         cftp client. This test works because the 'remote' server is running
         out of a local directory.
         """
-        d = self.runCommand("lmkdir {}/testLocalDirectory".format(self.testDir.path))
+        d = self.runCommand(f"lmkdir {self.testDir.path}/testLocalDirectory")
         d.addCallback(self.assertEqual, b"")
         d.addCallback(lambda _: self.runCommand("rmdir testLocalDirectory"))
         d.addCallback(self.assertEqual, b"")
@@ -1339,7 +1339,7 @@ class OurServerBatchFileTests(CFTPClientTestBase):
             "-v -b %s 127.0.0.1"
         ) % (port, fn)
         cmds = test_conch._makeArgs(cmds.split(), mod="cftp")[1:]
-        log.msg("running {} {}".format(sys.executable, cmds))
+        log.msg(f"running {sys.executable} {cmds}")
         env = os.environ.copy()
         env["PYTHONPATH"] = os.pathsep.join(sys.path)
 

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -650,7 +650,7 @@ class OpenSSHKeyExchangeTests(ConchServerSetupMixin, OpenSSHClientMixin, TestCas
             pass
 
         if keyExchangeAlgo not in kexAlgorithms:
-            raise SkipTest("{} not supported by ssh client".format(keyExchangeAlgo))
+            raise SkipTest(f"{keyExchangeAlgo} not supported by ssh client")
 
         d = self.execute(
             "echo hello",

--- a/src/twisted/conch/test/test_connection.py
+++ b/src/twisted/conch/test/test_connection.py
@@ -372,7 +372,7 @@ class ConnectionTests(unittest.TestCase):
             common.NS(b"conch-error-args") + b"\x00\x00\x00\x01" * 4
         )
         errors = self.flushLoggedErrors(error.ConchError)
-        self.assertEqual(len(errors), 1, "Expected one error, got: {!r}".format(errors))
+        self.assertEqual(len(errors), 1, f"Expected one error, got: {errors!r}")
         self.assertEqual(errors[0].value.args, (123, "error args in wrong order"))
         self.assertEqual(
             self.transport.packets,

--- a/src/twisted/conch/test/test_default.py
+++ b/src/twisted/conch/test/test_default.py
@@ -179,7 +179,7 @@ class SSHUserAuthClientTests(TestCase):
 
         def _getPassword(prompt):
             self.assertEqual(
-                prompt, "Enter passphrase for key '{}': ".format(self.rsaFile.path)
+                prompt, f"Enter passphrase for key '{self.rsaFile.path}': "
             )
             return nativeString(passphrase)
 

--- a/src/twisted/conch/test/test_endpoints.py
+++ b/src/twisted/conch/test/test_endpoints.py
@@ -307,7 +307,7 @@ class SSHCommandClientEndpointTestsMixin:
         Override this to implement creation in an interesting way the endpoint.
         """
         raise NotImplementedError(
-            "{!r} did not implement create".format(self.__class__.__name__)
+            f"{self.__class__.__name__!r} did not implement create"
         )
 
     def assertClientTransportState(self, client, immediateClose):
@@ -332,7 +332,7 @@ class SSHCommandClientEndpointTestsMixin:
         attempted initiated using C{self.reactor}.
         """
         raise NotImplementedError(
-            "{!r} did not implement finishConnection".format(self.__class__.__name__)
+            f"{self.__class__.__name__!r} did not implement finishConnection"
         )
 
     def connectedServerAndClient(self, serverFactory, clientFactory):
@@ -1504,13 +1504,13 @@ class NewConnectionHelperTests(TestCase):
         knownHosts.addHostKey(b"127.0.0.1", key)
         knownHosts.save()
 
-        msg("Created known_hosts file at {!r}".format(path.path))
+        msg(f"Created known_hosts file at {path.path!r}")
 
         # Unexpand ${HOME} to make sure ~ syntax is respected.
         home = os.path.expanduser("~/")
         default = path.path.replace(home, "~/")
         self.patch(_NewConnectionHelper, "_KNOWN_HOSTS", default)
-        msg("Patched _KNOWN_HOSTS with {!r}".format(default))
+        msg(f"Patched _KNOWN_HOSTS with {default!r}")
 
         loaded = _NewConnectionHelper._knownHosts()
         self.assertTrue(loaded.hasHostKey(b"127.0.0.1", key))

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -186,7 +186,7 @@ class OurServerOurClientTests(SFTPTestBase):
         """
         self.assertTrue(
             filetransfer.ISFTPServer.providedBy(self.server.client),
-            "ISFTPServer not provided by {!r}".format(self.server.client),
+            f"ISFTPServer not provided by {self.server.client!r}",
         )
 
     def test_openedFileClosedWithConnection(self):

--- a/src/twisted/conch/test/test_insults.py
+++ b/src/twisted/conch/test/test_insults.py
@@ -284,7 +284,7 @@ class PrintableCharactersTests(ByteGroupingsMixin, unittest.TestCase):
             self.assertEqual(occurrences(result), [])
 
         occs = occurrences(proto)
-        self.assertFalse(occs, "{!r} should have been []".format(occs))
+        self.assertFalse(occs, f"{occs!r} should have been []")
 
 
 class ServerFunctionKeysTests(ByteGroupingsMixin, unittest.TestCase):
@@ -587,7 +587,7 @@ class ClientControlSequencesTests(unittest.TestCase, MockMixin):
         self.parser.dataReceived(data)
         while calls:
             self.assertCall(occs.pop(0), *calls.pop(0))
-        self.assertFalse(occs, "No other calls should happen: {!r}".format(occs))
+        self.assertFalse(occs, f"No other calls should happen: {occs!r}")
 
     def test_shiftInAfterApplicationData(self):
         """

--- a/src/twisted/conch/test/test_recvline.py
+++ b/src/twisted/conch/test/test_recvline.py
@@ -414,7 +414,7 @@ else:
             width,
             height,
             *a,
-            **kw
+            **kw,
         ):
             self.protocolFactory = protocolFactory
             self.protocolArgs = protocolArgs

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -61,7 +61,7 @@ class ConchTestRealm:
             self.avatar = ConchTestAvatar()
             return interfaces[0], self.avatar, self.avatar.logout
         raise UnauthorizedLogin(
-            "Only {!r} may log in, not {!r}".format(self.expectedAvatarID, avatarID)
+            f"Only {self.expectedAvatarID!r} may log in, not {avatarID!r}"
         )
 
 
@@ -388,7 +388,7 @@ if cryptography is not None and pyasn1 is not None:
                 return
             if not hasattr(self, "expectedLoseConnection"):
                 raise unittest.FailTest(
-                    "unexpectedly lost connection {}\n{}".format(self, reason)
+                    f"unexpectedly lost connection {self}\n{reason}"
                 )
             self.done = 1
 
@@ -409,7 +409,7 @@ if cryptography is not None and pyasn1 is not None:
             self.loseConnection()
 
         def receiveUnimplemented(self, seqID):
-            raise unittest.FailTest("got unimplemented: seqid {}".format(seqID))
+            raise unittest.FailTest(f"got unimplemented: seqid {seqID}")
 
     class ConchTestServer(ConchTestBase, transport.SSHServerTransport):
         def connectionLost(self, reason):
@@ -507,7 +507,7 @@ if cryptography is not None and pyasn1 is not None:
             if dataType == connection.EXTENDED_DATA_STDERR:
                 self.receivedExt.append(data)
             else:
-                log.msg("Unrecognized extended data: {!r}".format(dataType))
+                log.msg(f"Unrecognized extended data: {dataType!r}")
 
         def request_exit_status(self, status):
             [self.status] = struct.unpack(">L", status)

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -353,7 +353,7 @@ def generatePredictableKey(transport):
             x, dh.DHPublicNumbers(y, dh.DHParameterNumbers(p, g))
         ).private_key(default_backend())
     except ValueError:
-        print("\np={}\ng={}\nx={}\n".format(p, g, x))
+        print(f"\np={p}\ng={g}\nx={x}\n")
         raise
     transport.dhSecretKeyPublicMP = common.MP(
         transport.dhSecretKey.public_key().public_numbers().y
@@ -2734,7 +2734,7 @@ class SSHCiphersTests(TestCase):
             self.assertEqual(
                 mac,
                 binascii.hexlify(outMAC.makeMAC(seqid, shortened)),
-                "Failed HMAC test vector; key={!r} data={!r}".format(key, data),
+                f"Failed HMAC test vector; key={key!r} data={data!r}",
             )
 
 

--- a/src/twisted/conch/unix.py
+++ b/src/twisted/conch/unix.py
@@ -223,12 +223,12 @@ class SSHSessionForUnixConchUser:
         shellExec = os.path.basename(shell)
         peer = self.avatar.conn.transport.transport.getPeer()
         host = self.avatar.conn.transport.transport.getHost()
-        self.environ["SSH_CLIENT"] = "{} {} {}".format(peer.host, peer.port, host.port)
+        self.environ["SSH_CLIENT"] = f"{peer.host} {peer.port} {host.port}"
         self.getPtyOwnership()
         self.pty = self._reactor.spawnProcess(
             proto,
             shell,
-            ["-{}".format(shellExec)],
+            [f"-{shellExec}"],
             self.environ,
             homeDir,
             uid,
@@ -251,7 +251,7 @@ class SSHSessionForUnixConchUser:
         command = (shell, "-c", cmd)
         peer = self.avatar.conn.transport.transport.getPeer()
         host = self.avatar.conn.transport.transport.getHost()
-        self.environ["SSH_CLIENT"] = "{} {} {}".format(peer.host, peer.port, host.port)
+        self.environ["SSH_CLIENT"] = f"{peer.host} {peer.port} {host.port}"
         if self.ptyTuple:
             self.getPtyOwnership()
         self.pty = self._reactor.spawnProcess(
@@ -299,9 +299,9 @@ class SSHSessionForUnixConchUser:
                 else:
                     attr[flag] = attr[flag] & ~ttyval
             elif ttyMode == "OSPEED":
-                attr[tty.OSPEED] = getattr(tty, "B{}".format(modeValue))
+                attr[tty.OSPEED] = getattr(tty, f"B{modeValue}")
             elif ttyMode == "ISPEED":
-                attr[tty.ISPEED] = getattr(tty, "B{}".format(modeValue))
+                attr[tty.ISPEED] = getattr(tty, f"B{modeValue}")
             else:
                 if not hasattr(tty, ttyMode):
                     continue

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -136,9 +136,7 @@ class CredTests(unittest.TestCase):
 
         # whitebox
         self.assertEqual(iface, ITestable)
-        self.assertTrue(
-            iface.providedBy(impl), "{} does not implement {}".format(impl, iface)
-        )
+        self.assertTrue(iface.providedBy(impl), f"{impl} does not implement {iface}")
 
         # greybox
         self.assertTrue(impl.original.loggedIn)
@@ -158,9 +156,7 @@ class CredTests(unittest.TestCase):
 
         # whitebox
         self.assertEqual(iface, ITestable)
-        self.assertTrue(
-            iface.providedBy(impl), "{} does not implement {}".format(impl, iface)
-        )
+        self.assertTrue(iface.providedBy(impl), f"{impl} does not implement {iface}")
 
         # greybox
         self.assertTrue(impl.original.loggedIn)

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -215,7 +215,7 @@ class ConnectionPool:
         self.connkw = connkw
 
         for arg in self.CP_ARGS:
-            cpArg = "cp_{}".format(arg)
+            cpArg = f"cp_{arg}"
             if cpArg in connkw:
                 setattr(self, arg, connkw[cpArg])
                 del connkw[cpArg]
@@ -409,7 +409,7 @@ class ConnectionPool:
         conn = self.connections.get(tid)
         if conn is None:
             if self.noisy:
-                log.msg("adbapi connecting: {}".format(self.dbapiName))
+                log.msg(f"adbapi connecting: {self.dbapiName}")
             conn = self.dbapi.connect(*self.connargs, **self.connkw)
             if self.openfun is not None:
                 self.openfun(conn)
@@ -433,7 +433,7 @@ class ConnectionPool:
 
     def _close(self, conn):
         if self.noisy:
-            log.msg("adbapi closing: {}".format(self.dbapiName))
+            log.msg(f"adbapi closing: {self.dbapiName}")
         try:
             conn.close()
         except BaseException:

--- a/src/twisted/internet/_dumbwin32proc.py
+++ b/src/twisted/internet/_dumbwin32proc.py
@@ -398,4 +398,4 @@ class Process(_pollingfile._PollingTimer, BaseProcess):
         """
         Return a string representation of the process.
         """
-        return "<{} pid={}>".format(self.__class__.__name__, self.pid)
+        return f"<{self.__class__.__name__} pid={self.pid}>"

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1192,7 +1192,7 @@ def optionsForClientTLS(
     clientCertificate=None,
     acceptableProtocols=None,
     *,
-    extraCertificateOptions=None
+    extraCertificateOptions=None,
 ):
     """
     Create a L{client connection creator <IOpenSSLClientConnectionCreator>} for

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -327,9 +327,7 @@ class DistinguishedName(dict):
 
     def __setattr__(self, attr, value):
         if attr not in _x509names:
-            raise AttributeError(
-                "{} is not a valid OpenSSL X509 name field".format(attr)
-            )
+            raise AttributeError(f"{attr} is not a valid OpenSSL X509 name field")
         realAttr = _x509names[attr]
         if not isinstance(value, bytes):
             value = value.encode("ascii")
@@ -410,9 +408,7 @@ def _handleattrhelper(Class, transport, methodName):
     and null certificates and raises the appropriate exception or returns the
     appropriate certificate object.
     """
-    method = getattr(
-        transport.getHandle(), "get_{}_certificate".format(methodName), None
-    )
+    method = getattr(transport.getHandle(), f"get_{methodName}_certificate", None)
     if method is None:
         raise CertificateError(
             "non-TLS transport {!r} did not have {} certificate".format(
@@ -583,9 +579,7 @@ class CertificateRequest(CertBase):
         dn = DistinguishedName()
         dn._copyFrom(req.get_subject())
         if not req.verify(req.get_pubkey()):
-            raise VerifyError(
-                "Can't verify that request for {!r} is self-signed.".format(dn)
-            )
+            raise VerifyError(f"Can't verify that request for {dn!r} is self-signed.")
         return Class(req)
 
     def dump(self, format=crypto.FILETYPE_ASN1):
@@ -737,7 +731,7 @@ class PublicKey:
         return self.keyHash() == otherKey.keyHash()
 
     def __repr__(self) -> str:
-        return "<{} {}>".format(self.__class__.__name__, self.keyHash())
+        return f"<{self.__class__.__name__} {self.keyHash()}>"
 
     def keyHash(self):
         """
@@ -761,7 +755,7 @@ class PublicKey:
         return h.hexdigest()
 
     def inspect(self):
-        return "Public Key with Hash: {}".format(self.keyHash())
+        return f"Public Key with Hash: {self.keyHash()}"
 
 
 class KeyPair(PublicKey):

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -513,7 +513,7 @@ def isIPAddress(addr: str, family: int = AF_INET) -> bool:
         if addr.count(".") != 3:
             return False
     else:
-        raise ValueError("unknown address family {!r}".format(family))
+        raise ValueError(f"unknown address family {family!r}")
     try:
         # This might be a native implementation or the one from
         # twisted.python.compat.

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -143,7 +143,7 @@ class UNIXAddress:
         name = self.name
         if name:
             name = _coerceToFilesystemEncoding("", self.name)
-        return "UNIXAddress({!r})".format(name)
+        return f"UNIXAddress({name!r})"
 
     def __hash__(self):
         if self.name is None:

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -57,9 +57,7 @@ class AsyncioSelectorReactor(PosixReactorBase):
         # Windows was changed to return a ProactorEventLoop
         # unless the loop policy has been changed.
         if not isinstance(_eventloop, SelectorEventLoop):
-            raise TypeError(
-                "SelectorEventLoop required, instead got: {}".format(_eventloop)
-            )
+            raise TypeError(f"SelectorEventLoop required, instead got: {_eventloop}")
 
         self._asyncioEventloop = _eventloop  # type: SelectorEventLoop
         self._writers = {}  # type: Dict[Type[FileDescriptor], int]

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -295,9 +295,7 @@ class ThreadedResolver:
         self._runningQueries = {}  # type: Dict[Deferred, Tuple[Deferred, IDelayedCall]]
 
     def _fail(self, name: str, err: str) -> Failure:
-        lookupError = error.DNSLookupError(
-            "address {!r} not found: {}".format(name, err)
-        )
+        lookupError = error.DNSLookupError(f"address {name!r} not found: {err}")
         return Failure(lookupError)
 
     def _cleanup(self, name: str, lookupDeferred: Deferred) -> None:
@@ -358,7 +356,7 @@ class BlockingResolver:
         try:
             address = socket.gethostbyname(name)
         except OSError:
-            msg = "address {!r} not found".format(name)
+            msg = f"address {name!r} not found"
             err = error.DNSLookupError(msg)
             return defer.fail(err)
         else:
@@ -792,7 +790,7 @@ class ReactorBase(PluggableResolverMixin):
         """
         See twisted.internet.interfaces.IReactorCore.addSystemEventTrigger.
         """
-        assert builtins.callable(callable), "{} is not callable".format(callable)
+        assert builtins.callable(callable), f"{callable} is not callable"
         if eventType not in self._eventTriggers:
             self._eventTriggers[eventType] = _ThreePhaseEvent()
         return _SystemEventID(
@@ -868,8 +866,8 @@ class ReactorBase(PluggableResolverMixin):
         """
         See twisted.internet.interfaces.IReactorTime.callLater.
         """
-        assert builtins.callable(callable), "{} is not callable".format(callable)
-        assert delay >= 0, "{} is not greater than or equal to 0 seconds".format(delay)
+        assert builtins.callable(callable), f"{callable} is not callable"
+        assert delay >= 0, f"{delay} is not greater than or equal to 0 seconds"
         delayedCall = DelayedCall(
             self.seconds() + delay,
             callable,
@@ -1101,9 +1099,7 @@ class ReactorBase(PluggableResolverMixin):
         for arg in args:
             _arg = argChecker(arg)
             if _arg is None:
-                raise TypeError(
-                    "Arguments contain a non-string value: {!r}".format(arg)
-                )
+                raise TypeError(f"Arguments contain a non-string value: {arg!r}")
             else:
                 outputArgs.append(_arg)
 
@@ -1151,7 +1147,7 @@ class ReactorBase(PluggableResolverMixin):
             See
             L{twisted.internet.interfaces.IReactorFromThreads.callFromThread}.
             """
-            assert callable(f), "{} is not callable".format(f)
+            assert callable(f), f"{f} is not callable"
             # lists are thread-safe in CPython, but not in Jython
             # this is probably a bug in Jython, but until fixed this code
             # won't work in Jython.
@@ -1218,7 +1214,7 @@ class ReactorBase(PluggableResolverMixin):
         def callFromThread(
             self, f: Callable[..., Any], *args: object, **kwargs: object
         ) -> None:
-            assert callable(f), "{} is not callable".format(f)
+            assert callable(f), f"{f} is not callable"
             # See comment in the other callFromThread implementation.
             self.threadCallQueue.append((f, args, kwargs))
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -416,7 +416,7 @@ class _ThreePhaseEvent:
         phase: str,
         callable: _ThreePhaseEventTriggerCallable,
         *args: object,
-        **kwargs: object
+        **kwargs: object,
     ) -> _ThreePhaseEventTriggerHandle:
         """
         Add a trigger to the indicate phase.
@@ -787,7 +787,7 @@ class ReactorBase(PluggableResolverMixin):
         eventType: str,
         callable: Callable[..., Any],
         *args: object,
-        **kwargs: object
+        **kwargs: object,
     ) -> _SystemEventID:
         """
         See twisted.internet.interfaces.IReactorCore.addSystemEventTrigger.

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -736,8 +736,8 @@ class Deferred:
         elif result is _NO_RESULT:
             result = ""
         else:
-            result = " current result: {!r}".format(result)
-        return "<{} at 0x{:x}{}>".format(cname, myID, result)
+            result = f" current result: {result!r}"
+        return f"<{cname} at 0x{myID:x}{result}>"
 
     __repr__ = __str__
 
@@ -900,7 +900,7 @@ class Deferred:
         @rtype: L{Deferred}
         """
         if not iscoroutine(coro) and not isinstance(coro, types.GeneratorType):
-            raise NotACoroutineError("{!r} is not a coroutine".format(coro))
+            raise NotACoroutineError(f"{coro!r} is not a coroutine")
 
         return _cancellableInlineCallbacks(coro)
 
@@ -952,9 +952,7 @@ def ensureDeferred(coro):
         except NotACoroutineError:
             # It's not a coroutine. Raise an exception, but say that it's also
             # not a Deferred so the error makes sense.
-            raise NotACoroutineError(
-                "{!r} is not a coroutine or a Deferred".format(coro)
-            )
+            raise NotACoroutineError(f"{coro!r} is not a coroutine or a Deferred")
 
 
 class DebugInfo:
@@ -1234,7 +1232,7 @@ class waitForDeferred:
 
         if not isinstance(d, Deferred):
             raise TypeError(
-                "You must give waitForDeferred a Deferred. You gave it {!r}.".format(d)
+                f"You must give waitForDeferred a Deferred. You gave it {d!r}."
             )
         self.d = d
 

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -840,7 +840,7 @@ class HostnameEndpoint:
             # constructor, which is already a native string.
             host = self._hostStr
         elif isIPv6Address(self._hostStr):
-            host = "[{}]".format(self._hostStr)
+            host = f"[{self._hostStr}]"
         else:
             # Convert the bytes representation to a native string to ensure
             # that we display the punycoded version of the hostname, which is
@@ -935,7 +935,7 @@ class HostnameEndpoint:
             or fails a connection-related error.
         """
         if self._badHostname:
-            return defer.fail(ValueError("invalid hostname: {}".format(self._hostStr)))
+            return defer.fail(ValueError(f"invalid hostname: {self._hostStr}"))
 
         d = Deferred()
         addresses = []
@@ -960,9 +960,7 @@ class HostnameEndpoint:
 
         d.addErrback(
             lambda ignored: defer.fail(
-                error.DNSLookupError(
-                    "Couldn't find the hostname '{}'".format(self._hostStr)
-                )
+                error.DNSLookupError(f"Couldn't find the hostname '{self._hostStr}'")
             )
         )
 
@@ -1022,7 +1020,7 @@ class HostnameEndpoint:
             """
             if not endpoints:
                 raise error.DNSLookupError(
-                    "no results for hostname lookup: {}".format(self._hostStr)
+                    f"no results for hostname lookup: {self._hostStr}"
                 )
             iterEndpoints = iter(endpoints)
             pending = []
@@ -1715,7 +1713,7 @@ def _matchPluginToPrefix(plugins, endpointType):
     for plugin in plugins:
         if _matchingString(plugin.prefix.lower(), endpointType) == endpointType:
             return plugin
-    raise ValueError("Unknown endpoint type: '{}'".format(endpointType))
+    raise ValueError(f"Unknown endpoint type: '{endpointType}'")
 
 
 def serverFromString(reactor, description):

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -2226,7 +2226,7 @@ def _parseClientTLS(
     privateKey=None,
     trustRoots=None,
     endpoint=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Internal method to construct an endpoint from string parameters.

--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -92,7 +92,7 @@ class ConnectError(Exception):
     def __str__(self) -> str:
         s = self.MESSAGE
         if self.osError:
-            s = "{}: {}".format(s, self.osError)
+            s = f"{s}: {self.osError}"
         if self.args[0]:
             s = "{}: {}".format(s, self.args[0])
         s = "%s." % s

--- a/src/twisted/internet/inotify.py
+++ b/src/twisted/internet/inotify.py
@@ -379,7 +379,7 @@ class INotify(FileDescriptor):
         path = path.asBytesMode()
         wd = self._isWatched(path)
         if wd is None:
-            raise KeyError("{!r} is not watched".format(path))
+            raise KeyError(f"{path!r} is not watched")
         else:
             self._rmWatch(wd)
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1344,7 +1344,7 @@ class IReactorCore(Interface):
         eventType: str,
         callable: Callable[..., Any],
         *args: object,
-        **kwargs: object
+        **kwargs: object,
     ) -> Any:
         """
         Add a function to be called when a system event occurs.

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -357,7 +357,7 @@ class Server(Connection):
         self.clientAddr = clientAddr
         self.sessionno = sessionno
         logPrefix = self._getLogPrefix(self.protocol)
-        self.logstr = "{},{},{}".format(logPrefix, sessionno, self.clientAddr.host)
+        self.logstr = f"{logPrefix},{sessionno},{self.clientAddr.host}"
         self.repstr = "<{} #{} on {}>".format(
             self.protocol.__class__.__name__,
             self.sessionno,
@@ -490,7 +490,7 @@ class Port(_SocketCloser, _LogOwner):
         """
         Log message for closing port
         """
-        log.msg("({} Port {} Closed)".format(self._type, self._realPortNumber))
+        log.msg(f"({self._type} Port {self._realPortNumber} Closed)")
 
     def connectionLost(self, reason):
         """

--- a/src/twisted/internet/iocpreactor/udp.py
+++ b/src/twisted/internet/iocpreactor/udp.py
@@ -81,9 +81,9 @@ class Port(abstract.FileHandle):
 
     def __repr__(self) -> str:
         if self._realPortNumber is not None:
-            return "<{} on {}>".format(self.protocol.__class__, self._realPortNumber)
+            return f"<{self.protocol.__class__} on {self._realPortNumber}>"
         else:
-            return "<{} not connected>".format(self.protocol.__class__)
+            return f"<{self.protocol.__class__} not connected>"
 
     def getHandle(self):
         """

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -82,7 +82,7 @@ def registerReapProcessHandler(pid, process):
     try:
         auxPID, status = os.waitpid(pid, os.WNOHANG)
     except BaseException:
-        log.msg("Failed to reap {}:".format(pid))
+        log.msg(f"Failed to reap {pid}:")
         log.err()
 
         if pid is None:
@@ -301,7 +301,7 @@ class _BaseProcess(BaseProcess):
                 else:
                     raise
         except BaseException:
-            log.msg("Failed to reap {}:".format(self.pid))
+            log.msg(f"Failed to reap {self.pid}:")
             log.err()
             pid = None
         if pid:
@@ -328,7 +328,7 @@ class _BaseProcess(BaseProcess):
         @type signalID: C{str} or C{int}
         """
         if signalID in ("HUP", "STOP", "INT", "KILL", "TERM"):
-            signalID = getattr(signal, "SIG{}".format(signalID))
+            signalID = getattr(signal, f"SIG{signalID}")
         if self.pid is None:
             raise ProcessExitedAlready()
         try:
@@ -696,7 +696,7 @@ class Process(_BaseProcess):
                     fdmap[childFD] = readFD  # child reads from this
                     helpers[childFD] = writeFD  # parent writes to this
                 else:
-                    assert type(target) == int, "{!r} should be an int".format(target)
+                    assert type(target) == int, f"{target!r} should be an int"
                     fdmap[childFD] = target  # parent ignores this
             if debug:
                 print("fdmap", fdmap)

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -189,7 +189,7 @@ class _InstanceFactory(ClientFactory):
         self.deferred = deferred
 
     def __repr__(self) -> str:
-        return "<ClientCreator factory: {!r}>".format(self.instance)
+        return f"<ClientCreator factory: {self.instance!r}>"
 
     def buildProtocol(self, addr):
         """
@@ -394,7 +394,7 @@ class ReconnectingClientFactory(ClientFactory):
         """
         if not self.continueTrying:
             if self.noisy:
-                log.msg("Abandoning {} on explicit request".format(connector))
+                log.msg(f"Abandoning {connector} on explicit request")
             return
 
         if connector is None:

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -798,7 +798,7 @@ class Server(_TLSServerMixin, Connection):
         self.hostname = client[0]
 
         logPrefix = self._getLogPrefix(self.protocol)
-        self.logstr = "{},{},{}".format(logPrefix, sessionno, self.hostname)
+        self.logstr = f"{logPrefix},{sessionno},{self.hostname}"
         if self.server is not None:
             self.repstr = "<{} #{} on {}>".format(
                 self.protocol.__class__.__name__,
@@ -1442,7 +1442,7 @@ class Port(base.BasePort, _SocketCloser):
         """
         Log message for closing port
         """
-        log.msg("({} Port {} Closed)".format(self._type, self._realPortNumber))
+        log.msg(f"({self._type} Port {self._realPortNumber} Closed)")
 
     def connectionLost(self, reason):
         """
@@ -1493,7 +1493,7 @@ class Connector(base.BaseConnector):
             try:
                 port = socket.getservbyname(port, "tcp")
             except OSError as e:
-                raise error.ServiceNameUnknownError(string="{} ({!r})".format(e, port))
+                raise error.ServiceNameUnknownError(string=f"{e} ({port!r})")
         self.host, self.port = host, port
         if abstract.isIPv6Address(host):
             self._addressType = address.IPv6Address

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -167,5 +167,5 @@ def posixGetLinkLocalIPv6Addresses():
         interface = nativeString(interface)
         address = nativeString(address)
         if family == socket.AF_INET6 and address.startswith("fe80:"):
-            retList.append("{}%{}".format(address, interface))
+            retList.append(f"{address}%{interface}")
     return retList

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -190,7 +190,7 @@ def _getWriters(reactor):
         return reactor.handles
     else:
         # Cannot tell what is going on.
-        raise Exception("Cannot find writers on {!r}".format(reactor))
+        raise Exception(f"Cannot find writers on {reactor!r}")
 
 
 class _AcceptOneClient(ServerFactory):
@@ -243,7 +243,7 @@ class Stop(ClientFactory):
 
     def clientConnectionFailed(self, connector, reason):
         self.failReason = reason
-        msg("Stop(CF) cCFailed: {}".format(reason.getErrorMessage()))
+        msg(f"Stop(CF) cCFailed: {reason.getErrorMessage()}")
         self.reactor.stop()
 
 
@@ -262,7 +262,7 @@ class ClosingLaterProtocol(ConnectableProtocol):
         msg("ClosingLaterProtocol.connectionMade")
 
     def dataReceived(self, bytes):
-        msg("ClosingLaterProtocol.dataReceived {!r}".format(bytes))
+        msg(f"ClosingLaterProtocol.dataReceived {bytes!r}")
         self.transport.loseConnection()
 
     def connectionLost(self, reason):
@@ -326,7 +326,7 @@ class ConnectionTestsMixin:
         )
 
         def listening(port):
-            msg("Listening on {!r}".format(port.getHost()))
+            msg(f"Listening on {port.getHost()!r}")
             endpoint = self.endpoints.client(reactor, port.getHost())
 
             lostConnectionDeferred = Deferred()
@@ -334,13 +334,13 @@ class ConnectionTestsMixin:
             client = endpoint.connect(ClientFactory.forProtocol(protocol))
 
             def write(proto):
-                msg("About to write to {!r}".format(proto))
+                msg(f"About to write to {proto!r}")
                 proto.transport.write(b"x")
 
             client.addCallbacks(write, lostConnectionDeferred.errback)
 
             def disconnected(proto):
-                msg("{!r} disconnected".format(proto))
+                msg(f"{proto!r} disconnected")
                 proto.transport.write(b"some bytes to get lost")
                 proto.transport.writeSequence([b"some", b"more"])
                 finished.append(True)
@@ -374,13 +374,13 @@ class ConnectionTestsMixin:
         )
 
         def listening(port):
-            msg("Listening on {!r}".format(port.getHost()))
+            msg(f"Listening on {port.getHost()!r}")
             endpoint = self.endpoints.client(reactor, port.getHost())
 
             client = endpoint.connect(ClientFactory.forProtocol(lambda: clientProtocol))
 
             def disconnect(proto):
-                msg("About to disconnect {!r}".format(proto))
+                msg(f"About to disconnect {proto!r}")
                 proto.transport.loseConnection()
 
             client.addCallback(disconnect)

--- a/src/twisted/internet/test/process_gireactornocompat.py
+++ b/src/twisted/internet/test/process_gireactornocompat.py
@@ -22,4 +22,4 @@ try:
 except ImportError:
     sys.stdout.write("success")
 else:
-    sys.stdout.write("failure: {} was imported".format(gobject.__path__))
+    sys.stdout.write(f"failure: {gobject.__path__} was imported")

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -336,9 +336,7 @@ class ReactorBuilder:
         timedOutCall = reactor.callLater(timeout, stop)
         reactor.run()
         if timedOut:
-            raise TestTimeoutError(
-                "reactor still running after {} seconds".format(timeout)
-            )
+            raise TestTimeoutError(f"reactor still running after {timeout} seconds")
         else:
             timedOutCall.cancel()
 

--- a/src/twisted/internet/test/test_core.py
+++ b/src/twisted/internet/test/test_core.py
@@ -34,7 +34,7 @@ class ObjectModelIntegrationMixin:
         mro = inspect.getmro(type(instance))
         for subclass in mro:
             self.assertTrue(
-                issubclass(subclass, object), "{!r} is not new-style".format(subclass)
+                issubclass(subclass, object), f"{subclass!r} is not new-style"
             )
 
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -3116,7 +3116,7 @@ class ServerStringTests(unittest.TestCase):
         """
         reactor = object()
         server = endpoints.serverFromString(
-            reactor, "ssl:4321:privateKey={}".format(escapedPEMPathName)
+            reactor, f"ssl:4321:privateKey={escapedPEMPathName}"
         )
         self.assertIsInstance(server, endpoints.SSL4ServerEndpoint)
         self.assertIs(server._reactor, reactor)
@@ -3749,7 +3749,7 @@ class SystemdEndpointPluginTests(unittest.TestCase):
             if isinstance(p, self._parserClass):
                 break
         else:
-            self.fail("Did not find systemd parser in {!r}".format(parsers))
+            self.fail(f"Did not find systemd parser in {parsers!r}")
 
     def test_interface(self):
         """
@@ -3831,7 +3831,7 @@ class TCP6ServerEndpointPluginTests(unittest.TestCase):
             if isinstance(p, self._parserClass):
                 break
         else:
-            self.fail("Did not find TCP6ServerEndpoint parser in {!r}".format(parsers))
+            self.fail(f"Did not find TCP6ServerEndpoint parser in {parsers!r}")
 
     def test_interface(self):
         """
@@ -3875,7 +3875,7 @@ class StandardIOEndpointPluginTests(unittest.TestCase):
             if isinstance(p, self._parserClass):
                 break
         else:
-            self.fail("Did not find StandardIOEndpoint parser in {!r}".format(parsers))
+            self.fail(f"Did not find StandardIOEndpoint parser in {parsers!r}")
 
     def test_interface(self):
         """

--- a/src/twisted/internet/test/test_fdset.py
+++ b/src/twisted/internet/test/test_fdset.py
@@ -290,7 +290,7 @@ class ReactorFDSetTestsBuilder(ReactorBuilder):
             # set without generating a notification.  That means epollreactor
             # will not call any methods on Victim after the close, so there's
             # no chance to notice the socket is no longer valid.
-            raise SkipTest("{!r} cannot detect lost file descriptors".format(name))
+            raise SkipTest(f"{name!r} cannot detect lost file descriptors")
 
         client, server = self._connectedPair()
 

--- a/src/twisted/internet/test/test_iocp.py
+++ b/src/twisted/internet/test/test_iocp.py
@@ -78,7 +78,7 @@ class SupportTests(TestCase):
         for the port to be available, then there might a bug in the code and
         not the test (or a very, very busy VM running the tests).
         """
-        msg("family = {!r}".format(family))
+        msg(f"family = {family!r}")
         port = socket(family, SOCK_STREAM)
         self.addCleanup(port.close)
         port.bind(("", 0))

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -301,7 +301,7 @@ class ProcessTestsBuilderBase(ReactorBuilder):
                 msg("childConnectionLost(%d)" % (fd,))
 
             def processExited(self, reason):
-                msg("processExited({!r})".format(reason))
+                msg(f"processExited({reason!r})")
                 # Protect the Deferred from the failure so that it follows
                 # the callback chain.  This doesn't use the errback chain
                 # because it wants to make sure reason is a Failure.  An
@@ -310,7 +310,7 @@ class ProcessTestsBuilderBase(ReactorBuilder):
                 exited.callback([reason])
 
             def processEnded(self, reason):
-                msg("processEnded({!r})".format(reason))
+                msg(f"processEnded({reason!r})")
 
         reactor = self.buildReactor()
         reactor.callWhenRunning(
@@ -534,7 +534,7 @@ sys.stdout.flush()""".format(
 
         @param which: Either C{b"uid"} or C{b"gid"}.
         """
-        program = ["import os", "raise SystemExit(os.get{}() != 1)".format(which)]
+        program = ["import os", f"raise SystemExit(os.get{which}() != 1)"]
 
         container = []
 
@@ -700,10 +700,10 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
                 lost.append(childFD)
 
             def processExited(self, reason):
-                msg("processExited({!r})".format(reason))
+                msg(f"processExited({reason!r})")
 
             def processEnded(self, reason):
-                msg("processEnded({!r})".format(reason))
+                msg(f"processEnded({reason!r})")
                 ended.callback([reason])
 
         reactor = self.buildReactor()
@@ -752,7 +752,7 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
                     allLost.callback(None)
 
             def processExited(self, reason):
-                msg("processExited({!r})".format(reason))
+                msg(f"processExited({reason!r})")
                 # See test_processExitedWithSignal
                 exited.callback([reason])
                 self.transport.loseConnection()
@@ -777,7 +777,7 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
         def cbExited(args):
             (failure,) = args
             failure.trap(ProcessDone)
-            msg("cbExited; lost = {}".format(lost))
+            msg(f"cbExited; lost = {lost}")
             self.assertEqual(lost, [])
             return allLost
 

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -662,7 +662,7 @@ class TCPClientTestsBase(ReactorBuilder, ConnectionTestsMixin, StreamClientTests
             while True:
                 port = findFreePort(self.interface, self.family)
                 bindAddress = (self.interface, port[1])
-                log.msg("Connect attempt with bindAddress {}".format(bindAddress))
+                log.msg(f"Connect attempt with bindAddress {bindAddress}")
                 try:
                     reactor.connectTCP(
                         fakeDomain,
@@ -741,9 +741,7 @@ class TCPClientTestsBase(ReactorBuilder, ConnectionTestsMixin, StreamClientTests
 
         self.runReactor(reactor)
 
-        self.assertEqual(
-            len(results), 1, "more than one callback result: {}".format(results)
-        )
+        self.assertEqual(len(results), 1, f"more than one callback result: {results}")
 
         if isinstance(results[0], Failure):
             # self.fail(Failure)
@@ -1510,7 +1508,7 @@ class TCPPortTestsMixin:
         """
         Get the expected connection lost message for a TCP port.
         """
-        return "(TCP Port {} Closed)".format(port.getHost().port)
+        return f"(TCP Port {port.getHost().port} Closed)"
 
     def test_portGetHostOnIPv4(self):
         """

--- a/src/twisted/internet/test/test_testing.py
+++ b/src/twisted/internet/test/test_testing.py
@@ -392,7 +392,7 @@ class DeprecationTests(TestCase):
     """
 
     def helper(self, test, obj):
-        new_path = "twisted.internet.testing.{}".format(obj.__name__)
+        new_path = f"twisted.internet.testing.{obj.__name__}"
         warnings = self.flushWarnings([test])
         self.assertEqual(DeprecationWarning, warnings[0]["category"])
         self.assertEqual(1, len(warnings))

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -337,7 +337,7 @@ class TLSPortTestsBuilder(
         """
         Get the expected connection lost message for a TLS port.
         """
-        return "(TLS Port {} Closed)".format(port.getHost().port)
+        return f"(TLS Port {port.getHost().port} Closed)"
 
     def test_badContext(self):
         """

--- a/src/twisted/internet/test/test_udp.py
+++ b/src/twisted/internet/test/test_udp.py
@@ -89,7 +89,7 @@ class DatagramTransportTestsMixin(LogObserverMixin):
         loggedMessages = self.observe()
         reactor = self.buildReactor()
         p = self.getListeningPort(reactor, DatagramProtocol())
-        expectedMessage = "(UDP Port {} Closed)".format(p.getHost().port)
+        expectedMessage = f"(UDP Port {p.getHost().port} Closed)"
 
         def stopReactor(ignored):
             reactor.stop()

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -203,9 +203,7 @@ class ReceiveFileDescriptor(ConnectableProtocol):
         """
         if self.waiting is not None:
             self.waiting.errback(
-                Failure(
-                    Exception("Received bytes ({!r}) before descriptor.".format(data))
-                )
+                Failure(Exception(f"Received bytes ({data!r}) before descriptor."))
             )
             self.waiting = None
 

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -164,9 +164,9 @@ class Port(base.BasePort):
 
     def __repr__(self) -> str:
         if self._realPortNumber is not None:
-            return "<{} on {}>".format(self.protocol.__class__, self._realPortNumber)
+            return f"<{self.protocol.__class__} on {self._realPortNumber}>"
         else:
-            return "<{} not connected>".format(self.protocol.__class__)
+            return f"<{self.protocol.__class__} not connected>"
 
     def getHandle(self):
         """

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -364,7 +364,7 @@ class Port(_UNIXPort, tcp.Port):
                 _coerceToFilesystemEncoding("", self.port),
             )
         else:
-            return "<{} (not listening)>".format(factoryName)
+            return f"<{factoryName} (not listening)>"
 
     def _buildAddr(self, name):
         return address.UNIXAddress(name)
@@ -503,9 +503,9 @@ class DatagramPort(_UNIXPort, udp.Port):
             self.protocol.__class__,
         )
         if hasattr(self, "socket"):
-            return "<{} on {!r}>".format(protocolName, self.port)
+            return f"<{protocolName} on {self.port!r}>"
         else:
-            return "<{} (not listening)>".format(protocolName)
+            return f"<{protocolName} (not listening)>"
 
     def _bindSocket(self):
         log.msg("{} starting on {}".format(self.protocol.__class__, repr(self.port)))

--- a/src/twisted/internet/utils.py
+++ b/src/twisted/internet/utils.py
@@ -41,7 +41,7 @@ class _UnexpectedErrorOutput(IOError):
     """
 
     def __init__(self, text, processEnded):
-        IOError.__init__(self, "got stderr: {!r}".format(text))
+        IOError.__init__(self, f"got stderr: {text!r}")
         self.processEnded = processEnded
 
 

--- a/src/twisted/logger/_filter.py
+++ b/src/twisted/logger/_filter.py
@@ -84,7 +84,7 @@ def shouldLogEvent(predicates: Iterable[ILogFilterPredicate], event: LogEvent) -
             return False
         if result == PredicateResult.maybe:
             continue
-        raise TypeError("Invalid predicate result: {!r}".format(result))
+        raise TypeError(f"Invalid predicate result: {result!r}")
     return True
 
 

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -253,7 +253,7 @@ def _formatEvent(event: LogEvent) -> str:
         elif isinstance(format, bytes):
             format = format.decode("utf-8")
         else:
-            raise TypeError("Log format must be str, not {!r}".format(format))
+            raise TypeError(f"Log format must be str, not {format!r}")
 
         return formatWithCall(format, event)
 

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -147,7 +147,7 @@ class Logger:
         format: str,
         failure: Optional[Failure] = None,
         level: LogLevel = LogLevel.critical,
-        **kwargs: object
+        **kwargs: object,
     ) -> None:
         """
         Log a failure and emit a traceback.

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -101,7 +101,7 @@ class Logger:
         )
 
     def __repr__(self) -> str:
-        return "<{} {!r}>".format(self.__class__.__name__, self.namespace)
+        return f"<{self.__class__.__name__} {self.namespace!r}>"
 
     def emit(
         self, level: LogLevel, format: Optional[str] = None, **kwargs: object

--- a/src/twisted/logger/_observer.py
+++ b/src/twisted/logger/_observer.py
@@ -40,7 +40,7 @@ class LogPublisher:
         @param observer: An L{ILogObserver} to add.
         """
         if not callable(observer):
-            raise TypeError("Observer is not callable: {!r}".format(observer))
+            raise TypeError(f"Observer is not callable: {observer!r}")
         if observer not in self._observers:
             self._observers.append(observer)
 

--- a/src/twisted/logger/_util.py
+++ b/src/twisted/logger/_util.py
@@ -26,9 +26,9 @@ def formatTrace(trace: LogTrace) -> str:
 
     def formatWithName(obj: object) -> str:
         if hasattr(obj, "name"):
-            return "{} ({})".format(obj, obj.name)  # type: ignore[attr-defined]
+            return f"{obj} ({obj.name})"  # type: ignore[attr-defined]
         else:
-            return "{}".format(obj)
+            return f"{obj}"
 
     result = []
     lineage = []  # type: List[Logger]

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -261,7 +261,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
         """
 
         def formatTime(t: Optional[float]) -> str:
-            return "__{}__".format(t)
+            return f"__{t}__"
 
         event = dict(log_format="XYZZY", log_time=12345)
         self.assertEqual(

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -224,8 +224,8 @@ class LogBeginnerTests(unittest.TestCase):
         compareEvents(self, events2, [warning, dict(event="postwarn")])
 
         output = fileHandle.getvalue()
-        self.assertIn("<{}:{}>".format(firstFilename, firstLine), output)
-        self.assertIn("<{}:{}>".format(secondFilename, secondLine), output)
+        self.assertIn(f"<{firstFilename}:{firstLine}>", output)
+        self.assertIn(f"<{secondFilename}:{secondLine}>", output)
 
     def test_criticalLogging(self) -> None:
         """

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -226,9 +226,7 @@ class FileLogObserverTests(TestCase):
             observer = jsonFileLogObserver(fileHandle, recordSeparator)
             event = dict(x=1)
             observer(event)
-            self.assertEqual(
-                fileHandle.getvalue(), '{0}{{"x": 1}}\n'.format(recordSeparator)
-            )
+            self.assertEqual(fileHandle.getvalue(), f'{recordSeparator}{{"x": 1}}\n')
 
     def test_observeWritesDefaultRecordSeparator(self) -> None:
         """

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -57,7 +57,7 @@ class LogComposedObject:
         self.state = state
 
     def __str__(self) -> str:
-        return "<LogComposedObject {state}>".format(state=self.state)
+        return f"<LogComposedObject {self.state}>"
 
 
 class LoggerTests(unittest.TestCase):

--- a/src/twisted/mail/_except.py
+++ b/src/twisted/mail/_except.py
@@ -134,7 +134,7 @@ class SMTPClientError(SMTPError):
 
     def __bytes__(self) -> bytes:
         if self.code > 0:
-            res = ["{:03d} ".format(self.code).encode("utf-8") + self.resp]
+            res = [f"{self.code:03d} ".encode("utf-8") + self.resp]
         else:
             res = [self.resp]
         if self.log:

--- a/src/twisted/mail/alias.py
+++ b/src/twisted/mail/alias.py
@@ -205,7 +205,7 @@ class AddressAlias(AliasBase):
         @rtype: L{bytes}
         @return: A string containing the destination address.
         """
-        return "<Address {}>".format(self.alias)
+        return f"<Address {self.alias}>"
 
     def createMessageReceiver(self):
         """
@@ -314,7 +314,7 @@ class FileWrapper:
         @rtype: L{bytes}
         @return: A string containing the file name of the message.
         """
-        return "<FileWrapper {}>".format(self.finalname)
+        return f"<FileWrapper {self.finalname}>"
 
 
 @implementer(IAlias)
@@ -344,7 +344,7 @@ class FileAlias(AliasBase):
         @rtype: L{bytes}
         @return: A string containing the name of the file.
         """
-        return "<File {}>".format(self.filename)
+        return f"<File {self.filename}>"
 
     def createMessageReceiver(self):
         """
@@ -480,9 +480,7 @@ class MessageWrapper:
         """
         self._timeoutCallID = None
         self.protocol.transport.signalProcess("KILL")
-        exc = ProcessAliasTimeout(
-            "No answer after {} seconds".format(self.completionTimeout)
-        )
+        exc = ProcessAliasTimeout(f"No answer after {self.completionTimeout} seconds")
         self.protocol.onEnd = None
         self.completion.errback(failure.Failure(exc))
 
@@ -498,7 +496,7 @@ class MessageWrapper:
         @rtype: L{bytes}
         @return: A string containing the name of the process.
         """
-        return "<ProcessWrapper {}>".format(self.processName)
+        return f"<ProcessWrapper {self.processName}>"
 
 
 class ProcessAliasProtocol(protocol.ProcessProtocol):
@@ -566,7 +564,7 @@ class ProcessAlias(AliasBase):
         @rtype: L{bytes}
         @return: A string containing the command used to invoke the process.
         """
-        return "<Process {}>".format(self.path)
+        return f"<Process {self.path}>"
 
     def spawnProcess(self, proto, program, path):
         """

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -536,7 +536,7 @@ class Command:
         wantResponse=(),
         continuation=None,
         *contArgs,
-        **contKw
+        **contKw,
     ):
         self.command = command
         self.args = args

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -1263,7 +1263,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
         (iface, avatar, logout) = result
         if iface is not IAccount:
             self.sendBadResponse(tag, b"Server error: login returned unexpected value")
-            log.err("__cbLogin called with {!r}, IAccount expected".format(iface))
+            log.err(f"__cbLogin called with {iface!r}, IAccount expected")
         else:
             self.account = avatar
             self._onLogout = logout
@@ -2627,7 +2627,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
                 log.err()
                 self.transport.loseConnection()
         else:
-            log.err("Cannot dispatch: {}, {!r}, {!r}".format(self.state, tag, rest))
+            log.err(f"Cannot dispatch: {self.state}, {tag!r}, {rest!r}")
             self.transport.loseConnection()
 
     def response_UNAUTH(self, tag, rest):
@@ -2713,7 +2713,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
                 values, _ = self._parseFetchPairs(response[2])
                 flags.setdefault(mId, []).extend(values.get("FLAGS", ()))
             else:
-                log.msg("Unhandled unsolicited response: {}".format(response))
+                log.msg(f"Unhandled unsolicited response: {response}")
 
         if flags:
             self.flagsChanged(flags)
@@ -3201,7 +3201,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
                         nativeString(flag) for flag in content[1]
                     )
                 else:
-                    log.err("Unhandled SELECT response (2): {}".format(split))
+                    log.err(f"Unhandled SELECT response (2): {split}")
             elif len(split) == 2:
                 # Handle FLAGS, EXISTS, and RECENT
                 if split[0].upper() == b"FLAGS":
@@ -3215,11 +3215,11 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
                     elif split[1].upper() == b"RECENT":
                         datum["RECENT"] = self._intOrRaise(split[0], split)
                     else:
-                        log.err("Unhandled SELECT response (0): {}".format(split))
+                        log.err(f"Unhandled SELECT response (0): {split}")
                 else:
-                    log.err("Unhandled SELECT response (1): {}".format(split))
+                    log.err(f"Unhandled SELECT response (1): {split}")
             else:
-                log.err("Unhandled SELECT response (4): {}".format(split))
+                log.err(f"Unhandled SELECT response (4): {split}")
         return datum
 
     def create(self, name):
@@ -3331,7 +3331,7 @@ class IMAP4Client(basic.LineReceiver, policies.TimeoutMixin):
             delimiter and the mailbox name are L{str}s.
         """
         cmd = b"LIST"
-        args = ('"{}" "{}"'.format(reference, wildcard)).encode("imap4-utf-7")
+        args = (f'"{reference}" "{wildcard}"').encode("imap4-utf-7")
         resp = (b"LIST",)
         d = self.sendCommand(Command(cmd, args, wantResponse=resp))
         d.addCallback(self.__cbList, b"LIST")
@@ -4578,7 +4578,7 @@ def Query(sorted=0, **kwarg):
         elif isinstance(v, int):
             cmd.extend([k, "%d" % (v,)])
         else:
-            cmd.extend([k, "{}".format(v)])
+            cmd.extend([k, f"{v}"])
     if len(cmd) > 1:
         return "(" + " ".join(cmd) + ")"
     else:
@@ -4599,7 +4599,7 @@ def Or(*args):
 
 def Not(query):
     """The negation of a query"""
-    return "(NOT {})".format(query)
+    return f"(NOT {query})"
 
 
 def wildcardToRegexp(wildcard, delim=None):
@@ -4959,9 +4959,7 @@ class MemoryAccountWithoutNamespaces:
         # iff there are no hierarchically inferior names, we will
         # delete it from our ken.
         if len(self._inferiorNames(name)) > 1:
-            raise MailboxException(
-                'Name "{}" has inferior hierarchical names'.format(name)
-            )
+            raise MailboxException(f'Name "{name}" has inferior hierarchical names')
         del self.mailboxes[name]
 
     def rename(self, oldname, newname):
@@ -4999,7 +4997,7 @@ class MemoryAccountWithoutNamespaces:
     def unsubscribe(self, name):
         name = _parseMbox(name.upper())
         if name not in self.subscriptions:
-            raise MailboxException("Not currently subscribed to {}".format(name))
+            raise MailboxException(f"Not currently subscribed to {name}")
         self.subscriptions.remove(name)
 
     def listMailboxes(self, ref, wildcard):
@@ -5614,8 +5612,8 @@ class MessageProducer:
             boundary = parts.get("boundary")
             if boundary is None:
                 # Bastards
-                boundary = "----={}".format(self._uuid4().hex)
-                headers["content-type"] += '; boundary="{}"'.format(boundary)
+                boundary = f"----={self._uuid4().hex}"
+                headers["content-type"] += f'; boundary="{boundary}"'
             else:
                 if boundary.startswith('"') and boundary.endswith('"'):
                     boundary = boundary[1:-1]
@@ -5884,7 +5882,7 @@ class _FetchParser:
         elif l.startswith(b"body"):
             used = 4
         else:
-            raise Exception("Nothing recognized in fetch_att: {}".format(l))
+            raise Exception(f"Nothing recognized in fetch_att: {l}")
 
         self.pending_body = b
         self.state.extend(("got_body", "maybe_partial", "maybe_section"))
@@ -5942,7 +5940,7 @@ class _FetchParser:
             elif l.startswith(b"header.fields"):
                 used += 13
             else:
-                raise Exception("Unhandled section contents: {!r}".format(l))
+                raise Exception(f"Unhandled section contents: {l!r}")
 
             self.pending_body.header = h
             self.state.extend(("finish_section", "header_list", "whitespace"))
@@ -6070,14 +6068,14 @@ def parseTime(s):
     }
     m = re.match("%(day)s-%(mon)s-%(year)s" % expr, s)
     if not m:
-        raise ValueError("Cannot parse time string {!r}".format(s))
+        raise ValueError(f"Cannot parse time string {s!r}")
     d = m.groupdict()
     try:
         d["mon"] = 1 + (months.index(d["mon"].lower()) % 12)
         d["year"] = int(d["year"])
         d["day"] = int(d["day"])
     except ValueError:
-        raise ValueError("Cannot parse time string {!r}".format(s))
+        raise ValueError(f"Cannot parse time string {s!r}")
     else:
         return time.struct_time((d["year"], d["mon"], d["day"], 0, 0, 0, -1, -1, -1))
 

--- a/src/twisted/mail/mail.py
+++ b/src/twisted/mail/mail.py
@@ -172,7 +172,7 @@ class DomainWithDefaultDict:
         @return: A string containing the mapping of domain names to domain
             objects.
         """
-        return "<DomainWithDefaultDict {}>".format(self.domains)
+        return f"<DomainWithDefaultDict {self.domains}>"
 
     def __repr__(self) -> str:
         """
@@ -182,7 +182,7 @@ class DomainWithDefaultDict:
         @return: A pseudo-executable string describing the underlying domain
             mapping of this object.
         """
-        return "DomainWithDefaultDict({})".format(self.domains)
+        return f"DomainWithDefaultDict({self.domains})"
 
     def get(self, key, default=None):
         """
@@ -700,7 +700,7 @@ class FileMonitoringService(internet.TimerService):
             except BaseException:
                 now = 0
             if now > mtime:
-                log.msg("{} changed, notifying listener".format(name))
+                log.msg(f"{name} changed, notifying listener")
                 self.files[self.index][3] = now
                 callback(name)
         self._setupMonitor()

--- a/src/twisted/mail/maildir.py
+++ b/src/twisted/mail/maildir.py
@@ -78,7 +78,7 @@ class _MaildirNameGenerator:
         t = self._clock.seconds()
         seconds = str(int(t))
         microseconds = "%07d" % (int((t - int(t)) * 10e6),)
-        return "{}.M{}P{}Q{}.{}".format(seconds, microseconds, self.p, self.n, self.s)
+        return f"{seconds}.M{microseconds}P{self.p}Q{self.n}.{self.s}"
 
 
 _generateMaildirName = _MaildirNameGenerator(reactor).generate
@@ -256,7 +256,7 @@ class AbstractMaildirDomain:
         filename = os.path.join(dir, "tmp", fname)
         fp = open(filename, "w")
         return MaildirMessage(
-            "{}@{}".format(name, domain), fp, filename, os.path.join(dir, "new", fname)
+            f"{name}@{domain}", fp, filename, os.path.join(dir, "new", fname)
         )
 
     def willRelay(self, user, protocol):

--- a/src/twisted/mail/protocols.py
+++ b/src/twisted/mail/protocols.py
@@ -195,7 +195,7 @@ class SMTPFactory(smtp.SMTPFactory):
         @rtype: L{SMTP}
         @return: An SMTP protocol.
         """
-        log.msg("Connection from {}".format(addr))
+        log.msg(f"Connection from {addr}")
         p = smtp.SMTPFactory.buildProtocol(self, addr)
         p.service = self.service
         p.portal = self.portal

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -1087,7 +1087,7 @@ class MXCalculator:
             # try to look up an A record.  This provides behavior described as
             # a special case in RFC 974 in the section headed I{Interpreting
             # the List of MX RRs}.
-            return Failure(error.DNSNameError("No MX records for {!r}".format(domain)))
+            return Failure(error.DNSNameError(f"No MX records for {domain!r}"))
 
     def _ebMX(self, failure, domain):
         """
@@ -1135,5 +1135,5 @@ class MXCalculator:
             d.addCallbacks(cbResolved, ebResolved)
             return d
         elif failure.check(error.DNSNameError):
-            raise OSError("No MX found for {!r}".format(domain))
+            raise OSError(f"No MX found for {domain!r}")
         return failure

--- a/src/twisted/mail/scripts/mailmail.py
+++ b/src/twisted/mail/scripts/mailmail.py
@@ -163,13 +163,13 @@ def parseOptions(argv):
             buffer.write(line)
 
     if not requiredHeaders["from"]:
-        buffer.write("From: {}\r\n".format(o.sender))
+        buffer.write(f"From: {o.sender}\r\n")
     if not requiredHeaders["to"]:
         if not o.to:
             raise SystemExit("No recipients specified.")
         buffer.write("To: {}\r\n".format(", ".join(o.to)))
     if not requiredHeaders["date"]:
-        buffer.write("Date: {}\r\n".format(smtp.rfc822date()))
+        buffer.write(f"Date: {smtp.rfc822date()}\r\n")
 
     buffer.write(line)
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -788,7 +788,7 @@ class SMTP(basic.LineOnlyReceiver, policies.TimeoutMixin):
             msg = "Could not send e-mail"
             resultLen = len(resultList)
             if resultLen > 1:
-                msg += " ({} failures out of {} recipients)".format(failures, resultLen)
+                msg += f" ({failures} failures out of {resultLen} recipients)"
             self.sendCode(550, networkString(msg))
         else:
             self.sendCode(250, b"Delivery in progress")
@@ -805,7 +805,7 @@ class SMTP(basic.LineOnlyReceiver, policies.TimeoutMixin):
             self.deliveryFactory = None
             self.delivery = avatar
         else:
-            raise RuntimeError("{} is not a supported interface".format(iface.__name__))
+            raise RuntimeError(f"{iface.__name__} is not a supported interface")
         self._onLogout = logout
         self.challenger = None
 
@@ -1008,7 +1008,7 @@ class SMTPClient(basic.LineReceiver, policies.TimeoutMixin):
             self.sendError(
                 SMTPProtocolError(
                     -1,
-                    "Invalid response from SMTP server: {}".format(line),
+                    f"Invalid response from SMTP server: {line}",
                     self.log.str(),
                 )
             )
@@ -2238,7 +2238,7 @@ def xtext_encode(s, errors=None):
     for ch in iterbytes(s):
         o = ord(ch)
         if ch == "+" or ch == "=" or o < 33 or o > 126:
-            r.append(networkString("+{:02X}".format(o)))
+            r.append(networkString(f"+{o:02X}"))
         else:
             r.append(bytes((o,)))
     return (b"".join(r), len(s))

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1401,13 +1401,13 @@ class IMAP4HelperTests(TestCase):
         """
         # Check all the printable exclusions
         self.assertEqual(
-            "({} twistedrocks)".format(keyword.upper()),
+            f"({keyword.upper()} twistedrocks)",
             imap4.Query(**{keyword: r'twisted (){%*"\] rocks'}),
         )
 
         # Check all the non-printable exclusions
         self.assertEqual(
-            "({} twistedrocks)".format(keyword.upper()),
+            f"({keyword.upper()} twistedrocks)",
             imap4.Query(
                 **{
                     keyword: "twisted %s rocks"
@@ -1520,9 +1520,7 @@ class IMAP4HelperTests(TestCase):
                 self.assertRaises(TypeError, len, imap4.parseIdList(input))
             else:
                 L = len(imap4.parseIdList(input))
-                self.assertEqual(
-                    L, expected, "len({!r}) = {!r} != {!r}".format(input, L, expected)
-                )
+                self.assertEqual(L, expected, f"len({input!r}) = {L!r} != {expected!r}")
 
     def test_parseTimeInvalidFormat(self):
         """
@@ -2589,7 +2587,7 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
                     expectedContents,
                 )
 
-            self.assertFalse(listed, "More results than expected: {!r}".format(listed))
+            self.assertFalse(listed, f"More results than expected: {listed!r}")
 
         return d
 
@@ -4843,7 +4841,7 @@ class IMAP4ClientExpungeTests(PreauthIMAP4ClientMixin, SynchronousTestCase):
 
     def _response(self, sequenceNumbers):
         for number in sequenceNumbers:
-            self.client.lineReceived(networkString("* {} EXPUNGE".format(number)))
+            self.client.lineReceived(networkString(f"* {number} EXPUNGE"))
         self.client.lineReceived(b"0001 OK EXPUNGE COMPLETED")
 
     def test_expunge(self):

--- a/src/twisted/mail/test/test_mailmail.py
+++ b/src/twisted/mail/test/test_mailmail.py
@@ -120,7 +120,7 @@ class OptionsTests(TestCase):
         # SystemExit.code is None on success
         self.assertEqual(systemExitCode.code, None)
         data = out.getvalue()
-        self.assertEqual(data, "mailmail version: {}\n".format(version))
+        self.assertEqual(data, f"mailmail version: {version}\n")
 
     def test_backgroundDelivery(self):
         """

--- a/src/twisted/mail/test/test_pop3.py
+++ b/src/twisted/mail/test/test_pop3.py
@@ -265,7 +265,7 @@ class MyPOP3Downloader(pop3.POP3Client):
         parts = line.split()
         code = parts[0]
         if code != b"+OK":
-            raise AssertionError("code is: {} , parts is: {} ".format(code, parts))
+            raise AssertionError(f"code is: {code} , parts is: {parts} ")
         self.lines = []
         self.retr(1)
 

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -637,7 +637,7 @@ class POP3ClientModuleStructureTests(TestCase):
             if not pc == "POP3Client":
                 self.assertTrue(
                     hasattr(twisted.mail.pop3, pc),
-                    "{} not in {}".format(pc, twisted.mail.pop3),
+                    f"{pc} not in {twisted.mail.pop3}",
                 )
             else:
                 self.assertTrue(hasattr(twisted.mail.pop3, "AdvancedPOP3Client"))

--- a/src/twisted/names/_rfc1982.py
+++ b/src/twisted/names/_rfc1982.py
@@ -84,9 +84,7 @@ class SerialNumber(FancyStrMixin):
         @raise TypeError: If C{other} is not compatible.
         """
         if not isinstance(other, SerialNumber):
-            raise TypeError(
-                "cannot compare or combine {!r} and {!r}".format(self, other)
-            )
+            raise TypeError(f"cannot compare or combine {self!r} and {other!r}")
 
         if self._serialBits != other._serialBits:
             raise TypeError(

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -412,11 +412,11 @@ class BindAuthority(FileAuthority):
             domain = domain + b"." + owner[:-1]
         else:
             domain = domain[:-1]
-        f = getattr(self, "class_{}".format(cls), None)
+        f = getattr(self, f"class_{cls}", None)
         if f:
             f(ttl, type, domain, rdata)
         else:
-            raise NotImplementedError("Record class {!r} not supported".format(cls))
+            raise NotImplementedError(f"Record class {cls!r} not supported")
 
     def class_IN(self, ttl, type, domain, rdata):
         """

--- a/src/twisted/names/client.py
+++ b/src/twisted/names/client.py
@@ -155,7 +155,7 @@ class Resolver(common.ResolverBase):
             with resolvConf:
                 mtime = os.fstat(resolvConf.fileno()).st_mtime
                 if mtime != self._lastResolvTime:
-                    log.msg("{} changed, reparsing".format(self.resolv))
+                    log.msg(f"{self.resolv} changed, reparsing")
                     self._lastResolvTime = mtime
                     self.parseConfig(resolvConf)
 
@@ -171,7 +171,7 @@ class Resolver(common.ResolverBase):
             if L.startswith(b"nameserver"):
                 resolver = (nativeString(L.split()[1]), dns.PORT)
                 servers.append(resolver)
-                log.msg("Resolver added {!r} to server list".format(resolver))
+                log.msg(f"Resolver added {resolver!r} to server list")
             elif L.startswith(b"domain"):
                 try:
                     self.domain = L.split()[1]

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -478,7 +478,7 @@ class IEncodableRecord(IEncodable, IRecord):
 class Charstr:
     def __init__(self, string=b""):
         if not isinstance(string, bytes):
-            raise ValueError("{!r} is not a byte string".format(string))
+            raise ValueError(f"{string!r} is not a byte string")
         self.string = string
 
     def encode(self, strio, compDict=None):
@@ -683,10 +683,10 @@ class Query:
             self.type, EXT_QUERIES.get(self.type, "UNKNOWN (%d)" % self.type)
         )
         c = QUERY_CLASSES.get(self.cls, "UNKNOWN (%d)" % self.cls)
-        return "<Query {} {} {}>".format(self.name, t, c)
+        return f"<Query {self.name} {t} {c}>"
 
     def __repr__(self) -> str:
-        return "Query({!r}, {!r}, {!r})".format(self.name.name, self.type, self.cls)
+        return f"Query({self.name.name!r}, {self.type!r}, {self.cls!r})"
 
 
 @implementer(IEncodable)
@@ -1243,7 +1243,7 @@ class Record_A(tputil.FancyEqMixin):
         return hash(self.address)
 
     def __str__(self) -> str:
-        return "<A address={} ttl={}>".format(self.dottedQuad(), self.ttl)
+        return f"<A address={self.dottedQuad()} ttl={self.ttl}>"
 
     __repr__ = __str__
 
@@ -2360,7 +2360,7 @@ def _getDisplayableArguments(obj, alwaysShow, fieldNames):
         defaultValue = signature.parameters[name].default
         fieldValue = getattr(obj, name, defaultValue)
         if (name in alwaysShow) or (fieldValue != defaultValue):
-            displayableArgs.append(" {}={!r}".format(name, fieldValue))
+            displayableArgs.append(f" {name}={fieldValue!r}")
 
     return displayableArgs
 
@@ -2410,7 +2410,7 @@ def _compactRepr(
     for name in sectionNames:
         section = getattr(obj, name, [])
         if section:
-            out.append(" {}={!r}".format(name, section))
+            out.append(f" {name}={section!r}")
 
     out.append(">")
 

--- a/src/twisted/names/server.py
+++ b/src/twisted/names/server.py
@@ -398,7 +398,7 @@ class DNSServerFactory(protocol.ServerFactory):
         """
         message.rCode = dns.ENOTIMP
         self.sendReply(protocol, message, address)
-        self._verboseLog("Inverse query from {!r}".format(address))
+        self._verboseLog(f"Inverse query from {address!r}")
 
     def handleStatus(self, message, protocol, address):
         """
@@ -425,7 +425,7 @@ class DNSServerFactory(protocol.ServerFactory):
         """
         message.rCode = dns.ENOTIMP
         self.sendReply(protocol, message, address)
-        self._verboseLog("Status request from {!r}".format(address))
+        self._verboseLog(f"Status request from {address!r}")
 
     def handleNotify(self, message, protocol, address):
         """
@@ -452,7 +452,7 @@ class DNSServerFactory(protocol.ServerFactory):
         """
         message.rCode = dns.ENOTIMP
         self.sendReply(protocol, message, address)
-        self._verboseLog("Notify message from {!r}".format(address))
+        self._verboseLog(f"Notify message from {address!r}")
 
     def handleOther(self, message, protocol, address):
         """

--- a/src/twisted/names/srvconnect.py
+++ b/src/twisted/names/srvconnect.py
@@ -224,9 +224,7 @@ class SRVConnector:
 
                 return str(chosen.target), chosen.port
 
-        raise RuntimeError(
-            "Impossible {} pickServer result.".format(self.__class__.__name__)
-        )
+        raise RuntimeError(f"Impossible {self.__class__.__name__} pickServer result.")
 
     def _reallyConnect(self):
         if self.stopAfterDNS:

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -468,7 +468,7 @@ class RoundtripDNSTests(unittest.TestCase):
             k1, k2 = k(), k()
             hk1 = hash(k1)
             hk2 = hash(k2)
-            self.assertEqual(hk1, hk2, "{} != {} (for {})".format(hk1, hk2, k))
+            self.assertEqual(hk1, hk2, f"{hk1} != {hk2} (for {k})")
 
     def test_Charstr(self):
         """
@@ -2488,7 +2488,7 @@ def assertIsSubdomainOf(testCase, descendant, ancestor):
     """
     testCase.assertTrue(
         dns._isSubdomainOf(descendant, ancestor),
-        "{!r} is not a subdomain of {!r}".format(descendant, ancestor),
+        f"{descendant!r} is not a subdomain of {ancestor!r}",
     )
 
 
@@ -2507,7 +2507,7 @@ def assertIsNotSubdomainOf(testCase, descendant, ancestor):
     """
     testCase.assertFalse(
         dns._isSubdomainOf(descendant, ancestor),
-        "{!r} is a subdomain of {!r}".format(descendant, ancestor),
+        f"{descendant!r} is a subdomain of {ancestor!r}",
     )
 
 

--- a/src/twisted/names/test/test_examples.py
+++ b/src/twisted/names/test/test_examples.py
@@ -56,9 +56,7 @@ class ExampleTestBase:
         for childName in self.exampleRelativePath.split("/"):
             here = here.child(childName)
             if not here.exists():
-                raise SkipTest(
-                    "Examples ({}) not found - cannot test".format(here.path)
-                )
+                raise SkipTest(f"Examples ({here.path}) not found - cannot test")
         self.examplePath = here
 
         # Add the example parent folder to the Python path

--- a/src/twisted/names/test/test_rootresolve.py
+++ b/src/twisted/names/test/test_rootresolve.py
@@ -175,7 +175,7 @@ class RootResolverTests(TestCase):
         resolver = Resolver(roots, maximumQueries)
 
         def query(query, serverAddresses, timeout, filter):
-            msg("Query for QNAME {} at {!r}".format(query.name, serverAddresses))
+            msg(f"Query for QNAME {query.name} at {serverAddresses!r}")
             for addr in serverAddresses:
                 try:
                     server = serverResponses[addr]

--- a/src/twisted/newsfragments/10108.misc
+++ b/src/twisted/newsfragments/10108.misc
@@ -1,0 +1,1 @@
+update lint tooling target versions to py3.6+

--- a/src/twisted/pair/test/test_ip.py
+++ b/src/twisted/pair/test/test_ip.py
@@ -40,7 +40,7 @@ class MyProtocol:
             assert (
                 expectKw[k] == localVariables[k]
             ), "Expected {}={!r}, got {!r}".format(k, expectKw[k], localVariables[k])
-        assert expectData == data, "Expected {!r}, got {!r}".format(expectData, data)
+        assert expectData == data, f"Expected {expectData!r}, got {data!r}"
 
     def addProto(self, num, proto):
         # IRawDatagramProtocol.addProto

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -243,7 +243,7 @@ class TuntapPort(abstract.FileDescriptor):
         self.maxPacketSize = maxPacketSize
 
         logPrefix = self._getLogPrefix(self.protocol)
-        self.logstr = "{} ({})".format(logPrefix, self._mode.name)
+        self.logstr = f"{logPrefix} ({self._mode.name})"
 
     def __repr__(self) -> str:
         args = (fullyQualifiedName(self.protocol.__class__),)  # type: Tuple[str, ...]
@@ -328,9 +328,7 @@ class TuntapPort(abstract.FileDescriptor):
                 self.protocol.datagramReceived(data, partial=0)
             except BaseException:
                 cls = fullyQualifiedName(self.protocol.__class__)
-                log.err(
-                    None, "Unhandled exception from {}.datagramReceived".format(cls)
-                )
+                log.err(None, f"Unhandled exception from {cls}.datagramReceived")
 
     def write(self, datagram):
         """

--- a/src/twisted/persisted/aot.py
+++ b/src/twisted/persisted/aot.py
@@ -127,16 +127,12 @@ class Ref:
 
     def setRef(self, num):
         if self.refnum:
-            raise ValueError(
-                "Error setting id {}, I already have {}".format(num, self.refnum)
-            )
+            raise ValueError(f"Error setting id {num}, I already have {self.refnum}")
         self.refnum = num
 
     def setObj(self, obj):
         if self.obj:
-            raise ValueError(
-                "Error setting obj {}, I already have {}".format(obj, self.obj)
-            )
+            raise ValueError(f"Error setting obj {obj}, I already have {self.obj}")
         self.obj = obj
 
     def getSource(self):
@@ -229,9 +225,7 @@ def prettify(obj):
             out.append(len(obj) and "\n\0)" or ")")
             return "".join(out)
         else:
-            raise TypeError(
-                "Unsupported type {} when trying to prettify {}.".format(t, obj)
-            )
+            raise TypeError(f"Unsupported type {t} when trying to prettify {obj}.")
 
 
 def indentify(s):

--- a/src/twisted/persisted/crefutil.py
+++ b/src/twisted/persisted/crefutil.py
@@ -97,7 +97,7 @@ class _InstanceMethod(NotKnown):
         import traceback
 
         log.msg("instance method {}.{}".format(reflect.qual(self.my_class), self.name))
-        log.msg("being called with {!r} {!r}".format(args, kw))
+        log.msg(f"being called with {args!r} {kw!r}")
         traceback.print_stack(file=log.logfile)
         assert 0
 

--- a/src/twisted/persisted/sob.py
+++ b/src/twisted/persisted/sob.py
@@ -59,11 +59,11 @@ class Persistent:
             finalname = filename
             filename = finalname + "-2"
         elif tag:
-            filename = "{}-{}-2.{}".format(self.name, tag, ext)
-            finalname = "{}-{}.{}".format(self.name, tag, ext)
+            filename = f"{self.name}-{tag}-2.{ext}"
+            finalname = f"{self.name}-{tag}.{ext}"
         else:
-            filename = "{}-2.{}".format(self.name, ext)
-            finalname = "{}.{}".format(self.name, ext)
+            filename = f"{self.name}-2.{ext}"
+            finalname = f"{self.name}.{ext}"
         return finalname, filename
 
     def _saveTemp(self, filename, dumpFunc):

--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -97,7 +97,7 @@ def _pickleFunction(f):
     @rtype: 2-tuple of C{callable, native string}
     """
     if f.__name__ == "<lambda>":
-        raise _UniversalPicklingError("Cannot pickle lambda function: {}".format(f))
+        raise _UniversalPicklingError(f"Cannot pickle lambda function: {f}")
     return (_unpickleFunction, tuple([".".join([f.__module__, f.__qualname__])]))
 
 
@@ -233,7 +233,7 @@ class Ephemeral:
 
             if getattr(gc, "get_referrers", None):
                 for r in gc.get_referrers(self):
-                    log.msg(" referred to by {}".format(r))
+                    log.msg(f" referred to by {r}")
         return None
 
     def __setstate__(self, state):

--- a/src/twisted/plugins/cred_file.py
+++ b/src/twisted/plugins/cred_file.py
@@ -53,7 +53,7 @@ class FileCheckerFactory:
         if not argstring.strip():
             raise ValueError("%r requires a filename" % self.authType)
         elif not FilePath(argstring).isfile():
-            self.errorOutput.write("{}: {}\n".format(invalidFileWarning, argstring))
+            self.errorOutput.write(f"{invalidFileWarning}: {argstring}\n")
         return FilePasswordDB(argstring)
 
 

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -65,7 +65,7 @@ class _BaseSentence:
             return self._sentenceData.get(name, None)
         else:
             className = self.__class__.__name__
-            msg = "{} sentences have no {} attributes".format(className, name)
+            msg = f"{className} sentences have no {name} attributes"
             raise AttributeError(msg)
 
     def __repr__(self) -> str:
@@ -76,13 +76,13 @@ class _BaseSentence:
         @rtype: C{str}
         """
         items = self._sentenceData.items()
-        data = ["{}: {}".format(k, v) for k, v in sorted(items) if k != "type"]
+        data = [f"{k}: {v}" for k, v in sorted(items) if k != "type"]
         dataRepr = ", ".join(data)
 
         typeRepr = self._sentenceData.get("type") or "unknown type"
         className = self.__class__.__name__
 
-        return "<{} ({}) {{{}}}>".format(className, typeRepr, dataRepr)
+        return f"<{className} ({typeRepr}) {{{dataRepr}}}>"
 
 
 class _PositioningSentenceProducerMixin:

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -482,7 +482,7 @@ class Altitude(FancyEqMixin):
         @return: The string representation.
         @rtype: C{str}
         """
-        return "<Altitude ({} m)>".format(self._altitude)
+        return f"<Altitude ({self._altitude} m)>"
 
 
 class _BaseSpeed(FancyEqMixin):
@@ -549,7 +549,7 @@ class _BaseSpeed(FancyEqMixin):
         @rtype: C{str}
         """
         speedValue = round(self.inMetersPerSecond, 2)
-        return "<{} ({} m/s)>".format(self.__class__.__name__, speedValue)
+        return f"<{self.__class__.__name__} ({speedValue} m/s)>"
 
 
 class Speed(_BaseSpeed):
@@ -568,7 +568,7 @@ class Speed(_BaseSpeed):
         @raises ValueError: Raised if C{speed} is negative.
         """
         if speed < 0:
-            raise ValueError("negative speed: {!r}".format(speed))
+            raise ValueError(f"negative speed: {speed!r}")
 
         _BaseSpeed.__init__(self, speed)
 
@@ -846,7 +846,7 @@ class PositioningBeacon:
         @return: The string representation.
         @rtype: C{str}
         """
-        return "<Beacon ({s.identifier})>".format(s=self)
+        return f"<Beacon ({self.identifier})>"
 
 
 class Satellite(PositioningBeacon):

--- a/src/twisted/positioning/nmea.py
+++ b/src/twisted/positioning/nmea.py
@@ -120,7 +120,7 @@ def _split(sentence):
     elif sentence[-1:] == b"*":  # Sentence without checksum
         return sentence[1:-1].split(b",")
     else:
-        raise base.InvalidSentence("malformed sentence {}".format(sentence))
+        raise base.InvalidSentence(f"malformed sentence {sentence}")
 
 
 def _validateChecksum(sentence):
@@ -139,7 +139,7 @@ def _validateChecksum(sentence):
         reference, source = int(sentence[-2:], 16), sentence[1:-3]
         computed = reduce(operator.xor, [ord(x) for x in iterbytes(source)])
         if computed != reference:
-            raise base.InvalidChecksum("{:02x} != {:02x}".format(computed, reference))
+            raise base.InvalidChecksum(f"{computed:02x} != {reference:02x}")
 
 
 class NMEAProtocol(LineReceiver, _sentence._PositioningSentenceProducerMixin):
@@ -527,7 +527,7 @@ class NMEAAdapter:
         elif coordinateType is Angles.VARIATION:
             hemisphereKey = "magneticVariationDirection"
         else:
-            raise ValueError("unknown coordinate type {}".format(coordinateType))
+            raise ValueError(f"unknown coordinate type {coordinateType}")
 
         hemisphere = getattr(self.currentSentence, hemisphereKey).upper()
 
@@ -536,7 +536,7 @@ class NMEAAdapter:
         elif hemisphere in "SW":
             return -1
         else:
-            raise ValueError("bad hemisphere/direction: {}".format(hemisphere))
+            raise ValueError(f"bad hemisphere/direction: {hemisphere}")
 
     def _convert(self, key, converter):
         """

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -553,7 +553,7 @@ class RemoteAmpError(AmpError):
         # Backslash-escape errorCode. Python 3.5 can do this natively
         # ("backslashescape") but Python 2.7 and Python 3.4 can't.
         errorCodeForMessage = "".join(
-            "\\x{:2x}".format(c) if c >= 0x80 else chr(c) for c in errorCode
+            f"\\x{c:2x}" if c >= 0x80 else chr(c) for c in errorCode
         )
 
         if othertb:
@@ -671,9 +671,7 @@ class AmpBox(dict):
             if type(k) == str:
                 raise TypeError("Unicode key not allowed: %r" % k)
             if type(v) == str:
-                raise TypeError(
-                    "Unicode value for key {!r} not allowed: {!r}".format(k, v)
-                )
+                raise TypeError(f"Unicode value for key {k!r} not allowed: {v!r}")
             if len(k) > MAX_KEY_LENGTH:
                 raise TooLong(True, True, k, None)
             if len(v) > MAX_VALUE_LENGTH:
@@ -717,7 +715,7 @@ class QuitBox(AmpBox):
     __slots__ = []  # type: List[str]
 
     def __repr__(self) -> str:
-        return "QuitBox(**{})".format(super().__repr__())
+        return f"QuitBox(**{super().__repr__()})"
 
     def _sendTo(self, proto):
         """
@@ -1055,7 +1053,7 @@ class BoxDispatcher:
         cmd = box[COMMAND]
         responder = self.locator.locateResponder(cmd)
         if responder is None:
-            description = "Unhandled Command: {!r}".format(cmd)
+            description = f"Unhandled Command: {cmd!r}"
             return fail(
                 RemoteAmpError(
                     UNHANDLED_ERROR_CODE,
@@ -1466,7 +1464,7 @@ class Float(Argument):
 
     def toString(self, inString):
         if not isinstance(inString, float):
-            raise ValueError("Bad float value {!r}".format(inString))
+            raise ValueError(f"Bad float value {inString!r}")
         return str(inString).encode("ascii")
 
 
@@ -1481,7 +1479,7 @@ class Boolean(Argument):
         elif inString == b"False":
             return False
         else:
-            raise TypeError("Bad boolean value: {!r}".format(inString))
+            raise TypeError(f"Bad boolean value: {inString!r}")
 
     def toString(self, inObject):
         if inObject:
@@ -1707,14 +1705,10 @@ class _CommandMeta(type):
             )
         for name, _ in newtype.arguments:
             if not isinstance(name, bytes):
-                raise TypeError(
-                    "Argument names must be byte strings, got: {!r}".format(name)
-                )
+                raise TypeError(f"Argument names must be byte strings, got: {name!r}")
         for name, _ in newtype.response:
             if not isinstance(name, bytes):
-                raise TypeError(
-                    "Response names must be byte strings, got: {!r}".format(name)
-                )
+                raise TypeError(f"Response names must be byte strings, got: {name!r}")
 
         errors = {}  # type: Dict[Type[Exception], bytes]
         fatalErrors = {}  # type: Dict[Type[Exception], bytes]
@@ -1735,13 +1729,11 @@ class _CommandMeta(type):
 
         for _, name in newtype.errors.items():
             if not isinstance(name, bytes):
-                raise TypeError(
-                    "Error names must be byte strings, got: {!r}".format(name)
-                )
+                raise TypeError(f"Error names must be byte strings, got: {name!r}")
         for _, name in newtype.fatalErrors.items():
             if not isinstance(name, bytes):
                 raise TypeError(
-                    "Fatal error names must be byte strings, got: {!r}".format(name)
+                    f"Fatal error names must be byte strings, got: {name!r}"
                 )
 
         return newtype
@@ -1872,7 +1864,7 @@ class Command(metaclass=_CommandMeta):
 
         for intendedArg in objects:
             if intendedArg not in allowedNames:
-                raise InvalidSignature("{} is not a valid argument".format(intendedArg))
+                raise InvalidSignature(f"{intendedArg} is not a valid argument")
         return _objectsToStrings(objects, cls.arguments, cls.commandType(), proto)
 
     @classmethod
@@ -2573,7 +2565,7 @@ class AMP(BinaryBoxProtocol, BoxDispatcher, CommandLocator, SimpleStringLocator)
         AMP connection.
         """
         if self.innerProtocol is not None:
-            innerRepr = " inner {!r}".format(self.innerProtocol)
+            innerRepr = f" inner {self.innerProtocol!r}"
         else:
             innerRepr = ""
         return "<{}{} at 0x{:x}>".format(self.__class__.__name__, innerRepr, id(self))
@@ -2791,7 +2783,7 @@ class DateTime(Argument):
         s = nativeString(s)
 
         if len(s) != 32:
-            raise ValueError("invalid date format {!r}".format(s))
+            raise ValueError(f"invalid date format {s!r}")
 
         values = [int(s[p]) for p in self._positions]
         sign = s[26]

--- a/src/twisted/protocols/dict.py
+++ b/src/twisted/protocols/dict.py
@@ -122,9 +122,7 @@ class DictClient(basic.LineReceiver):
                 return
             code = int(line[:3])
             line = line[4:]
-        method = getattr(
-            self, "dictCode_{}_{}".format(code, self.state), self.dictCode_default
-        )
+        method = getattr(self, f"dictCode_{code}_{self.state}", self.dictCode_default)
         method(line)
 
     def dictCode_default(self, line):

--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -804,7 +804,7 @@ class FTP(basic.LineReceiver, policies.TimeoutMixin):
                 msg in err.value.args[0]
                 for msg in ("takes exactly", "required positional argument")
             ):
-                self.reply(SYNTAX_ERR, "{} requires an argument.".format(cmd))
+                self.reply(SYNTAX_ERR, f"{cmd} requires an argument.")
             else:
                 log.msg("Unexpected FTP error")
                 log.err(err)
@@ -886,7 +886,7 @@ class FTP(basic.LineReceiver, policies.TimeoutMixin):
             else:
                 return dtpPort
         raise error.CannotListenError(
-            "", portn, "No port available in range {}".format(self.passivePortRange)
+            "", portn, f"No port available in range {self.passivePortRange}"
         )
 
     def ftp_USER(self, username):
@@ -1562,7 +1562,7 @@ class FTPFactory(policies.LimitTotalConnectionsFactory):
     userAnonymous = "anonymous"
     timeOut = 600
 
-    welcomeMessage = "Twisted {} FTP Server".format(copyright.version)
+    welcomeMessage = f"Twisted {copyright.version} FTP Server"
 
     passivePortRange = range(0, 1)
 
@@ -1808,7 +1808,7 @@ def _testPermissions(uid, gid, spath, mode="r"):
         oth = stat.S_IWOTH
         amode = os.W_OK
     else:
-        raise ValueError("Invalid mode {!r}: must specify 'r' or 'w'".format(mode))
+        raise ValueError(f"Invalid mode {mode!r}: must specify 'r' or 'w'")
 
     access = False
     if os.path.exists(spath):
@@ -2218,7 +2218,7 @@ class BaseFTPRealm:
         @rtype: L{FilePath}
         """
         raise NotImplementedError(
-            "{!r} did not override getHomeDirectory".format(self.__class__)
+            f"{self.__class__!r} did not override getHomeDirectory"
         )
 
     def requestAvatar(self, avatarId, mind, *interfaces):
@@ -2411,7 +2411,7 @@ def decodeHostPort(line):
         if x < 0 or x > 255:
             raise ValueError("Out of range", line, x)
     a, b, c, d, e, f = parsed
-    host = "{}.{}.{}.{}".format(a, b, c, d)
+    host = f"{a}.{b}.{c}.{d}"
     port = (int(e) << 8) + int(f)
     return host, port
 
@@ -2648,7 +2648,7 @@ class FTPClientBasic(basic.LineReceiver):
             self.nextDeferred.errback(failure.Failure(CommandFailed(response)))
         else:
             # This shouldn't happen unless something screwed up.
-            log.msg("Server sent invalid response code {}".format(code))
+            log.msg(f"Server sent invalid response code {code}")
             self.nextDeferred.errback(failure.Failure(BadResponse(response)))
 
         # Run the next command

--- a/src/twisted/protocols/haproxy/_wrapper.py
+++ b/src/twisted/protocols/haproxy/_wrapper.py
@@ -83,7 +83,7 @@ class HAProxyWrappingFactory(policies.WrappingFactory):
             logPrefix = self.wrappedFactory.logPrefix()
         else:
             logPrefix = self.wrappedFactory.__class__.__name__
-        return "{} (PROXY)".format(logPrefix)
+        return f"{logPrefix} (PROXY)"
 
 
 def proxyEndpoint(wrappedEndpoint):

--- a/src/twisted/protocols/ident.py
+++ b/src/twisted/protocols/ident.py
@@ -215,7 +215,7 @@ class IdentClient(basic.LineOnlyReceiver):
 
     def lineReceived(self, line):
         if not self.queries:
-            log.msg("Unexpected server response: {!r}".format(line))
+            log.msg(f"Unexpected server response: {line!r}")
         else:
             d, _, _ = self.queries.pop(0)
             self.parseResponse(d, line)

--- a/src/twisted/protocols/loopback.py
+++ b/src/twisted/protocols/loopback.py
@@ -322,7 +322,7 @@ class LoopbackRelay:
         self.producer = None
 
     def logPrefix(self):
-        return "Loopback({!r})".format(self.target.__class__.__name__)
+        return f"Loopback({self.target.__class__.__name__!r})"
 
 
 class LoopbackClientFactory(protocol.ClientFactory):

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -32,7 +32,7 @@ def _wrappedLogPrefix(wrapper, wrapped):
         logPrefix = wrapped.logPrefix()
     else:
         logPrefix = wrapped.__class__.__name__
-    return "{} ({})".format(logPrefix, wrapper.__class__.__name__)
+    return f"{logPrefix} ({wrapper.__class__.__name__})"
 
 
 class ProtocolWrapper(Protocol):

--- a/src/twisted/protocols/portforward.py
+++ b/src/twisted/protocols/portforward.py
@@ -23,7 +23,7 @@ class Proxy(protocol.Protocol):
             self.peer.transport.loseConnection()
             self.peer = None
         elif self.noisy:
-            log.msg("Unable to connect to peer: {}".format(reason))
+            log.msg(f"Unable to connect to peer: {reason}")
 
     def dataReceived(self, data):
         self.peer.transport.write(data)

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -165,7 +165,7 @@ class Via:
         rport=_absent,
         branch=None,
         maddr=None,
-        **kw
+        **kw,
     ):
         """
         Set parameters of this Via header. All arguments correspond to

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -236,24 +236,24 @@ class Via:
         """
         Serialize this header for use in a request or response.
         """
-        s = "SIP/2.0/{} {}:{}".format(self.transport, self.host, self.port)
+        s = f"SIP/2.0/{self.transport} {self.host}:{self.port}"
         if self.hidden:
             s += ";hidden"
         for n in "ttl", "branch", "maddr", "received":
             value = getattr(self, n)
             if value is not None:
-                s += ";{}={}".format(n, value)
+                s += f";{n}={value}"
         if self.rportRequested:
             s += ";rport"
         elif self.rportValue is not None:
-            s += ";rport={}".format(self.rport)
+            s += f";rport={self.rport}"
 
         etc = sorted(self.otherParams.items())
         for k, v in etc:
             if v is None:
                 s += ";" + k
             else:
-                s += ";{}={}".format(k, v)
+                s += f";{k}={v}"
         return s
 
 
@@ -271,7 +271,7 @@ def parseViaHeader(value):
     result = {}
     pname, pversion, transport = protocolinfo.split("/")
     if pname != "SIP" or pversion != "2.0":
-        raise ValueError("wrong protocol or version: {!r}".format(value))
+        raise ValueError(f"wrong protocol or version: {value!r}")
     result["transport"] = transport
     if ":" in by:
         host, port = by.split(":")
@@ -356,7 +356,7 @@ class URL:
         for n in ("transport", "ttl", "maddr", "method", "tag"):
             v = getattr(self, n)
             if v != None:
-                w(";{}={}".format(n, v))
+                w(f";{n}={v}")
         for v in self.other:
             w(";%s" % v)
         if self.headers:
@@ -557,7 +557,7 @@ class Request(Message):
         return "<SIP Request %d:%s %s>" % (id(self), self.method, self.uri.toString())
 
     def _getHeaderLine(self):
-        return "{} {} SIP/2.0".format(self.method, self.uri.toString())
+        return f"{self.method} {self.uri.toString()} SIP/2.0"
 
 
 class Response(Message):
@@ -576,7 +576,7 @@ class Response(Message):
         return "<SIP Response %d:%s>" % (id(self), self.code)
 
     def _getHeaderLine(self):
-        return "SIP/2.0 {} {}".format(self.code, self.phrase)
+        return f"SIP/2.0 {self.code} {self.phrase}"
 
 
 class MessagesParser(basic.LineReceiver):
@@ -764,7 +764,7 @@ class Base(protocol.DatagramProtocol):
         for m in self.messages:
             self._fixupNAT(m, addr)
             if self.debug:
-                log.msg("Received {!r} from {!r}".format(m.toString(), addr))
+                log.msg(f"Received {m.toString()!r} from {addr!r}")
             if isinstance(m, Request):
                 self.handle_request(m, addr)
             else:
@@ -818,7 +818,7 @@ class Base(protocol.DatagramProtocol):
         if destURL.transport not in ("udp", None):
             raise RuntimeError("only UDP currently supported")
         if self.debug:
-            log.msg("Sending {!r} to {!r}".format(message.toString(), destURL))
+            log.msg(f"Sending {message.toString()!r} to {destURL!r}")
         data = message.toString()
         if isinstance(data, str):
             data = data.encode("utf-8")
@@ -1094,9 +1094,9 @@ class RegisterProxy(Proxy):
         for scheme, auth in self.authorizers.items():
             chal = auth.getChallenge((host, port))
             if chal is None:
-                value = '{} realm="{}"'.format(scheme.title(), self.host)
+                value = f'{scheme.title()} realm="{self.host}"'
             else:
-                value = '{} {},realm="{}"'.format(scheme.title(), chal, self.host)
+                value = f'{scheme.title()} {chal},realm="{self.host}"'
             m.headers.setdefault("www-authenticate", []).append(value)
         self.deliverResponse(m)
 
@@ -1243,9 +1243,7 @@ class InMemoryRegistry:
             dc.reset(3600)
         else:
             dc = reactor.callLater(3600, self._expireRegistration, logicalURL.username)
-        log.msg(
-            "Registered {} at {}".format(logicalURL.toString(), physicalURL.toString())
-        )
+        log.msg(f"Registered {logicalURL.toString()} at {physicalURL.toString()}")
         self.users[logicalURL.username] = (dc, physicalURL)
         return defer.succeed(Registration(int(dc.getTime() - time.time()), physicalURL))
 

--- a/src/twisted/protocols/socks.py
+++ b/src/twisted/protocols/socks.py
@@ -149,7 +149,7 @@ class SOCKSv4(protocol.Protocol):
             d = self.listenClass(0, SOCKSv4IncomingFactory, self, server)
             d.addCallback(lambda x, self=self: self.makeReply(90, 0, x[1], x[0]))
         else:
-            raise RuntimeError("Bad Connect Code: {}".format(code))
+            raise RuntimeError(f"Bad Connect Code: {code}")
         assert self.buf == b"", "hmm, still stuff in buffer... %s" % repr(self.buf)
 
     def connectionLost(self, reason):

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -759,7 +759,7 @@ class TLSMemoryBIOFactory(WrappingFactory):
             logPrefix = self.wrappedFactory.logPrefix()
         else:
             logPrefix = self.wrappedFactory.__class__.__name__
-        return "{} (TLS)".format(logPrefix)
+        return f"{logPrefix} (TLS)"
 
     def _applyProtocolNegotiation(self, connection):
         """

--- a/src/twisted/python/_inotify.py
+++ b/src/twisted/python/_inotify.py
@@ -43,7 +43,7 @@ def add(fd: int, path: FilePath, mask: int) -> int:
     """
     wd = cast(int, libc.inotify_add_watch(fd, path.asBytesMode().path, mask))
     if wd < 0:
-        raise INotifyError("Failed to add watch on '{!r}' - ({!r})".format(path, wd))
+        raise INotifyError(f"Failed to add watch on '{path!r}' - ({wd!r})")
     return wd
 
 

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -68,7 +68,7 @@ class TwistedSphinxInventory(SphinxInventory):
             if relativeLink is None:
                 return None
 
-            return "{}/{}".format(baseURL, relativeLink)
+            return f"{baseURL}/{relativeLink}"
 
         return None
 

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -118,7 +118,7 @@ class GitCommand:
             runCommand(["git", "rev-parse"], cwd=path.path)
         except (CalledProcessError, OSError):
             raise NotWorkingDirectory(
-                "{} does not appear to be a Git repository.".format(path.path)
+                f"{path.path} does not appear to be a Git repository."
             )
 
     @staticmethod
@@ -193,9 +193,7 @@ def getRepositoryCommand(directory):
         # It's not Git, but that's okay, eat the error
         pass
 
-    raise NotWorkingDirectory(
-        "No supported VCS can be found in {}".format(directory.path)
-    )
+    raise NotWorkingDirectory(f"No supported VCS can be found in {directory.path}")
 
 
 class Project:
@@ -212,7 +210,7 @@ class Project:
         self.directory = directory
 
     def __repr__(self) -> str:
-        return "{}({!r})".format(self.__class__.__name__, self.directory)
+        return f"{self.__class__.__name__}({self.directory!r})"
 
     def getVersion(self):
         """
@@ -373,7 +371,7 @@ class SphinxBuilder:
         """
         output = self.build(FilePath(args[0]).child("docs"))
         if output:
-            sys.stdout.write("Unclean build:\n{}\n".format(output))
+            sys.stdout.write(f"Unclean build:\n{output}\n")
             raise sys.exit(1)
 
     def build(self, docDir, buildDir=None, version=""):

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -140,7 +140,7 @@ class SubcommandAction(usage.Completer):
     def _shellCode(self, optName, shellType):
         if shellType == usage._ZSH:
             return "*::subcmd:->subcmd"
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class ZshBuilder:
@@ -574,7 +574,7 @@ class ZshArgumentsGenerator:
             return action._shellCode(longname, usage._ZSH)
 
         if longname in self.paramNameToDefinition:
-            return ":{}:_files".format(longname)
+            return f":{longname}:_files"
         return ""
 
     def getDescription(self, longname):

--- a/src/twisted/python/_tzhelper.py
+++ b/src/twisted/python/_tzhelper.py
@@ -59,7 +59,7 @@ class FixedOffsetTimeZone(TZInfo):
             hours = -hours
             minutes = -minutes
         elif sign != "+":
-            raise ValueError("Invalid sign for timezone {!r}".format(sign))
+            raise ValueError(f"Invalid sign for timezone {sign!r}")
         return cls(TimeDelta(hours=hours, minutes=minutes), name)
 
     @classmethod

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -67,7 +67,7 @@ def registerAdapter(adapterFactory, origInterface, *interfaceClasses):
     for interfaceClass in interfaceClasses:
         factory = self.registered([origInterface], interfaceClass)
         if factory is not None and not ALLOW_DUPLICATES:
-            raise ValueError("an adapter ({}) was already registered.".format(factory))
+            raise ValueError(f"an adapter ({factory}) was already registered.")
     for interfaceClass in interfaceClasses:
         self.register([origInterface], interfaceClass, "", adapterFactory)
 

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -123,17 +123,17 @@ def _fullyQualifiedName(obj):
 
     if inspect.isclass(obj) or inspect.isfunction(obj):
         moduleName = obj.__module__
-        return "{}.{}".format(moduleName, name)
+        return f"{moduleName}.{name}"
     elif inspect.ismethod(obj):
         try:
             cls = obj.im_class
         except AttributeError:
             # Python 3 eliminates im_class, substitutes __module__ and
             # __qualname__ to provide similar information.
-            return "{}.{}".format(obj.__module__, obj.__qualname__)
+            return f"{obj.__module__}.{obj.__qualname__}"
         else:
             className = _fullyQualifiedName(cls)
-            return "{}.{}".format(className, name)
+            return f"{className}.{name}"
     return name
 
 
@@ -155,7 +155,7 @@ def _getReplacementString(replacement):
     """
     if callable(replacement):
         replacement = _fullyQualifiedName(replacement)
-    return "please use {} instead".format(replacement)
+    return f"please use {replacement} instead"
 
 
 def _getDeprecationDocstring(version, replacement=None):
@@ -703,13 +703,11 @@ def _passedSignature(signature, positional, keyword):
         elif param.kind == inspect.Parameter.KEYWORD_ONLY:
             if name not in keyword:
                 if param.default == inspect.Parameter.empty:
-                    raise TypeError("missing keyword arg {}".format(name))
+                    raise TypeError(f"missing keyword arg {name}")
                 else:
                     result[name] = param.default
         else:
-            raise TypeError(
-                "'{}' parameter is invalid kind: {}".format(name, param.kind)
-            )
+            raise TypeError(f"'{name}' parameter is invalid kind: {param.kind}")
 
     if len(positional) > numPositional:
         raise TypeError("Too many arguments.")

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -56,10 +56,10 @@ def format_frames(frames, write, detail="default"):
     w = write
     if detail == "brief":
         for method, filename, lineno, localVars, globalVars in frames:
-            w("{}:{}:{}\n".format(filename, lineno, method))
+            w(f"{filename}:{lineno}:{method}\n")
     elif detail == "default":
         for method, filename, lineno, localVars, globalVars in frames:
-            w('  File "{}", line {}, in {}\n'.format(filename, lineno, method))
+            w(f'  File "{filename}", line {lineno}, in {method}\n')
             w("    %s\n" % linecache.getline(filename, lineno).strip())
     elif detail == "verbose-vars-not-captured":
         for method, filename, lineno, localVars, globalVars in frames:
@@ -705,7 +705,7 @@ class Failure(BaseException):
         if self.frames:
             if not elideFrameworkCode:
                 format_frames(self.stack[-traceupLength:], w, formatDetail)
-                w("{}\n".format(EXCEPTION_CAUGHT_HERE))
+                w(f"{EXCEPTION_CAUGHT_HERE}\n")
             format_frames(self.frames, w, formatDetail)
         elif not detail == "brief":
             # Yeah, it's not really a traceback, despite looking like one...

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -417,7 +417,7 @@ class AbstractFilePath:
             p = p.parent()
         if f == ancestor and segments:
             return segments
-        raise ValueError("{!r} not parent of {!r}".format(ancestor, self))
+        raise ValueError(f"{ancestor!r} not parent of {self!r}")
 
     # new in 8.0
     def __hash__(self):
@@ -744,17 +744,15 @@ class FilePath(AbstractFilePath):
 
         if platform.isWindows() and path.count(colon):
             # Catch paths like C:blah that don't have a slash
-            raise InsecurePath("{!r} contains a colon.".format(path))
+            raise InsecurePath(f"{path!r} contains a colon.")
 
         norm = normpath(path)
         if sep in norm:
-            raise InsecurePath(
-                "{!r} contains one or more directory separators".format(path)
-            )
+            raise InsecurePath(f"{path!r} contains one or more directory separators")
 
         newpath = abspath(joinpath(ourPath, norm))
         if not newpath.startswith(ourPath):
-            raise InsecurePath("{!r} is not a child of {}".format(newpath, ourPath))
+            raise InsecurePath(f"{newpath!r} is not a child of {ourPath}")
         return self.clonePath(newpath)
 
     def preauthChild(self, path):
@@ -772,7 +770,7 @@ class FilePath(AbstractFilePath):
 
         newpath = abspath(joinpath(ourPath, normpath(path)))
         if not newpath.startswith(ourPath):
-            raise InsecurePath("{} is not a child of {}".format(newpath, ourPath))
+            raise InsecurePath(f"{newpath} is not a child of {ourPath}")
         return self.clonePath(newpath)
 
     def childSearchPreauth(self, *paths):
@@ -1245,7 +1243,7 @@ class FilePath(AbstractFilePath):
         return splitext(self.path)
 
     def __repr__(self) -> str:
-        return "FilePath({!r})".format(self.path)
+        return f"FilePath({self.path!r})"
 
     def touch(self):
         """

--- a/src/twisted/python/lockfile.py
+++ b/src/twisted/python/lockfile.py
@@ -217,7 +217,7 @@ class FilesystemLock:
         """
         pid = readlink(self.name)
         if int(pid) != os.getpid():
-            raise ValueError("Lock {!r} not owned by this process".format(self.name))
+            raise ValueError(f"Lock {self.name!r} not owned by this process")
         rmlink(self.name)
         self.locked = False
 

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -269,7 +269,7 @@ class PythonAttribute:
         self.pythonValue = pythonValue
 
     def __repr__(self) -> str:
-        return "PythonAttribute<{!r}>".format(self.name)
+        return f"PythonAttribute<{self.name!r}>"
 
     def isLoaded(self):
         """
@@ -331,7 +331,7 @@ class PythonModule(_ModuleIteratorHelper):
         """
         Return a string representation including the module name.
         """
-        return "PythonModule<{!r}>".format(self.name)
+        return f"PythonModule<{self.name!r}>"
 
     def isLoaded(self):
         """
@@ -455,7 +455,7 @@ class PathEntry(_ModuleIteratorHelper):
         return self
 
     def __repr__(self) -> str:
-        return "PathEntry<{!r}>".format(self.filePath)
+        return f"PathEntry<{self.filePath!r}>"
 
     def _packagePaths(self):
         yield self.filePath
@@ -738,7 +738,7 @@ class PythonPath:
         """
         Display my sysPath and moduleDict in a string representation.
         """
-        return "PythonPath({!r},{!r})".format(self.sysPath, self.moduleDict)
+        return f"PythonPath({self.sysPath!r},{self.moduleDict!r})"
 
     def iterModules(self):
         """

--- a/src/twisted/python/reflect.py
+++ b/src/twisted/python/reflect.py
@@ -300,9 +300,9 @@ def namedAny(name):
                 moduleNames.pop()
         else:
             if len(names) == 1:
-                raise ModuleNotFound("No module named {!r}".format(name))
+                raise ModuleNotFound(f"No module named {name!r}")
             else:
-                raise ObjectNotFound("{!r} does not name an object".format(name))
+                raise ObjectNotFound(f"{name!r} does not name an object")
 
     obj = topLevelPackage
     for n in names[1:]:
@@ -452,7 +452,7 @@ class QueueMethod:
 def fullFuncName(func):
     qualName = str(pickle.whichmodule(func, func.__name__)) + "." + func.__name__
     if namedObject(qualName) is not func:
-        raise Exception("Couldn't find {} as {}.".format(func, qualName))
+        raise Exception(f"Couldn't find {func} as {qualName}.")
     return qualName
 
 

--- a/src/twisted/python/roots.py
+++ b/src/twisted/python/roots.py
@@ -233,9 +233,7 @@ class Homogenous(Constrained):
         if isinstance(entity, self.entityType):
             return 1
         else:
-            raise ConstraintViolation(
-                "{} of incorrect type ({})".format(entity, self.entityType)
-            )
+            raise ConstraintViolation(f"{entity} of incorrect type ({self.entityType})")
 
     def getNameType(self):
         return "Name"

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -440,7 +440,7 @@ def callTestFunction():
         """
         self.assertTrue(
             normcase(first.path) == normcase(second.path),
-            "{!r} != {!r}".format(first, second),
+            f"{first!r} != {second!r}",
         )
 
     def test_renamedFile(self):
@@ -530,7 +530,7 @@ def callTestFunction():
             msg.endswith(
                 "module.py:9: DeprecationWarning: A Warning String\n" "  return a\n"
             ),
-            "Unexpected warning string: {!r}".format(msg),
+            f"Unexpected warning string: {msg!r}",
         )
 
 

--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -175,14 +175,14 @@ class StructureAssertingMixin:
             if callable(expectation):
                 self.assertTrue(expectation(child))
             elif isinstance(expectation, dict):
-                self.assertTrue(child.isdir(), "{} is not a dir!".format(child.path))
+                self.assertTrue(child.isdir(), f"{child.path} is not a dir!")
                 self.assertStructure(child, expectation)
             else:
                 actual = child.getContent().decode().replace(os.linesep, "\n")
                 self.assertEqual(actual, expectation)
             children.remove(pathSegment)
         if children:
-            self.fail("There were extra children in {}: {}".format(root.path, children))
+            self.fail(f"There were extra children in {root.path}: {children}")
 
 
 class ProjectTests(ExternalTempdirTestCase):
@@ -419,10 +419,10 @@ class APIBuilderTests(ExternalTempdirTestCase):
         indexPath = outputPath.child("index.html")
 
         self.assertTrue(
-            indexPath.exists(), "API index {!r} did not exist.".format(outputPath.path)
+            indexPath.exists(), f"API index {outputPath.path!r} did not exist."
         )
         self.assertIn(
-            '<a href="{}">{}</a>'.format(projectURL, projectName),
+            f'<a href="{projectURL}">{projectName}</a>',
             indexPath.getContent().decode(),
             "Project name/location not in file contents.",
         )
@@ -430,7 +430,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
         quuxPath = outputPath.child("quux.html")
         self.assertTrue(
             quuxPath.exists(),
-            "Package documentation file {!r} did not exist.".format(quuxPath.path),
+            f"Package documentation file {quuxPath.path!r} did not exist.",
         )
         self.assertIn(
             docstring,
@@ -438,7 +438,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
             "Docstring not in package documentation file.",
         )
         self.assertIn(
-            '<a href="{}/{}/__init__.py">(source)</a>'.format(sourceURL, packageName),
+            f'<a href="{sourceURL}/{packageName}/__init__.py">(source)</a>',
             quuxPath.getContent().decode(),
         )
         self.assertIn(
@@ -476,7 +476,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
 
         indexPath = outputPath.child("index.html")
         self.assertTrue(
-            indexPath.exists(), "API index {} did not exist.".format(outputPath.path)
+            indexPath.exists(), f"API index {outputPath.path} did not exist."
         )
         self.assertIn(
             '<a href="http://twistedmatrix.com/">Twisted</a>',
@@ -487,7 +487,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
         twistedPath = outputPath.child("twisted.html")
         self.assertTrue(
             twistedPath.exists(),
-            "Package documentation file {!r} did not exist.".format(twistedPath.path),
+            f"Package documentation file {twistedPath.path!r} did not exist.",
         )
         self.assertIn(
             docstring,
@@ -547,7 +547,7 @@ class APIBuilderTests(ExternalTempdirTestCase):
         quuxPath = outputPath.child("quux.html")
         self.assertTrue(
             quuxPath.exists(),
-            "Package documentation file {!r} did not exist.".format(quuxPath.path),
+            f"Package documentation file {quuxPath.path!r} did not exist.",
         )
 
         self.assertIn(

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -79,7 +79,7 @@ class _FDHolder:
         If C{self._fd} is unclosed, raise a warning.
         """
         if self._fd:
-            warnings.warn("FD {} was not closed!".format(self._fd), ResourceWarning)
+            warnings.warn(f"FD {self._fd} was not closed!", ResourceWarning)
             self.close()
 
     def __enter__(self):

--- a/src/twisted/python/test/test_tzhelper.py
+++ b/src/twisted/python/test/test_tzhelper.py
@@ -41,7 +41,7 @@ def mktime(t9):
     try:
         return mktime_real(t9)
     except OverflowError:
-        raise SkipTest("Platform cannot construct time zone for {!r}".format(t9))
+        raise SkipTest(f"Platform cannot construct time zone for {t9!r}")
 
 
 def setTZ(name):
@@ -100,8 +100,8 @@ class FixedOffsetTimeZoneTests(TestCase):
             tzDST = FixedOffsetTimeZone.fromLocalTimeStamp(localDST)
             tzSTD = FixedOffsetTimeZone.fromLocalTimeStamp(localSTD)
 
-            self.assertEqual(tzDST.tzname(localDST), "UTC{}".format(expectedOffsetDST))
-            self.assertEqual(tzSTD.tzname(localSTD), "UTC{}".format(expectedOffsetSTD))
+            self.assertEqual(tzDST.tzname(localDST), f"UTC{expectedOffsetDST}")
+            self.assertEqual(tzSTD.tzname(localSTD), f"UTC{expectedOffsetSTD}")
 
             self.assertEqual(tzDST.dst(localDST), timedelta(0))
             self.assertEqual(tzSTD.dst(localSTD), timedelta(0))

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -503,7 +503,7 @@ class TestURL(SynchronousTestCase):
         """
         u1 = URL.fromText("http://localhost/a")
         u2 = URL.fromText("http://localhost/b")
-        self.assertFalse(u1 == u2, "{!r} != {!r}".format(u1, u2))
+        self.assertFalse(u1 == u2, f"{u1!r} != {u2!r}")
         self.assertNotEqual(u1, u2)
 
     def test_otherTypesNotEqual(self):
@@ -529,7 +529,7 @@ class TestURL(SynchronousTestCase):
         """
         u1 = URL.fromText("http://localhost/")
         u2 = URL.fromText("http://localhost/")
-        self.assertFalse(u1 != u2, "{!r} == {!r}".format(u1, u2))
+        self.assertFalse(u1 != u2, f"{u1!r} == {u2!r}")
 
     def test_differentUnequal(self):
         """
@@ -537,7 +537,7 @@ class TestURL(SynchronousTestCase):
         """
         u1 = URL.fromText("http://localhost/a")
         u2 = URL.fromText("http://localhost/b")
-        self.assertTrue(u1 != u2, "{!r} == {!r}".format(u1, u2))
+        self.assertTrue(u1 != u2, f"{u1!r} == {u2!r}")
 
     def test_otherTypesUnequal(self):
         """
@@ -568,9 +568,7 @@ class TestURL(SynchronousTestCase):
         self.assertEqual(iri.asText(), unicodey)
         expectedURI = "http://xn--9ca.com/%C3%A9?%C3%A1=%C3%AD#%C3%BA"
         actualURI = uri.asText()
-        self.assertEqual(
-            actualURI, expectedURI, "{!r} != {!r}".format(actualURI, expectedURI)
-        )
+        self.assertEqual(actualURI, expectedURI, f"{actualURI!r} != {expectedURI!r}")
 
     def test_asIRI(self):
         """
@@ -591,9 +589,7 @@ class TestURL(SynchronousTestCase):
             "#\N{LATIN SMALL LETTER U WITH ACUTE}"
         )
         actualIRI = iri.asText()
-        self.assertEqual(
-            actualIRI, expectedIRI, "{!r} != {!r}".format(actualIRI, expectedIRI)
-        )
+        self.assertEqual(actualIRI, expectedIRI, f"{actualIRI!r} != {expectedIRI!r}")
 
     def test_badUTF8AsIRI(self):
         """
@@ -609,9 +605,7 @@ class TestURL(SynchronousTestCase):
             "\N{LATIN SMALL LETTER E WITH ACUTE}"
         )
         actualIRI = iri.asText()
-        self.assertEqual(
-            actualIRI, expectedIRI, "{!r} != {!r}".format(actualIRI, expectedIRI)
-        )
+        self.assertEqual(actualIRI, expectedIRI, f"{actualIRI!r} != {expectedIRI!r}")
 
     def test_alreadyIRIAsIRI(self):
         """

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -109,9 +109,7 @@ class NameToLabelTests(TestCase):
         ]
         for inp, out in nameData:
             got = util.nameToLabel(inp)
-            self.assertEqual(
-                got, out, "nameToLabel({!r}) == {!r} != {!r}".format(inp, got, out)
-            )
+            self.assertEqual(got, out, f"nameToLabel({inp!r}) == {got!r} != {out!r}")
 
 
 class UntilConcludesTests(TestCase):

--- a/src/twisted/python/text.py
+++ b/src/twisted/python/text.py
@@ -29,7 +29,7 @@ def stringyString(object, indentation=""):
             if isMultiline(value):
                 if endsInNewline(value):
                     value = value[: -len("\n")]
-                sl.append("{} {}:\n{}".format(indentation, key, value))
+                sl.append(f"{indentation} {key}:\n{value}")
             else:
                 # Oops.  Will have to move that indentation.
                 sl.append(

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -302,6 +302,6 @@ class ThreadPool:
         Dump some plain-text informational messages to the log about the state
         of this L{ThreadPool}.
         """
-        log.msg("waiters: {}".format(self.waiters))
-        log.msg("workers: {}".format(self.working))
-        log.msg("total: {}".format(self.threads))
+        log.msg(f"waiters: {self.waiters}")
+        log.msg(f"workers: {self.working}")
+        log.msg(f"total: {self.threads}")

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -53,13 +53,11 @@ class CoerceParameter:
         returned value.
         """
         if value is None:
-            raise UsageError(
-                "Parameter '{}' requires an argument.".format(parameterName)
-            )
+            raise UsageError(f"Parameter '{parameterName}' requires an argument.")
         try:
             value = self.coerce(value)
         except ValueError as e:
-            raise UsageError("Parameter type enforcement failed: {}".format(e))
+            raise UsageError(f"Parameter type enforcement failed: {e}")
 
         self.options.opts[parameterName] = value
 
@@ -248,7 +246,7 @@ class Options(dict):
             if optMangled not in self.synonyms:
                 optMangled = opt.replace("-", "_")
                 if optMangled not in self.synonyms:
-                    raise UsageError("No such option '{}'".format(opt))
+                    raise UsageError(f"No such option '{opt}'")
 
             optMangled = self.synonyms[optMangled]
             if isinstance(self._dispatch[optMangled], CoerceParameter):
@@ -617,7 +615,7 @@ class Completer:
         """
         if shellType == _ZSH:
             return "{}:{}:".format(self._repeatFlag, self._description(optName))
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteFiles(Completer):
@@ -631,9 +629,9 @@ class CompleteFiles(Completer):
 
     def _description(self, optName):
         if self._descr is not None:
-            return "{} ({})".format(self._descr, self._globPattern)
+            return f"{self._descr} ({self._globPattern})"
         else:
-            return "{} ({})".format(optName, self._globPattern)
+            return f"{optName} ({self._globPattern})"
 
     def _shellCode(self, optName, shellType):
         if shellType == _ZSH:
@@ -642,7 +640,7 @@ class CompleteFiles(Completer):
                 self._description(optName),
                 self._globPattern,
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteDirs(Completer):
@@ -655,7 +653,7 @@ class CompleteDirs(Completer):
             return "{}:{}:_directories".format(
                 self._repeatFlag, self._description(optName)
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteList(Completer):
@@ -676,7 +674,7 @@ class CompleteList(Completer):
                     self._items,
                 ),
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteMultiList(Completer):
@@ -696,7 +694,7 @@ class CompleteMultiList(Completer):
                 self._description(optName),
                 " ".join(self._items),
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteUsernames(Completer):
@@ -707,7 +705,7 @@ class CompleteUsernames(Completer):
     def _shellCode(self, optName, shellType):
         if shellType == _ZSH:
             return "{}:{}:_users".format(self._repeatFlag, self._description(optName))
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteGroups(Completer):
@@ -720,7 +718,7 @@ class CompleteGroups(Completer):
     def _shellCode(self, optName, shellType):
         if shellType == _ZSH:
             return "{}:{}:_groups".format(self._repeatFlag, self._description(optName))
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteHostnames(Completer):
@@ -731,7 +729,7 @@ class CompleteHostnames(Completer):
     def _shellCode(self, optName, shellType):
         if shellType == _ZSH:
             return "{}:{}:_hosts".format(self._repeatFlag, self._description(optName))
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteUserAtHost(Completer):
@@ -758,7 +756,7 @@ class CompleteUserAtHost(Completer):
                 '_alternative "hosts:remote host name:_ssh_hosts" "$tmp[@]"'
                 " && ret=0 fi}" % (self._repeatFlag, self._description(optName))
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class CompleteNetInterfaces(Completer):
@@ -772,7 +770,7 @@ class CompleteNetInterfaces(Completer):
                 self._repeatFlag,
                 self._description(optName),
             )
-        raise NotImplementedError("Unknown shellType {!r}".format(shellType))
+        raise NotImplementedError(f"Unknown shellType {shellType!r}")
 
 
 class Completions:
@@ -955,7 +953,7 @@ def docMakeChunks(optList, width=80):
         ) is not None:
             d = opt["dispatch"]
             if isinstance(d, CoerceParameter) and d.doc:
-                doc = "{}. {}".format(doc, d.doc)
+                doc = f"{doc}. {d.doc}"
 
         if doc:
             column2_l = textwrap.wrap(doc, colWidth2)
@@ -965,7 +963,7 @@ def docMakeChunks(optList, width=80):
         optLines.append("{}{}\n".format(column1, column2_l.pop(0)))
 
         for line in column2_l:
-            optLines.append("{}{}\n".format(colFiller1, line))
+            optLines.append(f"{colFiller1}{line}\n")
 
         optChunks.append("".join(optLines))
 
@@ -1007,7 +1005,7 @@ def portCoerce(value):
     """
     value = int(value)
     if value < 0 or value > 65535:
-        raise ValueError("Port number not in range: {}".format(value))
+        raise ValueError(f"Port number not in range: {value}")
     return value
 
 

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -164,7 +164,7 @@ class InsensitiveDict(MutableMapping):
         """
         String representation of the dictionary.
         """
-        items = ", ".join([("{!r}: {!r}".format(k, v)) for k, v in self.items()])
+        items = ", ".join([(f"{k!r}: {v!r}") for k, v in self.items()])
         return "InsensitiveDict({%s})" % items
 
     def iterkeys(self):
@@ -449,12 +449,12 @@ def searchupwards(start, files=[], dirs=[]):
         candidate = join(parents) + os.sep
         allpresent = 1
         for f in files:
-            if not exists("{}{}".format(candidate, f)):
+            if not exists(f"{candidate}{f}"):
                 allpresent = 0
                 break
         if allpresent:
             for d in dirs:
-                if not isdir("{}{}".format(candidate, d)):
+                if not isdir(f"{candidate}{d}"):
                     allpresent = 0
                     break
         if allpresent:
@@ -733,8 +733,8 @@ def switchUID(uid, gid, euid=False):
     if uid is not None:
         if uid == getuid():
             uidText = euid and "euid" or "uid"
-            actionText = "tried to drop privileges and set{} {}".format(uidText, uid)
-            problemText = "{} is already {}".format(uidText, getuid())
+            actionText = f"tried to drop privileges and set{uidText} {uid}"
+            problemText = f"{uidText} is already {getuid()}"
             warnings.warn(
                 "{} but {}; should we be root? Continuing.".format(
                     actionText, problemText

--- a/src/twisted/runner/inetdconf.py
+++ b/src/twisted/runner/inetdconf.py
@@ -160,9 +160,7 @@ class InetdConf(SimpleConfFile):
                 port = int(serviceName)
                 serviceName = "unknown"
             except BaseException:
-                raise UnknownService(
-                    "Unknown service: {} ({})".format(serviceName, protocol)
-                )
+                raise UnknownService(f"Unknown service: {serviceName} ({protocol})")
 
         self.services.append(
             InetdService(

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -248,7 +248,7 @@ class ProcessMonitor(service.Service):
         @raise KeyError: If a process with the given name already exists.
         """
         if name in self._processes:
-            raise KeyError("remove {} first".format(name))
+            raise KeyError(f"remove {name} first")
         self._processes[name] = _Process(args, uid, gid, env, cwd)
         self.delay[name] = self.minRestartDelay
         if self.running:
@@ -369,7 +369,7 @@ class ProcessMonitor(service.Service):
         @param name: The name of the process to be stopped
         """
         if name not in self._processes:
-            raise KeyError("Unrecognized process name: {}".format(name))
+            raise KeyError(f"Unrecognized process name: {name}")
 
         proto = self.protocols.get(name, None)
         if proto is not None:
@@ -404,5 +404,5 @@ class ProcessMonitor(service.Service):
 
             if uidgid:
                 uidgid = "(" + uidgid + ")"
-            lst.append("{!r}{}: {!r}".format(name, uidgid, proc.args))
+            lst.append(f"{name!r}{uidgid}: {proc.args!r}")
         return "<" + self.__class__.__name__ + " " + " ".join(lst) + ">"

--- a/src/twisted/scripts/_twistd_unix.py
+++ b/src/twisted/scripts/_twistd_unix.py
@@ -74,9 +74,7 @@ class ServerOptions(app.ServerOptions):
         """
         Print version information and exit.
         """
-        print(
-            "twistd (the Twisted daemon) {}".format(copyright.version), file=self.stdout
-        )
+        print(f"twistd (the Twisted daemon) {copyright.version}", file=self.stdout)
         print(copyright.copyright, file=self.stdout)
         sys.exit()
 
@@ -94,13 +92,13 @@ def checkPID(pidfile):
             with open(pidfile) as f:
                 pid = int(f.read())
         except ValueError:
-            sys.exit("Pidfile {} contains non-numeric value".format(pidfile))
+            sys.exit(f"Pidfile {pidfile} contains non-numeric value")
         try:
             os.kill(pid, 0)
         except OSError as why:
             if why.errno == errno.ESRCH:
                 # The pid doesn't exist.
-                log.msg("Removing stale pidfile {}".format(pidfile), isError=True)
+                log.msg(f"Removing stale pidfile {pidfile}", isError=True)
                 os.remove(pidfile)
             else:
                 sys.exit(
@@ -233,7 +231,7 @@ class UnixApplicationRunner(app.ApplicationRunner):
             -1
         ]
         # remove the trailing newline
-        formattedMessage = "1 {}".format(exceptionLine.strip())
+        formattedMessage = f"1 {exceptionLine.strip()}"
         # On Python 3, encode the message the same way Python 2's
         # format_exception_only does
         formattedMessage = formattedMessage.encode("ascii", "backslashreplace")
@@ -413,7 +411,7 @@ class UnixApplicationRunner(app.ApplicationRunner):
         """
         if uid is not None or gid is not None:
             extra = euid and "e" or ""
-            desc = "{}uid/{}gid {}/{}".format(extra, extra, uid, gid)
+            desc = f"{extra}uid/{extra}gid {uid}/{gid}"
             try:
                 switchUID(uid, gid, euid)
             except OSError as e:
@@ -423,7 +421,7 @@ class UnixApplicationRunner(app.ApplicationRunner):
                 )
                 sys.exit(1)
             else:
-                log.msg("set {}".format(desc))
+                log.msg(f"set {desc}")
 
     def startApplication(self, application):
         """

--- a/src/twisted/scripts/_twistw.py
+++ b/src/twisted/scripts/_twistw.py
@@ -21,7 +21,7 @@ class ServerOptions(app.ServerOptions):
         Print version information and exit.
         """
         print(
-            "twistd (the Twisted Windows runner) {}".format(copyright.version),
+            f"twistd (the Twisted Windows runner) {copyright.version}",
             file=self.stdout,
         )
         print(copyright.copyright, file=self.stdout)

--- a/src/twisted/scripts/htmlizer.py
+++ b/src/twisted/scripts/htmlizer.py
@@ -63,7 +63,7 @@ def run():
     with open(filename + ".html", "wb") as output:
         outHeader = header % {
             "title": filename,
-            "generator": "htmlizer/{}".format(copyright.longversion),
+            "generator": f"htmlizer/{copyright.longversion}",
             "alternate": alternateLink % {"source": filename},
             "stylesheet": stylesheet,
         }

--- a/src/twisted/scripts/trial.py
+++ b/src/twisted/scripts/trial.py
@@ -45,7 +45,7 @@ def _parseLocalVariables(line):
     start = line.find(paren) + len(paren)
     end = line.rfind(paren)
     if start == -1 or end == -1:
-        raise ValueError("{!r} not a valid local variable declaration".format(line))
+        raise ValueError(f"{line!r} not a valid local variable declaration")
     items = line[start:end].split(";")
     localVars = {}
     for item in items:
@@ -53,9 +53,7 @@ def _parseLocalVariables(line):
             continue
         split = item.split(":")
         if len(split) != 2:
-            raise ValueError(
-                "{!r} contains invalid declaration {!r}".format(line, item)
-            )
+            raise ValueError(f"{line!r} contains invalid declaration {item!r}")
         localVars[split[0].strip()] = split[1].strip()
     return localVars
 
@@ -262,7 +260,7 @@ class _BasicOptions:
         """
         coverdir = "coverage"
         result = FilePath(self["temp-directory"]).child(coverdir)
-        print("Setting coverage directory to {}.".format(result.path))
+        print(f"Setting coverage directory to {result.path}.")
         return result
 
     # TODO: Some of the opt_* methods on this class have docstrings and some do
@@ -299,7 +297,7 @@ class _BasicOptions:
         # a list of files to Trial with the general expectation of "these files,
         # whatever they are, will get tested"
         if not os.path.isfile(filename):
-            sys.stderr.write("File {!r} doesn't exist\n".format(filename))
+            sys.stderr.write(f"File {filename!r} doesn't exist\n")
             return
         filename = os.path.abspath(filename)
         if isTestFile(filename):
@@ -399,7 +397,7 @@ class _BasicOptions:
 
     def _loadReporterByName(self, name):
         for p in plugin.getPlugins(itrial.IReporter):
-            qual = "{}.{}".format(p.module, p.klass)
+            qual = f"{p.module}.{p.klass}"
             if p.longOpt == name:
                 return reflect.namedAny(qual)
         raise usage.UsageError(
@@ -505,10 +503,10 @@ class Options(_BasicOptions, usage.Options, app.ReactorSelectionMixin):
         for option in self._workerFlags:
             if self.get(option) is not None:
                 if self[option]:
-                    args.append("--{}".format(option))
+                    args.append(f"--{option}")
         for option in self._workerParameters:
             if self.get(option) is not None:
-                args.extend(["--{}".format(option), str(self[option])])
+                args.extend([f"--{option}", str(self[option])])
         return args
 
     def postOptions(self):
@@ -623,7 +621,7 @@ def _makeRunner(config):
                     args["debugger"] = reflect.namedAny(debugger)
                 except reflect.ModuleNotFound:
                     raise _DebuggerNotFound(
-                        "{!r} debugger could not be found.".format(debugger)
+                        f"{debugger!r} debugger could not be found."
                     )
             else:
                 args["debugger"] = _wrappedPdb()

--- a/src/twisted/spread/banana.py
+++ b/src/twisted/spread/banana.py
@@ -246,9 +246,7 @@ class Banana(protocol.Protocol, styles.Ephemeral):
                     # the sender issues VOCAB only for dialect pb
                     gotItem(item)
                 else:
-                    raise NotImplementedError(
-                        "Invalid item for pb protocol {!r}".format(item)
-                    )
+                    raise NotImplementedError(f"Invalid item for pb protocol {item!r}")
             elif typebyte == FLOAT:
                 if len(rest) >= 8:
                     buffer = rest[8:]
@@ -256,7 +254,7 @@ class Banana(protocol.Protocol, styles.Ephemeral):
                 else:
                     return
             else:
-                raise NotImplementedError("Invalid Type Byte {!r}".format(typebyte))
+                raise NotImplementedError(f"Invalid Type Byte {typebyte!r}")
             while listStack and (len(listStack[-1][1]) == listStack[-1][0]):
                 item = listStack.pop()[1]
                 gotItem(item)

--- a/src/twisted/spread/flavors.py
+++ b/src/twisted/spread/flavors.py
@@ -126,11 +126,11 @@ class Referenceable(Serializable):
 
         method = getattr(self, "remote_%s" % message, None)
         if method is None:
-            raise NoSuchMethod("No such method: remote_{}".format(message))
+            raise NoSuchMethod(f"No such method: remote_{message}")
         try:
             state = method(*args, **kw)
         except TypeError:
-            log.msg("{} didn't accept {} and {}".format(method, args, kw))
+            log.msg(f"{method} didn't accept {args} and {kw}")
             raise
         return broker.serialize(state, self.perspective)
 
@@ -231,7 +231,7 @@ class ViewPoint(Referenceable):
         try:
             state = method(*(self.perspective,) + args, **kw)
         except TypeError:
-            log.msg("{} didn't accept {} and {}".format(method, args, kw))
+            log.msg(f"{method} didn't accept {args} and {kw}")
             raise
         rv = broker.serialize(state, self.perspective, method, args, kw)
         return rv
@@ -438,7 +438,7 @@ class RemoteCache(RemoteCopy, Serializable):
         try:
             state = method(*args, **kw)
         except TypeError:
-            log.msg("{} didn't accept {} and {}".format(method, args, kw))
+            log.msg(f"{method} didn't accept {args} and {kw}")
             raise
         return broker.serialize(state, None, method, args, kw)
 

--- a/src/twisted/spread/jelly.py
+++ b/src/twisted/spread/jelly.py
@@ -267,7 +267,7 @@ def setUnjellyableForClassTree(module, baseClass, prefix=None):
             "It's not a class."
         else:
             if yes:
-                setUnjellyableForClass("{}{}".format(prefix, name), loaded)
+                setUnjellyableForClass(f"{prefix}{name}", loaded)
 
 
 def getInstanceState(inst, jellier):
@@ -578,9 +578,7 @@ class _Jellier:
                         )
                 return self.preserve(obj, sxp)
         else:
-            raise InsecureJelly(
-                "Type not allowed for object: {} {}".format(objType, obj)
-            )
+            raise InsecureJelly(f"Type not allowed for object: {objType} {obj}")
 
     def _jellyIterable(self, atom, obj):
         """
@@ -679,7 +677,7 @@ class _Unjellier:
             modName = ".".join(nameSplit[:-1])
             if not self.taster.isModuleAllowed(modName):
                 raise InsecureJelly(
-                    "Module {} not allowed (in type {}).".format(modName, jelTypeText)
+                    f"Module {modName} not allowed (in type {jelTypeText})."
                 )
             clz = namedObject(jelTypeText)
             if not self.taster.isClassAllowed(clz):
@@ -831,9 +829,7 @@ class _Unjellier:
         if type(moduleName) != str:
             raise InsecureJelly("Attempted to unjelly a module with a non-string name.")
         if not self.taster.isModuleAllowed(moduleName):
-            raise InsecureJelly(
-                "Attempted to unjelly module named {!r}".format(moduleName)
-            )
+            raise InsecureJelly(f"Attempted to unjelly module named {moduleName!r}")
         mod = __import__(moduleName, {}, {}, "x")
         return mod
 

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -240,7 +240,7 @@ class Avatar:
         try:
             state = method(*args, **kw)
         except TypeError:
-            log.msg("{} didn't accept {} and {}".format(method, args, kw))
+            log.msg(f"{method} didn't accept {args} and {kw}")
             raise
         return broker.serialize(state, self, method, args, kw)
 
@@ -409,7 +409,7 @@ class Local:
         self.refcount = 1
 
     def __repr__(self) -> str:
-        return "<pb.Local {!r} ref:{}>".format(self.object, self.refcount)
+        return f"<pb.Local {self.object!r} ref:{self.refcount}>"
 
     def incref(self):
         """
@@ -616,9 +616,7 @@ class Broker(banana.Banana):
         """
 
         if vnum != self.version:
-            raise ProtocolError(
-                "Version Incompatibility: {} {}".format(self.version, vnum)
-            )
+            raise ProtocolError(f"Version Incompatibility: {self.version} {vnum}")
 
     def sendCall(self, *exp):
         """

--- a/src/twisted/spread/test/test_banana.py
+++ b/src/twisted/spread/test/test_banana.py
@@ -148,7 +148,7 @@ class BananaTests(BananaTestBase):
             object.
         """
         exc = self.assertRaises(banana.BananaError, self.enc.sendEncoded, obj)
-        self.assertIn("Banana cannot send {} objects".format(name), str(exc))
+        self.assertIn(f"Banana cannot send {name} objects", str(exc))
 
     def test_int(self):
         """

--- a/src/twisted/spread/test/test_pb.py
+++ b/src/twisted/spread/test/test_pb.py
@@ -298,9 +298,7 @@ def createFactoryCopy(state):
             "factory copy state has no 'id' member {}".format(repr(state))
         )
     if stateId not in SimpleFactoryCopy.allIDs:
-        raise RuntimeError(
-            "factory class has no ID: {}".format(SimpleFactoryCopy.allIDs)
-        )
+        raise RuntimeError(f"factory class has no ID: {SimpleFactoryCopy.allIDs}")
     inst = SimpleFactoryCopy.allIDs[stateId]
     if not inst:
         raise RuntimeError("factory method found no object with id")
@@ -670,7 +668,7 @@ class BrokerTests(unittest.TestCase):
             pass
 
     def thunkErrorBad(self, error):
-        self.fail("This should cause a return value, not {}".format(error))
+        self.fail(f"This should cause a return value, not {error}")
 
     def thunkResultGood(self, result):
         self.thunkResult = result
@@ -679,7 +677,7 @@ class BrokerTests(unittest.TestCase):
         pass
 
     def thunkResultBad(self, result):
-        self.fail("This should cause an error, not {}".format(result))
+        self.fail(f"This should cause an error, not {result}")
 
     def test_reference(self):
         c, s, pump = connectedServerAndClient(test=self)
@@ -934,7 +932,7 @@ class BrokerTests(unittest.TestCase):
         self.assertEqual(
             self.thunkResult,
             ID,
-            "ID not correct on factory object {}".format(self.thunkResult),
+            f"ID not correct on factory object {self.thunkResult}",
         )
 
 
@@ -1110,7 +1108,7 @@ class DisconnectionTests(unittest.TestCase):
     """
 
     def error(self, *args):
-        raise RuntimeError("I shouldn't have been called: {}".format(args))
+        raise RuntimeError(f"I shouldn't have been called: {args}")
 
     def gotDisconnected(self):
         """

--- a/src/twisted/test/__init__.py
+++ b/src/twisted/test/__init__.py
@@ -13,7 +13,7 @@ from twisted.test import proto_helpers
 for obj in proto_helpers.__all__:
     deprecatedModuleAttribute(
         Version("Twisted", 19, 7, 0),
-        "Please use twisted.internet.testing.{} instead.".format(obj),
+        f"Please use twisted.internet.testing.{obj} instead.",
         "twisted.test.proto_helpers",
         obj,
     )

--- a/src/twisted/test/iosim.py
+++ b/src/twisted/test/iosim.py
@@ -33,7 +33,7 @@ class TLSNegotiation:
         self.readyToSend = connectState
 
     def __repr__(self) -> str:
-        return "TLSNegotiation({!r})".format(self.obj)
+        return f"TLSNegotiation({self.obj!r})"
 
     def pretendToVerify(self, other, tpt):
         # Set the transport problems list here?  disconnections?

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -1233,7 +1233,7 @@ class AMPTests(TestCase):
         ]:
             self.assertTrue(
                 interface.implementedBy(implementation),
-                "{} does not implements({})".format(implementation, interface),
+                f"{implementation} does not implements({interface})",
             )
 
     def test_helloWorld(self):

--- a/src/twisted/test/test_application.py
+++ b/src/twisted/test/test_application.py
@@ -554,7 +554,7 @@ class InternetTests(TestCase):
         for cls in internet.__all__:
             self.assertTrue(
                 hasattr(internet, cls),
-                "{} not importable from twisted.application.internet".format(cls),
+                f"{cls} not importable from twisted.application.internet",
             )
 
     def test_reactorParametrizationInServer(self):

--- a/src/twisted/test/test_cooperator.py
+++ b/src/twisted/test/test_cooperator.py
@@ -223,7 +223,7 @@ class CooperatorTests(unittest.TestCase):
                 self.func = func
 
             def __repr__(self) -> str:
-                return "<FakeCall {!r}>".format(self.func)
+                return f"<FakeCall {self.func!r}>"
 
         def sched(f):
             self.assertFalse(calls, repr(calls))

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1227,7 +1227,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         """
         d = defer.Deferred()
         address = id(d)
-        self.assertEqual(repr(d), "<Deferred at 0x{:x}>".format(address))
+        self.assertEqual(repr(d), f"<Deferred at 0x{address:x}>")
 
     def test_reprWithResult(self):
         """
@@ -2004,7 +2004,7 @@ class LogTests(unittest.SynchronousTestCase):
         expected = "Unhandled Error\nTraceback "
         self.assertTrue(
             msg.startswith(expected),
-            "Expected message starting with: {!r}".format(expected),
+            f"Expected message starting with: {expected!r}",
         )
 
     def test_errorLogDebugInfo(self):
@@ -2029,7 +2029,7 @@ class LogTests(unittest.SynchronousTestCase):
         expected = "(debug:  I"
         self.assertTrue(
             msg.startswith(expected),
-            "Expected message starting with: {!r}".format(expected),
+            f"Expected message starting with: {expected!r}",
         )
 
     def test_chainedErrorCleanup(self):

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -107,9 +107,7 @@ class FailureTests(SynchronousTestCase):
         @param prefix: The string that C{s} should start with.
         @type prefix: C{str}
         """
-        self.assertTrue(
-            s.startswith(prefix), "{!r} is not the start of {!r}".format(prefix, s)
-        )
+        self.assertTrue(s.startswith(prefix), f"{prefix!r} is not the start of {s!r}")
 
     def assertEndsWith(self, s, suffix):
         """
@@ -120,9 +118,7 @@ class FailureTests(SynchronousTestCase):
         @param suffix: The string that C{s} should end with.
         @type suffix: C{str}
         """
-        self.assertTrue(
-            s.endswith(suffix), "{!r} is not the end of {!r}".format(suffix, s)
-        )
+        self.assertTrue(s.endswith(suffix), f"{suffix!r} is not the end of {s!r}")
 
     def assertTracebackFormat(self, tb, prefix, suffix):
         """
@@ -256,13 +252,13 @@ class FailureTests(SynchronousTestCase):
         tb = out.getvalue()
         stack = ""
         for method, filename, lineno, localVars, globalVars in f.frames:
-            stack += "{}:{}:{}\n".format(filename, lineno, method)
+            stack += f"{filename}:{lineno}:{method}\n"
 
         zde = repr(ZeroDivisionError)
         self.assertTracebackFormat(
             tb,
-            "Traceback: {}: ".format(zde),
-            "{}\n{}".format(failure.EXCEPTION_CAUGHT_HERE, stack),
+            f"Traceback: {zde}: ",
+            f"{failure.EXCEPTION_CAUGHT_HERE}\n{stack}",
         )
 
         if captureVars:
@@ -303,7 +299,7 @@ class FailureTests(SynchronousTestCase):
         tb = out.getvalue()
         stack = ""
         for method, filename, lineno, localVars, globalVars in f.frames:
-            stack += '  File "{}", line {}, in {}\n'.format(filename, lineno, method)
+            stack += f'  File "{filename}", line {lineno}, in {method}\n'
             stack += "    {}\n".format(linecache.getline(filename, lineno).strip())
 
         self.assertTracebackFormat(

--- a/src/twisted/test/test_ftp.py
+++ b/src/twisted/test/test_ftp.py
@@ -1063,7 +1063,7 @@ class FTPServerPasvDataConnectionTests(FTPServerTestCase):
 
         d.addCallback(loggedIn)
 
-        self._download("{} something".format(command), chainDeferred=d)
+        self._download(f"{command} something", chainDeferred=d)
 
         def checkDownload(download):
             self.assertEqual(expectedOutput, download)
@@ -3827,6 +3827,6 @@ class FTPResponseCodeTests(TestCase):
                 self.assertNotIn(
                     value,
                     seenValues,
-                    "Duplicate code {!r} with value {!r}".format(key, value),
+                    f"Duplicate code {key!r} with value {value!r}",
                 )
                 seenValues.add(value)

--- a/src/twisted/test/test_iosim.py
+++ b/src/twisted/test/test_iosim.py
@@ -72,12 +72,12 @@ class StrictPushProducer:
 
     def pauseProducing(self):
         if self._state != "running":
-            raise ValueError("Cannot pause {} IPushProducer".format(self._state))
+            raise ValueError(f"Cannot pause {self._state} IPushProducer")
         self._state = "paused"
 
     def resumeProducing(self):
         if self._state != "paused":
-            raise ValueError("Cannot resume {} IPushProducer".format(self._state))
+            raise ValueError(f"Cannot resume {self._state} IPushProducer")
         self._state = "running"
 
 

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -343,7 +343,7 @@ class LogPublisherTestCaseMixin:
         setting, if it was modified by L{setUp}.
         """
         for chunk in self.out:
-            self.assertIsInstance(chunk, str, "{!r} was not a string".format(chunk))
+            self.assertIsInstance(chunk, str, f"{chunk!r} was not a string")
 
         if self._origEncoding is not None:
             sys.setdefaultencoding(self._origEncoding)
@@ -748,7 +748,7 @@ class FileObserverTests(LogPublisherTestCaseMixin, unittest.SynchronousTestCase)
 
         self.assertTrue(
             result.startswith(prefix),
-            "{!r} does not start with {!r}".format(result, prefix),
+            f"{result!r} does not start with {prefix!r}",
         )
 
     def test_emitNewline(self):
@@ -768,7 +768,7 @@ class FileObserverTests(LogPublisherTestCaseMixin, unittest.SynchronousTestCase)
 
         self.assertTrue(
             result.endswith(suffix),
-            "{!r} does not end with {!r}".format(result, suffix),
+            f"{result!r} does not end with {suffix!r}",
         )
 
 
@@ -816,7 +816,7 @@ class PythonLoggingObserverTests(unittest.SynchronousTestCase):
         output = self.out.getvalue()
         self.assertTrue(
             output.startswith(prefix),
-            "Does not start with {!r}: {!r}".format(prefix, output),
+            f"Does not start with {prefix!r}: {output!r}",
         )
 
     def test_formatString(self):

--- a/src/twisted/test/test_logfile.py
+++ b/src/twisted/test/test_logfile.py
@@ -70,19 +70,19 @@ class LogFileTests(TestCase):
             log.write("123")
             log.write("4567890")
             log.write("1" * 11)
-            self.assertTrue(os.path.exists("{}.1".format(self.path)))
-            self.assertFalse(os.path.exists("{}.2".format(self.path)))
+            self.assertTrue(os.path.exists(f"{self.path}.1"))
+            self.assertFalse(os.path.exists(f"{self.path}.2"))
             log.write("")
-            self.assertTrue(os.path.exists("{}.1".format(self.path)))
-            self.assertTrue(os.path.exists("{}.2".format(self.path)))
-            self.assertFalse(os.path.exists("{}.3".format(self.path)))
+            self.assertTrue(os.path.exists(f"{self.path}.1"))
+            self.assertTrue(os.path.exists(f"{self.path}.2"))
+            self.assertFalse(os.path.exists(f"{self.path}.3"))
             log.write("3")
-            self.assertFalse(os.path.exists("{}.3".format(self.path)))
+            self.assertFalse(os.path.exists(f"{self.path}.3"))
 
             # test manual rotation
             log.rotate()
-            self.assertTrue(os.path.exists("{}.3".format(self.path)))
-            self.assertFalse(os.path.exists("{}.4".format(self.path)))
+            self.assertTrue(os.path.exists(f"{self.path}.3"))
+            self.assertFalse(os.path.exists(f"{self.path}.4"))
 
         self.assertEqual(log.listLogs(), [1, 2, 3])
 
@@ -215,20 +215,20 @@ class LogFileTests(TestCase):
         self.addCleanup(log.close)
         log.write("1" * 11)
         log.write("2" * 11)
-        self.assertTrue(os.path.exists("{}.1".format(self.path)))
+        self.assertTrue(os.path.exists(f"{self.path}.1"))
 
         log.write("3" * 11)
-        self.assertTrue(os.path.exists("{}.2".format(self.path)))
+        self.assertTrue(os.path.exists(f"{self.path}.2"))
 
         log.write("4" * 11)
-        self.assertTrue(os.path.exists("{}.3".format(self.path)))
-        with open("{}.3".format(self.path)) as fp:
+        self.assertTrue(os.path.exists(f"{self.path}.3"))
+        with open(f"{self.path}.3") as fp:
             self.assertEqual(fp.read(), "1" * 11)
 
         log.write("5" * 11)
-        with open("{}.3".format(self.path)) as fp:
+        with open(f"{self.path}.3") as fp:
             self.assertEqual(fp.read(), "2" * 11)
-        self.assertFalse(os.path.exists("{}.4".format(self.path)))
+        self.assertFalse(os.path.exists(f"{self.path}.4"))
 
     def test_fromFullPath(self):
         """
@@ -321,9 +321,9 @@ class LogFileTests(TestCase):
         log = logfile.LogFile(self.name, self.dir)
         self.addCleanup(log.close)
 
-        with open("{}.1".format(log.path), "w") as fp:
+        with open(f"{log.path}.1", "w") as fp:
             fp.write("123")
-        with open("{}.bad-file".format(log.path), "w") as fp:
+        with open(f"{log.path}.bad-file", "w") as fp:
             fp.write("123")
 
         self.assertEqual([1], log.listLogs())
@@ -336,7 +336,7 @@ class LogFileTests(TestCase):
         self.addCleanup(log.close)
 
         for i in range(0, 3):
-            with open("{}.{}".format(log.path, i), "w") as fp:
+            with open(f"{log.path}.{i}", "w") as fp:
                 fp.write("123")
 
         self.assertEqual([1, 2], log.listLogs())

--- a/src/twisted/test/test_main.py
+++ b/src/twisted/test/test_main.py
@@ -37,7 +37,7 @@ class MainTests(TestCase):
             output = f.getvalue().replace(b"\r\n", b"\n")
 
             options = TwistOptions()
-            message = "{}\n".format(options).encode("utf-8")
+            message = f"{options}\n".encode("utf-8")
             self.assertEqual(output, message)
 
         return d.addCallback(processEnded)
@@ -60,7 +60,7 @@ class MainTests(TestCase):
             output = f.getvalue().replace(b"\r\n", b"\n")
 
             options = trial.Options()
-            message = "{}\n".format(options).encode("utf-8")
+            message = f"{options}\n".encode("utf-8")
             self.assertEqual(output, message)
 
         return d.addCallback(processEnded)

--- a/src/twisted/test/test_modules.py
+++ b/src/twisted/test/test_modules.py
@@ -38,7 +38,7 @@ class TwistedModulesTestCase(TwistedModulesMixin, TestCase):
         for modinfo in where.walkModules(importPackages=importPackages):
             if modinfo.name == modname:
                 return modinfo
-        self.fail("Unable to find module {!r} through iteration.".format(modname))
+        self.fail(f"Unable to find module {modname!r} through iteration.")
 
 
 class BasicTests(TwistedModulesTestCase):

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -500,7 +500,7 @@ class PermissionsTests(BytesTestCase):
 
         def _rwxFromStat(statModeInt, who):
             def getPermissionBit(what, who):
-                return (statModeInt & getattr(stat, "S_I{}{}".format(what, who))) > 0
+                return (statModeInt & getattr(stat, f"S_I{what}{who}")) > 0
 
             return filepath.RWX(
                 *[getPermissionBit(what, who) for what in ("R", "W", "X")]
@@ -515,17 +515,17 @@ class PermissionsTests(BytesTestCase):
                     self.assertEqual(
                         perm.user,
                         _rwxFromStat(chmodVal, "USR"),
-                        "{}: got user: {}".format(chmodString, perm.user),
+                        f"{chmodString}: got user: {perm.user}",
                     )
                     self.assertEqual(
                         perm.group,
                         _rwxFromStat(chmodVal, "GRP"),
-                        "{}: got group: {}".format(chmodString, perm.group),
+                        f"{chmodString}: got group: {perm.group}",
                     )
                     self.assertEqual(
                         perm.other,
                         _rwxFromStat(chmodVal, "OTH"),
-                        "{}: got other: {}".format(chmodString, perm.other),
+                        f"{chmodString}: got other: {perm.other}",
                     )
         perm = filepath.Permissions(0o777)
         for who in ("user", "group", "other"):
@@ -856,7 +856,7 @@ class FilePathTests(AbstractFilePathTests):
         ts = self.path.temporarySibling(testExtension)
         self.assertTrue(
             ts.basename().endswith(testExtension),
-            "{} does not end with {}".format(ts.basename(), testExtension),
+            f"{ts.basename()} does not end with {testExtension}",
         )
 
     def test_removeDirectory(self):

--- a/src/twisted/test/test_plugin.py
+++ b/src/twisted/test/test_plugin.py
@@ -126,7 +126,7 @@ class PluginTests(unittest.TestCase):
         cache = plugin.getCache(self.module)
 
         dropin = cache[self.originalPlugin]
-        self.assertEqual(dropin.moduleName, "mypackage.{}".format(self.originalPlugin))
+        self.assertEqual(dropin.moduleName, f"mypackage.{self.originalPlugin}")
         self.assertIn("I'm a test drop-in.", dropin.description)
 
         # Note, not the preferred way to get a plugin by its interface.
@@ -144,7 +144,7 @@ class PluginTests(unittest.TestCase):
         # The plugin should match the class present in sys.modules
         self.assertIs(
             realPlugin,
-            sys.modules["mypackage.{}".format(self.originalPlugin)].TestPlugin,
+            sys.modules[f"mypackage.{self.originalPlugin}"].TestPlugin,
         )
 
         # And it should also match if we import it classicly

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -231,12 +231,12 @@ class TestProcessProtocol(protocol.ProcessProtocol):
         if childFD == 1:
             self.stages.append(2)
             if self.data != b"abcd":
-                raise RuntimeError("Data was {!r} instead of 'abcd'".format(self.data))
+                raise RuntimeError(f"Data was {self.data!r} instead of 'abcd'")
             self.transport.write(b"1234")
         elif childFD == 2:
             self.stages.append(3)
             if self.err != b"1234":
-                raise RuntimeError("Err was {!r} instead of '1234'".format(self.err))
+                raise RuntimeError(f"Err was {self.err!r} instead of '1234'")
             self.transport.write(b"abcd")
             self.stages.append(4)
         elif childFD == 0:
@@ -309,7 +309,7 @@ class SignalProtocol(protocol.ProcessProtocol):
         is set up and ready to receive the signal) by sending the signal to
         it.  Also log all output to help with debugging.
         """
-        msg("Received {!r} from child stdout".format(data))
+        msg(f"Received {data!r} from child stdout")
         if not self.signaled:
             self.signaled = True
             self.transport.signalProcess(self.signal)
@@ -319,7 +319,7 @@ class SignalProtocol(protocol.ProcessProtocol):
         Log all data received from the child's stderr to help with
         debugging.
         """
-        msg("Received {!r} from child stderr".format(data))
+        msg(f"Received {data!r} from child stderr")
 
     def processEnded(self, reason):
         """
@@ -329,11 +329,9 @@ class SignalProtocol(protocol.ProcessProtocol):
         of the exited process. Otherwise, errback with a C{ValueError}
         describing the problem.
         """
-        msg("Child exited: {!r}".format(reason.getTraceback()))
+        msg(f"Child exited: {reason.getTraceback()!r}")
         if not reason.check(error.ProcessTerminated):
-            return self.deferred.errback(
-                ValueError("wrong termination: {}".format(reason))
-            )
+            return self.deferred.errback(ValueError(f"wrong termination: {reason}"))
         v = reason.value
         if isinstance(self.signal, str):
             signalValue = getattr(signal, "SIG" + self.signal)
@@ -341,9 +339,7 @@ class SignalProtocol(protocol.ProcessProtocol):
             signalValue = self.signal
         if v.exitCode is not None:
             return self.deferred.errback(
-                ValueError(
-                    "SIG{}: exitCode is {}, not None".format(self.signal, v.exitCode)
-                )
+                ValueError(f"SIG{self.signal}: exitCode is {v.exitCode}, not None")
             )
         if v.signal != signalValue:
             return self.deferred.errback(
@@ -899,13 +895,11 @@ class FDChecker(protocol.ProcessProtocol):
                 self.transport.writeToChild(3, b"efgh")
                 return
         if self.state == 2:
-            self.fail("read '{}' on fd {} during state 2".format(childFD, data))
+            self.fail(f"read '{childFD}' on fd {data} during state 2")
             return
         if self.state == 3:
             if childFD != 1:
-                self.fail(
-                    "read '{}' on fd {} (not 1) during state 3".format(childFD, data)
-                )
+                self.fail(f"read '{childFD}' on fd {data} (not 1) during state 3")
                 return
             self.data += data
             if len(self.data) == 6:
@@ -915,7 +909,7 @@ class FDChecker(protocol.ProcessProtocol):
                 self.state = 4
             return
         if self.state == 4:
-            self.fail("read '{}' on fd {} during state 4".format(childFD, data))
+            self.fail(f"read '{childFD}' on fd {data} during state 4")
             return
 
     def childConnectionLost(self, childFD):
@@ -1034,7 +1028,7 @@ class PosixProcessBase:
         elif usrbinLoc.exists():
             return usrbinLoc._asBytesPath()
         else:
-            raise RuntimeError("{} not found in /bin or /usr/bin".format(commandName))
+            raise RuntimeError(f"{commandName} not found in /bin or /usr/bin")
 
     def test_normalTermination(self):
         cmd = self.getCommand("true")
@@ -2226,14 +2220,10 @@ class Win32SignalProtocol(SignalProtocol):
         Otherwise, errback with a C{ValueError} describing the problem.
         """
         if not reason.check(error.ProcessTerminated):
-            return self.deferred.errback(
-                ValueError("wrong termination: {}".format(reason))
-            )
+            return self.deferred.errback(ValueError(f"wrong termination: {reason}"))
         v = reason.value
         if v.exitCode != 1:
-            return self.deferred.errback(
-                ValueError("Wrong exit code: {}".format(v.exitCode))
-            )
+            return self.deferred.errback(ValueError(f"Wrong exit code: {v.exitCode}"))
         self.deferred.callback(None)
 
 

--- a/src/twisted/test/test_reflect.py
+++ b/src/twisted/test/test_reflect.py
@@ -655,7 +655,7 @@ class FullyQualifiedNameTests(TestCase):
         L{fullyQualifiedName} returns the name of a class and its module.
         """
         self._checkFullyQualifiedName(
-            FullyQualifiedNameTests, "{}.FullyQualifiedNameTests".format(__name__)
+            FullyQualifiedNameTests, f"{__name__}.FullyQualifiedNameTests"
         )
 
     def test_function(self):
@@ -673,7 +673,7 @@ class FullyQualifiedNameTests(TestCase):
         """
         self._checkFullyQualifiedName(
             self.test_boundMethod,
-            "{}.{}.test_boundMethod".format(__name__, self.__class__.__name__),
+            f"{__name__}.{self.__class__.__name__}.test_boundMethod",
         )
 
     def test_unboundMethod(self):
@@ -683,7 +683,7 @@ class FullyQualifiedNameTests(TestCase):
         """
         self._checkFullyQualifiedName(
             self.__class__.test_unboundMethod,
-            "{}.{}.test_unboundMethod".format(__name__, self.__class__.__name__),
+            f"{__name__}.{self.__class__.__name__}.test_unboundMethod",
         )
 
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -1413,8 +1413,8 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
             "country name",
             "email address",
         ]:
-            self.assertIn(k, s, "{!r} was not in inspect output.".format(k))
-            self.assertIn(k.title(), s, "{!r} was not in inspect output.".format(k))
+            self.assertIn(k, s, f"{k!r} was not in inspect output.")
+            self.assertIn(k.title(), s, f"{k!r} was not in inspect output.")
 
     def testInspectDistinguishedNameWithoutAllFields(self):
         n = sslverify.DN(localityName=b"locality name")
@@ -1427,8 +1427,8 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
             "country name",
             "email address",
         ]:
-            self.assertNotIn(k, s, "{!r} was in inspect output.".format(k))
-            self.assertNotIn(k.title(), s, "{!r} was in inspect output.".format(k))
+            self.assertNotIn(k, s, f"{k!r} was in inspect output.")
+            self.assertNotIn(k.title(), s, f"{k!r} was in inspect output.")
         self.assertIn("locality name", s)
         self.assertIn("Locality Name", s)
 

--- a/src/twisted/test/test_stdio.py
+++ b/src/twisted/test/test_stdio.py
@@ -113,7 +113,7 @@ class StandardInputOutputTests(TestCase):
 
     def _requireFailure(self, d, callback):
         def cb(result):
-            self.fail("Process terminated with non-Failure: {!r}".format(result))
+            self.fail(f"Process terminated with non-Failure: {result!r}")
 
         def eb(err):
             return callback(err)
@@ -201,7 +201,7 @@ class StandardInputOutputTests(TestCase):
             """
             self.assertTrue(
                 p.data[1].endswith(UNIQUE_LAST_WRITE_STRING),
-                "Received {!r} from child, did not find expected bytes.".format(p.data),
+                f"Received {p.data!r} from child, did not find expected bytes.",
             )
             reason.trap(error.ProcessDone)
 

--- a/src/twisted/test/test_task.py
+++ b/src/twisted/test/test_task.py
@@ -479,14 +479,12 @@ class LoopTests(unittest.TestCase):
         # valid.  First, the "epsilon" value here measures the floating-point
         # inaccuracy in question, and so if it doesn't exist then we are not
         # triggering an interesting condition.
-        self.assertTrue(
-            abs(epsilon) > 0.0, "{} should be greater than zero".format(epsilon)
-        )
+        self.assertTrue(abs(epsilon) > 0.0, f"{epsilon} should be greater than zero")
         # Secondly, task.Clock should behave in such a way that once we have
         # advanced to this point, it has reached or exceeded the timespan.
         self.assertTrue(
             secondsValue >= timespan,
-            "{} should be greater than or equal to {}".format(secondsValue, timespan),
+            f"{secondsValue} should be greater than or equal to {timespan}",
         )
 
         self.assertEqual(sum(accumulator), count)

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -243,7 +243,7 @@ class ListeningTests(TestCase):
             portNumber = port.getHost().port
             self.assertEqual(
                 repr(serverProto.transport),
-                "<AccumulatingProtocol #0 on {}>".format(portNumber),
+                f"<AccumulatingProtocol #0 on {portNumber}>",
             )
             serverProto.transport.loseConnection()
             clientProto.transport.loseConnection()
@@ -873,11 +873,11 @@ class WriterProtocol(protocol.Protocol):
         self.transport.writeSequence(seq)
         peer = self.transport.getPeer()
         if peer.type != "TCP":
-            msg("getPeer returned non-TCP socket: {}".format(peer))
+            msg(f"getPeer returned non-TCP socket: {peer}")
             self.factory.problem = 1
         us = self.transport.getHost()
         if us.type != "TCP":
-            msg("getHost returned non-TCP socket: {}".format(us))
+            msg(f"getHost returned non-TCP socket: {us}")
             self.factory.problem = 1
         self.factory.done = 1
 
@@ -1073,7 +1073,7 @@ class WriteDataTests(TestCase):
             return client.lostReason
 
         clientConnectionLost.addCallback(cbClientLost)
-        msg("Connecting to {}:{}".format(addr.host, addr.port))
+        msg(f"Connecting to {addr.host}:{addr.port}")
         reactor.connectTCP(addr.host, addr.port, client)
 
         # By the end of the test, the client should have received notification

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -267,9 +267,7 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
 
         self._waitForLock(waiting)
 
-        self.assertFalse(
-            actor.failures, "run() re-entered {} times".format(actor.failures)
-        )
+        self.assertFalse(actor.failures, f"run() re-entered {actor.failures} times")
 
     def test_callInThread(self):
         """

--- a/src/twisted/test/test_threads.py
+++ b/src/twisted/test/test_threads.py
@@ -413,15 +413,11 @@ class StartupBehaviorTests(TestCase):
         def programFinished(result):
             (out, err, reason) = result
             if reason.check(error.ProcessTerminated):
-                self.fail(
-                    "Process did not exit cleanly (out: {} err: {})".format(out, err)
-                )
+                self.fail(f"Process did not exit cleanly (out: {out} err: {err})")
 
             if err:
-                log.msg("Unexpected output on standard error: {}".format(err))
-            self.assertFalse(
-                out, "Expected no output, instead received:\n{}".format(out)
-            )
+                log.msg(f"Unexpected output on standard error: {err}")
+            self.assertFalse(out, f"Expected no output, instead received:\n{out}")
 
         def programTimeout(err):
             err.trap(error.TimeoutError)

--- a/src/twisted/test/test_unix.py
+++ b/src/twisted/test/test_unix.py
@@ -219,14 +219,14 @@ class UnixSocketTests(unittest.TestCase):
         filename = self.mktemp()
         unixPort = reactor.listenUNIX(filename, serverFactory)
 
-        connectedString = "<{} on {!r}>".format(factoryName, filename)
+        connectedString = f"<{factoryName} on {filename!r}>"
         self.assertEqual(repr(unixPort), connectedString)
         self.assertEqual(str(unixPort), connectedString)
 
         d = defer.maybeDeferred(unixPort.stopListening)
 
         def stoppedListening(ign):
-            unconnectedString = "<{} (not listening)>".format(factoryName)
+            unconnectedString = f"<{factoryName} (not listening)>"
             self.assertEqual(repr(unixPort), unconnectedString)
             self.assertEqual(str(unixPort), unconnectedString)
 
@@ -359,14 +359,14 @@ class DatagramUnixSocketTests(unittest.TestCase):
         filename = self.mktemp()
         unixPort = reactor.listenUNIXDatagram(filename, serverProto)
 
-        connectedString = "<{} on {!r}>".format(protocolName, filename)
+        connectedString = f"<{protocolName} on {filename!r}>"
         self.assertEqual(repr(unixPort), connectedString)
         self.assertEqual(str(unixPort), connectedString)
 
         stopDeferred = defer.maybeDeferred(unixPort.stopListening)
 
         def stoppedListening(ign):
-            unconnectedString = "<{} (not listening)>".format(protocolName)
+            unconnectedString = f"<{protocolName} (not listening)>"
             self.assertEqual(repr(unixPort), unconnectedString)
             self.assertEqual(str(unixPort), unconnectedString)
 

--- a/src/twisted/test/test_usage.py
+++ b/src/twisted/test/test_usage.py
@@ -34,7 +34,7 @@ class WellBehaved(usage.Options):
         self.opts["myflag"] = "PONY!"
 
     def opt_myparam(self, value):
-        self.opts["myparam"] = "{} WITH A PONY!".format(value)
+        self.opts["myparam"] = f"{value} WITH A PONY!"
 
 
 class ParseCorrectnessTests(unittest.TestCase):

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -65,7 +65,7 @@ class TestCase(SynchronousTestCase):
 
         def _cb(ignore):
             raise self.failureException(
-                "did not catch an error, instead got {!r}".format(ignore)
+                f"did not catch an error, instead got {ignore!r}"
             )
 
         def _eb(failure):
@@ -88,7 +88,7 @@ class TestCase(SynchronousTestCase):
 
         def onTimeout(d):
             e = defer.TimeoutError(
-                "{!r} ({}) still running at {} secs".format(self, methodName, timeout)
+                f"{self!r} ({methodName}) still running at {timeout} secs"
             )
             f = failure.Failure(e)
             # try to errback the deferred that the test returns (for no gorram

--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -76,7 +76,7 @@ class MainTests(TestCase):
             self.assertEqual("wb", mode)
             return self.writeStream
         else:
-            raise AssertionError("Unexpected fd {!r}".format(fd))
+            raise AssertionError(f"Unexpected fd {fd!r}")
 
     def startLoggingWithObserver(self, emit, setStdout):
         """

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -65,7 +65,7 @@ class Todo:
         self.errors = errors
 
     def __repr__(self) -> str:
-        return "<Todo reason={!r} errors={!r}>".format(self.reason, self.errors)
+        return f"<Todo reason={self.reason!r} errors={self.errors!r}>"
 
     def expected(self, failure):
         """
@@ -438,7 +438,7 @@ class _Assertions(pyunit.TestCase):
         '%r is not %r' % (first, second)
         """
         if first is not second:
-            raise self.failureException(msg or "{!r} is not {!r}".format(first, second))
+            raise self.failureException(msg or f"{first!r} is not {second!r}")
         return first
 
     failUnlessIdentical = assertIs
@@ -454,7 +454,7 @@ class _Assertions(pyunit.TestCase):
         '%r is %r' % (first, second)
         """
         if first is second:
-            raise self.failureException(msg or "{!r} is {!r}".format(first, second))
+            raise self.failureException(msg or f"{first!r} is {second!r}")
         return first
 
     failIfIdentical = assertIsNot
@@ -468,7 +468,7 @@ class _Assertions(pyunit.TestCase):
         '%r == %r' % (first, second)
         """
         if not first != second:
-            raise self.failureException(msg or "{!r} == {!r}".format(first, second))
+            raise self.failureException(msg or f"{first!r} == {second!r}")
         return first
 
     assertNotEquals = assertNotEqual
@@ -486,9 +486,7 @@ class _Assertions(pyunit.TestCase):
                     '%r not in %r' % (first, second)
         """
         if containee not in container:
-            raise self.failureException(
-                msg or "{!r} not in {!r}".format(containee, container)
-            )
+            raise self.failureException(msg or f"{containee!r} not in {container!r}")
         return containee
 
     failUnlessIn = assertIn
@@ -504,9 +502,7 @@ class _Assertions(pyunit.TestCase):
                     '%r in %r' % (first, second)
         """
         if containee in container:
-            raise self.failureException(
-                msg or "{!r} in {!r}".format(containee, container)
-            )
+            raise self.failureException(msg or f"{containee!r} in {container!r}")
         return containee
 
     failIfIn = assertNotIn
@@ -525,7 +521,7 @@ class _Assertions(pyunit.TestCase):
         """
         if round(second - first, places) == 0:
             raise self.failureException(
-                msg or "{!r} == {!r} within {!r} places".format(first, second, places)
+                msg or f"{first!r} == {second!r} within {places!r} places"
             )
         return first
 
@@ -547,7 +543,7 @@ class _Assertions(pyunit.TestCase):
         """
         if round(second - first, places) != 0:
             raise self.failureException(
-                msg or "{!r} != {!r} within {!r} places".format(first, second, places)
+                msg or f"{first!r} != {second!r} within {places!r} places"
             )
         return first
 
@@ -562,7 +558,7 @@ class _Assertions(pyunit.TestCase):
                     '%r ~== %r' % (first, second)
         """
         if abs(first - second) > tolerance:
-            raise self.failureException(msg or "{} ~== {}".format(first, second))
+            raise self.failureException(msg or f"{first} ~== {second}")
         return first
 
     failUnlessApproximates = assertApproximates
@@ -614,7 +610,7 @@ class _Assertions(pyunit.TestCase):
         # Use starts with because of .pyc/.pyo issues.
         self.assertTrue(
             filename.startswith(first.filename),
-            "Warning in {!r}, expected {!r}".format(first.filename, filename),
+            f"Warning in {first.filename!r}, expected {filename!r}",
         )
 
         # It would be nice to be able to check the line number as well, but
@@ -647,9 +643,7 @@ class _Assertions(pyunit.TestCase):
                 suffix = ""
             else:
                 suffix = ": " + message
-            self.fail(
-                "{!r} is not an instance of {}{}".format(instance, classOrTuple, suffix)
-            )
+            self.fail(f"{instance!r} is not an instance of {classOrTuple}{suffix}")
 
     failUnlessIsInstance = assertIsInstance
 
@@ -666,7 +660,7 @@ class _Assertions(pyunit.TestCase):
         @type classOrTuple: class, type, or tuple.
         """
         if isinstance(instance, classOrTuple):
-            self.fail("{!r} is an instance of {}".format(instance, classOrTuple))
+            self.fail(f"{instance!r} is an instance of {classOrTuple}")
 
     failIfIsInstance = assertNotIsInstance
 
@@ -1144,9 +1138,7 @@ class SynchronousTestCase(_Assertions):
                     if not isinstance(
                         aFunction, (types.FunctionType, types.MethodType)
                     ):
-                        raise ValueError(
-                            "{!r} is not a function or method".format(aFunction)
-                        )
+                        raise ValueError(f"{aFunction!r} is not a function or method")
 
                     # inspect.getabsfile(aFunction) sometimes returns a
                     # filename which disagrees with the filename the warning
@@ -1218,7 +1210,7 @@ class SynchronousTestCase(_Assertions):
         attr = getattr(module, name)
         warningsShown = self.flushWarnings([self.getDeprecatedModuleAttribute])
         if len(warningsShown) == 0:
-            self.fail("{} is not deprecated.".format(fqpn))
+            self.fail(f"{fqpn} is not deprecated.")
 
         observedWarning = warningsShown[0]["message"]
         expectedWarning = DEPRECATION_WARNING_FORMAT % {
@@ -1229,7 +1221,7 @@ class SynchronousTestCase(_Assertions):
             expectedWarning = expectedWarning + ": " + message
         self.assert_(
             observedWarning.startswith(expectedWarning),
-            "Expected {!r} to start with {!r}".format(observedWarning, expectedWarning),
+            f"Expected {observedWarning!r} to start with {expectedWarning!r}",
         )
 
         return attr
@@ -1276,7 +1268,7 @@ class SynchronousTestCase(_Assertions):
             [since, replacement] = info
 
         if len(warningsShown) == 0:
-            self.fail("{!r} is not deprecated.".format(f))
+            self.fail(f"{f!r} is not deprecated.")
 
         observedWarning = warningsShown[0]["message"]
         expectedWarning = getDeprecationWarningString(f, since, replacement=replacement)

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -638,7 +638,7 @@ class Reporter(TestResult):
         )
 
     def _printUnexpectedSuccess(self, todo):
-        ret = "Reason: {!r}\n".format(todo.reason)
+        ret = f"Reason: {todo.reason!r}\n"
         if todo.errors:
             ret += "Expected errors: {}\n".format(", ".join(todo.errors))
         return ret
@@ -881,7 +881,7 @@ class _AnsiColorizer:
         @param color: A string label for a color. e.g. 'red', 'white'.
         """
         color = self._colors[color]
-        self.stream.write("\x1b[{};1m{}\x1b[0m".format(color, text))
+        self.stream.write(f"\x1b[{color};1m{text}\x1b[0m")
 
 
 class _Win32Colorizer:

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -101,7 +101,7 @@ def filenameToModule(fn):
     @raise ValueError: If C{fn} does not exist.
     """
     if not os.path.exists(fn):
-        raise ValueError("{!r} doesn't exist".format(fn))
+        raise ValueError(f"{fn!r} doesn't exist")
     try:
         ret = reflect.namedAny(reflect.filenameToModuleName(fn))
     except (ValueError, AttributeError):
@@ -145,7 +145,7 @@ def _resolveDirectory(fn):
         if initFile:
             fn = os.path.join(fn, initFile)
         else:
-            raise ValueError("{!r} is not a package directory".format(fn))
+            raise ValueError(f"{fn!r} is not a package directory")
     return fn
 
 
@@ -462,9 +462,7 @@ class TestLoader:
                     raise
 
                 if remaining == "":
-                    raise reflect.ModuleNotFound(
-                        "The module {} does not exist.".format(name)
-                    )
+                    raise reflect.ModuleNotFound(f"The module {name} does not exist.")
 
         if obj is None:
             # If it's none here, we didn't get to import anything.
@@ -479,7 +477,7 @@ class TestLoader:
                 # class from just holding onto the method.
                 parent, obj = obj, getattr(obj, part)
         except AttributeError:
-            raise AttributeError("{} does not exist.".format(name))
+            raise AttributeError(f"{name} does not exist.")
 
         return self.loadAnything(
             obj, parent=parent, qualName=remaining, recurse=recurse
@@ -501,7 +499,7 @@ class TestLoader:
         ## a custom suite.
         ## OR, should I add another method
         if not isinstance(module, types.ModuleType):
-            raise TypeError("{!r} is not a module".format(module))
+            raise TypeError(f"{module!r} is not a module")
         if hasattr(module, "testSuite"):
             return module.testSuite()
         elif hasattr(module, "test_suite"):
@@ -525,9 +523,9 @@ class TestLoader:
         @param klass: The class to load tests from.
         """
         if not isinstance(klass, type):
-            raise TypeError("{!r} is not a class".format(klass))
+            raise TypeError(f"{klass!r} is not a class")
         if not isTestCase(klass):
-            raise ValueError("{!r} is not a test case".format(klass))
+            raise ValueError(f"{klass!r} is not a test case")
         names = self.getTestCaseNames(klass)
         tests = self.sort(
             [self._makeCase(klass, self.methodPrefix + name) for name in names]
@@ -570,7 +568,7 @@ class TestLoader:
         tests.
         """
         if not isPackage(package):
-            raise TypeError("{!r} is not a package".format(package))
+            raise TypeError(f"{package!r} is not a package")
         pkgobj = modules.getModule(package.__name__)
         if recurse:
             discovery = pkgobj.walkModules()
@@ -666,7 +664,7 @@ class TestLoader:
             # We've found a test suite.
             return obj
         else:
-            raise TypeError("don't know how to make test from: {}".format(obj))
+            raise TypeError(f"don't know how to make test from: {obj}")
 
     def loadByName(self, name, recurse=False):
         """
@@ -733,7 +731,7 @@ class TestLoader:
             module = SourceFileLoader(name, fileName).load_module()
             return self.loadAnything(module, recurse=recurse)
         except OSError:
-            raise ValueError("{} is not a Python file.".format(fileName))
+            raise ValueError(f"{fileName} is not a Python file.")
 
 
 def _qualNameWalker(qualName):

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -36,7 +36,7 @@ class MockEquality(FancyEqMixin):
         self.name = name
 
     def __repr__(self) -> str:
-        return "MockEquality({})".format(self.name)
+        return f"MockEquality({self.name})"
 
 
 class ComparisonError:
@@ -123,9 +123,9 @@ class AssertFalseTests(unittest.SynchronousTestCase):
         @param method: The test method to test.
         """
         for notTrue in [0, 0.0, False, None, (), []]:
-            result = method(notTrue, "failed on {!r}".format(notTrue))
+            result = method(notTrue, f"failed on {notTrue!r}")
             if result != notTrue:
-                self.fail("Did not return argument {!r}".format(notTrue))
+                self.fail(f"Did not return argument {notTrue!r}")
 
     def _assertFalseTrue(self, method):
         """
@@ -135,12 +135,12 @@ class AssertFalseTests(unittest.SynchronousTestCase):
         """
         for true in [1, True, "cat", [1, 2], (3, 4)]:
             try:
-                method(true, "failed on {!r}".format(true))
+                method(true, f"failed on {true!r}")
             except self.failureException as e:
                 self.assertIn(
-                    "failed on {!r}".format(true),
+                    f"failed on {true!r}",
                     str(e),
-                    "Raised incorrect exception on {!r}: {!r}".format(true, e),
+                    f"Raised incorrect exception on {true!r}: {e!r}",
                 )
             else:
                 self.fail(
@@ -201,12 +201,12 @@ class AssertTrueTests(unittest.SynchronousTestCase):
         """
         for notTrue in [0, 0.0, False, None, (), []]:
             try:
-                method(notTrue, "failed on {!r}".format(notTrue))
+                method(notTrue, f"failed on {notTrue!r}")
             except self.failureException as e:
                 self.assertIn(
-                    "failed on {!r}".format(notTrue),
+                    f"failed on {notTrue!r}",
                     str(e),
-                    "Raised incorrect exception on {!r}: {!r}".format(notTrue, e),
+                    f"Raised incorrect exception on {notTrue!r}: {e!r}",
                 )
             else:
                 self.fail(
@@ -224,9 +224,9 @@ class AssertTrueTests(unittest.SynchronousTestCase):
         @param method: The test method to test.
         """
         for true in [1, True, "cat", [1, 2], (3, 4)]:
-            result = method(true, "failed on {!r}".format(true))
+            result = method(true, f"failed on {true!r}")
             if result != true:
-                self.fail("Did not return argument {!r}".format(true))
+                self.fail(f"Did not return argument {true!r}")
 
     def test_assertTrueFalse(self):
         """
@@ -294,12 +294,10 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
                 got = str(ourFailure)
                 expected = str(theirFailure)
                 if expected != got:
-                    self.fail("Expected: {!r}; Got: {!r}".format(expected, got))
+                    self.fail(f"Expected: {expected!r}; Got: {got!r}")
 
         if not raised:
-            self.fail(
-                "Call to assertEqual({!r}, {!r}) didn't fail".format(first, second)
-            )
+            self.fail(f"Call to assertEqual({first!r}, {second!r}) didn't fail")
 
     def test_assertEqual_basic(self):
         self._testEqualPair("cat", "cat")
@@ -393,7 +391,7 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
         )
         self.assertTrue(
             isinstance(x, self.failureException),
-            "Expected {!r} instance to be returned".format(self.failureException),
+            f"Expected {self.failureException!r} instance to be returned",
         )
         try:
             x = self.failUnlessRaises(
@@ -480,7 +478,7 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
             if typeError:
                 errors.append("expected TypeError in exception message")
             if errors:
-                self.fail("; ".join(errors), "message = {}".format(message))
+                self.fail("; ".join(errors), f"message = {message}")
         else:
             self.fail("Mismatched exception type should have caused test failure.")  # type: ignore[unreachable]
 
@@ -697,7 +695,7 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
         A = type("A", (object,), {})
         a = A()
         error = self.assertRaises(self.failureException, self.assertNotIsInstance, a, A)
-        self.assertEqual(str(error), "{!r} is an instance of {}".format(a, A))
+        self.assertEqual(str(error), f"{a!r} is an instance of {A}")
 
     def test_assertNotIsInstanceErrorMultipleClasses(self):
         """
@@ -1502,9 +1500,7 @@ class AssertionNamesTests(unittest.SynchronousTestCase):
             if not callable(value):
                 continue
             if name.endswith("Equal"):
-                self.assertTrue(
-                    hasattr(self, name + "s"), "{} but no {}s".format(name, name)
-                )
+                self.assertTrue(hasattr(self, name + "s"), f"{name} but no {name}s")
                 self.assertEqual(value, getattr(self, name + "s"))
             if name.endswith("Equals"):
                 self.assertTrue(
@@ -1587,9 +1583,7 @@ class CallDeprecatedTests(unittest.SynchronousTestCase):
         # by callDeprecated.  Flush it now to make sure it did happen and to
         # prevent it from showing up on stdout.
         warningsShown = self.flushWarnings()
-        self.assertEqual(
-            len(warningsShown), 1, "Unexpected warnings: {}".format(warningsShown)
-        )
+        self.assertEqual(len(warningsShown), 1, f"Unexpected warnings: {warningsShown}")
 
     def test_callDeprecationWithMessage(self):
         """

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -160,9 +160,7 @@ class FileTests(packages.SysPathManglingTest):
         emptyDir.createDirectory()
 
         err = self.assertRaises(ValueError, runner.filenameToModule, emptyDir.path)
-        self.assertEqual(
-            str(err), "{!r} is not a package directory".format(emptyDir.path)
-        )
+        self.assertEqual(str(err), f"{emptyDir.path!r} is not a package directory")
 
     def test_filenameNotPython(self):
         """

--- a/src/twisted/trial/test/test_pyunitcompat.py
+++ b/src/twisted/trial/test/test_pyunitcompat.py
@@ -28,7 +28,7 @@ class PyUnitTestTests(SynchronousTestCase):
         """
         Tests must be callable in order to be used with Python's unittest.py.
         """
-        self.assertTrue(callable(self.test), "{!r} is not callable.".format(self.test))
+        self.assertTrue(callable(self.test), f"{self.test!r} is not callable.")
 
 
 class PyUnitResultTests(SynchronousTestCase):

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -76,7 +76,7 @@ class StringTest(unittest.SynchronousTestCase):
                     % (line_number, exp.pattern, out),
                 )
             else:
-                raise TypeError("don't know what to do with object {!r}".format(exp))
+                raise TypeError(f"don't know what to do with object {exp!r}")
 
 
 class TestResultTests(unittest.SynchronousTestCase):
@@ -148,7 +148,7 @@ class ErrorReportingTests(StringTest):
                 "twisted.trial.test.erroneous.FoolishError: "
                 "I am a broken setUp method"
             ),
-            "{}.{}.test_noop".format(cls.__module__, cls.__name__),
+            f"{cls.__module__}.{cls.__name__}.test_noop",
         ]
         self.stringComparison(match, output)
 

--- a/src/twisted/trial/test/test_script.py
+++ b/src/twisted/trial/test/test_script.py
@@ -202,9 +202,7 @@ class TestModuleTests(unittest.SynchronousTestCase):
         try:
             self.config.opt_testmodule(filename)
             self.assertEqual(0, len(self.config["tests"]))
-            self.assertEqual(
-                "File {!r} doesn't exist\n".format(filename), buffy.getvalue()
-            )
+            self.assertEqual(f"File {filename!r} doesn't exist\n", buffy.getvalue())
         finally:
             sys.stderr = stderr
 
@@ -227,9 +225,7 @@ class TestModuleTests(unittest.SynchronousTestCase):
         try:
             self.config.opt_testmodule(moduleName)
             self.assertEqual(0, len(self.config["tests"]))
-            self.assertEqual(
-                "File {!r} doesn't exist\n".format(moduleName), buffy.getvalue()
-            )
+            self.assertEqual(f"File {moduleName!r} doesn't exist\n", buffy.getvalue())
         finally:
             sys.stderr = stderr
 
@@ -307,7 +303,7 @@ class TestModuleTests(unittest.SynchronousTestCase):
         for filename in ["test_script.py", "twisted/trial/test/test_script.py"]:
             self.assertTrue(
                 trial.isTestFile(filename),
-                "{!r} should be a test file".format(filename),
+                f"{filename!r} should be a test file",
             )
         for filename in [
             "twisted/trial/test/moduletest.py",
@@ -316,7 +312,7 @@ class TestModuleTests(unittest.SynchronousTestCase):
         ]:
             self.assertFalse(
                 trial.isTestFile(filename),
-                "{!r} should *not* be a test file".format(filename),
+                f"{filename!r} should *not* be a test file",
             )
 
 

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -194,7 +194,7 @@ def acquireAttribute(objects, attr, default=_DEFAULT):
             return getattr(obj, attr)
     if default is not _DEFAULT:
         return default
-    raise AttributeError("attribute {!r} not found in {!r}".format(attr, objects))
+    raise AttributeError(f"attribute {attr!r} not found in {objects!r}")
 
 
 def excInfoOrFailureToExcInfo(err):
@@ -274,7 +274,7 @@ def _removeSafely(path):
     """
     if not path.child(b"_trial_marker").exists():
         raise _NoTrialMarker(
-            "{!r} is not a trial temporary path, refusing to remove it".format(path)
+            f"{path!r} is not a trial temporary path, refusing to remove it"
         )
     try:
         path.remove()

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -607,7 +607,7 @@ def _ensureValidMethod(method):
     """
     if _VALID_METHOD.match(method):
         return method
-    raise ValueError("Invalid method {!r}".format(method))
+    raise ValueError(f"Invalid method {method!r}")
 
 
 _VALID_URI = re.compile(br"\A[\x21-\x7e]+\Z")
@@ -633,7 +633,7 @@ def _ensureValidURI(uri):
     """
     if _VALID_URI.match(uri):
         return uri
-    raise ValueError("Invalid URI {!r}".format(uri))
+    raise ValueError(f"Invalid URI {uri!r}")
 
 
 @implementer(IClientRequest)
@@ -1029,9 +1029,7 @@ def makeStatefulDispatcher(name, template):
     def dispatcher(self, *args, **kwargs):
         func = getattr(self, "_" + name + "_" + self._state, None)
         if func is None:
-            raise RuntimeError(
-                "{!r} has no {} method in state {}".format(self, name, self._state)
-            )
+            raise RuntimeError(f"{self!r} has no {name} method in state {self._state}")
         return func(*args, **kwargs)
 
     dispatcher.__doc__ = template.__doc__

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -64,7 +64,7 @@ class slot:
         self.columnNumber = columnNumber
 
     def __repr__(self) -> str:
-        return "slot({!r})".format(self.name)
+        return f"slot({self.name!r})"
 
 
 class Tag:
@@ -262,7 +262,7 @@ class Tag:
             rstr += ", attributes=%r" % self.attributes
         if self.children:
             rstr += ", children=%r" % self.children
-        return "Tag({!r}{})".format(self.tagName, rstr)
+        return f"Tag({self.tagName!r}{rstr})"
 
 
 voidElements = (
@@ -302,7 +302,7 @@ class CDATA:
         self.data = data
 
     def __repr__(self) -> str:
-        return "CDATA({!r})".format(self.data)
+        return f"CDATA({self.data!r})"
 
 
 class Comment:
@@ -319,7 +319,7 @@ class Comment:
         self.data = data
 
     def __repr__(self) -> str:
-        return "Comment({!r})".format(self.data)
+        return f"Comment({self.data!r})"
 
 
 class CharRef:

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -392,7 +392,7 @@ class HTTPClientFactory(protocol.ClientFactory):
         return self._disconnectedDeferred
 
     def __repr__(self) -> str:
-        return "<{}: {}>".format(self.__class__.__name__, self.url)
+        return f"<{self.__class__.__name__}: {self.url}>"
 
     def setURL(self, url):
         _ensureValidURI(url.strip())
@@ -1610,7 +1610,7 @@ class _StandardEndpointFactory:
             )
             return wrapClientTLS(connectionCreator, endpoint)
         else:
-            raise SchemeNotSupported("Unsupported scheme: {!r}".format(uri.scheme))
+            raise SchemeNotSupported(f"Unsupported scheme: {uri.scheme!r}")
 
 
 @implementer(IAgent)

--- a/src/twisted/web/domhelpers.py
+++ b/src/twisted/web/domhelpers.py
@@ -191,7 +191,7 @@ class RawText(microdom.Text):
         nsprefixes=None,
         namespace=None,
     ):
-        writer.write("{}{}{}".format(indent, self.data, newl))
+        writer.write(f"{indent}{self.data}{newl}")
 
 
 def findNodes(parent, matcher, accum=None):

--- a/src/twisted/web/error.py
+++ b/src/twisted/web/error.py
@@ -224,7 +224,7 @@ class UnsupportedMethod(Exception):
             )
 
     def __str__(self) -> str:
-        return "Expected one of {!r}".format(self.allowedMethods)
+        return f"Expected one of {self.allowedMethods!r}"
 
 
 class SchemeNotSupported(Exception):
@@ -274,7 +274,7 @@ class MissingTemplateLoader(RenderError):
         self.element = element
 
     def __repr__(self) -> str:
-        return "{!r}: {!r} had no loader".format(self.__class__.__name__, self.element)
+        return f"{self.__class__.__name__!r}: {self.element!r} had no loader"
 
 
 class UnexposedMethodError(Exception):

--- a/src/twisted/web/html.py
+++ b/src/twisted/web/html.py
@@ -35,7 +35,7 @@ def linkList(lst):
     io = StringIO()
     io.write("<ul>\n")
     for hr, el in lst:
-        io.write('<li> <a href="{}">{}</a></li>\n'.format(hr, el))
+        io.write(f'<li> <a href="{hr}">{el}</a></li>\n')
     io.write("</ul>")
     return io.getvalue()
 
@@ -50,6 +50,6 @@ def output(func, *args, **kw):
     try:
         return func(*args, **kw)
     except BaseException:
-        log.msg("Error calling {!r}:".format(func))
+        log.msg(f"Error calling {func!r}:")
         log.err()
         return PRE("An error occurred.")

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -831,11 +831,7 @@ class Request:
         if self.producer:
             self._log.failure(
                 "",
-                Failure(
-                    RuntimeError(
-                        "Producer was not unregistered for {}".format(self.uri)
-                    )
-                ),
+                Failure(RuntimeError(f"Producer was not unregistered for {self.uri}")),
             )
             self.unregisterProducer()
         self.channel.requestDone(self)
@@ -1893,7 +1889,7 @@ class _ChunkedTransferDecoder:
         data = self._buffer + data
         self._buffer = b""
         while data:
-            data = getattr(self, "_dataReceived_{}".format(self.state))(data)
+            data = getattr(self, f"_dataReceived_{self.state}")(data)
 
     def noMoreData(self):
         """

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -355,7 +355,7 @@ class Document(Node):
 
         w('<?xml version="1.0"?>' + newl)
         if self.doctype:
-            w("<!DOCTYPE {}>{}".format(self.doctype, newl))
+            w(f"<!DOCTYPE {self.doctype}>{newl}")
         self.documentElement.writexml(
             stream, indent, addindent, newl, strip, nsprefixes, namespace
         )
@@ -443,7 +443,7 @@ class Comment(CharacterData):
     ):
         w = _streamWriteWrapper(stream)
         val = self.data
-        w("<!--{}-->".format(val))
+        w(f"<!--{val}-->")
 
     def cloneNode(self, deep=0, parent=None):
         return Comment(self.nodeValue, parent)
@@ -813,11 +813,11 @@ class Element(Node):
     def __repr__(self) -> str:
         rep = "Element(%s" % repr(self.nodeName)
         if self.attributes:
-            rep += ", attributes={!r}".format(self.attributes)
+            rep += f", attributes={self.attributes!r}"
         if self._filename:
-            rep += ", filename={!r}".format(self._filename)
+            rep += f", filename={self._filename!r}"
         if self._markpos:
-            rep += ", markpos={!r}".format(self._markpos)
+            rep += f", markpos={self._markpos!r}"
         return rep + ")"
 
     def __str__(self) -> str:

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -750,7 +750,7 @@ class Session(components.Componentized):
             self._expireCall.reset(self.sessionTimeout)
 
 
-version = networkString("TwistedWeb/{}".format(copyright.version))
+version = networkString(f"TwistedWeb/{copyright.version}")
 
 
 @implementer(interfaces.IProtocolNegotiationFactory)

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -301,9 +301,7 @@ class File(resource.Resource, filepath.FilePath):
                 # leaving us with raw bytes.
                 path = path.decode("utf-8")
             except UnicodeDecodeError:
-                log.err(
-                    None, "Could not decode path segment as utf-8: {!r}".format(path)
-                )
+                log.err(None, f"Could not decode path segment as utf-8: {path!r}")
                 return self.childNotFound
 
         self.restat(reraise=False)
@@ -364,36 +362,36 @@ class File(resource.Resource, filepath.FilePath):
             raise ValueError("Missing '=' separator")
         kind = kind.strip()
         if kind != b"bytes":
-            raise ValueError("Unsupported Bytes-Unit: {!r}".format(kind))
+            raise ValueError(f"Unsupported Bytes-Unit: {kind!r}")
         unparsedRanges = list(filter(None, map(bytes.strip, value.split(b","))))
         parsedRanges = []
         for byteRange in unparsedRanges:
             try:
                 start, end = byteRange.split(b"-", 1)
             except ValueError:
-                raise ValueError("Invalid Byte-Range: {!r}".format(byteRange))
+                raise ValueError(f"Invalid Byte-Range: {byteRange!r}")
             if start:
                 try:
                     start = int(start)
                 except ValueError:
-                    raise ValueError("Invalid Byte-Range: {!r}".format(byteRange))
+                    raise ValueError(f"Invalid Byte-Range: {byteRange!r}")
             else:
                 start = None
             if end:
                 try:
                     end = int(end)
                 except ValueError:
-                    raise ValueError("Invalid Byte-Range: {!r}".format(byteRange))
+                    raise ValueError(f"Invalid Byte-Range: {byteRange!r}")
             else:
                 end = None
             if start is not None:
                 if end is not None and start > end:
                     # Start must be less than or equal to end or it is invalid.
-                    raise ValueError("Invalid Byte-Range: {!r}".format(byteRange))
+                    raise ValueError(f"Invalid Byte-Range: {byteRange!r}")
             elif end is None:
                 # One or both of start and end must be specified.  Omitting
                 # both is invalid.
-                raise ValueError("Invalid Byte-Range: {!r}".format(byteRange))
+                raise ValueError(f"Invalid Byte-Range: {byteRange!r}")
             parsedRanges.append((start, end))
         return parsedRanges
 
@@ -604,7 +602,7 @@ class File(resource.Resource, filepath.FilePath):
         try:
             parsedRanges = self._parseRangeHeader(byteRange)
         except ValueError:
-            log.msg("Ignoring malformed Range header {!r}".format(byteRange.decode()))
+            log.msg(f"Ignoring malformed Range header {byteRange.decode()!r}")
             self._setContentHeaders(request)
             request.setResponseCode(http.OK)
             return NoRangeStaticProducer(request, fileForReading)

--- a/src/twisted/web/sux.py
+++ b/src/twisted/web/sux.py
@@ -76,7 +76,7 @@ class ParseError(Exception):
         self.message = message
 
     def __str__(self) -> str:
-        return "{}:{}:{}: {}".format(self.filename, self.line, self.col, self.message)
+        return f"{self.filename}:{self.line}:{self.col}: {self.message}"
 
 
 class XMLParser(Protocol):
@@ -211,7 +211,7 @@ class XMLParser(Protocol):
             if self.beExtremelyLenient:
                 self._leadingBodyData = byte
                 return "bodydata"
-            self._parseError("First char of document [{!r}] wasn't <".format(byte))
+            self._parseError(f"First char of document [{byte!r}] wasn't <")
         return "tagstart"
 
     def begin_comment(self, byte):
@@ -389,9 +389,7 @@ class XMLParser(Protocol):
             # something is really broken. let's leave this attribute where it
             # is and move on to the next thing
             return
-        self._parseError(
-            "Invalid attribute name: {!r} {!r}".format(self.attrname, byte)
-        )
+        self._parseError(f"Invalid attribute name: {self.attrname!r} {byte!r}")
 
     def do_beforeattrval(self, byte):
         if byte in "\"'":

--- a/src/twisted/web/tap.py
+++ b/src/twisted/web/tap.py
@@ -188,7 +188,7 @@ demo webserver that has the Test class from twisted.web.demo in it."""
         try:
             application = reflect.namedAny(name)
         except (AttributeError, ValueError):
-            raise usage.UsageError("No such WSGI application: {!r}".format(name))
+            raise usage.UsageError(f"No such WSGI application: {name!r}")
         pool = threadpool.ThreadPool()
         reactor.callWhenRunning(pool.start)
         reactor.addSystemEventTrigger("after", "shutdown", pool.stop)

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -235,19 +235,19 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
             if nsPrefix is None:
                 attrKey = attrName
             else:
-                attrKey = "{}:{}".format(nsPrefix, attrName)
+                attrKey = f"{nsPrefix}:{attrName}"
             nonTemplateAttrs[attrKey] = v
 
         if ns == TEMPLATE_NAMESPACE and name == "attr":
             if not self.stack:
                 # TODO: define a better exception for this?
                 raise AssertionError(
-                    "<{{{}}}attr> as top-level element".format(TEMPLATE_NAMESPACE)
+                    f"<{{{TEMPLATE_NAMESPACE}}}attr> as top-level element"
                 )
             if "name" not in nonTemplateAttrs:
                 # TODO: same here
                 raise AssertionError(
-                    "<{{{}}}attr> requires a name attribute".format(TEMPLATE_NAMESPACE)
+                    f"<{{{TEMPLATE_NAMESPACE}}}attr> requires a name attribute"
                 )
             el = Tag(
                 "",
@@ -459,7 +459,7 @@ class XMLFile:
                 return _flatsaxParse(f)
 
     def __repr__(self) -> str:
-        return "<XMLFile of {!r}>".format(self._path)
+        return f"<XMLFile of {self._path!r}>"
 
     def load(self):
         """
@@ -621,7 +621,7 @@ class _TagFactory:
         # allow for E.del as E.del_
         tagName = tagName.rstrip("_")
         if tagName not in VALID_HTML_TAG_NAMES:
-            raise AttributeError("unknown tag {!r}".format(tagName))
+            raise AttributeError(f"unknown tag {tagName!r}")
         return Tag(tagName)
 
 

--- a/src/twisted/web/test/_util.py
+++ b/src/twisted/web/test/_util.py
@@ -27,7 +27,7 @@ def _render(resource, request):
         else:
             return request.notifyFinish()
     else:
-        raise ValueError("Unexpected return value: {!r}".format(result))
+        raise ValueError(f"Unexpected return value: {result!r}")
 
 
 class FlattenTestCase(TestCase):

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -27,7 +27,7 @@ from twisted.web.server import NOT_DONE_YET, Session, Site
 from twisted.web._responses import FOUND
 
 
-textLinearWhitespaceComponents = ["Foo{}bar".format(lw) for lw in ["\r", "\n", "\r\n"]]
+textLinearWhitespaceComponents = [f"Foo{lw}bar" for lw in ["\r", "\n", "\r\n"]]
 
 sanitizedText = "Foo bar"
 bytesLinearWhitespaceComponents = [
@@ -60,9 +60,7 @@ class DummyChannel:
 
         def write(self, data):
             if not isinstance(data, bytes):
-                raise TypeError(
-                    "Can only write bytes to a transport, not {!r}".format(data)
-                )
+                raise TypeError(f"Can only write bytes to a transport, not {data!r}")
             self.written.write(data)
 
         def writeSequence(self, iovec):

--- a/src/twisted/web/test/test_cgi.py
+++ b/src/twisted/web/test/test_cgi.py
@@ -280,7 +280,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
     test_ReadEmptyInput.timeout = 5  # type: ignore[attr-defined]
 
     def _test_ReadEmptyInput_1(self, res):
-        expected = "readinput ok{}".format(os.linesep)
+        expected = f"readinput ok{os.linesep}"
         expected = expected.encode("ascii")
         self.assertEqual(res, expected)
 
@@ -305,7 +305,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
     test_ReadInput.timeout = 5  # type: ignore[attr-defined]
 
     def _test_ReadInput_1(self, res):
-        expected = "readinput ok{}".format(os.linesep)
+        expected = f"readinput ok{os.linesep}"
         expected = expected.encode("ascii")
         self.assertEqual(res, expected)
 
@@ -329,7 +329,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
     test_ReadAllInput.timeout = 5  # type: ignore[attr-defined]
 
     def _test_ReadAllInput_1(self, res):
-        expected = "readallinput ok{}".format(os.linesep)
+        expected = f"readallinput ok{os.linesep}"
         expected = expected.encode("ascii")
         self.assertEqual(res, expected)
 
@@ -385,7 +385,7 @@ class CGIScriptTests(_StartServerAndTearDownMixin, unittest.TestCase):
         return d
 
     def _test_urlParameters_1(self, res):
-        expected = "1234{}".format(os.linesep)
+        expected = f"1234{os.linesep}"
         expected = expected.encode("ascii")
         self.assertEqual(res, expected)
 

--- a/src/twisted/web/test/test_client.py
+++ b/src/twisted/web/test/test_client.py
@@ -21,7 +21,7 @@ class DummyEndPoint:
         self.someString = someString
 
     def __repr__(self) -> str:
-        return "DummyEndPoint({})".format(self.someString)
+        return f"DummyEndPoint({self.someString})"
 
     def connect(self, factory):
         return defer.succeed(dict(factory=factory))

--- a/src/twisted/web/test/test_distrib.py
+++ b/src/twisted/web/test/test_distrib.py
@@ -97,7 +97,7 @@ class DistribTests(TestCase):
         f2 = MySite(r2)
         self.port2 = reactor.listenTCP(0, f2)
         agent = client.Agent(reactor)
-        url = "http://127.0.0.1:{}/here/there".format(self.port2.getHost().port)
+        url = f"http://127.0.0.1:{self.port2.getHost().port}/here/there"
         url = url.encode("ascii")
         d = agent.request(b"GET", url)
         d.addCallback(client.readBody)
@@ -144,7 +144,7 @@ class DistribTests(TestCase):
         """
         mainPort, mainAddr = self._setupDistribServer(child)
         agent = client.Agent(reactor)
-        url = "http://{}:{}/child".format(mainAddr.host, mainAddr.port)
+        url = f"http://{mainAddr.host}:{mainAddr.port}/child"
         url = url.encode("ascii")
         d = agent.request(b"GET", url, **kwargs)
         d.addCallback(client.readBody)
@@ -165,7 +165,7 @@ class DistribTests(TestCase):
         """
         mainPort, mainAddr = self._setupDistribServer(child)
 
-        url = "http://{}:{}/child".format(mainAddr.host, mainAddr.port)
+        url = f"http://{mainAddr.host}:{mainAddr.port}/child"
         url = url.encode("ascii")
         d = client.Agent(reactor).request(b"GET", url, **kwargs)
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -248,17 +248,15 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         def verifyComment(c):
             self.assertTrue(
                 c.startswith(b"<!--"),
-                "{!r} does not start with the comment prefix".format(c),
+                f"{c!r} does not start with the comment prefix",
             )
             self.assertTrue(
                 c.endswith(b"-->"),
-                "{!r} does not end with the comment suffix".format(c),
+                f"{c!r} does not end with the comment suffix",
             )
             # If it is shorter than 7, then the prefix and suffix overlap
             # illegally.
-            self.assertTrue(
-                len(c) >= 7, "{!r} is too short to be a legal comment".format(c)
-            )
+            self.assertTrue(len(c) >= 7, f"{c!r} is too short to be a legal comment")
             content = c[4:-3]
             self.assertNotIn(b"--", content)
             self.assertNotIn(b">", content)

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1656,7 +1656,7 @@ class ParsingTests(unittest.TestCase):
         """
         requestLines = [b"GET / HTTP/1.0"]
         for i in range(http.HTTPChannel.maxHeaders + 2):
-            requestLines.append(networkString("{}: foo".format(i)))
+            requestLines.append(networkString(f"{i}: foo"))
         requestLines.extend([b"", b""])
 
         self.assertRequestRejected(requestLines)

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -296,7 +296,7 @@ class BytesHeadersTests(TestCase):
         baz = b"baz"
         self.assertEqual(
             repr(Headers({foo: [bar, baz]})),
-            "Headers({{{!r}: [{!r}, {!r}]}})".format(foo, bar, baz),
+            f"Headers({{{foo!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_reprWithRawBytes(self):
@@ -313,7 +313,7 @@ class BytesHeadersTests(TestCase):
         baz = b"baz\xe1"
         self.assertEqual(
             repr(Headers({foo: [bar, baz]})),
-            "Headers({{{!r}: [{!r}, {!r}]}})".format(foo, bar, baz),
+            f"Headers({{{foo!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_subclassRepr(self):
@@ -330,7 +330,7 @@ class BytesHeadersTests(TestCase):
 
         self.assertEqual(
             repr(FunnyHeaders({foo: [bar, baz]})),
-            "FunnyHeaders({{{!r}: [{!r}, {!r}]}})".format(foo, bar, baz),
+            f"FunnyHeaders({{{foo!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_copy(self):

--- a/src/twisted/web/test/test_httpauth.py
+++ b/src/twisted/web/test/test_httpauth.py
@@ -60,9 +60,7 @@ class BasicAuthTestsMixin:
         L{basic.BasicCredentialFactory.decode} along with a response value.
         Override this in a subclass.
         """
-        raise NotImplementedError(
-            "{!r} did not implement makeRequest".format(self.__class__)
-        )
+        raise NotImplementedError(f"{self.__class__!r} did not implement makeRequest")
 
     def test_interface(self):
         """

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -105,7 +105,7 @@ def assertWrapperExceptionTypes(self, deferred, mainType, reasonTypes):
         self.assertEqual(
             len(err.reasons),
             len(reasonTypes),
-            "len({}) != len({})".format(err.reasons, reasonTypes),
+            f"len({err.reasons}) != len({reasonTypes})",
         )
         return err
 

--- a/src/twisted/web/test/test_static.py
+++ b/src/twisted/web/test/test_static.py
@@ -1162,9 +1162,7 @@ class RangeTests(TestCase):
         """
         logItem = self.catcher.pop()
         self.assertEqual(logItem["message"][0], expected)
-        self.assertEqual(
-            self.catcher, [], "An additional log occurred: {!r}".format(logItem)
-        )
+        self.assertEqual(self.catcher, [], f"An additional log occurred: {logItem!r}")
 
     def test_invalidRanges(self):
         """
@@ -1264,7 +1262,7 @@ class RangeTests(TestCase):
         range = b"foobar=0-43"
         self.request.requestHeaders.addRawHeader(b"range", range)
         self.resource.render(self.request)
-        expected = "Ignoring malformed Range header {!r}".format(range.decode())
+        expected = f"Ignoring malformed Range header {range.decode()!r}"
         self._assertLogged(expected)
         self.assertEqual(b"".join(self.request.written), self.payload)
         self.assertEqual(self.request.responseCode, http.OK)
@@ -1314,7 +1312,7 @@ class RangeTests(TestCase):
         """
         startEnds = [(0, 2), (20, 30), (40, 50)]
         rangeHeaderValue = b",".join(
-            [networkString("{}-{}".format(s, e)) for (s, e) in startEnds]
+            [networkString(f"{s}-{e}") for (s, e) in startEnds]
         )
         self.request.requestHeaders.addRawHeader(b"range", b"bytes=" + rangeHeaderValue)
         self.resource.render(self.request)
@@ -1341,7 +1339,7 @@ class RangeTests(TestCase):
         """
         startEnds = [(0, 2), (40, len(self.payload) + 10)]
         rangeHeaderValue = b",".join(
-            [networkString("{}-{}".format(s, e)) for (s, e) in startEnds]
+            [networkString(f"{s}-{e}") for (s, e) in startEnds]
         )
         self.request.requestHeaders.addRawHeader(b"range", b"bytes=" + rangeHeaderValue)
         self.resource.render(self.request)
@@ -1738,8 +1736,8 @@ class DirectoryListerTests(TestCase):
         """
         path = FilePath(self.mktemp())
         lister = static.DirectoryLister(path.path)
-        self.assertEqual(repr(lister), "<DirectoryLister of {!r}>".format(path.path))
-        self.assertEqual(str(lister), "<DirectoryLister of {!r}>".format(path.path))
+        self.assertEqual(repr(lister), f"<DirectoryLister of {path.path!r}>")
+        self.assertEqual(str(lister), f"<DirectoryLister of {path.path!r}>")
 
     def test_formatFileSize(self):
         """

--- a/src/twisted/web/test/test_tap.py
+++ b/src/twisted/web/test/test_tap.py
@@ -166,7 +166,7 @@ class ServiceTests(TestCase):
         options = Options()
         options.parseOptions(["--personal"])
         path = os.path.expanduser(os.path.join("~", UserDirectory.userSocketName))
-        self.assertEqual(options["ports"][0], "unix:{}".format(path))
+        self.assertEqual(options["ports"][0], f"unix:{path}")
 
     def test_defaultPort(self):
         """
@@ -218,7 +218,7 @@ class ServiceTests(TestCase):
         options = Options()
         for name in [__name__ + ".nosuchthing", "foo."]:
             exc = self.assertRaises(UsageError, options.parseOptions, ["--wsgi", name])
-            self.assertEqual(str(exc), "No such WSGI application: {!r}".format(name))
+            self.assertEqual(str(exc), f"No such WSGI application: {name!r}")
 
     @skipIf(requireModule("OpenSSL.SSL") is not None, "SSL module is available.")
     def test_HTTPSFailureOnMissingSSL(self):

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -186,14 +186,14 @@ class XMLFileReprTests(TestCase):
         An L{XMLFile} with a L{FilePath} returns a useful repr().
         """
         path = FilePath("/tmp/fake.xml")
-        self.assertEqual("<XMLFile of {!r}>".format(path), repr(XMLFile(path)))
+        self.assertEqual(f"<XMLFile of {path!r}>", repr(XMLFile(path)))
 
     def test_filename(self):
         """
         An L{XMLFile} with a filename returns a useful repr().
         """
         fname = "/tmp/fake.xml"
-        self.assertEqual("<XMLFile of {!r}>".format(fname), repr(XMLFile(fname)))
+        self.assertEqual(f"<XMLFile of {fname!r}>", repr(XMLFile(fname)))
 
     test_filename.suppress = [_xmlFileSuppress]  # type: ignore[attr-defined]
 
@@ -202,7 +202,7 @@ class XMLFileReprTests(TestCase):
         An L{XMLFile} with a file object returns a useful repr().
         """
         fobj = StringIO("not xml")
-        self.assertEqual("<XMLFile of {!r}>".format(fobj), repr(XMLFile(fobj)))
+        self.assertEqual(f"<XMLFile of {fobj!r}>", repr(XMLFile(fobj)))
 
     test_file.suppress = [_xmlFileSuppress]  # type: ignore[attr-defined]
 

--- a/src/twisted/web/test/test_webclient.py
+++ b/src/twisted/web/test/test_webclient.py
@@ -508,9 +508,7 @@ class WebClientTests(unittest.TestCase):
         called back with the contents of the page.
         """
         d = client.getPage(self.getURL("host"), timeout=100)
-        d.addCallback(
-            self.assertEqual, networkString("127.0.0.1:{}".format(self.portno))
-        )
+        d.addCallback(self.assertEqual, networkString(f"127.0.0.1:{self.portno}"))
         return d
 
     def test_timeoutTriggering(self):
@@ -903,10 +901,10 @@ class WebClientRedirectBetweenSSLandPlainTextTests(unittest.TestCase):
         skip = "Reactor doesn't support SSL"
 
     def getHTTPS(self, path):
-        return networkString("https://127.0.0.1:{}/{}".format(self.tlsPortno, path))
+        return networkString(f"https://127.0.0.1:{self.tlsPortno}/{path}")
 
     def getHTTP(self, path):
-        return networkString("http://127.0.0.1:{}/{}".format(self.plainPortno, path))
+        return networkString(f"http://127.0.0.1:{self.plainPortno}/{path}")
 
     def setUp(self):
         plainRoot = Data(b"not me", "text/plain")

--- a/src/twisted/web/test/test_wsgi.py
+++ b/src/twisted/web/test/test_wsgi.py
@@ -878,7 +878,7 @@ class InputStreamTestMixin(WSGITestsMixin):
 
     def getFileType(self):
         raise NotImplementedError(
-            "{}.getFile must be implemented".format(self.__class__.__name__)
+            f"{self.__class__.__name__}.getFile must be implemented"
         )
 
     def _renderAndReturnReaderResult(self, reader, content):
@@ -1482,7 +1482,7 @@ class StartResponseTests(WSGITestsMixin, TestCase):
 
         def checkMessage(error):
             self.assertEqual(
-                "header must be (str, str) tuple, not ({!r}, 'value')".format(key),
+                f"header must be (str, str) tuple, not ({key!r}, 'value')",
                 str(error),
             )
 
@@ -1504,7 +1504,7 @@ class StartResponseTests(WSGITestsMixin, TestCase):
 
         def checkMessage(error):
             self.assertEqual(
-                "header must be (str, str) tuple, not ('key', {!r})".format(value),
+                f"header must be (str, str) tuple, not ('key', {value!r})",
                 str(error),
             )
 

--- a/src/twisted/web/test/test_xml.py
+++ b/src/twisted/web/test/test_xml.py
@@ -230,21 +230,13 @@ alert("I hate you");
         # however this assertion tests preserving case for start and
         # end tags while still matching stuff like <bOrk></BoRk>
         self.assertEqual(d.documentElement.toxml(), s)
-        self.assertTrue(
-            d.isEqualToDocument(d2), "{!r} != {!r}".format(d.toxml(), d2.toxml())
-        )
-        self.assertTrue(
-            d2.isEqualToDocument(d3), "{!r} != {!r}".format(d2.toxml(), d3.toxml())
-        )
+        self.assertTrue(d.isEqualToDocument(d2), f"{d.toxml()!r} != {d2.toxml()!r}")
+        self.assertTrue(d2.isEqualToDocument(d3), f"{d2.toxml()!r} != {d3.toxml()!r}")
         # caseInsensitive=0 on the left, NOT perserveCase=1 on the right
         ## XXX THIS TEST IS TURNED OFF UNTIL SOMEONE WHO CARES ABOUT FIXING IT DOES
         # self.assertFalse(d3.isEqualToDocument(d2), "%r == %r" % (d3.toxml(), d2.toxml()))
-        self.assertTrue(
-            d3.isEqualToDocument(d4), "{!r} != {!r}".format(d3.toxml(), d4.toxml())
-        )
-        self.assertTrue(
-            d4.isEqualToDocument(d5), "{!r} != {!r}".format(d4.toxml(), d5.toxml())
-        )
+        self.assertTrue(d3.isEqualToDocument(d4), f"{d3.toxml()!r} != {d4.toxml()!r}")
+        self.assertTrue(d4.isEqualToDocument(d5), f"{d4.toxml()!r} != {d5.toxml()!r}")
 
     def test_differentQuotes(self):
         s = "<test a=\"a\" b='b' />"
@@ -482,9 +474,7 @@ alert("I hate you");
             ("&amp;", "&amp;"),
             ("&hello monkey", "&amp;hello monkey"),
         ]:
-            d = microdom.parseString(
-                "{}<pre>{}</pre>".format(prefix, i), beExtremelyLenient=1
-            )
+            d = microdom.parseString(f"{prefix}<pre>{i}</pre>", beExtremelyLenient=1)
             self.assertEqual(d.documentElement.toxml(), "<pre>%s</pre>" % o)
         # non-space preserving
         d = microdom.parseString("<t>hello & there</t>", beExtremelyLenient=1)

--- a/src/twisted/web/test/test_xmlrpc.py
+++ b/src/twisted/web/test/test_xmlrpc.py
@@ -208,7 +208,7 @@ class TestLookupProcedure(XMLRPC):
         if procedureName == "echo":
             return self.echo
         raise xmlrpc.NoSuchFunction(
-            self.NOT_FOUND, "procedure {} not found".format(procedureName)
+            self.NOT_FOUND, f"procedure {procedureName} not found"
         )
 
 

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -405,18 +405,14 @@ class _WSGIResponse:
 
             # However, the sequence MUST contain only 2 elements.
             if len(header) != 2:
-                raise TypeError(
-                    "header must be a (str, str) tuple, not {!r}".format(header)
-                )
+                raise TypeError(f"header must be a (str, str) tuple, not {header!r}")
 
             # Both elements MUST be native strings. Non-native strings will be
             # rejected by the underlying HTTP machinery in any case, but we
             # reject them here in order to provide a more informative error.
             for elem in header:
                 if not isinstance(elem, str):
-                    raise TypeError(
-                        "header must be (str, str) tuple, not {!r}".format(header)
-                    )
+                    raise TypeError(f"header must be (str, str) tuple, not {header!r}")
 
         self.status = status
         self.headers = headers

--- a/src/twisted/web/xmlrpc.py
+++ b/src/twisted/web/xmlrpc.py
@@ -142,7 +142,7 @@ class XMLRPC(resource.Resource):
                 request.content.read(), use_datetime=self.useDateTime
             )
         except Exception as e:
-            f = Fault(self.FAILURE, "Can't deserialize input: {}".format(e))
+            f = Fault(self.FAILURE, f"Can't deserialize input: {e}")
             self._cbRender(f, request)
         else:
             try:
@@ -177,7 +177,7 @@ class XMLRPC(resource.Resource):
                     result, methodresponse=True, allow_none=self.allowNone
                 )
             except Exception as e:
-                f = Fault(self.FAILURE, "Can't serialize output: {}".format(e))
+                f = Fault(self.FAILURE, f"Can't serialize output: {e}")
                 content = xmlrpclib.dumps(
                     f, methodresponse=True, allow_none=self.allowNone
                 )

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -57,10 +57,10 @@ class AbstractGroup:
         self.account.client.leaveGroup(self.name)
 
     def __repr__(self) -> str:
-        return "<{} {!r}>".format(self.__class__, self.name)
+        return f"<{self.__class__} {self.name!r}>"
 
     def __str__(self) -> str:
-        return "{}@{}".format(self.name, self.account.accountName)
+        return f"{self.name}@{self.account.accountName}"
 
 
 class AbstractPerson:
@@ -84,10 +84,10 @@ class AbstractPerson:
         return "--"
 
     def __repr__(self) -> str:
-        return "<{} {!r}/{}>".format(self.__class__, self.name, self.status)
+        return f"<{self.__class__} {self.name!r}/{self.status}>"
 
     def __str__(self) -> str:
-        return "{}@{}".format(self.name, self.account.accountName)
+        return f"{self.name}@{self.account.accountName}"
 
 
 class AbstractClientMixin:

--- a/src/twisted/words/im/ircsupport.py
+++ b/src/twisted/words/im/ircsupport.py
@@ -50,9 +50,7 @@ class IRCGroup(basesupport.AbstractGroup):
         if self.account.client is None:
             raise locals.OfflineError
         reason = "for great justice!"
-        self.account.client.sendLine(
-            "KICK #{} {} :{}".format(self.name, target.name, reason)
-        )
+        self.account.client.sendLine(f"KICK #{self.name} {target.name} :{reason}")
 
     ### Interface Implementation
     def setTopic(self, topic):

--- a/src/twisted/words/im/locals.py
+++ b/src/twisted/words/im/locals.py
@@ -11,7 +11,7 @@ class Enum:
         self.label = label
 
     def __repr__(self) -> str:
-        return "<{}: {}>".format(self.group, self.label)
+        return f"<{self.group}: {self.label}>"
 
     def __str__(self) -> str:
         return self.label

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -174,7 +174,7 @@ class _CommandDispatcherMixin:
         """
 
         def _getMethodName(command):
-            return "{}_{}".format(self.prefix, command)
+            return f"{self.prefix}_{command}"
 
         def _getMethod(name):
             return getattr(self, _getMethodName(name), None)
@@ -218,7 +218,7 @@ def parseModes(modes, params, paramModes=("", "")):
         raise IRCBadModes("Empty mode string")
 
     if modes[0] not in "+-":
-        raise IRCBadModes("Malformed modes string: {!r}".format(modes))
+        raise IRCBadModes(f"Malformed modes string: {modes!r}")
 
     changes = ([], [])
 
@@ -227,7 +227,7 @@ def parseModes(modes, params, paramModes=("", "")):
     for ch in modes:
         if ch in "+-":
             if count == 0:
-                raise IRCBadModes("Empty mode sequence: {!r}".format(modes))
+                raise IRCBadModes(f"Empty mode sequence: {modes!r}")
             direction = "+-".index(ch)
             count = 0
         else:
@@ -236,15 +236,15 @@ def parseModes(modes, params, paramModes=("", "")):
                 try:
                     param = params.pop(0)
                 except IndexError:
-                    raise IRCBadModes("Not enough parameters: {!r}".format(ch))
+                    raise IRCBadModes(f"Not enough parameters: {ch!r}")
             changes[direction].append((ch, param))
             count += 1
 
     if len(params) > 0:
-        raise IRCBadModes("Too many parameters: {!r} {!r}".format(modes, params))
+        raise IRCBadModes(f"Too many parameters: {modes!r} {params!r}")
 
     if count == 0:
-        raise IRCBadModes("Empty mode sequence: {!r}".format(modes))
+        raise IRCBadModes(f"Empty mode sequence: {modes!r}")
 
     return changes
 
@@ -333,17 +333,17 @@ class IRC(protocol.Protocol):
         if " " in command or command[0] == ":":
             # Not the ONLY way to screw up, but provides a little
             # sanity checking to catch likely dumb mistakes.
-            raise ValueError('Invalid command: "{}"'.format(command))
+            raise ValueError(f'Invalid command: "{command}"')
 
         if tags is None:
             tags = {}
 
         line = " ".join([command] + list(parameters))
         if prefix:
-            line = ":{} {}".format(prefix, line)
+            line = f":{prefix} {line}"
         if tags:
             tagStr = self._stringTags(tags)
-            line = "@{} {}".format(tagStr, line)
+            line = f"@{tagStr} {line}"
         self.sendLine(line)
 
         if len(parameters) > 15:
@@ -497,7 +497,7 @@ class IRC(protocol.Protocol):
         @type message: C{str} or C{unicode}
         @param message: The message being sent.
         """
-        self.sendCommand("NOTICE", (recip, ":{}".format(message)), sender)
+        self.sendCommand("NOTICE", (recip, f":{message}"), sender)
 
     def action(self, sender, recip, message):
         """
@@ -514,7 +514,7 @@ class IRC(protocol.Protocol):
         @type message: C{str} or C{unicode}
         @param message: The action being sent.
         """
-        self.sendLine(":{} ACTION {} :{}".format(sender, recip, message))
+        self.sendLine(f":{sender} ACTION {recip} :{message}")
 
     def topic(self, user, channel, topic, author=None):
         """
@@ -747,7 +747,7 @@ class IRC(protocol.Protocol):
         @type where: C{str} or C{unicode}
         @param where: The channel the user is joining.
         """
-        self.sendLine(":{} JOIN {}".format(who, where))
+        self.sendLine(f":{who} JOIN {where}")
 
     def part(self, who, where, reason=None):
         """
@@ -765,9 +765,9 @@ class IRC(protocol.Protocol):
             soul to depart.
         """
         if reason:
-            self.sendLine(":{} PART {} :{}".format(who, where, reason))
+            self.sendLine(f":{who} PART {where} :{reason}")
         else:
-            self.sendLine(":{} PART {}".format(who, where))
+            self.sendLine(f":{who} PART {where}")
 
     def channelMode(self, user, channel, mode, *args):
         """
@@ -870,7 +870,7 @@ class ServerSupportedFeatures(_CommandDispatcherMixin):
                 try:
                     octet = int(octet, 16)
                 except ValueError:
-                    raise ValueError("Invalid hex octet: {!r}".format(octet))
+                    raise ValueError(f"Invalid hex octet: {octet!r}")
                 yield chr(octet) + rest
 
         if "\\x" not in value:
@@ -1556,9 +1556,9 @@ class IRCClient(basic.LineReceiver):
         if channel[0] not in CHANNEL_PREFIXES:
             channel = "#" + channel
         if key:
-            self.sendLine("JOIN {} {}".format(channel, key))
+            self.sendLine(f"JOIN {channel} {key}")
         else:
-            self.sendLine("JOIN {}".format(channel))
+            self.sendLine(f"JOIN {channel}")
 
     def leave(self, channel, reason=None):
         """
@@ -1573,9 +1573,9 @@ class IRCClient(basic.LineReceiver):
         if channel[0] not in CHANNEL_PREFIXES:
             channel = "#" + channel
         if reason:
-            self.sendLine("PART {} :{}".format(channel, reason))
+            self.sendLine(f"PART {channel} :{reason}")
         else:
-            self.sendLine("PART {}".format(channel))
+            self.sendLine(f"PART {channel}")
 
     def kick(self, channel, user, reason=None):
         """
@@ -1592,9 +1592,9 @@ class IRCClient(basic.LineReceiver):
         if channel[0] not in CHANNEL_PREFIXES:
             channel = "#" + channel
         if reason:
-            self.sendLine("KICK {} {} :{}".format(channel, user, reason))
+            self.sendLine(f"KICK {channel} {user} :{reason}")
         else:
-            self.sendLine("KICK {} {}".format(channel, user))
+            self.sendLine(f"KICK {channel} {user}")
 
     part = leave
 
@@ -1611,7 +1611,7 @@ class IRCClient(basic.LineReceiver):
         """
         if channel[0] not in CHANNEL_PREFIXES:
             channel = "#" + channel
-        self.sendLine("INVITE {} {}".format(user, channel))
+        self.sendLine(f"INVITE {user} {channel}")
 
     def topic(self, channel, topic=None):
         """
@@ -1631,9 +1631,9 @@ class IRCClient(basic.LineReceiver):
         if channel[0] not in CHANNEL_PREFIXES:
             channel = "#" + channel
         if topic != None:
-            self.sendLine("TOPIC {} :{}".format(channel, topic))
+            self.sendLine(f"TOPIC {channel} :{topic}")
         else:
-            self.sendLine("TOPIC {}".format(channel))
+            self.sendLine(f"TOPIC {channel}")
 
     def mode(self, chan, set, modes, limit=None, user=None, mask=None):
         """
@@ -1658,15 +1658,15 @@ class IRCClient(basic.LineReceiver):
             users to be banned from the channel.
         """
         if set:
-            line = "MODE {} +{}".format(chan, modes)
+            line = f"MODE {chan} +{modes}"
         else:
-            line = "MODE {} -{}".format(chan, modes)
+            line = f"MODE {chan} -{modes}"
         if limit is not None:
             line = "%s %d" % (line, limit)
         elif user is not None:
-            line = "{} {}".format(line, user)
+            line = f"{line} {user}"
         elif mask is not None:
-            line = "{} {}".format(line, mask)
+            line = f"{line} {mask}"
         self.sendLine(line)
 
     def say(self, channel, message, length=None):
@@ -1735,7 +1735,7 @@ class IRCClient(basic.LineReceiver):
             value.
         @type length: C{int}
         """
-        fmt = "PRIVMSG {} :".format(user)
+        fmt = f"PRIVMSG {user} :"
 
         if length is None:
             length = self._safeMaximumLineLength(fmt)
@@ -1762,7 +1762,7 @@ class IRCClient(basic.LineReceiver):
         @type message: C{str}
         @param message: The contents of the notice to send.
         """
-        self.sendLine("NOTICE {} :{}".format(user, message))
+        self.sendLine(f"NOTICE {user} :{message}")
 
     def away(self, message=""):
         """
@@ -1792,7 +1792,7 @@ class IRCClient(basic.LineReceiver):
         if server is None:
             self.sendLine("WHOIS " + nickname)
         else:
-            self.sendLine("WHOIS {} {}".format(server, nickname))
+            self.sendLine(f"WHOIS {server} {nickname}")
 
     def register(self, nickname, hostname="foo", servername="bar"):
         """
@@ -2213,7 +2213,7 @@ class IRCClient(basic.LineReceiver):
         No CTCP I{ERRMSG} reply is made to remove a potential denial of service
         avenue.
         """
-        log.msg("Unknown CTCP query from {!r}: {!r} {!r}".format(user, tag, data))
+        log.msg(f"Unknown CTCP query from {user!r}: {tag!r} {data!r}")
 
     def ctcpQuery_ACTION(self, user, channel, data):
         self.action(user, channel, data)
@@ -2224,9 +2224,7 @@ class IRCClient(basic.LineReceiver):
 
     def ctcpQuery_FINGER(self, user, channel, data):
         if data is not None:
-            self.quirkyMessage(
-                "Why did {} send '{}' with a FINGER query?".format(user, data)
-            )
+            self.quirkyMessage(f"Why did {user} send '{data}' with a FINGER query?")
         if not self.fingerReply:
             return
 
@@ -2240,9 +2238,7 @@ class IRCClient(basic.LineReceiver):
 
     def ctcpQuery_VERSION(self, user, channel, data):
         if data is not None:
-            self.quirkyMessage(
-                "Why did {} send '{}' with a VERSION query?".format(user, data)
-            )
+            self.quirkyMessage(f"Why did {user} send '{data}' with a VERSION query?")
 
         if self.versionName:
             nick = user.split("!")[0]
@@ -2263,9 +2259,7 @@ class IRCClient(basic.LineReceiver):
 
     def ctcpQuery_SOURCE(self, user, channel, data):
         if data is not None:
-            self.quirkyMessage(
-                "Why did {} send '{}' with a SOURCE query?".format(user, data)
-            )
+            self.quirkyMessage(f"Why did {user} send '{data}' with a SOURCE query?")
         if self.sourceURL:
             nick = user.split("!")[0]
             # The CTCP document (Zeuge, Rollo, Mesander 1994) says that SOURCE
@@ -2276,9 +2270,7 @@ class IRCClient(basic.LineReceiver):
 
     def ctcpQuery_USERINFO(self, user, channel, data):
         if data is not None:
-            self.quirkyMessage(
-                "Why did {} send '{}' with a USERINFO query?".format(user, data)
-            )
+            self.quirkyMessage(f"Why did {user} send '{data}' with a USERINFO query?")
         if self.userinfo:
             nick = user.split("!")[0]
             self.ctcpMakeReply(nick, [("USERINFO", self.userinfo)])
@@ -2325,9 +2317,7 @@ class IRCClient(basic.LineReceiver):
 
     def ctcpQuery_TIME(self, user, channel, data):
         if data is not None:
-            self.quirkyMessage(
-                "Why did {} send '{}' with a TIME query?".format(user, data)
-            )
+            self.quirkyMessage(f"Why did {user} send '{data}' with a TIME query?")
         nick = user.split("!")[0]
         self.ctcpMakeReply(
             nick, [("TIME", ":%s" % time.asctime(time.localtime(time.time())))]
@@ -2360,15 +2350,15 @@ class IRCClient(basic.LineReceiver):
             nick = user.split("!")[0]
             self.ctcpMakeReply(
                 nick,
-                [("ERRMSG", "DCC {} :Unknown DCC type '{}'".format(data, dcctype))],
+                [("ERRMSG", f"DCC {data} :Unknown DCC type '{dcctype}'")],
             )
-            self.quirkyMessage("{} offered unknown DCC type {}".format(user, dcctype))
+            self.quirkyMessage(f"{user} offered unknown DCC type {dcctype}")
 
     def dcc_SEND(self, user, channel, data):
         # Use shlex.split for those who send files with spaces in the names.
         data = shlex.split(data)
         if len(data) < 3:
-            raise IRCBadMessage("malformed DCC SEND request: {!r}".format(data))
+            raise IRCBadMessage(f"malformed DCC SEND request: {data!r}")
 
         (filename, address, port) = data[:3]
 
@@ -2376,7 +2366,7 @@ class IRCClient(basic.LineReceiver):
         try:
             port = int(port)
         except ValueError:
-            raise IRCBadMessage("Indecipherable port {!r}".format(port))
+            raise IRCBadMessage(f"Indecipherable port {port!r}")
 
         size = -1
         if len(data) >= 4:
@@ -2391,7 +2381,7 @@ class IRCClient(basic.LineReceiver):
     def dcc_ACCEPT(self, user, channel, data):
         data = shlex.split(data)
         if len(data) < 3:
-            raise IRCBadMessage("malformed DCC SEND ACCEPT request: {!r}".format(data))
+            raise IRCBadMessage(f"malformed DCC SEND ACCEPT request: {data!r}")
         (filename, port, resumePos) = data[:3]
         try:
             port = int(port)
@@ -2404,7 +2394,7 @@ class IRCClient(basic.LineReceiver):
     def dcc_RESUME(self, user, channel, data):
         data = shlex.split(data)
         if len(data) < 3:
-            raise IRCBadMessage("malformed DCC SEND RESUME request: {!r}".format(data))
+            raise IRCBadMessage(f"malformed DCC SEND RESUME request: {data!r}")
         (filename, port, resumePos) = data[:3]
         try:
             port = int(port)
@@ -2417,7 +2407,7 @@ class IRCClient(basic.LineReceiver):
     def dcc_CHAT(self, user, channel, data):
         data = shlex.split(data)
         if len(data) < 3:
-            raise IRCBadMessage("malformed DCC CHAT request: {!r}".format(data))
+            raise IRCBadMessage(f"malformed DCC CHAT request: {data!r}")
 
         (filename, address, port) = data[:3]
 
@@ -2425,7 +2415,7 @@ class IRCClient(basic.LineReceiver):
         try:
             port = int(port)
         except ValueError:
-            raise IRCBadMessage("Indecipherable port {!r}".format(port))
+            raise IRCBadMessage(f"Indecipherable port {port!r}")
 
         self.dccDoChat(user, channel, address, port, data)
 
@@ -2550,7 +2540,7 @@ class IRCClient(basic.LineReceiver):
     def ctcpReply_PING(self, user, channel, data):
         nick = user.split("!", 1)[0]
         if (not self._pings) or ((nick, data) not in self._pings):
-            raise IRCBadMessage("Bogus PING response from {}: {}".format(user, data))
+            raise IRCBadMessage(f"Bogus PING response from {user}: {data}")
 
         t0 = self._pings[(nick, data)]
         self.pong(user, time.time() - t0)
@@ -2575,7 +2565,7 @@ class IRCClient(basic.LineReceiver):
         # Add code for handling arbitrary queries and not treat them as
         # anomalies.
 
-        log.msg("Unknown CTCP reply from {}: {} {}\n".format(user, tag, data))
+        log.msg(f"Unknown CTCP reply from {user}: {tag} {data}\n")
 
     ### Error handlers
     ### You may override these with something more appropriate to your UI.
@@ -2707,7 +2697,7 @@ def dccParseAddress(address):
         try:
             address = int(address)
         except ValueError:
-            raise IRCBadMessage("Indecipherable address {!r}".format(address))
+            raise IRCBadMessage(f"Indecipherable address {address!r}")
         else:
             address = (
                 (address >> 24) & 0xFF,
@@ -2935,7 +2925,7 @@ class DccChat(basic.LineReceiver, styles.Ephemeral):
             self.lineReceived(line)
 
     def lineReceived(self, line):
-        log.msg("DCC CHAT<{}> {}".format(self.remoteParty, line))
+        log.msg(f"DCC CHAT<{self.remoteParty}> {line}")
         self.client.privmsg(self.remoteParty, self.client.nickname, line)
 
 
@@ -3011,7 +3001,7 @@ def dccDescribe(data):
             port,
         )
     elif dcctype == "CHAT":
-        dcc_text = "CHAT for host {}, port {}".format(address, port)
+        dcc_text = f"CHAT for host {address}, port {port}"
     else:
         dcc_text = orig_data
 
@@ -3165,7 +3155,7 @@ class DccFileReceive(DccFileReceiveBasic):
         @type reason: L{Failure}
         """
         self.connected = 0
-        logmsg = "{} closed.".format(self)
+        logmsg = f"{self} closed."
         if self.fileSize > 0:
             logmsg = "%s  %d/%d bytes received" % (
                 logmsg,
@@ -3180,12 +3170,12 @@ class DccFileReceive(DccFileReceiveBasic):
                     self.fileSize - self.bytesReceived,
                 )
             else:
-                logmsg = "{} (file larger than expected)".format(logmsg)
+                logmsg = f"{logmsg} (file larger than expected)"
         else:
             logmsg = "%s  %d bytes received" % (logmsg, self.bytesReceived)
 
         if hasattr(self, "file"):
-            logmsg = "{} and written to {}.\n".format(logmsg, self.file.name)
+            logmsg = f"{logmsg} and written to {self.file.name}.\n"
             if hasattr(self.file, "close"):
                 self.file.close()
 
@@ -3198,9 +3188,9 @@ class DccFileReceive(DccFileReceiveBasic):
         assert transport is not None
         from_ = str(transport.getPeer())
         if self.fromUser is not None:
-            from_ = "{!r} ({})".format(self.fromUser, from_)
+            from_ = f"{self.fromUser!r} ({from_})"
 
-        s = "DCC transfer of '{}' from {}".format(self.filename, from_)
+        s = f"DCC transfer of '{self.filename}' from {from_}"
         return s
 
     def __repr__(self) -> str:
@@ -3790,11 +3780,11 @@ def ctcpStringify(messages):
                 except TypeError:
                     # No?  Then use it's %s representation.
                     pass
-            m = "{} {}".format(tag, data)
+            m = f"{tag} {data}"
         else:
             m = str(tag)
         m = ctcpQuote(m)
-        m = "{}{}{}".format(X_DELIM, m, X_DELIM)
+        m = f"{X_DELIM}{m}{X_DELIM}"
         coded_messages.append(m)
 
     line = "".join(coded_messages)

--- a/src/twisted/words/protocols/jabber/component.py
+++ b/src/twisted/words/protocols/jabber/component.py
@@ -380,7 +380,7 @@ class Router:
         """
         destination = JID(stanza["to"])
 
-        log.msg("Routing to {}: {!r}".format(destination.full(), stanza.toXml()))
+        log.msg(f"Routing to {destination.full()}: {stanza.toXml()!r}")
 
         if destination.host in self.routes:
             self.routes[destination.host].send(stanza)

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -165,7 +165,7 @@ class JID:
         @rtype: L{str}
         """
         if self.user:
-            return "{}@{}".format(self.user, self.host)
+            return f"{self.user}@{self.host}"
         else:
             return self.host
 
@@ -195,12 +195,12 @@ class JID:
         """
         if self.user:
             if self.resource:
-                return "{}@{}/{}".format(self.user, self.host, self.resource)
+                return f"{self.user}@{self.host}/{self.resource}"
             else:
-                return "{}@{}".format(self.user, self.host)
+                return f"{self.user}@{self.host}"
         else:
             if self.resource:
-                return "{}/{}".format(self.host, self.resource)
+                return f"{self.host}/{self.resource}"
             else:
                 return self.host
 

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -134,9 +134,9 @@ class DigestMD5:
         self.password = password
         self.defaultRealm = host
 
-        self.digest_uri = "{}/{}".format(serv_type, host)
+        self.digest_uri = f"{serv_type}/{host}"
         if serv_name is not None:
-            self.digest_uri += "/{}".format(serv_name)
+            self.digest_uri += f"/{serv_name}"
 
     def getInitialResponse(self):
         return None

--- a/src/twisted/words/protocols/jabber/xmlstream.py
+++ b/src/twisted/words/protocols/jabber/xmlstream.py
@@ -71,7 +71,7 @@ def hashPassword(sid, password):
         raise TypeError("The session identifier must be a unicode object")
     if not isinstance(password, str):
         raise TypeError("The password must be a unicode object")
-    input = "{}{}".format(sid, password)
+    input = f"{sid}{password}"
     return sha1(input.encode("utf-8")).hexdigest()
 
 

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -212,13 +212,11 @@ class IRCUser(irc.IRC):
 
     # IChatClient implementation
     def userJoined(self, group, user):
-        self.join(
-            "{}!{}@{}".format(user.name, user.name, self.hostname), "#" + group.name
-        )
+        self.join(f"{user.name}!{user.name}@{self.hostname}", "#" + group.name)
 
     def userLeft(self, group, user, reason=None):
         self.part(
-            "{}!{}@{}".format(user.name, user.name, self.hostname),
+            f"{user.name}!{user.name}@{self.hostname}",
             "#" + group.name,
             (reason or "leaving"),
         )
@@ -235,7 +233,7 @@ class IRCUser(irc.IRC):
         text = message.get("text", "<an unrepresentable message>")
         for L in text.splitlines():
             self.privmsg(
-                "{}!{}@{}".format(sender.name, sender.name, self.hostname),
+                f"{sender.name}!{sender.name}@{self.hostname}",
                 recipientName,
                 L,
             )
@@ -248,7 +246,7 @@ class IRCUser(irc.IRC):
                 self.name,
                 "#" + group.name,
                 topic,
-                "{}!{}@{}".format(author, author, self.hostname),
+                f"{author}!{author}@{self.hostname}",
             )
 
     # irc.IRC callbacks - starting with login related stuff.
@@ -367,7 +365,7 @@ class IRCUser(irc.IRC):
 
     def _cbLogin(self, result):
         (iface, avatar, logout) = result
-        assert iface is iwords.IUser, "Realm is buggy, got {!r}".format(iface)
+        assert iface is iwords.IUser, f"Realm is buggy, got {iface!r}"
 
         # Let them send messages to the world
         del self.irc_PRIVMSG

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1349,7 +1349,7 @@ class ClientImplementationTests(IRCTestCase):
         """
         if target is None:
             target = "#chan"
-        message = ":Wolf!~wolf@yok.utu.fi MODE {} {} {}\r\n".format(target, msg, args)
+        message = f":Wolf!~wolf@yok.utu.fi MODE {target} {msg} {args}\r\n"
         self.client.dataReceived(message)
 
     def _parseModeChange(self, results, target=None):
@@ -1862,9 +1862,9 @@ class ClientMsgTests(IRCTestCase):
         L{IRCClient.msg} are sent in a single command.
         """
         msg = "barbazbo"
-        maxLen = len("PRIVMSG foo :{}".format(msg)) + 2
+        maxLen = len(f"PRIVMSG foo :{msg}") + 2
         self.client.msg("foo", msg, maxLen)
-        self.assertEqual(self.client.lines, ["PRIVMSG foo :{}".format(msg)])
+        self.assertEqual(self.client.lines, [f"PRIVMSG foo :{msg}"])
         self.client.lines = []
         self.client.msg("foo", msg, maxLen - 1)
         self.assertEqual(2, len(self.client.lines))
@@ -2056,7 +2056,7 @@ class ClientTests(IRCTestCase):
         message = "Sorry, I'm not here."
         self.protocol.away(message)
         expected = [
-            "AWAY :{}".format(message),
+            f"AWAY :{message}",
             "",
         ]
         self.assertEqualBufferValue(self.transport.value().split(b"\r\n"), expected)
@@ -2103,7 +2103,7 @@ class ClientTests(IRCTestCase):
         self.protocol.password = None
         self.protocol.register(username, hostname, servername)
         expected = [
-            "NICK {}".format(username),
+            f"NICK {username}",
             "USER %s %s %s :%s"
             % (username, hostname, servername, self.protocol.realname),
             "",
@@ -2123,8 +2123,8 @@ class ClientTests(IRCTestCase):
         self.protocol.password = "testpass"
         self.protocol.register(username, hostname, servername)
         expected = [
-            "PASS {}".format(self.protocol.password),
-            "NICK {}".format(username),
+            f"PASS {self.protocol.password}",
+            f"NICK {username}",
             "USER %s %s %s :%s"
             % (username, hostname, servername, self.protocol.realname),
             "",
@@ -2145,7 +2145,7 @@ class ClientTests(IRCTestCase):
         self.protocol.register(username, hostname, servername)
         self.protocol.irc_ERR_NICKNAMEINUSE("prefix", ["param"])
         lastLine = self.getLastLine(self.transport)
-        self.assertNotEqual(lastLine, "NICK {}".format(username))
+        self.assertNotEqual(lastLine, f"NICK {username}")
 
         # Keep chaining underscores for each collision
         self.protocol.irc_ERR_NICKNAMEINUSE("prefix", ["param"])
@@ -2175,7 +2175,7 @@ class ClientTests(IRCTestCase):
         self.protocol.irc_RPL_WELCOME("prefix", ["param"])
         self.protocol.setNick(newnick)
         self.assertEqual(self.protocol.nickname, oldnick)
-        self.protocol.irc_NICK("{}!quux@qux".format(oldnick), [newnick])
+        self.protocol.irc_NICK(f"{oldnick}!quux@qux", [newnick])
         self.assertEqual(self.protocol.nickname, newnick)
 
     def test_erroneousNick(self):
@@ -2190,9 +2190,7 @@ class ClientTests(IRCTestCase):
         self.protocol.register(badnick)
         self.protocol.irc_ERR_ERRONEUSNICKNAME("prefix", ["param"])
         lastLine = self.getLastLine(self.transport)
-        self.assertEqual(
-            lastLine, "NICK {}".format(self.protocol.erroneousNickFallback)
-        )
+        self.assertEqual(lastLine, f"NICK {self.protocol.erroneousNickFallback}")
         self.protocol.irc_RPL_WELCOME("prefix", ["param"])
         self.assertEqual(self.protocol._registered, True)
         self.protocol.setNick(self.protocol.erroneousNickFallback)
@@ -2204,7 +2202,7 @@ class ClientTests(IRCTestCase):
         self.protocol.setNick(badnick)
         self.protocol.irc_ERR_ERRONEUSNICKNAME("prefix", ["param"])
         lastLine = self.getLastLine(self.transport)
-        self.assertEqual(lastLine, "NICK {}".format(badnick))
+        self.assertEqual(lastLine, f"NICK {badnick}")
         self.assertEqual(self.protocol.nickname, oldnick)
 
     def test_describe(self):
@@ -2218,8 +2216,8 @@ class ClientTests(IRCTestCase):
         self.protocol.describe(target, action)
         self.protocol.describe(channel, action)
         expected = [
-            "PRIVMSG {} :\01ACTION {}\01".format(target, action),
-            "PRIVMSG {} :\01ACTION {}\01".format(channel, action),
+            f"PRIVMSG {target} :\01ACTION {action}\01",
+            f"PRIVMSG {channel} :\01ACTION {action}\01",
             "",
         ]
         self.assertEqualBufferValue(self.transport.value().split(b"\r\n"), expected)

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -192,13 +192,13 @@ class IRCProtocolTests(unittest.TestCase):
         for (prefix, command, args) in response:
             if command in expected:
                 expected.remove(command)
-        self.assertFalse(expected, "Missing responses for {!r}".format(expected))
+        self.assertFalse(expected, f"Missing responses for {expected!r}")
 
     def _login(self, user, nick, password=None):
         if password is None:
             password = nick + "_password"
-        user.write("PASS {}\r\n".format(password))
-        user.write("NICK {} extrainfo\r\n".format(nick))
+        user.write(f"PASS {password}\r\n")
+        user.write(f"NICK {nick} extrainfo\r\n")
 
     def _loggedInUser(self, name):
         user = self.successResultOf(self.realm.lookupUser(name))

--- a/src/twisted/words/xish/domish.py
+++ b/src/twisted/words/xish/domish.py
@@ -101,10 +101,10 @@ class _ListSerializer:
         if not prefix:
             write("<%s" % (name))
         else:
-            write("<{}:{}".format(prefix, name))
+            write(f"<{prefix}:{name}")
 
             if not inScope:
-                write(" xmlns:{}='{}'".format(prefix, uri))
+                write(f" xmlns:{prefix}='{uri}'")
                 self.prefixStack[-1].append(prefix)
                 inScope = True
 
@@ -114,7 +114,7 @@ class _ListSerializer:
             write(" xmlns='%s'" % (defaultUri))
 
         for p, u in elem.localPrefixes.items():
-            write(" xmlns:{}='{}'".format(p, u))
+            write(f" xmlns:{p}='{u}'")
 
         # Serialize attributes
         for k, v in elem.attributes.items():
@@ -124,7 +124,7 @@ class _ListSerializer:
                 attr_prefix = self.getPrefix(attr_uri)
 
                 if not self.prefixInScope(attr_prefix):
-                    write(" xmlns:{}='{}'".format(attr_prefix, attr_uri))
+                    write(f" xmlns:{attr_prefix}='{attr_uri}'")
                     self.prefixStack[-1].append(attr_prefix)
 
                 write(" {}:{}='{}'".format(attr_prefix, attr_name, escapeToXml(v, 1)))
@@ -146,7 +146,7 @@ class _ListSerializer:
             if not prefix:
                 write("</%s>" % (name))
             else:
-                write("</{}:{}>".format(prefix, name))
+                write(f"</{prefix}:{name}>")
         else:
             write("/>")
 


### PR DESCRIPTION
## Scope and purpose

update lint tooling target versions to py3.6+

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10108
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
