### PR TITLE
support py3.10a5 (by fixing twisted.trial.unittest.TestCase.flushWarnings) 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           # When updating the minimum Python version here, also update the
           # `python_requires` from `setup.cfg`.
           # Run on latest minor release of each major python version.
-          python-version: ["3.6.7", 3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
+          python-version: ["3.6.7", 3.6, 3.7, 3.8, 3.9, 3.10.0-alpha.5, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ dev_release =
 dev =
     %(dev_release)s
     pyflakes ~= 2.2
+    # TODO: support python-subunit in py3.10 https://twistedmatrix.com/trac/ticket/10115
     python-subunit ~= 1.4; python_version < "3.10"
     twistedchecker ~= 0.7
     coverage ~= 5.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev_release =
 dev =
     %(dev_release)s
     pyflakes ~= 2.2
-    python-subunit ~= 1.4
+    python-subunit ~= 1.4; python_version < "3.10"
     twistedchecker ~= 0.7
     coverage ~= 5.5
 

--- a/src/twisted/newsfragments/10111.feature
+++ b/src/twisted/newsfragments/10111.feature
@@ -1,1 +1,1 @@
-support py3.10a5
+support py3.10a5 (by fixing twisted.trial.unittest.TestCase.flushWarnings)

--- a/src/twisted/newsfragments/10111.feature
+++ b/src/twisted/newsfragments/10111.feature
@@ -1,0 +1,1 @@
+support py3.10a5

--- a/src/twisted/newsfragments/10111.misc
+++ b/src/twisted/newsfragments/10111.misc
@@ -1,1 +1,0 @@
-test on py3.10a5

--- a/src/twisted/newsfragments/10111.misc
+++ b/src/twisted/newsfragments/10111.misc
@@ -1,0 +1,1 @@
+test on py3.10a5

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -604,21 +604,15 @@ def warnAboutFunction(offender, warningString):
     # inspect.getmodule() is attractive, but somewhat
     # broken in Python < 2.6.  See Python bug 4845.
     offenderModule = sys.modules[offender.__module__]
-    filename = inspect.getabsfile(offenderModule)
-    lineStarts = list(findlinestarts(offender.__code__))
-    lastLineNo = lineStarts[-1][1]
-    globals = offender.__globals__
-
-    kwargs = dict(
+    warn_explicit(
+        warningString,
         category=DeprecationWarning,
-        filename=filename,
-        lineno=lastLineNo,
+        filename=inspect.getabsfile(offenderModule),
+        lineno=max(lineNumber for _, lineNumber in findlinestarts(offender.__code__)),
         module=offenderModule.__name__,
-        registry=globals.setdefault("__warningregistry__", {}),
+        registry=offender.__globals__.setdefault("__warningregistry__", {}),
         module_globals=None,
     )
-
-    warn_explicit(warningString, **kwargs)
 
 
 def _passedArgSpec(argspec, positional, keyword):

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -451,11 +451,11 @@ def callTestFunction():
         self.assertEqual(warningsShown[0]["message"], "A Warning String")
         self.assertEqual(len(warningsShown), 1)
 
-    def test_warningLineNumberPEP626(self):
+    def test_warningLineNumberDisFindlinestarts(self):
         """
         L{deprecate.warnAboutFunction} emits a C{DeprecationWarning} with the
-        number of a line within the implementation of the function passed to it
-        on py3.10 with PEP 626.
+        number of a line within the implementation handling the case in which
+        dis.findlinestarts returns the lines in random order.
         """
         from twisted_private_helper import pep626
 

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1154,10 +1154,11 @@ class SynchronousTestCase(_Assertions):
 
                     if filename != os.path.normcase(aWarning.filename):
                         continue
-                    lineStarts = list(_findlinestarts(aFunction.__code__))
-                    first = lineStarts[0][1]
-                    last = lineStarts[-1][1]
-                    if not (first <= aWarning.lineno <= last):
+                    lineNumbers = [
+                        lineNumber
+                        for _, lineNumber in _findlinestarts(aFunction.__code__)
+                    ]
+                    if not (min(lineNumbers) <= aWarning.lineno <= max(lineNumbers)):
                         continue
                     # The warning points to this function, flush it and move on
                     # to the next warning.

--- a/src/twisted/trial/test/test_warning.py
+++ b/src/twisted/trial/test/test_warning.py
@@ -365,9 +365,14 @@ def foo():
         # Flush it
         self.assertEqual(len(self.flushWarnings([module.foo])), 1)
 
-    def test_pep626(self):
+    def test_offendingFunctions_deep_branch(self):
         """
-        dis.findlinestarts is not guaranteed to be sorted ascending.
+        In Python 3.6 the dis.findlinestarts documented behaviour
+        was changed such that the reported lines might not be sorted ascending.
+        In Python 3.10 PEP 626 introduced byte-code change such that the last
+        line of a function wasn't always associated with the last byte-code.
+        In the past flushWarning was not detecting that such a function was
+        associated with any warnings.
         """
 
         def foo(a=1, b=1):

--- a/src/twisted/trial/test/test_warning.py
+++ b/src/twisted/trial/test/test_warning.py
@@ -365,6 +365,24 @@ def foo():
         # Flush it
         self.assertEqual(len(self.flushWarnings([module.foo])), 1)
 
+    def test_pep626(self):
+        """
+        dis.findlinestarts is not guaranteed to be sorted ascending.
+        """
+
+        def foo(a=1, b=1):
+            if a:
+                if b:
+                    warnings.warn("oh no")
+                else:
+                    pass
+
+        # Generate the warning
+        foo()
+
+        # Flush it
+        self.assertEqual(len(self.flushWarnings([foo])), 1)
+
 
 class FakeWarning(Warning):
     pass


### PR DESCRIPTION
It took a little while from 3.9's release to Twisted supporting it, I think it's worth trying to get support available before the release.

This is *just* the GHA ubuntu-latest machines

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10111
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.