### PR TITLE
[3795] Fix quadradics in _ChunkedTransferDecoder

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1870,12 +1870,13 @@ class _ChunkedTransferDecoder:
 
     def _dataReceived_CRLF(self) -> bool:
         """
-        Await the carriage return and line feed characters that follow the
+        Await the carriage return and line feed characters that are the end of chunk marker that follow the
         chunk data.
 
         @returns: C{True} when the CRLF have been read, otherwise C{False}.
         """
         # TODO: https://twistedmatrix.com/trac/ticket/10137
+        # It should raise an error when receiving malformed end of chunk markers.
         if self._buffer.startswith(b"\r\n"):
             self.state = "CHUNK_LENGTH"
             del self._buffer[0:2]

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1888,12 +1888,13 @@ class _ChunkedTransferDecoder:
         if len(self._buffer) >= self.length:
             chunk = memoryview(self._buffer)[: self.length].tobytes()
             del self._buffer[: self.length]
-            self.dataCallback(chunk)
             self.state = "CRLF"
+            self.dataCallback(chunk)
         elif self._buffer:
-            self.dataCallback(bytes(self._buffer))
-            self.length -= len(self._buffer)
+            chunk = bytes(self._buffer)
+            self.length -= len(chunk)
             self._buffer = bytearray()
+            self.dataCallback(chunk)
         return True
 
     def _dataReceived_FINISHED(self) -> bool:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1890,7 +1890,7 @@ class _ChunkedTransferDecoder:
             del self._buffer[: self.length]
             self.state = "CRLF"
             self.dataCallback(chunk)
-        elif self._buffer:
+        else:
             chunk = bytes(self._buffer)
             self.length -= len(chunk)
             self._buffer = bytearray()

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -100,8 +100,6 @@ import cgi
 import math
 import os
 import re
-
-# system imports
 import tempfile
 import time
 import warnings
@@ -111,10 +109,10 @@ from urllib.parse import (
     urlparse as _urlparse,
     unquote_to_bytes as unquote,
 )
+from typing import Callable
 
 from zope.interface import Attribute, Interface, implementer, provider
 
-# twisted imports
 from incremental import Version
 from twisted.logger import Logger
 from twisted.internet import address, interfaces, protocol
@@ -1803,7 +1801,7 @@ class _ChunkedTransferDecoder:
     noticed. -exarkun
 
     @ivar dataCallback: A one-argument callable which will be invoked each
-        time application data is received.
+        time application data is received. This callback is not reentrant.
 
     @ivar finishCallback: A one-argument callable which will be invoked when
         the terminal chunk is received.  It will be invoked with all bytes
@@ -1825,75 +1823,96 @@ class _ChunkedTransferDecoder:
 
     state = "CHUNK_LENGTH"
 
-    def __init__(self, dataCallback, finishCallback):
+    def __init__(
+        self,
+        dataCallback: Callable[[bytes], None],
+        finishCallback: Callable[[bytes], None],
+    ) -> None:
         self.dataCallback = dataCallback
         self.finishCallback = finishCallback
-        self._buffer = b""
+        self._buffer = bytearray()
+        self._start = 0
 
-    def _dataReceived_CHUNK_LENGTH(self, data):
-        if b"\r\n" in data:
-            line, rest = data.split(b"\r\n", 1)
-            parts = line.split(b";")
-            try:
-                self.length = int(parts[0], 16)
-            except ValueError:
-                raise _MalformedChunkedDataError("Chunk-size must be an integer.")
-            if self.length < 0:
-                raise _MalformedChunkedDataError("Chunk-size must not be negative.")
-            elif self.length == 0:
-                self.state = "TRAILER"
-            else:
-                self.state = "BODY"
-            return rest
+    def _dataReceived_CHUNK_LENGTH(self) -> bool:
+        """
+        Read the chunk size line, ignoring any extensions.
+
+        @returns: C{True} once the line has been read and removed from
+            C{self._buffer}.  C{False} when more data is required.
+
+        @raises _MalformedChunkedDataError: when the chunk size cannot be
+            decoded.
+        """
+        eolIndex = self._buffer.find(b"\r\n", self._start)
+        if eolIndex == -1:
+            self._start = len(self._buffer) - 1
+            return False
+
+        endOfLengthIndex = self._buffer.find(b";", 0, eolIndex)
+        if endOfLengthIndex == -1:
+            endOfLengthIndex = eolIndex
+        try:
+            length = int(self._buffer[0:endOfLengthIndex], 16)
+        except ValueError:
+            raise _MalformedChunkedDataError("Chunk-size must be an integer.")
+
+        if length < 0:
+            raise _MalformedChunkedDataError("Chunk-size must not be negative.")
+        elif length == 0:
+            self.state = "TRAILER"
         else:
-            self._buffer = data
-            return b""
+            self.state = "BODY"
 
-    def _dataReceived_CRLF(self, data):
-        if data.startswith(b"\r\n"):
+        self.length = length
+        del self._buffer[0 : eolIndex + 2]
+        self._start = 0
+        return True
+
+    def _dataReceived_CRLF(self) -> bool:
+        if self._buffer.startswith(b"\r\n"):
             self.state = "CHUNK_LENGTH"
-            return data[2:]
+            del self._buffer[0:2]
+            return True
         else:
-            self._buffer = data
-            return b""
+            return False
 
-    def _dataReceived_TRAILER(self, data):
-        if data.startswith(b"\r\n"):
-            data = data[2:]
+    def _dataReceived_TRAILER(self) -> bool:
+        if self._buffer.startswith(b"\r\n"):
+            data = memoryview(self._buffer)[2:].tobytes()
+            del self._buffer[:]
             self.state = "FINISHED"
             self.finishCallback(data)
-        else:
-            self._buffer = data
-        return b""
+        return False
 
-    def _dataReceived_BODY(self, data):
-        if len(data) >= self.length:
-            chunk, data = data[: self.length], data[self.length :]
+    def _dataReceived_BODY(self) -> bool:
+        if len(self._buffer) >= self.length:
+            chunk = memoryview(self._buffer)[: self.length].tobytes()
+            del self._buffer[: self.length]
             self.dataCallback(chunk)
             self.state = "CRLF"
-            return data
-        elif len(data) < self.length:
-            self.length -= len(data)
-            self.dataCallback(data)
-            return b""
+        elif self._buffer:
+            self.dataCallback(bytes(self._buffer))
+            self.length -= len(self._buffer)
+            self._buffer = bytearray()
+        return True
 
-    def _dataReceived_FINISHED(self, data):
+    def _dataReceived_FINISHED(self) -> bool:
         raise RuntimeError(
             "_ChunkedTransferDecoder.dataReceived called after last "
             "chunk was processed"
         )
 
-    def dataReceived(self, data):
+    def dataReceived(self, data: bytes) -> None:
         """
         Interpret data from a request or response body which uses the
         I{chunked} Transfer-Encoding.
         """
-        data = self._buffer + data
-        self._buffer = b""
-        while data:
-            data = getattr(self, f"_dataReceived_{self.state}")(data)
+        self._buffer += data
+        goOn = True
+        while goOn and self._buffer:
+            goOn = getattr(self, "_dataReceived_" + self.state)()
 
-    def noMoreData(self):
+    def noMoreData(self) -> None:
         """
         Verify that all data has been received.  If it has not been, raise
         L{_DataLoss}.

--- a/src/twisted/web/newsfragments/3795.bugfix
+++ b/src/twisted/web/newsfragments/3795.bugfix
@@ -1,0 +1,1 @@
+The server-side HTTP/1.1 chunking implementation no longer performs quadratic work when input arrives in small chunks, preventing CPU exhaustion.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1240,6 +1240,34 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         self.assertEqual(L, [b"a", b"b", b"c", b"1", b"2", b"3", b"4", b"5"])
         self.assertEqual(finished, [b""])
 
+    def test_long(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} delivers partial chunk data as
+        soon as it is received.
+        """
+        data = []
+        finished = []
+        p = http._ChunkedTransferDecoder(data.append, finished.append)
+        p.dataReceived(b"a;\r\n12345")
+        p.dataReceived(b"67890")
+        p.dataReceived(b"\r\n0;\r\n\r\n...")
+        self.assertEqual(data, [b"12345", b"67890"])
+        self.assertEqual(finished, [b"..."])
+
+    def test_empty(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} is robust against receiving
+        a zero-length input.
+        """
+        chunks = []
+        finished = []
+        p = http._ChunkedTransferDecoder(chunks.append, finished.append)
+        for s in iterbytes(b"3\r\nabc\r\n5\r\n12345\r\n0\r\n\r\n"):
+            p.dataReceived(b"")
+            p.dataReceived(s)
+        self.assertEqual(chunks, [b"a", b"b", b"c", b"1", b"2", b"3", b"4", b"5"])
+        self.assertEqual(finished, [b""])
+
     def test_newlines(self):
         """
         L{_ChunkedTransferDecoder.dataReceived} doesn't treat CR LF pairs

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1262,9 +1262,10 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         chunks = []
         finished = []
         p = http._ChunkedTransferDecoder(chunks.append, finished.append)
+        p.dataReceived(b"")
         for s in iterbytes(b"3\r\nabc\r\n5\r\n12345\r\n0\r\n\r\n"):
-            p.dataReceived(b"")
             p.dataReceived(s)
+            p.dataReceived(b"")
         self.assertEqual(chunks, [b"a", b"b", b"c", b"1", b"2", b"3", b"4", b"5"])
         self.assertEqual(finished, [b""])
 


### PR DESCRIPTION
## Scope and purpose

There were two issues here:

- Buffering was done by appending to a `bytes`, which as an immutable object may trigger reallocation and quadratic amounts copying. This is resolved by using `bytearray`, which is mutable with amortized O(n) append complexity. It's also [amortized O(n) to truncate it at the front ][1], which we make use of.
- Processing of the length line searched for `\r\n` on the entire input each time data arrived, resulting in quadratic work if input trickled in. This is solved by tracking the extent of the prior search and resuming it at that point.

The fix can be verified by running the proof-of-concept script attached to the ticket.

[1]: https://github.com/python-hyper/h11/blob/82d5e461bd8a3eca6f1aaa51a1c785a1779721a5/h11/_receivebuffer.py#L22-L26

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/3795
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1551 from twisted/3795-quadratic-http-chunking

Author: twm
Reviewer: adiroiban
Fixes: ticket:3795

Fix quadratic time complexity in twisted.web.http._ChunkedTransferDecoder
```
