### PR TITLE
apply com2ann to upgrade comment annotations to native variable annotations

### DIFF
--- a/src/twisted/application/internet.py
+++ b/src/twisted/application/internet.py
@@ -72,7 +72,7 @@ def _maybeGlobalReactor(maybeReactor):
 
 class _VolatileDataService(service.Service):
 
-    volatile = []  # type: List[str]
+    volatile: List[str] = []
 
     def __getstate__(self):
         d = service.Service.__getstate__(self)
@@ -100,7 +100,7 @@ class _AbstractServer(_VolatileDataService):
     """
 
     volatile = ["_port"]
-    method = ""  # type: str
+    method: str = ""
     reactor = None
 
     _port = None
@@ -163,7 +163,7 @@ class _AbstractClient(_VolatileDataService):
     """
 
     volatile = ["_connection"]
-    method = ""  # type: str
+    method: str = ""
     reactor = None
 
     _connection = None

--- a/src/twisted/application/runner/test/test_runner.py
+++ b/src/twisted/application/runner/test/test_runner.py
@@ -217,7 +217,7 @@ class RunnerTests(twisted.trial.unittest.TestCase):
         # running (started by trial) logging system.
 
         class LogBeginner:
-            observers = []  # type: List[ILogObserver]
+            observers: List[ILogObserver] = []
 
             def beginLoggingTo(self, observers: Iterable[ILogObserver]) -> None:
                 LogBeginner.observers = list(observers)
@@ -227,8 +227,8 @@ class RunnerTests(twisted.trial.unittest.TestCase):
         # Patch FilteringLogObserver so we can capture its arguments
 
         class MockFilteringLogObserver(FilteringLogObserver):
-            observer = None  # type: Optional[ILogObserver]
-            predicates = []  # type: List[LogLevelFilterPredicate]
+            observer: Optional[ILogObserver] = None
+            predicates: List[LogLevelFilterPredicate] = []
 
             def __init__(
                 self,
@@ -247,7 +247,7 @@ class RunnerTests(twisted.trial.unittest.TestCase):
         # Patch FileLogObserver so we can capture its arguments
 
         class MockFileLogObserver(FileLogObserver):
-            outFile = None  # type: Optional[TextIO]
+            outFile: Optional[TextIO] = None
 
             def __init__(self, outFile: TextIO) -> None:
                 MockFileLogObserver.outFile = outFile
@@ -426,7 +426,7 @@ class DummyKill:
     """
 
     def __init__(self) -> None:
-        self.calls = []  # type: List[Tuple[int, int]]
+        self.calls: List[Tuple[int, int]] = []
 
     def __call__(self, pid: int, sig: int) -> None:
         self.calls.append((pid, sig))

--- a/src/twisted/application/twist/test/test_options.py
+++ b/src/twisted/application/twist/test/test_options.py
@@ -45,7 +45,7 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         """
         Patch L{_options.open} so we can capture usage and prevent actual opens.
         """
-        self.opened = []  # type: List[Tuple[str, Optional[str]]]
+        self.opened: List[Tuple[str, Optional[str]]] = []
 
         def fakeOpen(name: str, mode: Optional[str] = None) -> object:
             if name == "nocanopen":
@@ -61,7 +61,7 @@ class OptionsTests(twisted.trial.unittest.TestCase):
         Patch C{_options.installReactor} so we can capture usage and prevent
         actual installs.
         """
-        self.installedReactors = {}  # type: Dict[str, IReactorCore]
+        self.installedReactors: Dict[str, IReactorCore] = {}
 
         def installReactor(name: str) -> IReactorCore:
             if name != "fusion":

--- a/src/twisted/application/twist/test/test_twist.py
+++ b/src/twisted/application/twist/test/test_twist.py
@@ -43,7 +43,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
         Patch C{_options.installReactor} so we can capture usage and prevent
         actual installs.
         """
-        self.installedReactors = {}  # type: Dict[str, IReactorCore]
+        self.installedReactors: Dict[str, IReactorCore] = {}
 
         def installReactor(_: TwistOptions, name: str) -> IReactorCore:
             reactor = MemoryReactor()
@@ -57,7 +57,7 @@ class TwistTests(twisted.trial.unittest.TestCase):
         Patch L{MultiService.startService} so we can capture usage and prevent
         actual starts.
         """
-        self.serviceStarts = []  # type: List[IService]
+        self.serviceStarts: List[IService] = []
 
         def startService(service: IService) -> None:
             self.serviceStarts.append(service)

--- a/src/twisted/conch/client/options.py
+++ b/src/twisted/conch/client/options.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Union
 
 class ConchOptions(usage.Options):
 
-    optParameters = [
+    optParameters: List[List[Optional[Union[str, int]]]] = [
         ["user", "l", None, "Log in using this user name."],
         ["identity", "i", None],
         ["ciphers", "c", None],
@@ -22,7 +22,7 @@ class ConchOptions(usage.Options):
         ["known-hosts", "", None, "File to check for host keys"],
         ["user-authentications", "", None, "Types of user authentications to use."],
         ["logfile", "", None, "File to log to, or - for stdout"],
-    ]  # type: List[List[Optional[Union[str, int]]]]
+    ]
 
     optFlags = [
         ["version", "V", "Display version number only."],

--- a/src/twisted/conch/manhole_ssh.py
+++ b/src/twisted/conch/manhole_ssh.py
@@ -141,8 +141,8 @@ class TerminalRealm:
 
 
 class ConchFactory(factory.SSHFactory):
-    publicKeys = {}  # type: Dict[bytes, bytes]
-    privateKeys = {}  # type: Dict[bytes, bytes]
+    publicKeys: Dict[bytes, bytes] = {}
+    privateKeys: Dict[bytes, bytes] = {}
 
     def __init__(self, portal):
         self.portal = portal

--- a/src/twisted/conch/recvline.py
+++ b/src/twisted/conch/recvline.py
@@ -19,7 +19,7 @@ from twisted.python import reflect
 from twisted.python.compat import iterbytes
 from twisted.logger import Logger
 
-_counters = {}  # type: Dict[str, int]
+_counters: Dict[str, int] = {}
 
 
 class Logging:

--- a/src/twisted/conch/scripts/cftp.py
+++ b/src/twisted/conch/scripts/cftp.py
@@ -37,12 +37,12 @@ class ClientOptions(options.ConchOptions):
         "executing commands to send and receive file information"
     )
 
-    optParameters = [
+    optParameters: List[List[Optional[Union[str, int]]]] = [
         ["buffersize", "B", 32768, "Size of the buffer to use for sending/receiving."],
         ["batchfile", "b", None, "File to read commands from, or '-' for stdin."],
         ["requests", "R", 5, "Number of requests to make before waiting for a reply."],
         ["subsystem", "s", "sftp", "Subsystem/server program to connect to."],
-    ]  # type: List[List[Optional[Union[str, int]]]]
+    ]
 
     compData = usage.Completions(
         descriptions={"buffersize": "Size of send/receive buffer (default: 32768)"},

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -75,8 +75,8 @@ class ClientOptions(ConchOptions):
         ],
     )
 
-    localForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
-    remoteForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
+    localForwards: List[Tuple[int, Tuple[int, int]]] = []
+    remoteForwards: List[Tuple[int, Tuple[int, int]]] = []
 
     def opt_escape(self, esc):
         """

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -271,9 +271,9 @@ class GeneralOptions(usage.Options):
         ],
     )
 
-    identitys = []  # type: List[str]
-    localForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
-    remoteForwards = []  # type: List[Tuple[int, Tuple[int, int]]]
+    identitys: List[str] = []
+    localForwards: List[Tuple[int, Tuple[int, int]]] = []
+    remoteForwards: List[Tuple[int, Tuple[int, int]]] = []
 
     def opt_identity(self, i):
         self.identitys.append(i)
@@ -499,7 +499,7 @@ class SSHClientTransport(transport.SSHClientTransport):
 
 
 class SSHUserAuthClient(userauth.SSHUserAuthClient):
-    usedFiles = []  # type: List[str]
+    usedFiles: List[str] = []
 
     def getPassword(self, prompt=None):
         if not prompt:

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -52,7 +52,7 @@ class SSHChannel(log.Logger):
     """
 
     _log = Logger()
-    name: bytes = None  # only needed for client channels
+    name: bytes = None  # type: ignore[assignment]  # only needed for client channels
 
     def __init__(
         self,

--- a/src/twisted/conch/ssh/channel.py
+++ b/src/twisted/conch/ssh/channel.py
@@ -52,7 +52,7 @@ class SSHChannel(log.Logger):
     """
 
     _log = Logger()
-    name = None  # type: bytes  # only needed for client channels
+    name: bytes = None  # only needed for client channels
 
     def __init__(
         self,

--- a/src/twisted/conch/ssh/filetransfer.py
+++ b/src/twisted/conch/ssh/filetransfer.py
@@ -24,7 +24,7 @@ class FileTransferBase(protocol.Protocol):
 
     versions = (3,)
 
-    packetTypes = {}  # type: Dict[int, str]
+    packetTypes: Dict[int, str] = {}
 
     def __init__(self):
         self.buf = b""

--- a/src/twisted/conch/ssh/service.py
+++ b/src/twisted/conch/ssh/service.py
@@ -13,7 +13,9 @@ from twisted.logger import Logger
 
 
 class SSHService:
-    name: bytes = None  # this is the ssh name for the service
+    # this is the ssh name for the service:
+    name: bytes = None  # type:ignore[assignment]
+
     protocolMessages: Dict[int, str] = {}  # map #'s -> protocol names
     transport = None  # gets set later
 

--- a/src/twisted/conch/ssh/service.py
+++ b/src/twisted/conch/ssh/service.py
@@ -13,8 +13,8 @@ from twisted.logger import Logger
 
 
 class SSHService:
-    name = None  # type: bytes  # this is the ssh name for the service
-    protocolMessages = {}  # type: Dict[int, str]  # map #'s -> protocol names
+    name: bytes = None  # this is the ssh name for the service
+    protocolMessages: Dict[int, str] = {}  # map #'s -> protocol names
     transport = None  # gets set later
 
     _log = Logger()

--- a/src/twisted/conch/test/test_insults.py
+++ b/src/twisted/conch/test/test_insults.py
@@ -218,7 +218,7 @@ def testByte%(groupName)s(self):
 
 
 class ByteGroupingsMixin(MockMixin):
-    protocolFactory = None  # type: Optional[Type[Protocol]]
+    protocolFactory: Optional[Type[Protocol]] = None
 
     for word, n in [
         ("Pairs", 2),

--- a/src/twisted/conch/test/test_manhole.py
+++ b/src/twisted/conch/test/test_manhole.py
@@ -11,7 +11,7 @@ Tests for L{twisted.conch.manhole}.
 import traceback
 from typing import Optional
 
-ssh = None  # type: Optional[bool]
+ssh: Optional[bool] = None
 
 from twisted.trial import unittest
 from twisted.internet import error, defer

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -365,7 +365,7 @@ class TransportTestCase(TestCase):
     Base class for transport test cases.
     """
 
-    klass = None  # type: Optional[Type[transport.SSHTransportBase]]
+    klass: Optional[Type[transport.SSHTransportBase]] = None
 
     if dependencySkip:
         skip = dependencySkip
@@ -462,7 +462,7 @@ class BaseSSHTransportBaseCase:
     Base case for TransportBase tests.
     """
 
-    klass = MockTransportBase  # type: Optional[Type[transport.SSHTransportBase]]
+    klass: Optional[Type[transport.SSHTransportBase]] = MockTransportBase
 
 
 class BaseSSHTransportTests(BaseSSHTransportBaseCase, TransportTestCase):
@@ -1366,9 +1366,7 @@ class ServerSSHTransportBaseCase(ServerAndClientSSHTransportBaseCase):
     Base case for SSHServerTransport tests.
     """
 
-    klass = (
-        transport.SSHServerTransport
-    )  # type: Optional[Type[transport.SSHTransportBase]]
+    klass: Optional[Type[transport.SSHTransportBase]] = transport.SSHServerTransport
 
     def setUp(self):
         TransportTestCase.setUp(self)
@@ -1921,9 +1919,7 @@ class ClientSSHTransportBaseCase(ServerAndClientSSHTransportBaseCase):
     Base case for SSHClientTransport tests.
     """
 
-    klass = (
-        transport.SSHClientTransport
-    )  # type: Optional[Type[transport.SSHTransportBase]]
+    klass: Optional[Type[transport.SSHTransportBase]] = transport.SSHClientTransport
 
     def verifyHostKey(self, pubKey, fingerprint):
         """

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -23,7 +23,7 @@ from twisted.protocols import loopback
 from twisted.python.reflect import requireModule
 from twisted.trial import unittest
 
-keys = None  # type: Optional[ModuleType]
+keys: Optional[ModuleType] = None
 if requireModule("cryptography") and requireModule("pyasn1"):
     from twisted.conch.ssh.common import NS
     from twisted.conch.checkers import SSHProtocolChecker

--- a/src/twisted/cred/strcred.py
+++ b/src/twisted/cred/strcred.py
@@ -142,7 +142,7 @@ class AuthOptionMixin:
         will send all help-related output. Default: L{sys.stdout}
     """
 
-    supportedInterfaces = None  # type: Optional[Sequence[Type[Interface]]]
+    supportedInterfaces: Optional[Sequence[Type[Interface]]] = None
     authOutput = sys.stdout
 
     def supportsInterface(self, interface):

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -564,7 +564,7 @@ class OptionsSupportsAllInterfaces(usage.Options, strcred.AuthOptionMixin):
 
 
 class OptionsSupportsNoInterfaces(usage.Options, strcred.AuthOptionMixin):
-    supportedInterfaces = []  # type: Sequence[Type[Interface]]
+    supportedInterfaces: Sequence[Type[Interface]] = []
 
 
 class LimitingInterfacesTests(TestCase):

--- a/src/twisted/internet/_baseprocess.py
+++ b/src/twisted/internet/_baseprocess.py
@@ -21,8 +21,8 @@ _missingProcessExited = (
 
 
 class BaseProcess:
-    pid = None  # type: Optional[int]
-    status = None  # type: Optional[int]
+    pid: Optional[int] = None
+    status: Optional[int] = None
     lostProcess = 0
     proto = None
 

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -16,7 +16,7 @@ from twisted.python.reflect import safe_str
 
 
 # This module exports nothing public, it's for internal Twisted use only.
-__all__ = []  # type: List[str]
+__all__: List[str] = []
 
 
 @implementer(IPushProducer)

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -186,7 +186,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             reactor = _reactor  # type: ignore[assignment]
         self.reactor = reactor
         # will be added to dataBuffer in doWrite
-        self._tempDataBuffer = []  # type: List[bytes]
+        self._tempDataBuffer: List[bytes] = []
         self._tempDataLen = 0
 
     def connectionLost(self, reason):

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -106,9 +106,9 @@ class UNIXAddress:
     @type name: C{bytes}
     """
 
-    name = attr.ib(
+    name: Optional[bytes] = attr.ib(
         converter=attr.converters.optional(_asFilesystemBytes)
-    )  # type: Optional[bytes]
+    )
 
     if getattr(os.path, "samefile", None) is not None:
 

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -49,7 +49,7 @@ class AsyncioSelectorReactor(PosixReactorBase):
 
     def __init__(self, eventloop: Optional[SelectorEventLoop] = None):
         if eventloop is None:
-            _eventloop = get_event_loop()  # type: AbstractEventLoop
+            _eventloop: AbstractEventLoop = get_event_loop()
         else:
             _eventloop = eventloop
 
@@ -59,9 +59,9 @@ class AsyncioSelectorReactor(PosixReactorBase):
         if not isinstance(_eventloop, SelectorEventLoop):
             raise TypeError(f"SelectorEventLoop required, instead got: {_eventloop}")
 
-        self._asyncioEventloop = _eventloop  # type: SelectorEventLoop
-        self._writers = {}  # type: Dict[Type[FileDescriptor], int]
-        self._readers = {}  # type: Dict[Type[FileDescriptor], int]
+        self._asyncioEventloop: SelectorEventLoop = _eventloop
+        self._writers: Dict[Type[FileDescriptor], int] = {}
+        self._readers: Dict[Type[FileDescriptor], int] = {}
         self._continuousPolling = _ContinuousPolling(self)
 
         self._scheduledAt = None

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -81,7 +81,7 @@ class DelayedCall:
     # enable .debug to record creator call stack, and it will be logged if
     # an exception occurs while the function is being run
     debug = False
-    _repr = None  # type: Optional[str]
+    _repr: Optional[str] = None
 
     def __init__(
         self,
@@ -238,7 +238,7 @@ class DelayedCall:
             # This code should be replaced by a utility function in reflect;
             # see ticket #6066:
             if hasattr(self.func, "__qualname__"):
-                func = self.func.__qualname__  # type: Optional[str]
+                func: Optional[str] = self.func.__qualname__
             elif hasattr(self.func, "__name__"):
                 func = self.func.func_name  # type: ignore[attr-defined]
                 if hasattr(self.func, "im_class"):
@@ -292,7 +292,7 @@ class ThreadedResolver:
 
     def __init__(self, reactor: "ReactorBase") -> None:
         self.reactor = reactor
-        self._runningQueries = {}  # type: Dict[Deferred, Tuple[Deferred, IDelayedCall]]
+        self._runningQueries: Dict[Deferred, Tuple[Deferred, IDelayedCall]] = {}
 
     def _fail(self, name: str, err: str) -> Failure:
         lookupError = error.DNSLookupError(f"address {name!r} not found: {err}")
@@ -404,9 +404,9 @@ class _ThreePhaseEvent:
     """
 
     def __init__(self) -> None:
-        self.before = []  # type: List[_ThreePhaseEventTrigger]
-        self.during = []  # type: List[_ThreePhaseEventTrigger]
-        self.after = []  # type: List[_ThreePhaseEventTrigger]
+        self.before: List[_ThreePhaseEventTrigger] = []
+        self.during: List[_ThreePhaseEventTrigger] = []
+        self.after: List[_ThreePhaseEventTrigger] = []
         self.state = "BASE"
 
     def addTrigger(
@@ -487,7 +487,7 @@ class _ThreePhaseEvent:
         """
         self.state = "BEFORE"
         self.finishedBefore = []
-        beforeResults = []  # type: List[object]
+        beforeResults: List[object] = []
         while self.before:
             callable, args, kwargs = self.before.pop(0)
             self.finishedBefore.append((callable, args, kwargs))
@@ -524,8 +524,8 @@ class PluggableResolverMixin:
     @ivar _nameResolver: The installed L{IHostnameResolver}.
     """
 
-    resolver = BlockingResolver()  # type: IResolverSimple
-    _nameResolver = _SimpleResolverComplexifier(resolver)  # type: IHostnameResolver
+    resolver: IResolverSimple = BlockingResolver()
+    _nameResolver: IHostnameResolver = _SimpleResolverComplexifier(resolver)
 
     # IReactorPluggableResolver
     def installResolver(self, resolver: IResolverSimple) -> IResolverSimple:
@@ -604,10 +604,10 @@ class ReactorBase(PluggableResolverMixin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.threadCallQueue = []  # type: List[_ThreadCall]
-        self._eventTriggers = {}  # type: Dict[str, _ThreePhaseEvent]
-        self._pendingTimedCalls = []  # type: List[DelayedCall]
-        self._newTimedCalls = []  # type: List[DelayedCall]
+        self.threadCallQueue: List[_ThreadCall] = []
+        self._eventTriggers: Dict[str, _ThreePhaseEvent] = {}
+        self._pendingTimedCalls: List[DelayedCall] = []
+        self._newTimedCalls: List[DelayedCall] = []
         self._cancellations = 0
         self.running = False
         self._started = False
@@ -615,8 +615,8 @@ class ReactorBase(PluggableResolverMixin):
         self._startedBefore = False
         # reactor internal readers, e.g. the waker.
         # Using Any as the type here… unable to find a suitable defined interface
-        self._internalReaders = set()  # type: Set[Any]
-        self.waker = None  # type: Any
+        self._internalReaders: Set[Any] = set()
+        self.waker: Any = None
 
         # Arrange for the running attribute to change to True at the right time
         # and let a subclass possibly do other things at that time (eg install
@@ -1263,7 +1263,7 @@ class BaseConnector(ABC):
         if not self.factoryStarted:
             self.factory.doStart()
             self.factoryStarted = 1
-        self.transport = self._makeTransport()  # type: Optional[Client]
+        self.transport: Optional[Client] = self._makeTransport()
         if self.timeout is not None:
             self.timeoutID = self.reactor.callLater(
                 self.timeout, self.transport.failIfNotConnected, error.TimeoutError()
@@ -1331,8 +1331,8 @@ class BasePort(abstract.FileDescriptor):
     Note: This does not actually implement IListeningPort.
     """
 
-    addressFamily = None  # type: socket.AddressFamily
-    socketType = None  # type: socket.SocketKind
+    addressFamily: socket.AddressFamily = None
+    socketType: socket.SocketKind = None
 
     def createInternetSocket(self) -> socket.socket:
         s = socket.socket(self.addressFamily, self.socketType)
@@ -1437,4 +1437,4 @@ class _SignalReactorMixin:
                 log.msg("Main loop terminated.")
 
 
-__all__ = []  # type: List[str]
+__all__: List[str] = []

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1331,8 +1331,8 @@ class BasePort(abstract.FileDescriptor):
     Note: This does not actually implement IListeningPort.
     """
 
-    addressFamily: socket.AddressFamily = None
-    socketType: socket.SocketKind = None
+    addressFamily: socket.AddressFamily = None  # type: ignore[assignment]
+    socketType: socket.SocketKind = None  # type: ignore[assignment]
 
     def createInternetSocket(self) -> socket.socket:
         s = socket.socket(self.addressFamily, self.socketType)

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -269,7 +269,7 @@ class Deferred:
     # sets it directly.
     debug = False
 
-    _chainedTo = None  # type: Optional[Deferred]
+    _chainedTo: Optional[Deferred] = None
 
     def __init__(self, canceller=None):
         """

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -269,7 +269,7 @@ class Deferred:
     # sets it directly.
     debug = False
 
-    _chainedTo: Optional[Deferred] = None
+    _chainedTo: "Optional[Deferred]" = None
 
     def __init__(self, canceller=None):
         """

--- a/src/twisted/internet/iocpreactor/reactor.py
+++ b/src/twisted/internet/iocpreactor/reactor.py
@@ -29,7 +29,7 @@ except ImportError:
     TLSMemoryBIOFactory = None
     # Either pyOpenSSL isn't installed, or it is too old for this code to work.
     # The reactor won't provide IReactorSSL.
-    _extraInterfaces = ()  # type: Tuple[Type[interfaces.IReactorSSL], ...]
+    _extraInterfaces: Tuple[Type[interfaces.IReactorSSL], ...] = ()
     warnings.warn(
         "pyOpenSSL 0.10 or newer is required for SSL support in iocpreactor. "
         "It is missing, so the reactor will not support SSL APIs."

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -407,7 +407,7 @@ class Port(_SocketCloser, _LogOwner):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber = None  # type: Optional[int]
+    _realPortNumber: Optional[int] = None
 
     # A string describing the connections which will be created by this port.
     # Normally this is C{"TCP"}, since this is a TCP port, but when the TLS

--- a/src/twisted/internet/iocpreactor/udp.py
+++ b/src/twisted/internet/iocpreactor/udp.py
@@ -44,7 +44,7 @@ class Port(abstract.FileHandle):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber = None  # type: Optional[int]
+    _realPortNumber: Optional[int] = None
 
     def __init__(self, port, proto, interface="", maxPacketSize=8192, reactor=None):
         """

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -503,11 +503,11 @@ class PosixReactorBase(_SignalReactorMixin, _DisconnectSelectableMixin, ReactorB
     # IReactorSocket (no AF_UNIX on Windows)
 
     if unixEnabled:
-        _supportedAddressFamilies = (
+        _supportedAddressFamilies: Sequence[socket.AddressFamily] = (
             socket.AF_INET,
             socket.AF_INET6,
             socket.AF_UNIX,
-        )  # type: Sequence[socket.AddressFamily]
+        )
     else:
         _supportedAddressFamilies = (
             socket.AF_INET,

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -56,7 +56,7 @@ else:
 # here for backwards compatibility:
 ProcessExitedAlready = error.ProcessExitedAlready
 
-reapProcessHandlers = {}  # type: Dict[int, Callable]
+reapProcessHandlers: Dict[int, Callable] = {}
 
 
 def reapAllProcesses():
@@ -275,7 +275,7 @@ class _BaseProcess(BaseProcess):
     Base class for Process and PTYProcess.
     """
 
-    status = None  # type: Optional[int]
+    status: Optional[int] = None
     pid = None
 
     def reapProcess(self):

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -29,7 +29,7 @@ class Factory:
     self.protocol.
     """
 
-    protocol: Optional[Callable[[], Protocol]] = None
+    protocol: "Optional[Callable[[], Protocol]]" = None
 
     numPorts = 0
     noisy = True

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -29,7 +29,7 @@ class Factory:
     self.protocol.
     """
 
-    protocol = None  # type: Optional[Callable[[], Protocol]]
+    protocol: Optional[Callable[[], Protocol]] = None
 
     numPorts = 0
     noisy = True
@@ -494,7 +494,7 @@ class BaseProtocol:
     """
 
     connected = 0
-    transport = None  # type: Optional[ITransport]
+    transport: Optional[ITransport] = None
 
     def makeConnection(self, transport):
         """
@@ -543,7 +543,7 @@ class Protocol(BaseProtocol):
     see the L{twisted.protocols.basic} module for a few of them.
     """
 
-    factory = None  # type: Optional[Factory]
+    factory: Optional[Factory] = None
 
     def logPrefix(self):
         """

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -49,7 +49,7 @@ else:
 try:
     from twisted.internet.win32eventreactor import _ThreadedWin32EventsMixin
 except ImportError:
-    _extraBase = object  # type: Type[object]
+    _extraBase: Type[object] = object
 else:
     _extraBase = _ThreadedWin32EventsMixin
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1246,7 +1246,7 @@ class Port(base.BasePort, _SocketCloser):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber = None  # type: Optional[int]
+    _realPortNumber: Optional[int] = None
 
     # An externally initialized socket that we will use, rather than creating
     # our own.

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -33,14 +33,14 @@ from twisted.python.compat import nativeString
 libc = CDLL(find_library("c") or "")
 
 if sys.platform.startswith("freebsd") or sys.platform == "darwin":
-    _sockaddrCommon = [
+    _sockaddrCommon: List[Tuple[str, Any]] = [
         ("sin_len", c_uint8),
         ("sin_family", c_uint8),
-    ]  # type: List[Tuple[str, Any]]
+    ]
 else:
-    _sockaddrCommon = [
+    _sockaddrCommon: List[Tuple[str, Any]] = [
         ("sin_family", c_ushort),
-    ]  # type: List[Tuple[str, Any]]
+    ]
 
 
 class in_addr(Structure):

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -277,7 +277,7 @@ class ConnectionTestsMixin:
     implementations.
     """
 
-    endpoints = None  # type: Optional[EndpointCreator]
+    endpoints: Optional[EndpointCreator] = None
 
     def test_logPrefix(self):
         """

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -178,8 +178,8 @@ class ReactorBuilder:
 
     reactorFactory = None
     originalHandler = None
-    requiredInterfaces = None  # type: Optional[Sequence[Type[Interface]]]
-    skippedReactors = {}  # type: Dict[str, str]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = None
+    skippedReactors: Dict[str, str] = {}
 
     def setUp(self):
         """
@@ -348,9 +348,9 @@ class ReactorBuilder:
         Create a L{SynchronousTestCase} subclass which mixes in C{cls} for each
         known reactor and return a dict mapping their names to them.
         """
-        classes = (
-            {}
-        )  # type: Dict[str, Union[Type['ReactorBuilder'], Type[SynchronousTestCase]]]
+        classes: Dict[
+            str, Union[Type["ReactorBuilder"], Type[SynchronousTestCase]]
+        ] = {}
         for reactor in cls._reactors:
             shortReactorName = reactor.split(".")[-1]
             name = (cls.__name__ + "." + shortReactorName + "Tests").replace(".", "_")

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -1496,7 +1496,7 @@ class TCPPortTestsMixin:
     Tests for L{IReactorTCP.listenTCP}
     """
 
-    requiredInterfaces = (IReactorTCP,)  # type: Optional[Sequence[Type[Interface]]]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorTCP,)
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """
@@ -2060,7 +2060,7 @@ class WriteSequenceTestsMixin:
     Test for L{twisted.internet.abstract.FileDescriptor.writeSequence}.
     """
 
-    requiredInterfaces = (IReactorTCP,)  # type: Optional[Sequence[Type[Interface]]]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorTCP,)
 
     def setWriteBufferSize(self, transport, value):
         """
@@ -2730,7 +2730,7 @@ class AbortConnectionMixin:
     """
 
     # Override in subclasses, should be an EndpointCreator instance:
-    endpoints = None  # type: Optional[EndpointCreator]
+    endpoints: Optional[EndpointCreator] = None
 
     def runAbortTest(self, clientClass, serverClass, clientConnectionLostReason=None):
         """

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -51,7 +51,7 @@ else:
 
 
 class TLSMixin:
-    requiredInterfaces = [IReactorSSL]  # type: Optional[Sequence[Type[Interface]]]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = [IReactorSSL]
 
     if platform.isWindows():
         msg = (

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -100,9 +100,7 @@ class UNIXCreator(EndpointCreator):
     Create UNIX socket end points.
     """
 
-    requiredInterfaces = (
-        interfaces.IReactorUNIX,
-    )  # type: Optional[Sequence[Type[Interface]]]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (interfaces.IReactorUNIX,)
 
     def server(self, reactor):
         """
@@ -727,10 +725,10 @@ class SocketUNIXMixin:
     UNIX ports.
     """
 
-    requiredInterfaces = (
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (
         IReactorUNIX,
         IReactorSocket,
-    )  # type: Optional[Sequence[Type[Interface]]]
+    )
 
     def getListeningPort(self, reactor, factory):
         """
@@ -799,7 +797,7 @@ class ListenUNIXMixin:
 
 
 class UNIXPortTestsMixin:
-    requiredInterfaces = (IReactorUNIX,)  # type: Optional[Sequence[Type[Interface]]]
+    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorUNIX,)
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -85,7 +85,7 @@ class Port(base.BasePort):
     socketType = socket.SOCK_DGRAM
     maxThroughput = 256 * 1024
 
-    _realPortNumber = None  # type: Optional[int]
+    _realPortNumber: Optional[int] = None
     _preexistingSocket = None
 
     def __init__(self, port, proto, interface="", maxPacketSize=8192, reactor=None):

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -67,7 +67,7 @@ class _SendmsgMixin:
         registered producer, if there is one.
     """
 
-    _writeSomeDataBase = None  # type: Optional[Type[FileDescriptor]]
+    _writeSomeDataBase: Optional[Type[FileDescriptor]] = None
     _fileDescriptorBufferSize = 64
 
     def __init__(self):

--- a/src/twisted/logger/_buffer.py
+++ b/src/twisted/logger/_buffer.py
@@ -40,7 +40,7 @@ class LimitedHistoryLogObserver:
         @param size: The maximum number of events to buffer.  If L{None}, the
             buffer is unbounded.
         """
-        self._buffer = deque(maxlen=size)  # type: Deque[LogEvent]
+        self._buffer: Deque[LogEvent] = deque(maxlen=size)
 
     def __call__(self, event: LogEvent) -> None:
         self._buffer.append(event)

--- a/src/twisted/logger/_capture.py
+++ b/src/twisted/logger/_capture.py
@@ -16,7 +16,7 @@ from ._interfaces import ILogObserver, LogEvent
 
 @contextmanager
 def capturedLogs() -> Iterator[Sequence[LogEvent]]:
-    events = []  # type: List[LogEvent]
+    events: List[LogEvent] = []
     observer = cast(ILogObserver, events.append)
 
     globalLogPublisher.addObserver(observer)

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -33,7 +33,7 @@ class FileLogObserver:
         @param formatEvent: A callable that formats an event.
         """
         if ioType(outFile) is not str:
-            self._encoding = "utf-8"  # type: Optional[str]
+            self._encoding: Optional[str] = "utf-8"
         else:
             self._encoding = None
 

--- a/src/twisted/logger/_filter.py
+++ b/src/twisted/logger/_filter.py
@@ -138,7 +138,7 @@ class LogLevelFilterPredicate:
         """
         @param defaultLogLevel: The default minimum log level.
         """
-        self._logLevelsByNamespace = {}  # type: Dict[str, NamedConstant]
+        self._logLevelsByNamespace: Dict[str, NamedConstant] = {}
         self.defaultLogLevel = defaultLogLevel
         self.clearLogLevels()
 

--- a/src/twisted/logger/_flatten.py
+++ b/src/twisted/logger/_flatten.py
@@ -28,7 +28,7 @@ class KeyFlattener:
         """
         Initialize a L{KeyFlattener}.
         """
-        self.keys = defaultdict(lambda: 0)  # type: Dict[str, int]
+        self.keys: Dict[str, int] = defaultdict(lambda: 0)
 
     def flatKey(
         self, fieldName: str, formatSpec: Optional[str], conversion: Optional[str]

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -91,7 +91,7 @@ class LogBeginner:
         self._log = Logger(observer=publisher)
         self._stdio = stdio
         self._warningsModule = warningsModule
-        self._temporaryObserver = LogPublisher(
+        self._temporaryObserver: Optional[ILogObserver] = LogPublisher(
             self._initialBuffer,
             FilteringLogObserver(
                 FileLogObserver(
@@ -105,7 +105,7 @@ class LogBeginner:
                 ),
                 [LogLevelFilterPredicate(defaultLogLevel=LogLevel.critical)],
             ),
-        )  # type: Optional[ILogObserver]
+        )
         self._previousBegin = ("", 0)
         publisher.addObserver(self._temporaryObserver)
         self._oldshowwarning = warningsModule.showwarning

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -64,7 +64,7 @@ class Logger:
         if observer is None:
             from ._global import globalLogPublisher
 
-            self.observer = globalLogPublisher  # type: ILogObserver
+            self.observer: ILogObserver = globalLogPublisher
         else:
             self.observer = observer
 
@@ -90,7 +90,7 @@ class Logger:
         assert owner is not None
 
         if instance is None:
-            source = owner  # type: Any
+            source: Any = owner
         else:
             source = instance
 

--- a/src/twisted/logger/_observer.py
+++ b/src/twisted/logger/_observer.py
@@ -60,7 +60,7 @@ class LogPublisher:
         Forward events to contained observers.
         """
         if "log_trace" not in event:
-            trace = None  # type: Optional[Callable[[ILogObserver], None]]
+            trace: Optional[Callable[[ILogObserver], None]] = None
 
         else:
 

--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -21,13 +21,13 @@ from ._format import formatEvent
 
 
 # Mappings to Python's logging module
-toStdlibLogLevelMapping = {
+toStdlibLogLevelMapping: Mapping[NamedConstant, int] = {
     LogLevel.debug: stdlibLogging.DEBUG,
     LogLevel.info: stdlibLogging.INFO,
     LogLevel.warn: stdlibLogging.WARNING,
     LogLevel.error: stdlibLogging.ERROR,
     LogLevel.critical: stdlibLogging.CRITICAL,
-}  # type: Mapping[NamedConstant, int]
+}
 
 
 def _reverseLogLevelMapping() -> Mapping[int, NamedConstant]:

--- a/src/twisted/logger/_util.py
+++ b/src/twisted/logger/_util.py
@@ -31,7 +31,7 @@ def formatTrace(trace: LogTrace) -> str:
             return f"{obj}"
 
     result = []
-    lineage = []  # type: List[Logger]
+    lineage: List[Logger] = []
 
     for parent, child in trace:
         if not lineage or lineage[-1] is not parent:

--- a/src/twisted/logger/test/test_buffer.py
+++ b/src/twisted/logger/test/test_buffer.py
@@ -42,7 +42,7 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         for event in events:
             observer(event)
 
-        outEvents = []  # type: List[LogEvent]
+        outEvents: List[LogEvent] = []
         observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events, outEvents)
 
@@ -58,6 +58,6 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         for event in events:
             observer(event)
 
-        outEvents = []  # type: List[LogEvent]
+        outEvents: List[LogEvent] = []
         observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events[-size:], outEvents)

--- a/src/twisted/logger/test/test_filter.py
+++ b/src/twisted/logger/test/test_filter.py
@@ -61,12 +61,12 @@ class FilteringLogObserverTests(unittest.TestCase):
 
         @return: event numbers or 2-tuple of lists of event numbers.
         """
-        events = [
+        events: List[LogEvent] = [
             dict(count=0),
             dict(count=1),
             dict(count=2),
             dict(count=3),
-        ]  # type: List[LogEvent]
+        ]
 
         class Filters:
             @staticmethod
@@ -134,8 +134,8 @@ class FilteringLogObserverTests(unittest.TestCase):
                 return None
 
         predicates = (getattr(Filters, f) for f in filters)
-        eventsSeen = []  # type: List[LogEvent]
-        eventsNotSeen = []  # type: List[LogEvent]
+        eventsSeen: List[LogEvent] = []
+        eventsNotSeen: List[LogEvent] = []
         trackingObserver = cast(ILogObserver, eventsSeen.append)
 
         if other:
@@ -205,10 +205,10 @@ class FilteringLogObserverTests(unittest.TestCase):
         """
         Test filtering results from each predicate type.
         """
-        e = dict(obj=object())  # type: LogEvent
+        e: LogEvent = dict(obj=object())
 
         def callWithPredicateResult(result: NamedConstant) -> List[LogEvent]:
-            seen = []  # type: List[LogEvent]
+            seen: List[LogEvent] = []
             observer = FilteringLogObserver(
                 cast(ILogObserver, lambda e: seen.append(e)),
                 (cast(ILogFilterPredicate, lambda e: result),),
@@ -224,7 +224,7 @@ class FilteringLogObserverTests(unittest.TestCase):
         """
         Tracing keeps track of forwarding through the filtering observer.
         """
-        event = dict(log_trace=[])  # type: LogEvent
+        event: LogEvent = dict(log_trace=[])
 
         oYes = cast(ILogObserver, lambda e: None)
         oNo = cast(ILogObserver, lambda e: None)
@@ -375,7 +375,7 @@ class LogLevelFilterPredicateTests(unittest.TestCase):
         def checkPredicate(
             namespace: str, level: NamedConstant, expectedResult: NamedConstant
         ) -> None:
-            event = dict(log_namespace=namespace, log_level=level)  # type: LogEvent
+            event: LogEvent = dict(log_namespace=namespace, log_level=level)
             self.assertEqual(expectedResult, predicate(event))
 
         checkPredicate("", LogLevel.debug, PredicateResult.no)

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -109,11 +109,11 @@ class FormattingTests(unittest.TestCase):
         """
         Formatting an unformattable event that has an unformattable key.
         """
-        event = {
+        event: LogEvent = {
             "log_format": "{evil()}",
             "evil": lambda: 1 / 0,
             cast(str, Unformattable()): "gurk",
-        }  # type: LogEvent
+        }
         result = formatEvent(event)
         self.assertIn("MESSAGE LOST: unformattable object logged:", result)
         self.assertIn("Recoverable data:", result)
@@ -414,7 +414,7 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}  # type: LogEvent
+        event: LogEvent = {"log_format": "This is a test log message"}
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn(str(f.getTraceback()), eventText)
@@ -429,7 +429,7 @@ class EventAsTextTests(unittest.TestCase):
             raise CapturedError("This is a fake error")
         except CapturedError:
             f = Failure()
-        event = {"log_format": ""}  # type: LogEvent
+        event: LogEvent = {"log_format": ""}
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn(str(f.getTraceback()), eventText)
@@ -466,11 +466,11 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {
+        event: LogEvent = {
             "log_format": "{evil()}",
             "evil": lambda: 1 / 0,
             cast(str, Unformattable()): "gurk",
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
@@ -483,7 +483,7 @@ class EventAsTextTests(unittest.TestCase):
         If a traceback cannot be appended, a message indicating this is true
         is appended.
         """
-        event = {"log_format": ""}  # type: LogEvent
+        event: LogEvent = {"log_format": ""}
         event["log_failure"] = object()
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
@@ -493,7 +493,7 @@ class EventAsTextTests(unittest.TestCase):
         """
         An event with no C{log_failure} key will not have a traceback appended.
         """
-        event = {"log_format": "This is a test log message"}  # type: LogEvent
+        event: LogEvent = {"log_format": "This is a test log message"}
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIsInstance(eventText, str)
         self.assertIn("This is a test log message", eventText)
@@ -507,7 +507,7 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}  # type: LogEvent
+        event: LogEvent = {"log_format": "This is a test log message"}
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn("€", eventText)
@@ -524,7 +524,7 @@ class EventAsTextTests(unittest.TestCase):
         except CapturedError:
             f = Failure()
 
-        event = {"log_format": "This is a test log message"}  # type: LogEvent
+        event: LogEvent = {"log_format": "This is a test log message"}
         event["log_failure"] = f
         eventText = eventAsText(event, includeTimestamp=True, includeSystem=False)
         self.assertIn("Traceback", eventText)
@@ -541,11 +541,11 @@ class EventAsTextTests(unittest.TestCase):
             f = Failure()
 
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
-        event = {
+        event: LogEvent = {
             "log_format": "ABCD",
             "log_system": "fake_system",
             "log_time": t,
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -575,11 +575,11 @@ class EventAsTextTests(unittest.TestCase):
             f = Failure()
 
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
-        event = {
+        event: LogEvent = {
             "log_format": "ABCD",
             "log_system": "fake_system",
             "log_time": t,
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -603,10 +603,10 @@ class EventAsTextTests(unittest.TestCase):
             f = Failure()
 
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
-        event = {
+        event: LogEvent = {
             "log_format": "ABCD",
             "log_time": t,
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -630,12 +630,12 @@ class EventAsTextTests(unittest.TestCase):
             f = Failure()
 
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
-        event = {
+        event: LogEvent = {
             "log_format": "ABCD",
             "log_time": t,
             "log_level": LogLevel.info,
             "log_namespace": "test",
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(
             event,
@@ -659,11 +659,11 @@ class EventAsTextTests(unittest.TestCase):
             f = Failure()
 
         t = mktime((2013, 9, 24, 11, 40, 47, 1, 267, 1))
-        event = {
+        event: LogEvent = {
             "log_format": "ABCD",
             "log_time": t,
             "log_level": LogLevel.info,
-        }  # type: LogEvent
+        }
         event["log_failure"] = f
         eventText = eventAsText(
             event,

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -66,9 +66,11 @@ class LogBeginnerTests(unittest.TestCase):
 
         class NotWarnings:
             def __init__(self) -> None:
-                self.warnings = (
-                    []
-                )  # type: List[Tuple[str, Type[Warning], str, int, Optional[IO[Any]], Optional[int]]]
+                self.warnings: List[
+                    Tuple[
+                        str, Type[Warning], str, int, Optional[IO[Any]], Optional[int]
+                    ]
+                ] = []
 
             def showwarning(
                 self,
@@ -109,8 +111,8 @@ class LogBeginnerTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []  # type: List[LogEvent]
-        events2 = []  # type: List[LogEvent]
+        events1: List[LogEvent] = []
+        events2: List[LogEvent] = []
 
         o1 = cast(ILogObserver, lambda e: events1.append(e))
         o2 = cast(ILogObserver, lambda e: events2.append(e))
@@ -128,8 +130,8 @@ class LogBeginnerTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []  # type: List[LogEvent]
-        events2 = []  # type: List[LogEvent]
+        events1: List[LogEvent] = []
+        events2: List[LogEvent] = []
 
         o1 = cast(ILogObserver, lambda e: events1.append(e))
         o2 = cast(ILogObserver, lambda e: events2.append(e))
@@ -154,7 +156,7 @@ class LogBeginnerTests(unittest.TestCase):
         """
         for count in range(limit + 1):
             self.publisher(dict(count=count))
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
         beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.assertEqual(
             list(range(1, limit + 1)),
@@ -190,8 +192,8 @@ class LogBeginnerTests(unittest.TestCase):
         message warning the user that they previously began logging, and add
         the new log observers.
         """
-        events1 = []  # type: List[LogEvent]
-        events2 = []  # type: List[LogEvent]
+        events1: List[LogEvent] = []
+        events2: List[LogEvent] = []
         fileHandle = io.StringIO()
         textObserver = textFileLogObserver(fileHandle)
         self.publisher(dict(event="prebuffer"))
@@ -252,7 +254,7 @@ class LogBeginnerTests(unittest.TestCase):
         error streams by setting the C{stdio} and C{stderr} attributes on its
         sys module object.
         """
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         print("Hello, world.", file=cast(TextIO, self.sysModule.stdout))
         compareEvents(
@@ -288,7 +290,7 @@ class LogBeginnerTests(unittest.TestCase):
         self.sysModule.stdout = weird
         self.sysModule.stderr = weirderr
 
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         stdout = cast(TextIO, self.sysModule.stdout)
         stderr = cast(TextIO, self.sysModule.stderr)
@@ -305,7 +307,7 @@ class LogBeginnerTests(unittest.TestCase):
         warnings module into the logging system.
         """
         self.warningsModule.showwarning("a message", DeprecationWarning, __file__, 1)
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.warningsModule.showwarning(
             "another message", DeprecationWarning, __file__, 2

--- a/src/twisted/logger/test/test_io.py
+++ b/src/twisted/logger/test/test_io.py
@@ -34,8 +34,8 @@ class TestLoggingFile(LoggingFile):
         encoding: Optional[str] = None,
     ) -> None:
         super().__init__(logger=logger, level=level, encoding=encoding)
-        self.events = []  # type: List[LogEvent]
-        self.messages = []  # type: List[str]
+        self.events: List[LogEvent] = []
+        self.messages: List[str] = []
 
     def __call__(self, event: LogEvent) -> None:
         self.events.append(event)
@@ -278,7 +278,7 @@ class LoggingFileTests(unittest.TestCase):
         # TestLoggingFile we will create, but that takes the Logger as an
         # argument, so we'll use an array to indirectly reference the
         # TestLoggingFile.
-        loggingFiles = []  # type: List[TestLoggingFile]
+        loggingFiles: List[TestLoggingFile] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -162,7 +162,7 @@ class SaveLoadTests(TestCase):
         Round-tripping a failure through L{eventAsJSON} preserves its class and
         structure.
         """
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
         log = Logger(observer=cast(ILogObserver, events.append))
         try:
             1 / 0
@@ -251,7 +251,7 @@ class FileLogObserverTests(TestCase):
         """
         io = StringIO()
         publisher = LogPublisher()
-        logged = []  # type: List[LogEvent]
+        logged: List[LogEvent] = []
         publisher.addObserver(cast(ILogObserver, logged.append))
         publisher.addObserver(jsonFileLogObserver(io))
         logger = Logger(observer=publisher)
@@ -284,7 +284,7 @@ class LogFileReaderTests(TestCase):
     """
 
     def setUp(self) -> None:
-        self.errorEvents = []  # type: List[LogEvent]
+        self.errorEvents: List[LogEvent] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:

--- a/src/twisted/logger/test/test_legacy.py
+++ b/src/twisted/logger/test/test_legacy.py
@@ -66,7 +66,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
 
         @return: the event as observed by the legacy wrapper
         """
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
 
         legacyObserver = cast(legacyLog.ILogObserver, lambda e: events.append(e))
         observer = LegacyLogObserverWrapper(legacyObserver)
@@ -282,7 +282,7 @@ class PublishToNewObserverTests(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.events = []  # type: List[LogEvent]
+        self.events: List[LogEvent] = []
         self.observer = cast(ILogObserver, self.events.append)
 
     def legacyEvent(self, *message: str, **values: object) -> legacyLog.EventDict:

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -86,7 +86,7 @@ class LoggerTests(unittest.TestCase):
         context in which is can't be determined automatically and no namespace
         was specified.
         """
-        result = []  # type: List[Logger]
+        result: List[Logger] = []
         exec(
             "result.append(Logger())",
             dict(Logger=Logger),
@@ -120,7 +120,7 @@ class LoggerTests(unittest.TestCase):
         """
         When used as a descriptor, the observer is propagated.
         """
-        observed = []  # type: List[LogEvent]
+        observed: List[LogEvent] = []
 
         class MyObject:
             log = Logger(observer=cast(ILogObserver, observed.append))

--- a/src/twisted/logger/test/test_observer.py
+++ b/src/twisted/logger/test/test_observer.py
@@ -94,9 +94,9 @@ class LogPublisherTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1 = []  # type: List[LogEvent]
-        events2 = []  # type: List[LogEvent]
-        events3 = []  # type: List[LogEvent]
+        events1: List[LogEvent] = []
+        events2: List[LogEvent] = []
+        events3: List[LogEvent] = []
 
         o1 = cast(ILogObserver, events1.append)
         o2 = cast(ILogObserver, events2.append)
@@ -116,7 +116,7 @@ class LogPublisherTests(unittest.TestCase):
         event = dict(foo=1, bar=2)
         exception = RuntimeError("ARGH! EVIL DEATH!")
 
-        events = []  # type: List[LogEvent]
+        events: List[LogEvent] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:
@@ -125,7 +125,7 @@ class LogPublisherTests(unittest.TestCase):
             if shouldRaise:
                 raise exception
 
-        collector = []  # type: List[LogEvent]
+        collector: List[LogEvent] = []
 
         publisher = LogPublisher(observer, cast(ILogObserver, collector.append))
         publisher(event)
@@ -169,7 +169,7 @@ class LogPublisherTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2, log_trace=[])
 
-        traces = {}  # type: Dict[int, Tuple[Tuple[Logger, ILogObserver]]]
+        traces: Dict[int, Tuple[Tuple[Logger, ILogObserver]]] = {}
 
         # Copy trace to a tuple; otherwise, both observers will store the same
         # mutable list, and we won't be able to see o1's view distinctly.

--- a/src/twisted/logger/test/test_stdlib.py
+++ b/src/twisted/logger/test/test_stdlib.py
@@ -284,7 +284,7 @@ class BufferedHandler(py_logging.Handler):
         Initialize this L{BufferedHandler}.
         """
         py_logging.Handler.__init__(self)
-        self.records = []  # type: List[LogRecord]
+        self.records: List[LogRecord] = []
 
     def emit(self, record: LogRecord) -> None:
         """

--- a/src/twisted/logger/test/test_util.py
+++ b/src/twisted/logger/test/test_util.py
@@ -25,7 +25,7 @@ class UtilTests(unittest.TestCase):
         """
         publisher = LogPublisher()
 
-        event = dict(log_trace=[])  # type: LogEvent
+        event: LogEvent = dict(log_trace=[])
 
         @implementer(ILogObserver)
         def o1(e: LogEvent) -> None:
@@ -64,7 +64,7 @@ class UtilTests(unittest.TestCase):
         """
         Format trace as string.
         """
-        event = dict(log_trace=[])  # type: LogEvent
+        event: LogEvent = dict(log_trace=[])
 
         @implementer(ILogObserver)
         def o1(e: LogEvent) -> None:

--- a/src/twisted/mail/_pop3client.py
+++ b/src/twisted/mail/_pop3client.py
@@ -1235,4 +1235,4 @@ class POP3Client(basic.LineOnlyReceiver, policies.TimeoutMixin):
         return self.sendShort(b"QUIT", None)
 
 
-__all__ = []  # type: List[str]
+__all__: List[str] = []

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -189,7 +189,7 @@ class MessageSet:
         that it will not be called out-of-order).
     """
 
-    _empty = []  # type: List[Any]
+    _empty: List[Any] = []
     _infinity = float("inf")
 
     def __init__(self, start=_empty, end=_empty):

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -434,7 +434,7 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
     @ivar _auth: Authorization credentials.
     """
 
-    magic = None  # type: Optional[bytes]
+    magic: Optional[bytes] = None
     _userIs = None
     _onLogout = None
 

--- a/src/twisted/mail/pop3client.py
+++ b/src/twisted/mail/pop3client.py
@@ -23,4 +23,4 @@ OK
 ERR
 POP3Client
 
-__all__ = []  # type: List[str]
+__all__: List[str] = []

--- a/src/twisted/mail/protocols.py
+++ b/src/twisted/mail/protocols.py
@@ -37,7 +37,7 @@ class DomainDeliveryBase:
     """
 
     service = None
-    protocolName = b"not-implemented-protocol"  # type: bytes
+    protocolName: bytes = b"not-implemented-protocol"
 
     def __init__(self, service, user, host=smtp.DNSNAME):
         """

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -156,7 +156,7 @@ class SMTPManagedRelayerFactory(protocol.ClientFactory):
     @ivar pKwArgs: Keyword arguments for L{SMTPClient.__init__}
     """
 
-    protocol = SMTPManagedRelayer  # type: Type[protocol.Protocol]
+    protocol: Type[protocol.Protocol] = SMTPManagedRelayer
 
     def __init__(self, messages, manager, *args, **kw):
         """
@@ -676,7 +676,7 @@ class SmartHostSMTPRelayingManager:
         filenames of messages the managed relayer is responsible for.
     """
 
-    factory = SMTPManagedRelayerFactory  # type: Type[protocol.ClientFactory]
+    factory: Type[protocol.ClientFactory] = SMTPManagedRelayerFactory
 
     PORT = 25
 

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -156,7 +156,7 @@ class SMTPManagedRelayerFactory(protocol.ClientFactory):
     @ivar pKwArgs: Keyword arguments for L{SMTPClient.__init__}
     """
 
-    protocol: Type[protocol.Protocol] = SMTPManagedRelayer
+    protocol: "Type[protocol.Protocol]" = SMTPManagedRelayer
 
     def __init__(self, messages, manager, *args, **kw):
         """

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -1875,7 +1875,7 @@ class SMTPSenderFactory(protocol.ClientFactory):
     """
 
     domain = DNSNAME
-    protocol = SMTPSender  # type: Type[SMTPClient]
+    protocol: Type[SMTPClient] = SMTPSender
 
     def __init__(self, fromEmail, toEmail, file, deferred, retries=5, timeout=None):
         """

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1566,7 +1566,7 @@ class IMAP4HelperTests(TestCase):
 @implementer(imap4.IMailboxInfo, imap4.IMailbox, imap4.ICloseableMailbox)
 class SimpleMailbox:
     flags = ("\\Flag1", "Flag2", "\\AnotherSysFlag", "LastFlag")
-    messages = []  # type: List[Tuple[bytes, list, bytes, int]]
+    messages: List[Tuple[bytes, list, bytes, int]] = []
     mUID = 0
     rw = 1
     closed = False
@@ -1654,7 +1654,7 @@ class UncloseableMailbox:
     """
 
     flags = ("\\Flag1", "Flag2", "\\AnotherSysFlag", "LastFlag")
-    messages = []  # type:List[Tuple[bytes, list, bytes, int]]
+    messages: List[Tuple[bytes, list, bytes, int]] = []
     mUID = 0
     rw = 1
     closed = False
@@ -1868,8 +1868,8 @@ class SimpleClient(imap4.IMAP4Client):
 
 class IMAP4HelperMixin:
 
-    serverCTX = None  # type: Optional[ServerTLSContext]
-    clientCTX = None  # type: Optional[ClientTLSContext]
+    serverCTX: Optional[ServerTLSContext] = None
+    clientCTX: Optional[ClientTLSContext] = None
 
     def setUp(self):
         d = defer.Deferred()
@@ -4565,7 +4565,7 @@ class PreauthIMAP4ClientMixin:
         C{transport}.
     """
 
-    clientProtocol = imap4.IMAP4Client  # type: Type[imap4.IMAP4Client]
+    clientProtocol: Type[imap4.IMAP4Client] = imap4.IMAP4Client
 
     def setUp(self):
         """

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -488,7 +488,7 @@ class POP3HelperMixin:
 class TLSServerFactory(protocol.ServerFactory):
     class protocol(basic.LineReceiver):
         context = None
-        output = []  # type: List[bytes]
+        output: List[bytes] = []
 
         def connectionMade(self):
             self.factory.input = []

--- a/src/twisted/mail/test/test_smtp.py
+++ b/src/twisted/mail/test/test_smtp.py
@@ -361,8 +361,8 @@ class DummyESMTP(DummyProto, smtp.ESMTP):
 
 
 class AnotherTestCase:
-    serverClass = None  # type: Optional[Type[protocol.Protocol]]
-    clientClass = None  # type: Optional[Type[smtp.SMTPClient]]
+    serverClass: Optional[Type[protocol.Protocol]] = None
+    clientClass: Optional[Type[smtp.SMTPClient]] = None
 
     messages = [
         (
@@ -408,11 +408,11 @@ To: foo
         ),
     ]
 
-    data = [
+    data: List[Tuple[bytes, bytes, Any, Any]] = [
         (b"", b"220.*\r\n$", None, None),
         (b"HELO foo.com\r\n", b"250.*\r\n$", None, None),
         (b"RSET\r\n", b"250.*\r\n$", None, None),
-    ]  # type: List[Tuple[bytes, bytes, Any, Any]]
+    ]
     for helo_, from_, to_, realfrom, realto, msg in messages:
         data.append((b"MAIL FROM:<" + from_ + b">\r\n", b"250.*\r\n", None, None))
         for rcpt in to_:

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -1076,7 +1076,7 @@ class SimpleRecord(tputil.FancyStrMixin, tputil.FancyEqMixin):
     showAttributes = (("name", "name", "%s"), "ttl")
     compareAttributes = ("name", "ttl")
 
-    TYPE = None  # type: Optional[int]
+    TYPE: Optional[int] = None
     name = None
 
     def __init__(self, name=b"", ttl=None):

--- a/src/twisted/newsfragments/10110.misc
+++ b/src/twisted/newsfragments/10110.misc
@@ -1,0 +1,1 @@
+apply com2ann to upgrade comment annotation syntax to native type annotation syntax

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -246,7 +246,7 @@ class TuntapPort(abstract.FileDescriptor):
         self.logstr = f"{logPrefix} ({self._mode.name})"
 
     def __repr__(self) -> str:
-        args = (fullyQualifiedName(self.protocol.__class__),)  # type: Tuple[str, ...]
+        args: Tuple[str, ...] = (fullyQualifiedName(self.protocol.__class__),)
         if self.connected:
             args = args + ("",)
         else:

--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -17,7 +17,7 @@ from twisted.python import log, reflect
 from io import StringIO as _cStringIO
 
 
-oldModules = {}  # type: Dict[str, types.ModuleType]
+oldModules: Dict[str, types.ModuleType] = {}
 
 
 _UniversalPicklingError = pickle.PicklingError
@@ -241,7 +241,7 @@ class Ephemeral:
         self.__class__ = Ephemeral
 
 
-versionedsToUpgrade = {}  # type: Dict[int, 'Versioned']
+versionedsToUpgrade: Dict[int, "Versioned"] = {}
 upgraded = {}
 
 

--- a/src/twisted/plugins/__init__.py
+++ b/src/twisted/plugins/__init__.py
@@ -18,4 +18,4 @@ from twisted.plugin import pluginPackagePaths
 from typing import List
 
 __path__.extend(pluginPackagePaths(__name__))  # type: ignore[name-defined]
-__all__ = []  # type: List[str] # nothing to see here, move along, move along
+__all__: List[str] = []  # nothing to see here, move along, move along

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -35,7 +35,7 @@ class _BaseSentence:
     @type ALLOWED_ATTRIBUTES: C{set} of C{str}
     """
 
-    ALLOWED_ATTRIBUTES = set()  # type: Set[str]
+    ALLOWED_ATTRIBUTES: Set[str] = set()
 
     def __init__(self, sentenceData):
         """

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -149,10 +149,10 @@ class Angle(FancyEqMixin):
         Angles.HEADING: "Heading",
     }
 
-    compareAttributes = (
+    compareAttributes: ClassVar[Sequence[str]] = (
         "angleType",
         "inDecimalDegrees",
-    )  # type: ClassVar[Sequence[str]]
+    )
 
     def __init__(self, angle=None, angleType=None):
         """

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -1082,7 +1082,7 @@ class _CommandLocatorMeta(type):
     metaclass.
     """
 
-    _currentClassCommands: List[Tuple[Command, Callable]] = []
+    _currentClassCommands: "List[Tuple[Command, Callable]]" = []
 
     def __new__(cls, name, bases, attrs):
         commands = cls._currentClassCommands[:]
@@ -1788,7 +1788,7 @@ class Command(metaclass=_CommandMeta):
     errors: Dict[Type[Exception], bytes] = {}
     fatalErrors: Dict[Type[Exception], bytes] = {}
 
-    commandType: Union[Type[Command], Type[Box]] = Box
+    commandType: "Union[Type[Command], Type[Box]]" = Box
     responseType: Type[AmpBox] = Box
 
     requiresAnswer = True

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -616,7 +616,7 @@ class AmpBox(dict):
 
     # be like a regular dictionary don't magically
     # acquire a __dict__...
-    __slots__ = []  # type: List[str]
+    __slots__: List[str] = []
 
     def __init__(self, *args, **kw):
         """
@@ -712,7 +712,7 @@ class QuitBox(AmpBox):
     I am an AmpBox that, upon being sent, terminates the connection.
     """
 
-    __slots__ = []  # type: List[str]
+    __slots__: List[str] = []
 
     def __repr__(self) -> str:
         return f"QuitBox(**{super().__repr__()})"
@@ -1082,7 +1082,7 @@ class _CommandLocatorMeta(type):
     metaclass.
     """
 
-    _currentClassCommands = []  # type: List[Tuple[Command, Callable]]
+    _currentClassCommands: List[Tuple[Command, Callable]] = []
 
     def __new__(cls, name, bases, attrs):
         commands = cls._currentClassCommands[:]
@@ -1710,8 +1710,8 @@ class _CommandMeta(type):
             if not isinstance(name, bytes):
                 raise TypeError(f"Response names must be byte strings, got: {name!r}")
 
-        errors = {}  # type: Dict[Type[Exception], bytes]
-        fatalErrors = {}  # type: Dict[Type[Exception], bytes]
+        errors: Dict[Type[Exception], bytes] = {}
+        fatalErrors: Dict[Type[Exception], bytes] = {}
         accumulateClassDict(newtype, "errors", errors)
         accumulateClassDict(newtype, "fatalErrors", fatalErrors)
 
@@ -1782,14 +1782,14 @@ class Command(metaclass=_CommandMeta):
     want one.
     """
 
-    arguments = []  # type: List[Tuple[bytes, Argument]]
-    response = []  # type: List[Tuple[bytes, Argument]]
-    extra = []  # type: List[Any]
-    errors = {}  # type: Dict[Type[Exception], bytes]
-    fatalErrors = {}  # type: Dict[Type[Exception], bytes]
+    arguments: List[Tuple[bytes, Argument]] = []
+    response: List[Tuple[bytes, Argument]] = []
+    extra: List[Any] = []
+    errors: Dict[Type[Exception], bytes] = {}
+    fatalErrors: Dict[Type[Exception], bytes] = {}
 
-    commandType = Box  # type: Union[Type[Command], Type[Box]]
-    responseType = Box  # type: Type[AmpBox]
+    commandType: Union[Type[Command], Type[Box]] = Box
+    responseType: Type[AmpBox] = Box
 
     requiresAnswer = True
 
@@ -2023,7 +2023,7 @@ class _TLSBox(AmpBox):
     I am an AmpBox that, upon being sent, initiates a TLS connection.
     """
 
-    __slots__ = []  # type: List[str]
+    __slots__: List[str] = []
 
     def __init__(self):
         if ssl is None:
@@ -2277,7 +2277,7 @@ class BinaryBoxProtocol(
 
     hostCertificate = None
     noPeerCertificate = False  # for tests
-    innerProtocol = None  # type: Optional[Protocol]
+    innerProtocol: Optional[Protocol] = None
     innerProtocolClientFactory = None
 
     def __init__(self, boxReceiver):

--- a/src/twisted/protocols/htb.py
+++ b/src/twisted/protocols/htb.py
@@ -42,8 +42,8 @@ class Bucket:
     @type rate: C{int}
     """
 
-    maxburst = None  # type: Optional[int]
-    rate = None  # type: Optional[int]
+    maxburst: Optional[int] = None
+    rate: Optional[int] = None
 
     _refcount = 0
 
@@ -129,7 +129,7 @@ class HierarchicalBucketFilter:
     """
 
     bucketFactory = Bucket
-    sweepInterval = None  # type: Optional[int]
+    sweepInterval: Optional[int] = None
 
     def __init__(self, parentFilter=None):
         self.buckets = {}

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -119,7 +119,7 @@ class WrappingFactory(ClientFactory):
     Wraps a factory and its protocols, and keeps track of them.
     """
 
-    protocol = ProtocolWrapper  # type: Type[Protocol]
+    protocol: Type[Protocol] = ProtocolWrapper
 
     def __init__(self, wrappedFactory):
         self.wrappedFactory = wrappedFactory
@@ -393,7 +393,7 @@ class LimitTotalConnectionsFactory(ServerFactory):
 
     connectionCount = 0
     connectionLimit = None
-    overflowProtocol = None  # type: Optional[Type[Protocol]]
+    overflowProtocol: Optional[Type[Protocol]] = None
 
     def buildProtocol(self, addr):
         if self.connectionLimit is None or self.connectionCount < self.connectionLimit:
@@ -626,7 +626,7 @@ class TimeoutMixin:
     @cvar timeOut: The number of seconds after which to timeout the connection.
     """
 
-    timeOut = None  # type: Optional[int]
+    timeOut: Optional[int] = None
 
     __timeoutCall = None
 

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -340,7 +340,7 @@ class URL:
             self.headers = headers
 
     def toString(self) -> str:
-        l = []  # type: List[str]
+        l: List[str] = []
         w = l.append
         w("sip:")
         if self.username != None:
@@ -1057,7 +1057,7 @@ class RegisterProxy(Proxy):
 
     registry = None  # Should implement IRegistry
 
-    authorizers = {}  # type: Dict[str, IAuthorizer]
+    authorizers: Dict[str, IAuthorizer] = {}
 
     def __init__(self, *args, **kw):
         Proxy.__init__(self, *args, **kw)

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -557,7 +557,7 @@ class TestNetstring(TestMixin, basic.NetstringReceiver):
 class LPTestCaseMixin:
 
     illegalStrings: Optional[List[bytes]] = []
-    protocol: Optional[Type[protocol.Protocol]] = None
+    protocol: "Optional[Type[protocol.Protocol]]" = None
 
     def getProtocol(self):
         """
@@ -801,7 +801,7 @@ class IntNTestCaseMixin(LPTestCaseMixin):
     TestCase mixin for int-prefixed protocols.
     """
 
-    protocol: Optional[Type[protocol.Protocol]] = None
+    protocol: "Optional[Type[protocol.Protocol]]" = None
     strings: Optional[List[bytes]] = None
     illegalStrings: Optional[List[bytes]] = None
     partialStrings: Optional[List[bytes]] = None

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -556,8 +556,8 @@ class TestNetstring(TestMixin, basic.NetstringReceiver):
 
 class LPTestCaseMixin:
 
-    illegalStrings = []  # type: Optional[List[bytes]]
-    protocol = None  # type: Optional[Type[protocol.Protocol]]
+    illegalStrings: Optional[List[bytes]] = []
+    protocol: Optional[Type[protocol.Protocol]] = None
 
     def getProtocol(self):
         """
@@ -801,10 +801,10 @@ class IntNTestCaseMixin(LPTestCaseMixin):
     TestCase mixin for int-prefixed protocols.
     """
 
-    protocol = None  # type: Optional[Type[protocol.Protocol]]
-    strings = None  # type: Optional[List[bytes]]
-    illegalStrings = None  # type: Optional[List[bytes]]
-    partialStrings = None  # type: Optional[List[bytes]]
+    protocol: Optional[Type[protocol.Protocol]] = None
+    strings: Optional[List[bytes]] = None
+    illegalStrings: Optional[List[bytes]] = None
+    partialStrings: Optional[List[bytes]] = None
 
     def test_receive(self):
         """

--- a/src/twisted/python/_pydoctor.py
+++ b/src/twisted/python/_pydoctor.py
@@ -60,7 +60,7 @@ class TwistedSphinxInventory(SphinxInventory):
             if name == "zope.interface.adapter.AdapterRegistry":
                 # FIXME:
                 # https://github.com/zopefoundation/zope.interface/issues/41
-                relativeLink = "adapter.html"  # type: Optional[str]
+                relativeLink: Optional[str] = "adapter.html"
             else:
                 # Not a known exception.
                 relativeLink = None

--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -217,7 +217,7 @@ class Project:
         @return: A L{incremental.Version} specifying the version number of the
             project based on live python modules.
         """
-        namespace = {}  # type: Dict[str, object]
+        namespace: Dict[str, object] = {}
         directory = self.directory
         while not namespace:
             if directory.path == "/":

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -116,9 +116,9 @@ def shellComplete(config, cmdName, words, shellCompFile):
                     subOptions = parser()
                     subOptions.parent = config
 
-                    gen = ZshSubcommandBuilder(
+                    gen: ZshBuilder = ZshSubcommandBuilder(
                         subOptions, config, cmdName, shellCompFile
-                    )  # type: ZshBuilder
+                    )
                     gen.write()
                     return
 
@@ -305,8 +305,8 @@ class ZshArgumentsGenerator:
 
         aCL = reflect.accumulateClassList
 
-        optFlags = []  # type: List[List[object]]
-        optParams = []  # type: List[List[object]]
+        optFlags: List[List[object]] = []
+        optParams: List[List[object]] = []
 
         aCL(options.__class__, "optFlags", optFlags)
         aCL(options.__class__, "optParameters", optParams)
@@ -481,7 +481,7 @@ class ZshArgumentsGenerator:
             if optList[1] != None:
                 longToShort[optList[0]] = optList[1]
 
-        excludes = {}  # type: Dict[str, Set[str]]
+        excludes: Dict[str, Set[str]] = {}
         for lst in self.mutuallyExclusive:
             for i, longname in enumerate(lst):
                 tmp = set(lst[:i] + lst[i + 1 :])
@@ -622,7 +622,7 @@ class ZshArgumentsGenerator:
         These will be defined by 'opt_foo' methods of the Options subclass
         @return: L{None}
         """
-        methodsDict = {}  # type: Dict[str, MethodType]
+        methodsDict: Dict[str, MethodType] = {}
         reflect.accumulateMethods(self.options, methodsDict, "opt_")
         methodToShort = {}
         for name in methodsDict.copy():

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -37,7 +37,7 @@ class _Attribute(FancyEqMixin):
     @ivar children: Child attributes.
     """
 
-    compareAttributes = ("children",)  # type: ClassVar[Sequence[str]]
+    compareAttributes: ClassVar[Sequence[str]] = ("children",)
 
     def __init__(self):
         self.children = []
@@ -206,7 +206,7 @@ class DefaultFormattingState(FancyEqMixin):
     text.
     """
 
-    compareAttributes = ("_dummy",)  # type: ClassVar[Sequence[str]]
+    compareAttributes: ClassVar[Sequence[str]] = ("_dummy",)
 
     _dummy = 0
 
@@ -295,7 +295,7 @@ def flatten(output, attrs, attributeRenderer="toVT102"):
     @return: A string expressing the text and display attributes specified by
         L{output}.
     """
-    flattened = []  # type: List[str]
+    flattened: List[str] = []
     output.serialize(flattened.append, attrs, attributeRenderer)
     return "".join(flattened)
 

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -333,7 +333,7 @@ def proxyForInterface(iface, originalAttribute="original"):
     def __init__(self, original):
         setattr(self, originalAttribute, original)
 
-    contents = {"__init__": __init__}  # type: Dict[str, object]
+    contents: Dict[str, object] = {"__init__": __init__}
     for name in iface:
         contents[name] = _ProxyDescriptor(name, originalAttribute)
     proxy = type("(Proxy for {})".format(reflect.qual(iface)), (object,), contents)

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -17,7 +17,7 @@ from threading import local
 from typing import Dict, Type
 
 
-defaultContextDict = {}  # type: Dict[Type[object], Dict[str, str]]
+defaultContextDict: Dict[Type[object], Dict[str, str]] = {}
 
 setDefault = defaultContextDict.__setitem__
 

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -640,7 +640,7 @@ def _passedArgSpec(argspec, positional, keyword):
         to values that were passed explicitly by the user.
     @rtype: L{dict} mapping L{str} to L{object}
     """
-    result = {}  # type: Dict[str, object]
+    result: Dict[str, object] = {}
     unpassed = len(argspec.args) - len(positional)
     if argspec.keywords is not None:
         kwargs = result[argspec.keywords] = {}

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -632,7 +632,7 @@ class FilePath(AbstractFilePath):
     """
 
     _statinfo = None
-    path: Union[bytes, str] = None
+    path: Union[bytes, str] = None  # type: ignore[assignment]
 
     def __init__(self, path, alwaysCreate=False):
         """

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -632,7 +632,7 @@ class FilePath(AbstractFilePath):
     """
 
     _statinfo = None
-    path = None  # type: Union[bytes, str]
+    path: Union[bytes, str] = None
 
     def __init__(self, path, alwaysCreate=False):
         """

--- a/src/twisted/python/formmethod.py
+++ b/src/twisted/python/formmethod.py
@@ -32,7 +32,7 @@ class Argument:
     """Base class for form arguments."""
 
     # default value for argument, if no other default is given
-    defaultDefault = None  # type: Any
+    defaultDefault: Any = None
 
     def __init__(
         self, name, default=None, shortDesc=None, longDesc=None, hints=None, allowNone=1
@@ -68,7 +68,7 @@ class Argument:
 class String(Argument):
     """A single string."""
 
-    defaultDefault = ""  # type: str
+    defaultDefault: str = ""
     min = 0
     max = None
 
@@ -136,7 +136,7 @@ class Hidden(String):
 class Integer(Argument):
     """A single integer."""
 
-    defaultDefault = None  # type: Optional[int]
+    defaultDefault: Optional[int] = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None
@@ -204,7 +204,7 @@ class IntegerRange(Integer):
 
 class Float(Argument):
 
-    defaultDefault = None  # type: Optional[float]
+    defaultDefault: Optional[float] = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None
@@ -344,7 +344,7 @@ def positiveInt(x):
 class Date(Argument):
     """A date -- (year, month, day) tuple."""
 
-    defaultDefault = None  # type: Optional[Tuple[int, int, int]]
+    defaultDefault: Optional[Tuple[int, int, int]] = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None

--- a/src/twisted/python/htmlizer.py
+++ b/src/twisted/python/htmlizer.py
@@ -73,11 +73,11 @@ class HTMLWriter:
     tokens as HTML spans.
     """
 
-    noSpan = []  # type: List[str]
+    noSpan: List[str] = []
 
     def __init__(self, writer):
         self.writer = writer
-        noSpan = []  # type: List[str]
+        noSpan: List[str] = []
         reflect.accumulateClassList(self.__class__, "noSpan", noSpan)
         self.noSpan = noSpan
 

--- a/src/twisted/python/log.py
+++ b/src/twisted/python/log.py
@@ -477,7 +477,7 @@ class FileLogObserver(_GlobalStartStopObserver):
     @ivar timeFormat: If not L{None}, the format string passed to strftime().
     """
 
-    timeFormat = None  # type: Optional[str]
+    timeFormat: Optional[str] = None
 
     def __init__(self, f):
         # Compatibility

--- a/src/twisted/python/logfile.py
+++ b/src/twisted/python/logfile.py
@@ -40,9 +40,9 @@ class BaseLogFile:
         self.name = name
         self.path = os.path.join(directory, name)
         if defaultMode is None and os.path.exists(self.path):
-            self.defaultMode = stat.S_IMODE(
+            self.defaultMode: Optional[int] = stat.S_IMODE(
                 os.stat(self.path)[stat.ST_MODE]
-            )  # type: Optional[int]
+            )
         else:
             self.defaultMode = defaultMode
         self._openFile()

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -61,7 +61,7 @@ class Sensitive:
             return anObject
 
 
-_modDictIDMap = {}  # type:Dict[int, ModuleType]
+_modDictIDMap: Dict[int, ModuleType] = {}
 
 
 def latestFunction(oldFunc):

--- a/src/twisted/python/runtime.py
+++ b/src/twisted/python/runtime.py
@@ -26,10 +26,10 @@ knownPlatforms = {
 }
 
 
-_timeFunctions = {
+_timeFunctions: Dict[Optional[str], Callable] = {
     #'win32': time.clock,
     "win32": time.time,
-}  # type: Dict[Optional[str], Callable]
+}
 
 
 class Platform:
@@ -37,7 +37,7 @@ class Platform:
     Gives us information about the platform we're running on.
     """
 
-    type = knownPlatforms.get(os.name)  # type: Optional[str]
+    type: Optional[str] = knownPlatforms.get(os.name)
     seconds = staticmethod(_timeFunctions.get(type, time.time))
     _platform = sys.platform
 

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -68,7 +68,7 @@ class ListenFDs:
         if start is None:
             start = cls._START
 
-        descriptors = []  # type: List[int]
+        descriptors: List[int] = []
 
         try:
             pid = int(environ["LISTEN_PID"])

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -459,7 +459,7 @@ class FighterAceOptions(usage.Options):
     Command-line options for an imaginary `Fighter Ace` game
     """
 
-    optFlags = [
+    optFlags: List[List[Optional[str]]] = [
         ["fokker", "f", "Select the Fokker Dr.I as your dogfighter aircraft"],
         ["albatros", "a", "Select the Albatros D-III as your dogfighter aircraft"],
         ["spad", "s", "Select the SPAD S.VII as your dogfighter aircraft"],
@@ -467,12 +467,12 @@ class FighterAceOptions(usage.Options):
         ["physics", "p", "Enable secret Twisted physics engine"],
         ["jam", "j", "Enable a small chance that your machine guns will jam!"],
         ["verbose", "v", "Verbose logging (may be specified more than once)"],
-    ]  # type: List[List[Optional[str]]]
+    ]
 
-    optParameters = [
+    optParameters: List[List[Optional[str]]] = [
         ["pilot-name", None, "What's your name, Ace?", "Manfred von Richthofen"],
         ["detail", "d", "Select the level of rendering detail (1-5)", "3"],
-    ]  # type: List[List[Optional[str]]]
+    ]
 
     subCommands = [
         ["server", None, FighterAceServerOptions, "Start FighterAce game-server."],

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -65,7 +65,7 @@ class ThreadPool:
         self.min = minthreads
         self.max = maxthreads
         self.name = name
-        self.threads = []  # type: List[Thread]
+        self.threads: List[Thread] = []
 
         def trackingThreadFactory(*a, **kw):
             thread = self.threadFactory(  # type: ignore[misc]

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -151,7 +151,7 @@ class Options(dict):
 
     subCommand: Optional[str] = None
     defaultSubCommand: Optional[str] = None
-    parent: Optional[Options] = None
+    parent: "Optional[Options]" = None
     completionData = None
     _shellCompFile = sys.stdout  # file to use if shell completion is requested
 

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -149,9 +149,9 @@ class Options(dict):
     or doc/core/howto/options.xhtml in your Twisted directory.
     """
 
-    subCommand = None  # type: Optional[str]
-    defaultSubCommand = None  # type: Optional[str]
-    parent = None  # type: Optional[Options]
+    subCommand: Optional[str] = None
+    defaultSubCommand: Optional[str] = None
+    parent: Optional[Options] = None
     completionData = None
     _shellCompFile = sys.stdout  # file to use if shell completion is requested
 
@@ -568,7 +568,7 @@ class Completer:
     subclasses for specific completion functionality.
     """
 
-    _descr = None  # type: Optional[str]
+    _descr: Optional[str] = None
 
     def __init__(self, descr=None, repeat=False):
         """

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -609,7 +609,9 @@ class FancyStrMixin:
     """
 
     # Override in subclasses:
-    showAttributes = ()  # type: Sequence[Union[str, Tuple[str, str, str], Tuple[str, Callable]]]
+    showAttributes: Sequence[
+        Union[str, Tuple[str, str, str], Tuple[str, Callable]]
+    ] = ()
 
     def __str__(self) -> str:
         r = ["<", getattr(self, "fancybasename", self.__class__.__name__)]
@@ -639,7 +641,7 @@ class FancyEqMixin:
     C{compareAttributes}.
     """
 
-    compareAttributes = ()  # type: ClassVar[Sequence[str]]
+    compareAttributes: ClassVar[Sequence[str]] = ()
 
     def __eq__(self, other: object) -> bool:
         if not self.compareAttributes:

--- a/src/twisted/python/win32.py
+++ b/src/twisted/python/win32.py
@@ -45,7 +45,7 @@ deprecatedModuleAttribute(
 
 
 try:
-    WindowsError = WindowsError  # type: OSError
+    WindowsError: OSError = WindowsError
 except NameError:
     WindowsError = FakeWindowsError  # type: ignore[misc,assignment]
 

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -220,7 +220,7 @@ class ZipArchive(ZipPath):
         self.pathInArchive = _coerceToFilesystemEncoding(archivePathname, "")
         # zipfile is already wasting O(N) memory on cached ZipInfo instances,
         # so there's no sense in trying to do this lazily or intelligently
-        self.childmap = {}  # type: Dict[str, Dict[str, int]]
+        self.childmap: Dict[str, Dict[str, int]] = {}
 
         for name in self.zipfile.namelist():
             name = _coerceToFilesystemEncoding(self.path, name).split(self.sep)

--- a/src/twisted/runner/inetdconf.py
+++ b/src/twisted/runner/inetdconf.py
@@ -45,7 +45,7 @@ class SimpleConfFile:
     """
 
     commentChar = "#"
-    defaultFilename = None  # type: Optional[str]
+    defaultFilename: Optional[str] = None
 
     def parseFile(self, file=None):
         """

--- a/src/twisted/runner/procmontap.py
+++ b/src/twisted/runner/procmontap.py
@@ -57,7 +57,7 @@ class Options(usage.Options):
         ],
     ]
 
-    optFlags = []  # type: List[Sequence[str]]
+    optFlags: List[Sequence[str]] = []
 
     longdesc = """\
 procmon runs processes, monitors their progress, and restarts them when they

--- a/src/twisted/spread/test/test_pb.py
+++ b/src/twisted/spread/test/test_pb.py
@@ -280,7 +280,7 @@ class SimpleFactoryCopy(pb.Copyable):
     @type allIDs: C{dict}
     """
 
-    allIDs = {}  # type: Dict[int, 'SimpleFactoryCopy']
+    allIDs: Dict[int, "SimpleFactoryCopy"] = {}
 
     def __init__(self, id):
         self.id = id

--- a/src/twisted/test/test_adbapi.py
+++ b/src/twisted/test/test_adbapi.py
@@ -29,7 +29,7 @@ class ADBAPITestBase:
     Test the asynchronous DB-API code.
     """
 
-    openfun_called = {}  # type: Dict[object, bool]
+    openfun_called: Dict[object, bool] = {}
 
     if interfaces.IReactorThreads(reactor, None) is None:
         skip = "ADB-API requires threads, no way to test without them"
@@ -335,7 +335,7 @@ class DBTestConnector:
     """
 
     # used for creating new test cases
-    TEST_PREFIX = None  # type: Optional[str]
+    TEST_PREFIX: Optional[str] = None
 
     DB_NAME = "twisted_test"
     DB_USER = "twisted_test"
@@ -348,7 +348,7 @@ class DBTestConnector:
     can_rollback = True  # rollback supported
     test_failures = True  # test bad sql?
     escape_slashes = True  # escape \ in sql?
-    good_sql = ConnectionPool.good_sql  # type: Optional[str]
+    good_sql: Optional[str] = ConnectionPool.good_sql
     early_reconnect = True  # cursor() will fail on closed connection
     can_clear = True  # can try to clear out tables when starting
 

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -136,9 +136,9 @@ class Hello(amp.Command):
 
     response = [(b"hello", amp.String()), (b"print", amp.Unicode(optional=True))]
 
-    errors = {UnfriendlyGreeting: b"UNFRIENDLY"}  # type: Dict[Type[Exception], bytes]
+    errors: Dict[Type[Exception], bytes] = {UnfriendlyGreeting: b"UNFRIENDLY"}
 
-    fatalErrors = {DeathThreat: b"DEAD"}  # type: Dict[Type[Exception], bytes]
+    fatalErrors: Dict[Type[Exception], bytes] = {DeathThreat: b"DEAD"}
 
 
 class NoAnswerHello(Hello):
@@ -2137,7 +2137,7 @@ class BaseCommand(amp.Command):
     This provides a command that will be subclassed.
     """
 
-    errors = {InheritedError: b"INHERITED_ERROR"}  # type: Dict[Type[Exception], bytes]
+    errors: Dict[Type[Exception], bytes] = {InheritedError: b"INHERITED_ERROR"}
 
 
 class InheritedCommand(BaseCommand):
@@ -2154,9 +2154,9 @@ class AddErrorsCommand(BaseCommand):
     """
 
     arguments = [(b"other", amp.Boolean())]
-    errors = {
+    errors: Dict[Type[Exception], bytes] = {
         OtherInheritedError: b"OTHER_INHERITED_ERROR"
-    }  # type: Dict[Type[Exception], bytes]
+    }
 
 
 class NormalCommandProtocol(amp.AMP):

--- a/src/twisted/test/test_postfix.py
+++ b/src/twisted/test/test_postfix.py
@@ -40,13 +40,13 @@ class PostfixTCPMapQuoteTests(unittest.TestCase):
 
 
 class PostfixTCPMapServerTestCase:
-    data = {
+    data: Dict[bytes, bytes] = {
         # 'key': 'value',
-    }  # type: Dict[bytes, bytes]
+    }
 
-    chat = [
+    chat: List[Tuple[bytes, bytes]] = [
         # (input, expected_output),
-    ]  # type: List[Tuple[bytes, bytes]]
+    ]
 
     def test_chat(self):
         """

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -374,7 +374,7 @@ class UtilityProcessProtocol(protocol.ProcessProtocol):
     @ivar programName: The name of the program to run.
     """
 
-    programName = b""  # type: bytes
+    programName: bytes = b""
 
     @classmethod
     def run(cls, reactor, argv, env):

--- a/src/twisted/test/test_tcp.py
+++ b/src/twisted/test/test_tcp.py
@@ -121,7 +121,7 @@ class MyProtocolFactoryMixin:
 
     protocolConnectionMade = None
     protocolConnectionLost = None
-    protocol = None  # type: Optional[Callable[[], Protocol]]
+    protocol: Optional[Callable[[], Protocol]] = None
     called = 0
 
     def __init__(self):

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -25,7 +25,7 @@ from twisted.python import failure
 from twisted.trial import itrial, util
 from twisted.trial._synctest import FailTest, SkipTest, SynchronousTestCase
 
-_wait_is_running = []  # type: List[None]
+_wait_is_running: List[None] = []
 
 
 @implementer(itrial.ITestCase)

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -947,7 +947,7 @@ class ReporterInterfaceTests(unittest.SynchronousTestCase):
         callable must take the same parameters as L{reporter.Reporter}.
     """
 
-    resultFactory = reporter.Reporter  # type: Type[itrial.IReporter]
+    resultFactory: Type[itrial.IReporter] = reporter.Reporter
 
     def setUp(self):
         self.test = sample.FooTest("test_foo")
@@ -1133,7 +1133,7 @@ class SubunitReporterTests(ReporterInterfaceTests):
     This just tests that the subunit reporter implements the basic interface.
     """
 
-    resultFactory = reporter.SubunitReporter  # type: Type[itrial.IReporter]
+    resultFactory: Type[itrial.IReporter] = reporter.SubunitReporter
 
     def setUp(self):
         if reporter.TestProtocolClient is None:
@@ -1346,7 +1346,7 @@ class SubunitReporterNotInstalledTests(unittest.SynchronousTestCase):
 
 
 class TimingReporterTests(ReporterTests):
-    resultFactory = reporter.TimingTextReporter  # type: Type[itrial.IReporter]
+    resultFactory: Type[itrial.IReporter] = reporter.TimingTextReporter
 
 
 class LoggingReporter(reporter.Reporter):

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -642,7 +642,7 @@ class UntilFailureTests(unittest.SynchronousTestCase):
         A test case that fails when run 3 times in a row.
         """
 
-        count = []  # type: List[None]
+        count: List[None] = []
 
         def test_foo(self):
             self.count.append(None)

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -151,7 +151,7 @@ class Element:
         return from C{render}.
     """
 
-    loader = None  # type: Optional[ITemplateLoader]
+    loader: Optional[ITemplateLoader] = None
 
     def __init__(self, loader=None):
         if loader is not None:

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -47,7 +47,7 @@ from twisted.web.error import ExcessiveBufferingError
 
 
 # This API is currently considered private.
-__all__ = []  # type: List[str]
+__all__: List[str] = []
 
 
 _END_STREAM_SENTINEL = object()

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -783,8 +783,8 @@ class Request:
     finished = 0
     code = OK
     code_message = RESPONSES[OK]
-    method = b"(no method yet)"  # type: bytes
-    clientproto = b"(no clientproto yet)"  # type: bytes
+    method: bytes = b"(no method yet)"
+    clientproto: bytes = b"(no clientproto yet)"
     uri = "(no uri yet)"
     startedWriting = 0
     chunked = 0

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -82,7 +82,7 @@ class Headers:
         self,
         rawHeaders: Optional[Mapping[AnyStr, Sequence[AnyStr]]] = None,
     ):
-        self._rawHeaders = {}  # type: Dict[bytes, List[bytes]]
+        self._rawHeaders: Dict[bytes, List[bytes]] = {}
         if rawHeaders is not None:
             for name, values in rawHeaders.items():
                 self.setRawHeaders(name, values)
@@ -186,7 +186,7 @@ class Headers:
                 )
 
         _name = _sanitizeLinearWhitespace(self._encodeName(name))
-        encodedValues = []  # type: List[bytes]
+        encodedValues: List[bytes] = []
         for v in values:
             if isinstance(v, str):
                 _v = v.encode("utf8")

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -107,8 +107,8 @@ class Request(Copyable, http.Request, components.Componentized):
 
     site = None
     appRootURL = None
-    prepath = None  # type: Optional[List[bytes]]
-    postpath = None  # type: Optional[bytes]
+    prepath: Optional[List[bytes]] = None
+    postpath: Optional[bytes] = None
     __pychecker__ = "unusednames=issuer"
     _inFakeHead = False
     _encoder = None

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -203,7 +203,7 @@ class File(resource.Resource, filepath.FilePath):
 
     contentEncodings = {".gz": "gzip", ".bz2": "bzip2"}
 
-    processors = {}  # type: Dict[str, Callable[[str, Any], Data]]
+    processors: Dict[str, Callable[[str, Any], Data]] = {}
 
     indexNames = ["index", "index.html", "index.htm", "index.rpy"]
 

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -206,7 +206,7 @@ class DummyRequest:
 
     uri = b"http://dummy/"
     method = b"GET"
-    client = None  # type: Optional[IAddress]
+    client: Optional[IAddress] = None
 
     def registerProducer(self, prod, s):
         """

--- a/src/twisted/web/test/test_domhelpers.py
+++ b/src/twisted/web/test/test_domhelpers.py
@@ -20,7 +20,7 @@ class DOMHelpersTestsMixin:
     subclass.
     """
 
-    dom = None  # type: Optional[Any]
+    dom: Optional[Any] = None
 
     def test_getElementsByTagName(self):
         doc1 = self.dom.parseString("<foo/>")

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -265,7 +265,7 @@ class HTTP1_0Tests(unittest.TestCase, ResponseTestMixin):
         b"\r\n"
     )
 
-    expected_response = [
+    expected_response: Union[Sequence[Sequence[bytes]], bytes] = [
         (
             b"HTTP/1.0 200 OK",
             b"Request: /",
@@ -274,7 +274,7 @@ class HTTP1_0Tests(unittest.TestCase, ResponseTestMixin):
             b"Content-Length: 13",
             b"'''\nNone\n'''\n",
         )
-    ]  # type: Union[Sequence[Sequence[bytes]], bytes]
+    ]
 
     def test_buffer(self):
         """

--- a/src/twisted/web/test/test_newclient.py
+++ b/src/twisted/web/test/test_newclient.py
@@ -191,7 +191,7 @@ class _HTTPParserTests:
     the task of parsing HTTP bytes.
     """
 
-    sep = None  # type: Optional[bytes]
+    sep: Optional[bytes] = None
 
     def test_statusCallback(self):
         """

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -98,7 +98,7 @@ class AbstractClientMixin:
     @ivar _logonDeferred: Fired when I am done logging in.
     """
 
-    _protoBase = None  # type: Type[Protocol]
+    _protoBase: Type[Protocol] = None
 
     def __init__(self, account, chatui, logonDeferred):
         for base in self.__class__.__bases__:

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -98,7 +98,7 @@ class AbstractClientMixin:
     @ivar _logonDeferred: Fired when I am done logging in.
     """
 
-    _protoBase: Type[Protocol] = None
+    _protoBase: Type[Protocol] = None  # type: ignore[assignment]
 
     def __init__(self, account, chatui, logonDeferred):
         for base in self.__class__.__bases__:

--- a/src/twisted/words/im/locals.py
+++ b/src/twisted/words/im/locals.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 
 class Enum:
-    group = None  # type: Optional[str]
+    group: Optional[str] = None
 
     def __init__(self, label: str) -> None:
         self.label = label

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -166,7 +166,7 @@ class _CommandDispatcherMixin:
     @ivar prefix: Command handler prefix, used to locate handler attributes
     """
 
-    prefix = None  # type: Optional[str]
+    prefix: Optional[str] = None
 
     def dispatch(self, commandName, *args):
         """
@@ -257,7 +257,7 @@ class IRC(protocol.Protocol):
     buffer = ""
     hostname = None
 
-    encoding = None  # type: Optional[str]
+    encoding: Optional[str] = None
 
     def connectionMade(self):
         self.channels = []
@@ -3050,7 +3050,7 @@ class DccFileReceive(DccFileReceiveBasic):
     fileSize = -1
     destDir = "."
     overwrite = 0
-    fromUser = None  # type: Optional[bytes]
+    fromUser: Optional[bytes] = None
     queryData = None
 
     def __init__(

--- a/src/twisted/words/protocols/jabber/error.py
+++ b/src/twisted/words/protocols/jabber/error.py
@@ -84,7 +84,7 @@ class BaseError(Exception):
     @type appCondition: object providing L{domish.IElement}.
     """
 
-    namespace = None  # type: Optional[str]
+    namespace: Optional[str] = None
 
     def __init__(self, condition, text=None, textLang=None, appCondition=None):
         Exception.__init__(self)

--- a/src/twisted/words/protocols/jabber/jid.py
+++ b/src/twisted/words/protocols/jabber/jid.py
@@ -114,7 +114,7 @@ def prep(user, host, resource):
     return (user, host, resource)
 
 
-__internJIDs = {}  # type: Dict[str, 'JID']
+__internJIDs: Dict[str, "JID"] = {}
 
 
 def internJID(jidstring):

--- a/src/twisted/words/protocols/jabber/xmlstream.py
+++ b/src/twisted/words/protocols/jabber/xmlstream.py
@@ -163,7 +163,7 @@ class ConnectAuthenticator(Authenticator):
     Authenticator for initiating entities.
     """
 
-    namespace = None  # type: Optional[str]
+    namespace: Optional[str] = None
 
     def __init__(self, otherHost):
         self.otherHost = otherHost
@@ -259,7 +259,7 @@ class ListenAuthenticator(Authenticator):
     Authenticator for receiving entities.
     """
 
-    namespace = None  # type: Optional[str]
+    namespace: Optional[str] = None
 
     def associateWithStream(self, xmlstream):
         """
@@ -315,7 +315,7 @@ class BaseFeatureInitiatingInitializer:
     @type required: C{bool}
     """
 
-    feature = None  # type: Optional[Tuple[str, str]]
+    feature: Optional[Tuple[str, str]] = None
 
     def __init__(self, xs, required=False):
         self.xmlstream = xs

--- a/src/twisted/words/tap.py
+++ b/src/twisted/words/tap.py
@@ -20,14 +20,14 @@ from twisted.cred import checkers, credentials, portal, strcred
 
 class Options(usage.Options, strcred.AuthOptionMixin):
     supportedInterfaces = [credentials.IUsernamePassword]
-    optParameters = [
+    optParameters: List[Sequence[Optional[str]]] = [
         (
             "hostname",
             None,
             socket.gethostname(),
             "Name of this server; purely an informative",
         )
-    ]  # type: List[Sequence[Optional[str]]]
+    ]
 
     compData = usage.Completions(multiUse=["group"])
 

--- a/src/twisted/words/xish/xmlstream.py
+++ b/src/twisted/words/xish/xmlstream.py
@@ -259,7 +259,7 @@ class XmlStreamFactory(XmlStreamFactoryMixin, protocol.ReconnectingClientFactory
     Factory for XmlStream protocol objects as a reconnection client.
     """
 
-    protocol: Type[protocol.Protocol] = XmlStream
+    protocol: "Type[protocol.Protocol]" = XmlStream
 
     def buildProtocol(self, addr):
         """

--- a/src/twisted/words/xish/xmlstream.py
+++ b/src/twisted/words/xish/xmlstream.py
@@ -259,7 +259,7 @@ class XmlStreamFactory(XmlStreamFactoryMixin, protocol.ReconnectingClientFactory
     Factory for XmlStream protocol objects as a reconnection client.
     """
 
-    protocol = XmlStream  # type: Type[protocol.Protocol]
+    protocol: Type[protocol.Protocol] = XmlStream
 
     def buildProtocol(self, addr):
         """


### PR DESCRIPTION
## Scope and purpose

apply `pipx run com2ann --python-minor-version=6 -s src` and fix any lint errors
Python 3.6 introduces variable annotation syntax, we should use it in favour of legacy type comments

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10110
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
