### PR TITLE
10145 upgrade comment type/attr.ib annotations to native type annotations 

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1706,7 +1706,7 @@ OpenSSLCertificateOptions.__setstate__ = deprecated(
 
 
 @implementer(ICipher)
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class OpenSSLCipher:
     """
     A representation of an OpenSSL cipher.
@@ -1716,7 +1716,7 @@ class OpenSSLCipher:
     @type fullName: L{unicode}
     """
 
-    fullName = attr.ib()
+    fullName: str
 
 
 @lru_cache(maxsize=32)

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -8,9 +8,10 @@ Address objects for network connections.
 
 import attr
 import os
-from typing import Optional
+from typing import Optional, Union
 from warnings import warn
 
+from typing_extensions import Literal
 from zope.interface import implementer
 from twisted.internet.interfaces import IAddress
 from twisted.python.filepath import _asFilesystemBytes
@@ -19,7 +20,7 @@ from twisted.python.runtime import platform
 
 
 @implementer(IAddress)
-@attr.s(hash=True)
+@attr.s(hash=True, auto_attribs=True)
 class IPv4Address:
     """
     An L{IPv4Address} represents the address of an IPv4 socket endpoint.
@@ -35,13 +36,15 @@ class IPv4Address:
     @type port: C{int}
     """
 
-    type = attr.ib(validator=attr.validators.in_(["TCP", "UDP"]))
-    host = attr.ib()
-    port = attr.ib()
+    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+        validator=attr.validators.in_(["TCP", "UDP"])
+    )
+    host: str
+    port: int
 
 
 @implementer(IAddress)
-@attr.s(hash=True)
+@attr.s(hash=True, auto_attribs=True)
 class IPv6Address:
     """
     An L{IPv6Address} represents the address of an IPv6 socket endpoint.
@@ -65,11 +68,13 @@ class IPv6Address:
     @type scopeID: L{int} or L{str}
     """
 
-    type = attr.ib(validator=attr.validators.in_(["TCP", "UDP"]))
-    host = attr.ib()
-    port = attr.ib()
-    flowInfo = attr.ib(default=0)
-    scopeID = attr.ib(default=0)
+    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+        validator=attr.validators.in_(["TCP", "UDP"])
+    )
+    host: str
+    port: int
+    flowInfo: int = 0
+    scopeID: Union[str, int] = 0
 
 
 @implementer(IAddress)
@@ -79,7 +84,7 @@ class _ProcessAddress:
     """
 
 
-@attr.s(hash=True)
+@attr.s(hash=True, auto_attribs=True)
 @implementer(IAddress)
 class HostnameAddress:
     """
@@ -92,11 +97,11 @@ class HostnameAddress:
     @type port: L{int}
     """
 
-    hostname = attr.ib()
-    port = attr.ib()
+    hostname: bytes
+    port: int
 
 
-@attr.s(hash=False, repr=False, eq=False)
+@attr.s(hash=False, repr=False, eq=False, auto_attribs=True)
 @implementer(IAddress)
 class UNIXAddress:
     """

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -335,7 +335,7 @@ class ThreadedResolver:
             timeoutDelay = sum(timeout)
         else:
             timeoutDelay = 60
-        userDeferred: Deferred[str] = defer.Deferred()
+        userDeferred: Deferred[str] = Deferred()
         lookupDeferred = threads.deferToThreadPool(
             self.reactor,
             cast(IReactorThreads, self.reactor).getThreadPool(),

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -335,7 +335,7 @@ class ThreadedResolver:
             timeoutDelay = sum(timeout)
         else:
             timeoutDelay = 60
-        userDeferred = defer.Deferred()  # type: Deferred[str]
+        userDeferred: Deferred[str] = defer.Deferred()
         lookupDeferred = threads.deferToThreadPool(
             self.reactor,
             cast(IReactorThreads, self.reactor).getThreadPool(),

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -126,7 +126,7 @@ def succeed(result: _T) -> "Deferred[_T]":
     @param result: The result to give to the Deferred's 'callback'
            method.
     """
-    d = Deferred()  # type: Deferred[_T]
+    d: Deferred[_T] = Deferred()
     d.callback(result)
     return d
 
@@ -142,7 +142,7 @@ def fail(result: Optional[Union[Failure, BaseException]] = None) -> "Deferred[An
     @raise NoCurrentExceptionError: If C{result} is L{None} but there is no
         current exception state.
     """
-    d = Deferred()  # type: Deferred[Any]
+    d: Deferred[Any] = Deferred()
     d.errback(result)
     return d
 
@@ -293,7 +293,7 @@ _CallbackChain = Tuple[
     ],
 ]
 
-_NONE_KWARGS = MappingProxyType({})  # type: _CallbackKeywordArguments
+_NONE_KWARGS: _CallbackKeywordArguments = MappingProxyType({})
 
 
 _DeferredResultT = TypeVar("_DeferredResultT", contravariant=True)
@@ -339,7 +339,7 @@ class Deferred(Awaitable[_DeferredResultT]):
 
     called = False
     paused = 0
-    _debugInfo = None  # type: Optional[DebugInfo]
+    _debugInfo: Optional[DebugInfo] = None
     _suppressAlreadyCalled = False
 
     # Are we currently running a user-installed callback?  Meant to prevent
@@ -379,7 +379,7 @@ class Deferred(Awaitable[_DeferredResultT]):
         @type canceller: a 1-argument callable which takes a L{Deferred}. The
             return result is ignored.
         """
-        self.callbacks = []  # type: List[_CallbackChain]
+        self.callbacks: List[_CallbackChain] = []
         self._canceller = canceller
         if self.debug:
             self._debugInfo = DebugInfo()
@@ -759,7 +759,7 @@ class Deferred(Awaitable[_DeferredResultT]):
         # added its _continuation() to the callbacks list of a second Deferred
         # and then that second Deferred being fired.  ie, if ever had _chainedTo
         # set to something other than None, you might end up on this stack.
-        chain = [self]  # type: List[Deferred[Any]]
+        chain: List[Deferred[Any]] = [self]
 
         while chain:
             current = chain[-1]
@@ -1078,9 +1078,9 @@ class DebugInfo:
     Deferred debug helper.
     """
 
-    failResult = None  # type: Optional[Failure]
-    creator = None  # type: Optional[List[str]]
-    invoker = None  # type: Optional[List[str]]
+    failResult: Optional[Failure] = None
+    creator: Optional[List[str]] = None
+    invoker: Optional[List[str]] = None
 
     def _getDebugTracebacks(self) -> str:
         info = ""
@@ -1222,9 +1222,9 @@ class DeferredList(Deferred[object]):
             logged.  This does not prevent C{fireOnOneErrback} from working.
         """
         self._deferredList = list(deferredList)
-        self.resultList = [None] * len(
+        self.resultList: List[Optional[_DeferredListResult]] = [None] * len(
             self._deferredList
-        )  # type: List[Optional[_DeferredListResult]]
+        )
         Deferred.__init__(self)
         if len(self._deferredList) == 0 and not fireOnOneCallback:
             self.callback(self.resultList)
@@ -1339,7 +1339,7 @@ class waitForDeferred:
     See L{deferredGenerator}.
     """
 
-    result = _NO_RESULT  # type: Any
+    result: Any = _NO_RESULT
 
     def __init__(self, d: Deferred[object]) -> None:
         warnings.warn(
@@ -1384,7 +1384,7 @@ def _deferGenerator(
     # type note: List[Any] because you can't annotate List items by index.
     #     …better fix would be to create a class, but we need to jettison
     #     deferredGenerator anyway.
-    waiting = [True, None]  # type: List[Any]
+    waiting: List[Any] = [True, None]
 
     while 1:
         try:
@@ -1532,8 +1532,8 @@ class _CancellationStatus:
         L{_inlineCallbacks} must fill out before returning)
     """
 
-    deferred = attr.ib()  # type: Deferred[object]
-    waitingOn = attr.ib(default=None)  # type: Optional[Deferred[object]]
+    deferred: Deferred[object] = attr.ib()
+    waitingOn: Optional[Deferred[object]] = attr.ib(default=None)
 
 
 @_extraneous
@@ -1569,7 +1569,7 @@ def _inlineCallbacks(
     # recursion.
 
     # waiting for result?  # result
-    waiting = [True, None]  # type: List[Any]
+    waiting: List[Any] = [True, None]
 
     # Get the current contextvars Context object.
     current_context = _copy_context()
@@ -1715,7 +1715,7 @@ def _cancellableInlineCallbacks(
         it.callbacks.extend(tmp)
         it.errback(_InternalInlineCallbacksCancelledError())
 
-    deferred = Deferred(cancel)  # type: Deferred[object]
+    deferred: Deferred[object] = Deferred(cancel)
     status = _CancellationStatus(deferred)
 
     def handleCancel(result: Failure) -> Deferred[object]:
@@ -1847,7 +1847,7 @@ _ConcurrencyPrimitiveT = TypeVar(
 
 class _ConcurrencyPrimitive(ABC, Generic[_DeferredResultT]):
     def __init__(self: _ConcurrencyPrimitiveT) -> None:
-        self.waiting = []  # type: List[Deferred[_ConcurrencyPrimitiveT]]
+        self.waiting: List[Deferred[_ConcurrencyPrimitiveT]] = []
 
     def _releaseAndReturn(self, r: _T) -> _T:
         self.release()
@@ -1943,7 +1943,7 @@ class DeferredLock(_ConcurrencyPrimitive):
         @return: a L{Deferred} which fires on lock acquisition.
         @rtype: a L{Deferred}
         """
-        d = Deferred(canceller=self._cancelAcquire)  # type: Deferred[_DeferredLockT]
+        d: Deferred[_DeferredLockT] = Deferred(canceller=self._cancelAcquire)
         if self.locked:
             self.waiting.append(d)
         else:
@@ -2020,9 +2020,7 @@ class DeferredSemaphore(_ConcurrencyPrimitive):
         assert (
             self.tokens >= 0
         ), "Internal inconsistency??  tokens should never be negative"
-        d = Deferred(
-            canceller=self._cancelAcquire
-        )  # type: Deferred[_DeferredSemaphoreT]
+        d: Deferred[_DeferredSemaphoreT] = Deferred(canceller=self._cancelAcquire)
         if not self.tokens:
             self.waiting.append(d)
         else:
@@ -2076,8 +2074,8 @@ class DeferredQueue(Generic[_T]):
     def __init__(
         self, size: Optional[int] = None, backlog: Optional[int] = None
     ) -> None:
-        self.waiting = []  # type: List[Deferred[_T]]
-        self.pending = []  # type: List[_T]
+        self.waiting: List[Deferred[_T]] = []
+        self.pending: List[_T] = []
         self.size = size
         self.backlog = backlog
 
@@ -2121,7 +2119,7 @@ class DeferredQueue(Generic[_T]):
         if self.pending:
             return succeed(self.pending.pop(0))
         elif self.backlog is None or len(self.waiting) < self.backlog:
-            d = Deferred(canceller=self._cancelGet)  # type: Deferred[_T]
+            d: Deferred[_T] = Deferred(canceller=self._cancelGet)
             self.waiting.append(d)
             return d
         else:
@@ -2151,8 +2149,8 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
     """
 
     _interval = 1
-    _tryLockCall = None  # type: Optional[IDelayedCall]
-    _timeoutCall = None  # type: Optional[IDelayedCall]
+    _tryLockCall: Optional[IDelayedCall] = None
+    _timeoutCall: Optional[IDelayedCall] = None
 
     def __init__(self, name: str, scheduler: Optional[IReactorTime] = None) -> None:
         """
@@ -2207,9 +2205,7 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
             else:
                 d.errback(reason)
 
-        d = Deferred(
-            lambda deferred: _cancelLock(CancelledError())
-        )  # type: Deferred[None]
+        d: Deferred[None] = Deferred(lambda deferred: _cancelLock(CancelledError()))
 
         def _tryLock() -> None:
             if self.lock():

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1521,7 +1521,7 @@ def returnValue(val: object) -> NoReturn:
     raise _DefGen_Return(val)
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class _CancellationStatus:
     """
     Cancellation status of an L{inlineCallbacks} invocation.
@@ -1532,8 +1532,8 @@ class _CancellationStatus:
         L{_inlineCallbacks} must fill out before returning)
     """
 
-    deferred: Deferred[object] = attr.ib()
-    waitingOn: Optional[Deferred[object]] = attr.ib(default=None)
+    deferred: Deferred[object]
+    waitingOn: Optional[Deferred[object]] = None
 
 
 @_extraneous

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -13,7 +13,7 @@ import socket
 import sys
 import os
 import struct
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, ClassVar
 
 import attr
 
@@ -952,7 +952,7 @@ class _FileDescriptorReservation:
         returns an object with a C{close} method.
     """
 
-    _log: typing_extensions.ClassVar[Logger] = Logger()
+    _log: ClassVar[Logger] = Logger()
 
     _fileFactory: Callable[[], _HasClose]
     _fileDescriptor: Optional[_HasClose] = attr.ib(init=False, default=None)

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -14,12 +14,11 @@ import os
 import socket
 
 from functools import wraps
-from typing import Optional, Sequence, Type, List, Callable
+from typing import Optional, Sequence, Type, List, Callable, ClassVar
 from unittest import skipIf
 
 import attr
 
-from typing_extensions import ClassVar
 from zope.interface import Interface, implementer
 from zope.interface.verify import verifyClass, verifyObject
 

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -14,11 +14,12 @@ import os
 import socket
 
 from functools import wraps
-from typing import Optional, Sequence, Type
+from typing import Optional, Sequence, Type, List, Callable
 from unittest import skipIf
 
 import attr
 
+from typing_extensions import ClassVar
 from zope.interface import Interface, implementer
 from zope.interface.verify import verifyClass, verifyObject
 
@@ -964,7 +965,7 @@ class _IExhaustsFileDescriptors(Interface):
 
 
 @implementer(_IExhaustsFileDescriptors)
-@attr.s
+@attr.s(auto_attribs=True)
 class _ExhaustsFileDescriptors:
     """
     A class that triggers C{EMFILE} by creating as many file
@@ -977,10 +978,14 @@ class _ExhaustsFileDescriptors:
         for passing to L{os.close}.
     """
 
-    _log = Logger()
-    _fileDescriptorFactory = attr.ib(default=lambda: os.dup(0), repr=False)
-    _close = attr.ib(default=os.close, repr=False)
-    _fileDescriptors = attr.ib(default=attr.Factory(list), init=False, repr=False)
+    _log: ClassVar[Logger] = Logger()
+    _fileDescriptorFactory: Callable[[], int] = attr.ib(
+        default=lambda: os.dup(0), repr=False
+    )
+    _close: Callable[[int], None] = attr.ib(default=os.close, repr=False)
+    _fileDescriptors: List[int] = attr.ib(
+        default=attr.Factory(list), init=False, repr=False
+    )
 
     def exhaust(self):
         """

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -5,6 +5,8 @@
 """
 Support for starting, monitoring, and restarting child process.
 """
+from typing import List, Optional, Dict
+
 import attr
 import incremental
 
@@ -15,7 +17,7 @@ from twisted.protocols import basic
 from twisted.logger import Logger
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class _Process:
     """
     The parameters of a process to be restarted.
@@ -37,11 +39,11 @@ class _Process:
     @type cwd: C{str}
     """
 
-    args = attr.ib()
-    uid = attr.ib(default=None)
-    gid = attr.ib(default=None)
-    env = attr.ib(default=attr.Factory(dict))
-    cwd = attr.ib(default=None)
+    args: List[str]
+    uid: Optional[int] = None
+    gid: Optional[int] = None
+    env: Dict[str, str] = attr.ib(default=attr.Factory(dict))
+    cwd: Optional[str] = None
 
     @deprecate.deprecated(incremental.Version("Twisted", 18, 7, 0))
     def toTuple(self):


### PR DESCRIPTION
## Scope and purpose

Python 3.6 and attr.s both support native variable and field annotation, so use them

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10145
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
