### PR TITLE
10136: t.w.server.Request.postpath is a list of bytes.

### DIFF
--- a/src/twisted/web/newsfragments/10136.bugfix
+++ b/src/twisted/web/newsfragments/10136.bugfix
@@ -1,0 +1,1 @@
+The type hint of twisted.web.server.Request.postpath is now correctly listed as Optional[List[bytes]]. This was incorrect in Twisted v21.2.0.

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -108,7 +108,7 @@ class Request(Copyable, http.Request, components.Componentized):
     site = None
     appRootURL = None
     prepath: Optional[List[bytes]] = None
-    postpath: Optional[bytes] = None
+    postpath: Optional[List[bytes]] = None
     __pychecker__ = "unusednames=issuer"
     _inFakeHead = False
     _encoder = None


### PR DESCRIPTION
Fixes the type of `twisted.web.server.Request.postpath` to match the docstring (and `prepath`) to be `Optional[List[bytes]]`.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10136
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
