### PR TITLE
[10121] Fix random PyPy CI failures. Improve GHA CI speed. Improve coverage reporting.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,12 +104,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox coverage coveralls
-        tox --notest
 
     - name: Test
       run: |
-        python --version
-        tox -q ${{ matrix.trial-target }}
+        tox ${{ matrix.trial-target }}
 
     - name: Prepare coverage
       if: always() && contains(matrix['tox-env'], 'withcov')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,8 @@ jobs:
         # As of 9 March 2021 GHA VM have 2 CPUs - Azure Standard_DS2_v2
         # Trial distributed jobs enabled to speed up the CI jobs.
         trial-args: ['-j 4']
+        # Tests are executed with the default target which is the full test suite.
+        trial-target: ['']
 
         include:
 
@@ -61,6 +63,10 @@ jobs:
             tox-env: alldeps-nocov-posix
           - python-version: pypy-3.7
             tox-env: alldeps-nocov-posix
+          # We still run some tests with coverage
+          - python-version: pypy-3.7
+            tox-env: alldeps-withcov-posix
+            trial-target: twisted.test.test_compat twisted.test.test_defer twisted.trial.test.test_tests
 
 
     steps:
@@ -103,11 +109,10 @@ jobs:
     - name: Test
       run: |
         python --version
-        tox -q
+        tox -q ${{ matrix.trial-target }}
 
     - name: Prepare coverage
       if: always() && contains(matrix['tox-env'], 'withcov')
-      continue-on-error: true
       run: |
         # sub-process coverage are generated in separate files so we combine them
         # to get an unified coverage for the local run.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TOXENV: "${{ matrix.tox-env }}"
+      # As of April 2021 GHA VM have 2 CPUs - Azure Standard_DS2_v2
+      # Trial distributed jobs enabled to speed up the CI jobs.
       TRIAL_ARGS: "-j 4"
     name: ${{ matrix.python-version }}${{ matrix.noipv6 }}-${{ matrix.tox-env }}
     strategy:
@@ -32,10 +34,8 @@ jobs:
         # Run on latest minor release of each major python version.
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-alpha.5]
         tox-env: ['alldeps-withcov-posix']
+        # By default, tests are executed without disabling IPv6.
         noipv6: ['']
-        # As of 9 March 2021 GHA VM have 2 CPUs - Azure Standard_DS2_v2
-        # Trial distributed jobs enabled to speed up the CI jobs.
-        trial-args: ['-j 4']
         # Tests are executed with the default target which is the full test suite.
         trial-target: ['']
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           # We still run some tests with coverage
           - python-version: pypy-3.7
             tox-env: alldeps-withcov-posix
-            trial-target: twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket
+            trial-target: twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests
 
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           # We still run some tests with coverage
           - python-version: pypy-3.7
             tox-env: alldeps-withcov-posix
-            trial-target: twisted.test.test_compat twisted.test.test_defer twisted.trial.test.test_tests
+            trial-target: twisted.test.test_compat twisted.test.test_defer
 
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           # We still run some tests with coverage
           - python-version: pypy-3.7
             tox-env: alldeps-withcov-posix
-            trial-target: twisted.test.test_compat twisted.test.test_defer
+            trial-target: twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket
 
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TOXENV: "${{ matrix.tox-env }}"
-      TRIAL_ARGS: "${{ matrix.trial-args }}"
+      TRIAL_ARGS: "-j 4"
     name: ${{ matrix.python-version }}${{ matrix.noipv6 }}-${{ matrix.tox-env }}
     strategy:
       fail-fast: false
@@ -47,22 +47,20 @@ jobs:
           # end to end functional test usage for non-distributed trial runs.
           - python-version: 3.6.7
             tox-env: nodeps-withcov-posix
-            trial-args: '-j 4'
           # `noipv6` is created to make sure all is OK on an OS which doesn't
           # have IPv6 available.
           # Any supported Python version is OK for this job.
           - python-version: 3.6
             tox-env: alldeps-withcov-posix
             noipv6: -noipv6
-            trial-args: '-j 4'
-          # On PYPY concurrent test jobs result in random failures so for now
-          # run non-distributed tests.
+          # On PYPY coverage is very slow (5min vs 30min) as there is no C
+          # extension.
+          # There is very little PYPY specific code so there is not much to
+          # gain from reporting coverage.
           - python-version: pypy-3.6
-            tox-env: alldeps-withcov-posix
-            trial-args:
+            tox-env: alldeps-nocov-posix
           - python-version: pypy-3.7
-            tox-env: alldeps-withcov-posix
-            trial-args:
+            tox-env: alldeps-nocov-posix
 
 
     steps:
@@ -99,7 +97,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox coveralls
+        python -m pip install --upgrade pip tox coverage coveralls
         tox --notest
 
     - name: Test
@@ -108,7 +106,7 @@ jobs:
         tox -q
 
     - name: Prepare coverage
-      if: always()
+      if: always() && contains(matrix['tox-env'], 'withcov')
       continue-on-error: true
       run: |
         # sub-process coverage are generated in separate files so we combine them
@@ -116,11 +114,10 @@ jobs:
         # The XML is generate to be used with 3rd party tools like diff-cover.
         python -m coverage combine
         python -m coverage xml -o coverage.xml -i
-        python -m coverage report
+        python -m coverage report --skip-covered
 
     - uses: codecov/codecov-action@v1
-      if: always()
-      continue-on-error: true
+      if: always() && contains(matrix['tox-env'], 'withcov')
       with:
         files: coverage.xml
         name: lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}
@@ -128,7 +125,7 @@ jobs:
         functionalities: gcov,search
 
     - name: Publish to Coveralls
-      if: always()
+      if: always() && contains(matrix['tox-env'], 'withcov')
       continue-on-error: true
       run: |
         python -m coveralls -v

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -89,9 +89,15 @@ steps:
 # https://github.com/TheKevJames/coveralls-python/blob/04b6a2876e4e7ab2e8cf0778f88ce23f94679931/coveralls/api.py#L147
 # https://github.com/TheKevJames/coveralls-python/blob/04b6a2876e4e7ab2e8cf0778f88ce23f94679931/coveralls/git.py#L31
 - bash: |
-    export CI_BRANCH=$SYSTEM_PULLREQUEST_SOURCEBRANCH
-    export CI_PULL_REQUEST=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
-    export CI_BUILD_URL=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI/pull/$CI_PULL_REQUEST
+    # Start by trying to get the branch for a push.
+    export CI_BRANCH=$BUILD_SOURCEBRANCHNAME
+    if ["$CI_BRANCH" == "merge"]; then
+      # Looks like we have a PR request.
+      export CI_BRANCH=$SYSTEM_PULLREQUEST_SOURCEBRANCH
+      export CI_PULL_REQUEST=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+      export CI_BUILD_URL=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI/pull/$CI_PULL_REQUEST
+    fi
+
     python -m coveralls -v
   displayName: 'Report to Coveralls'
   condition: always()

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,9 +19,22 @@ coverage:
   status:
     patch:
       default:
+        # New code should have 100% CI coverage as the minimum
+        # quality assurance measurement.
+        # If there is a good reason for new code not to have coverage,
+        # add inline pragma comments.
         target: 100%
     project:
       default:
+        # Allow for a bit of slack in overall project report.
+        # As long as the patch is 100% the PR should be ok.
+        # We report coverage even on errors.
+        # So a run on trunk might fail and during the failure process will
+        # exercise a different code branch (ex timeout errors).
+        # This code branch is reported at the end of the run.
+        # Future test runs will not trigger the error and the error handling
+        # code branch is not called, and if no other tests is touching that
+        # branch we are left with overall reduced code coverage.
         threshold: 0.02%
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,9 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 7
+    # We have at least 10 builds in GitHub Actions and 12 in Azure
+    # and lint + mypy + docs + ReadTheDocs
+    after_n_builds: 15
     wait_for_ci: yes
 
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,16 @@
 #
-# For documentation see https://codecov.io/gh/twisted/twisted/settings/yaml
+# For documentation: https://docs.codecov.io/docs/codecovyml-reference
+# Twisted settings: https://codecov.io/gh/twisted/twisted/settings/yaml
 #
 # We want 100% coverage for new patches to make sure we are always increasing
 # the coverage.
 #
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    after_n_builds: 7
+    wait_for_ci: yes
+
 coverage:
   precision: 2
   round: down
@@ -12,4 +19,12 @@ coverage:
       default:
         target: 100%
 
-comment: off
+# We don't want to receive general PR comments about coverage.
+# We have the commit status checks and that should be enough.
+# See https://docs.codecov.io/docs/pull-request-comments
+comment: false
+
+# See https://docs.codecov.io/docs/github-checks
+github_checks:
+  # We want codecov to send inline PR comments for missing coverage.
+  annotations: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,15 +26,9 @@ coverage:
         target: 100%
     project:
       default:
-        # Allow for a bit of slack in overall project report.
-        # As long as the patch is 100% the PR should be ok.
-        # We report coverage even on errors.
-        # So a run on trunk might fail and during the failure process will
-        # exercise a different code branch (ex timeout errors).
-        # This code branch is reported at the end of the run.
-        # Future test runs will not trigger the error and the error handling
-        # code branch is not called, and if no other tests is touching that
-        # branch we are left with overall reduced code coverage.
+        # Temporary allow for a bit of slack in overall code coverage due to
+        # swinging coverage that is not triggered by changes in a PR.
+        # See: https://twistedmatrix.com/trac/ticket/10170
         threshold: 0.02%
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,10 @@ coverage:
     patch:
       default:
         target: 100%
+    project:
+      default:
+        threshold: 0.02%
+
 
 # We don't want to receive general PR comments about coverage.
 # We have the commit status checks and that should be enough.

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -1166,6 +1166,7 @@ class TestDecoratorMixin:
         """
         getrefcount = getattr(sys, "getrefcount", None)
         if getrefcount is None:
+            # For example non CPython like _PYPY.
             raise unittest.SkipTest("getrefcount not supported on this platform")
         test = self.TestCase()
         suite = unittest.TestSuite([test])


### PR DESCRIPTION
## Scope and purpose

We got random failures on pypy (both 3.6 and 3.7 versions)

Also pypy jobs with coverage are very slow...30minutes.

See what can be done to speed up the CI.

## Changes

### PYPY coverage

Coverage was disabled for most of the PyPy..
The tests are much faster now without coverage 4m vs 30m
We still run coverage on PYPY, but only for compat and a few other test that are exercising the PYPY specific code.

In this way we can monitor if we continue to see random CI failures at the end of the test run on PY.

These are the tests required to get the extra coverage on pypy
* twisted.test.test_compat
* twisted.test.test_defer
* twisted.internet.test.test_socket
* twisted.trial.test.test_tests

### Linux / MacOS general CI speedup

All tests are now executed in parallel, including pypy.

To gain more speed, I have removed `tox --notests` as it was just wasting time.
We can later show the dependencies using the python-info action.

PR are waiting to be reviewed to also get parallel jobs on Windows.

### Coverage reporting

I have updated coverage XML generation and codecov.io reporting to make the check red on failures.
Only coveralls failures are ignored for now.
In this way it should be easier to observer coverage issues. 

I tried to fix the coveralls report for trunk merges.
I did some work in #1574  but there is no way to test this unless merged in trunk.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10121
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [NA] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
