### PR TITLE
[10143] Close file at end of test for twisted.test.test_twistd.

### DIFF
--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -1545,10 +1545,12 @@ class AppLoggerTests(TestCase):
         sut = app.AppLogger({"logfile": filename})
 
         observer = sut._getLogObserver()
-        self.addCleanup(logger.globalLogPublisher.removeObserver, observer)
+        self.addCleanup(observer._outFile.close)
 
         self.assertEqual(len(logFiles), 1)
         self.assertEqual(logFiles[0].path, os.path.abspath(filename))
+
+        logger.globalLogPublisher.removeObserver(observer)
 
     def test_stop(self):
         """
@@ -1687,7 +1689,7 @@ class UnixAppLoggerTests(TestCase):
         sut = UnixAppLogger({"logfile": filename})
 
         observer = sut._getLogObserver()
-        self.addCleanup(logger.globalLogPublisher.removeObserver, observer)
+        self.addCleanup(observer._outFile.close)
 
         self.assertEqual(len(logFiles), 1)
         self.assertEqual(logFiles[0].path, os.path.abspath(filename))
@@ -1721,7 +1723,7 @@ class UnixAppLoggerTests(TestCase):
         sut = UnixAppLogger({"logfile": filename})
 
         observer = sut._getLogObserver()
-        self.addCleanup(logger.globalLogPublisher.removeObserver, observer)
+        self.addCleanup(observer._outFile.close)
 
         self.assertEqual(self.signals, [])
 

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -1550,8 +1550,6 @@ class AppLoggerTests(TestCase):
         self.assertEqual(len(logFiles), 1)
         self.assertEqual(logFiles[0].path, os.path.abspath(filename))
 
-        logger.globalLogPublisher.removeObserver(observer)
-
     def test_stop(self):
         """
         L{app.AppLogger.stop} removes the observer created in C{start}, and


### PR DESCRIPTION
## Scope and purpose

Some tests in twisted.test.test_twistd are leaving the local log file open af the end of the test.

This will generate a warning in the garbage collection.

There are other tests that are checking for warning and the garbage collection warnings interfere with the expected warnings and are causing random test failures.

I am not reverting the fix for ticket 10123 as the changes from there are not introducing any new error. is just that they are not doing anything.

I was fooled by the fact that with `trial -j 18` the probability of seeing this error is much lower.

I ran the test with `$ trial -u -j 2 twisted.test.test_twistd ` and have observed the failured.

Then after the fix I tried `$ trial -u -j 16 twisted.test.test_twistd` and I was no longer observing the failure...and I thought that it was fixed.

I have tested this test with  `$ trial -u -j 2 twisted.test.test_twistd ` running for 5 minutes ... in trunk this fails in 10 seconds.

```
Ran 91168 tests in 312.525s

PASSED (skips=46620, successes=44548)

```

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10143
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10143

Update twisted.test.test_twistd to close the log file at the end of the test.
```
