### PR TITLE
[10130] Disallow negative HTTP chunk size

### DIFF
--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -1312,7 +1312,7 @@ class FTP(basic.LineReceiver, policies.TimeoutMixin):
 
         def cbSent(result):
             """
-            Called from data transport when tranfer is done.
+            Called from data transport when transfer is done.
             """
             return (TXFR_COMPLETE_OK,)
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1790,8 +1790,8 @@ class _IdentityTransferDecoder:
 
 class _ChunkedTransferDecoder:
     """
-    Protocol for decoding I{chunked} Transfer-Encoding, as defined by RFC 2616,
-    section 3.6.1.  This protocol can interpret the contents of a request or
+    Protocol for decoding I{chunked} Transfer-Encoding, as defined by RFC 7230,
+    section 4.1.  This protocol can interpret the contents of a request or
     response body which uses the I{chunked} Transfer-Encoding.  It cannot
     interpret any of the rest of the HTTP protocol.
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1842,7 +1842,9 @@ class _ChunkedTransferDecoder:
                 self.length = int(parts[0], 16)
             except ValueError:
                 raise _MalformedChunkedDataError("Chunk-size must be an integer.")
-            if self.length == 0:
+            if self.length < 0:
+                raise _MalformedChunkedDataError("Chunk-size must not be negative.")
+            elif self.length == 0:
                 self.state = "TRAILER"
             else:
                 self.state = "BODY"

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1707,7 +1707,7 @@ class PotentialDataLoss(Exception):
 
 class _MalformedChunkedDataError(Exception):
     """
-    C{_ChunkedTranferDecoder} raises L{_MalformedChunkedDataError} from its
+    C{_ChunkedTransferDecoder} raises L{_MalformedChunkedDataError} from its
     C{dataReceived} method when it encounters malformed data. This exception
     indicates a client-side error. If this exception is raised, the connection
     should be dropped with a 400 error.

--- a/src/twisted/web/newsfragments/10130.bugfix
+++ b/src/twisted/web/newsfragments/10130.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http's chunked encoding support now rejects chunk sizes that are invalid because they look like negative hexadecimal integers.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1260,6 +1260,27 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         p.dataReceived(b"3; x-foo=bar\r\nabc\r\n")
         self.assertEqual(L, [b"abc"])
 
+    def test_malformedChunkSize(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the chunk size can't be decoded as
+        a base-16 integer.
+        """
+        p = http._ChunkedTransferDecoder(lambda data: None, lambda data: None)
+        self.assertRaises(
+            http._MalformedChunkedDataError, p.dataReceived, b"bloop\r\nabc\r\n"
+        )
+
+    def test_malformedChunkSizeNegative(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the chunk size is negative.
+        """
+        p = http._ChunkedTransferDecoder(lambda b: None, lambda b: None)
+        self.assertRaises(
+            http._MalformedChunkedDataError, p.dataReceived, b"-3\r\nabc\r\n"
+        )
+
     def test_finish(self):
         """
         L{_ChunkedTransferDecoder.dataReceived} interprets a zero-length

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1266,7 +1266,10 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         L{_MalformedChunkedDataError} when the chunk size can't be decoded as
         a base-16 integer.
         """
-        p = http._ChunkedTransferDecoder(lambda data: None, lambda data: None)
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,  # pragma: nocov
+            lambda b: None,  # pragma: nocov
+        )
         self.assertRaises(
             http._MalformedChunkedDataError, p.dataReceived, b"bloop\r\nabc\r\n"
         )
@@ -1276,7 +1279,10 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         L{_ChunkedTransferDecoder.dataReceived} raises
         L{_MalformedChunkedDataError} when the chunk size is negative.
         """
-        p = http._ChunkedTransferDecoder(lambda b: None, lambda b: None)
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,  # pragma: nocov
+            lambda b: None,  # pragma: nocov
+        )
         self.assertRaises(
             http._MalformedChunkedDataError, p.dataReceived, b"-3\r\nabc\r\n"
         )


### PR DESCRIPTION
## Scope and purpose

`_ChunkedTransferDecoder` uses `int()` to parse the chunk size, which permits a leading `-`, resulting in a nonsensical negative chunk size. A chunk size is supposed to [consist only of HEXDIGits](https://tools.ietf.org/html/rfc7230#section-4.1), so treat a negative chunk size like any other malformed chunk size.

In addition to this fix, this PR includes a few docstring updates and typo fixes.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10130
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
