### PR TITLE
10142: Fix up type hints for getRawHeaders and getAllRawHeaders

### DIFF
--- a/src/twisted/newsfragments/10142.bugfix
+++ b/src/twisted/newsfragments/10142.bugfix
@@ -1,0 +1,2 @@
+twisted.web.http_headers.getRawHeaders and twisted.web.http_headers.getAllRawHeaders are now typed to return immutable sequences of header values instead of lists.
+twisted.web.http_headers.getRawHeaders is not typed to return a non-optional value if a non-None default value is given.

--- a/src/twisted/newsfragments/10142.bugfix
+++ b/src/twisted/newsfragments/10142.bugfix
@@ -1,2 +1,2 @@
 twisted.web.http_headers.getRawHeaders and twisted.web.http_headers.getAllRawHeaders are now typed to return immutable sequences of header values instead of lists.
-twisted.web.http_headers.getRawHeaders is not typed to return a non-optional value if a non-None default value is given.
+twisted.web.http_headers.getRawHeaders is now typed to return a non-optional value if a non-None default value is given.

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -221,7 +221,7 @@ class Headers:
             )
 
         # We secretly know getRawHeaders is really returning a list
-        values = cast(list, self.getRawHeaders(name, default=[]))
+        values = cast(List[AnyStr], self.getRawHeaders(name, default=[]))
         values.append(value)
 
         self.setRawHeaders(name, values)

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -17,10 +17,15 @@ from typing import (
     TypeVar,
     Tuple,
     Union,
+    cast,
+    overload,
 )
 from collections.abc import Sequence as _Sequence
 
 from twisted.python.compat import comparable, cmp
+
+
+_T = TypeVar("_T")
 
 
 def _dashCapitalize(name: bytes) -> bytes:
@@ -215,22 +220,25 @@ class Headers:
                 "bytes or str" % (type(value),)
             )
 
-        values = self.getRawHeaders(name)
-
-        if values is not None:
-            values.append(value)
-        else:
-            values = [value]
+        # We secretly know getRawHeaders is really returning a list
+        values = cast(list, self.getRawHeaders(name, default=[]))
+        values.append(value)
 
         self.setRawHeaders(name, values)
 
-    _T = TypeVar("_T")
+    @overload
+    def getRawHeaders(self, name: AnyStr) -> Optional[Sequence[AnyStr]]:
+        ...
+
+    @overload
+    def getRawHeaders(self, name: AnyStr, default: _T) -> Union[Sequence[AnyStr], _T]:
+        ...
 
     def getRawHeaders(
         self, name: AnyStr, default: Optional[_T] = None
-    ) -> Union[List[AnyStr], Optional[_T]]:
+    ) -> Union[Sequence[AnyStr], Optional[_T]]:
         """
-        Returns a list of headers matching the given name as the raw string
+        Returns a sequence of headers matching the given name as the raw string
         given.
 
         @param name: The name of the HTTP header to get the values of.
@@ -238,7 +246,7 @@ class Headers:
         @param default: The value to return if no header with the given C{name}
             exists.
 
-        @return: If the named header is present, a L{list} of its
+        @return: If the named header is present, a sequence of its
             values.  Otherwise, C{default}.
         """
         encodedName = self._encodeName(name)
@@ -250,7 +258,7 @@ class Headers:
             return [v.decode("utf8") for v in values]
         return values
 
-    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, List[bytes]]]:
+    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, Sequence[bytes]]]:
         """
         Return an iterator of key, value pairs of all headers contained in this
         object, as L{bytes}.  The keys are capitalized in canonical


### PR DESCRIPTION
## Scope and purpose

Clean up type hints for `getRawHeaders`

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10142
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [ ] The merge commit will use the below format

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
