### PR TITLE
Make cython-test-exception-raiser extension optional

### DIFF
--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -21,8 +21,10 @@ from twisted.python import failure
 
 from twisted.trial.unittest import SynchronousTestCase
 
-
-from cython_test_exception_raiser import raiser
+try:
+    from cython_test_exception_raiser import raiser
+except ImportError:
+    raiser = None
 
 
 def getDivisionFailure(*args, **kwargs):


### PR DESCRIPTION
## Scope and purpose

The function `test_failureConstructionWithMungedStackSucceeds` has a `@skipIf` decorator [[here](https://github.com/kulikjak/twisted/blob/625be70a220eb528f75e9f4d3c9aec15aa782fc9/src/twisted/test/test_failure.py#L671)] if `cython-test-exception-raiser` is not available, but the import is not as permissive. Since the rest of the test suite is not affected by the missing extension in any way, and the test itself is ready for that, it should be made optional.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10113
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
