### PR TITLE
[10122] Rewrite trial coroutine .todo tests.

### DIFF
--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -1235,7 +1235,7 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
         exception = Exception("Bad times")
         try:
             self.successResultOf(self.raisesException(exception))
-        except unittest.FailTest as e:
+        except self.failureException as e:
             self.assertIn("Success result expected on", str(e))
             self.assertIn("builtins.Exception: Bad times", str(e))
 
@@ -1301,7 +1301,7 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
         exception = Exception("Bad times")
         try:
             self.failureResultOf(self.raisesException(exception), KeyError)
-        except unittest.FailTest as e:
+        except self.failureException as e:
             self.assertIn("Failure of type (builtins.KeyError) expected on", str(e))
             self.assertIn("builtins.Exception: Bad times", str(e))
 
@@ -1338,7 +1338,7 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
 
         try:
             self.failureResultOf(self.raisesException(exception), KeyError, IOError)
-        except unittest.FailTest as e:
+        except self.failureException as e:
             self.assertIn(
                 "Failure of type (builtins.KeyError or builtins.OSError) expected on",
                 str(e),

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -1224,21 +1224,6 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
             self.failureException, self.successResultOf, self.raisesException()
         )
 
-    def test_successResultOfWithFailureHasTraceback(self):
-        """
-        L{SynchronousTestCase.successResultOf} raises a
-        L{SynchronousTestCase.failureException} that has the original failure
-        traceback when called with a coroutine with a failure result.
-        """
-        try:
-            self.successResultOf(self.raisesException())
-        except self.failureException as e:
-            self.assertIn(self.failure.getTraceback(), str(e))
-
-    test_successResultOfWithFailureHasTraceback.todo = (  # type: ignore[attr-defined]
-        "Tracebacks aren't preserved by exceptions later wrapped in Failures"
-    )
-
     def test_failureResultOfWithoutResult(self):
         """
         L{SynchronousTestCase.failureResultOf} raises
@@ -1290,23 +1275,6 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
                 str(e),
             )
 
-    def test_failureResultOfWithWrongExceptionOneExpectedExceptionHasTB(self):
-        """
-        L{SynchronousTestCase.failureResultOf} raises
-        L{SynchronousTestCase.failureException} when called with a coroutine
-        that raises an exception with a failure type that was not expected, and
-        the L{SynchronousTestCase.failureException} message contains the
-        original exception traceback.
-        """
-        try:
-            self.failureResultOf(self.raisesException(), KeyError)
-        except self.failureException as e:
-            self.assertIn(self.failure.getTraceback(), str(e))
-
-    test_failureResultOfWithWrongExceptionOneExpectedExceptionHasTB.todo = (  # type: ignore[attr-defined]
-        "Tracebacks aren't preserved by exceptions later wrapped in Failures"
-    )
-
     def test_failureResultOfWithWrongExceptionMultiExpectedExceptions(self):
         """
         L{SynchronousTestCase.failureResultOf} raises
@@ -1327,23 +1295,6 @@ class ResultOfCoroutineAssertionsTests(unittest.SynchronousTestCase):
                 ),
                 str(e),
             )
-
-    def test_failureResultOfWithWrongExceptionMultiExpectedExceptionsHasTB(self):
-        """
-        L{SynchronousTestCase.failureResultOf} raises
-        L{SynchronousTestCase.failureException} when called with a coroutine
-        that raises an exception of a type that was not expected, and the
-        L{SynchronousTestCase.failureException} message contains the original
-        exception traceback in the error message.
-        """
-        try:
-            self.failureResultOf(self.raisesException(), KeyError, IOError)
-        except self.failureException as e:
-            self.assertIn(self.failure.getTraceback(), str(e))
-
-    test_failureResultOfWithWrongExceptionMultiExpectedExceptionsHasTB.todo = (  # type: ignore[attr-defined]
-        "Tracebacks aren't preserved by exceptions later wrapped in Failures"
-    )
 
     def test_successResultOfWithSuccessResult(self):
         """


### PR DESCRIPTION
## Scope and purpose

This cleans the tests marked as .todo.

The tests are rewritten so that they will pass... I did the best I could.

The todo markers are not compliant with the dev policy ​https://docs.twistedmatrix.com/en/twisted-21.2.0/core/development/policy/test-standard.html#testing-new-functionality

The tests were marked for .todo for more than 20 moths and there is no plan to fix them.

They were skipped as part of the work in https://twistedmatrix.com/trac/ticket/9006 to add support for coroutine in trial. 
The PR link that added to .todo https://github.com/twisted/twisted/pull/691

If the rewrite is not ok, I think that they should be removed and have a separate followup ticket.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10122
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
