### PR TITLE
Specify class returning itself in `Logger.__get__`.

### DIFF
--- a/src/twisted/application/runner/_pidfile.py
+++ b/src/twisted/application/runner/_pidfile.py
@@ -9,7 +9,7 @@ PID file.
 import errno
 from os import getpid, kill, name as SYSTEM_NAME
 from types import TracebackType
-from typing import Optional, Type, cast
+from typing import Optional, Type
 
 from zope.interface import Interface, implementer
 
@@ -191,7 +191,7 @@ class PIDFile:
             if self.isRunning():
                 raise AlreadyRunningError()
         except StalePIDFileError:
-            cast(Logger, self._log).info("Replacing stale PID file: {log_source}")
+            self._log.info("Replacing stale PID file: {log_source}")
         self.writeRunningPID()
         return self
 

--- a/src/twisted/application/runner/_runner.py
+++ b/src/twisted/application/runner/_runner.py
@@ -9,7 +9,7 @@ Twisted application runner.
 from sys import stderr
 from signal import SIGTERM
 from os import kill
-from typing import Any, TextIO, Callable, Mapping, cast
+from typing import Any, TextIO, Callable, Mapping
 
 from attr import attrib, attrs, Factory
 
@@ -115,7 +115,7 @@ class Runner:
                 return  # type: ignore[unreachable]
 
             self.startLogging()
-            cast(Logger, self._log).info("Terminating process: {pid}", pid=pid)
+            self._log.info("Terminating process: {pid}", pid=pid)
 
             kill(pid, SIGTERM)
 
@@ -148,7 +148,7 @@ class Runner:
         """
         self._reactor.callWhenRunning(self.whenRunning)
 
-        cast(Logger, self._log).info("Starting reactor...")
+        self._log.info("Starting reactor...")
         self._reactor.run()
 
     def whenRunning(self) -> None:

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -68,7 +68,7 @@ class Logger:
         else:
             self.observer = observer
 
-    def __get__(self, instance: object, owner: Optional[type] = None) -> object:
+    def __get__(self, instance: object, owner: Optional[type] = None) -> "Logger":
         """
         When used as a descriptor, i.e.::
 

--- a/src/twisted/logger/test/test_capture.py
+++ b/src/twisted/logger/test/test_capture.py
@@ -5,8 +5,6 @@
 Test cases for L{twisted.logger._capture}.
 """
 
-from typing import cast
-
 from twisted.logger import Logger, LogLevel
 from twisted.trial.unittest import TestCase
 
@@ -27,8 +25,8 @@ class LogCaptureTests(TestCase):
         foo = object()
 
         with capturedLogs() as captured:
-            cast(Logger, self.log).debug("Capture this, please", foo=foo)
-            cast(Logger, self.log).info("Capture this too, please", foo=foo)
+            self.log.debug("Capture this, please", foo=foo)
+            self.log.info("Capture this too, please", foo=foo)
 
         self.assertTrue(len(captured) == 2)
         self.assertEqual(captured[0]["log_format"], "Capture this, please")

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -125,7 +125,7 @@ class LoggerTests(unittest.TestCase):
         class MyObject:
             log = Logger(observer=cast(ILogObserver, observed.append))
 
-        cast(Logger, MyObject.log).info("hello")
+        MyObject.log.info("hello")
         self.assertEqual(len(observed), 1)
         self.assertEqual(observed[0]["log_format"], "hello")
 


### PR DESCRIPTION
## Scope and purpose

This pull request aims to fix a type error reported by `mypy` when checking classes with a class attribute instantiating `twisted.logger.Logger`.

## Contributor Checklist:

* [X] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10119
* [X] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests. (I am not sure how to add any, as this is a mypy change. Open to suggestions.)
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
