### PR TITLE
update tests for incremental >= 21.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 35.0.2",
     "wheel >= 0.29.0",
-    "incremental >= 16.10.1",
+    "incremental >= 21.3.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.6.7
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1
-    incremental >= 16.10.1
+    incremental >= 21.3.0
     Automat >= 0.8.0
     hyperlink >= 17.1.1
     attrs >= 19.2.0

--- a/src/twisted/newsfragments/10112.misc
+++ b/src/twisted/newsfragments/10112.misc
@@ -1,0 +1,1 @@
+upgrade to incremental >= 21.3.0

--- a/src/twisted/python/test/test_versions.py
+++ b/src/twisted/python/test/test_versions.py
@@ -126,7 +126,7 @@ class VersionsTests(TestCase):
         Calling C{str} on a version with a prerelease includes the prerelease.
         """
         self.assertEqual(
-            str(Version("dummy", 1, 0, 0, prerelease=1)), "[dummy, version 1.0.0rc1]"
+            str(Version("dummy", 1, 0, 0, prerelease=1)), "[dummy, version 1.0.0.rc1]"
         )
 
     def testShort(self):
@@ -145,7 +145,7 @@ class VersionsTests(TestCase):
         """
         self.assertEqual(
             getVersionString(Version("whatever", 8, 0, 0, prerelease=1)),
-            "whatever 8.0.0rc1",
+            "whatever 8.0.0.rc1",
         )
 
     def test_base(self):
@@ -158,4 +158,4 @@ class VersionsTests(TestCase):
         """
         The base version includes 'preX' for versions with prereleases.
         """
-        self.assertEqual(Version("foo", 1, 0, 0, prerelease=8).base(), "1.0.0rc8")
+        self.assertEqual(Version("foo", 1, 0, 0, prerelease=8).base(), "1.0.0.rc8")


### PR DESCRIPTION
## Scope and purpose

CI fails without these test changes

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10112
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
