### PR TITLE
10139: Initialize Request.uri as bytes not str.

### DIFF
--- a/src/twisted/newsfragments/10139.bugfix
+++ b/src/twisted/newsfragments/10139.bugfix
@@ -1,0 +1,1 @@
+Fix type hint for http.Request.uri (from str to bytes).

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -783,9 +783,9 @@ class Request:
     finished = 0
     code = OK
     code_message = RESPONSES[OK]
-    method: bytes = b"(no method yet)"
-    clientproto: bytes = b"(no clientproto yet)"
-    uri = "(no uri yet)"
+    method = b"(no method yet)"
+    clientproto = b"(no clientproto yet)"
+    uri = b"(no uri yet)"
     startedWriting = 0
     chunked = 0
     sentLength = 0  # content-length of response, or total bytes sent via chunking


### PR DESCRIPTION
Fixes type for http.Request.uri.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10139
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [x] The merge commit will use the below format

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
