### PR TITLE
10126: HTTPParser: do not exclude connection headers from responses

### DIFF
--- a/src/twisted/newsfragments/10126.bugfix
+++ b/src/twisted/newsfragments/10126.bugfix
@@ -1,0 +1,1 @@
+twisted.web.client.HTTPConnectionPool no longer strips connection headers, such as Content-Length, from the resulting response objects.


### PR DESCRIPTION
## Scope and purpose

Modify `twisted.web._newclient.HTTPParser` so that, when using `twisted.web.client.HTTPConnectionPool`, response headers include connection headers, such as `Content-Length`, ultimately addressing https://github.com/scrapy/scrapy/issues/5009.

I’m hoping that this change in behavior is OK. I see no reason why those headers should have been hidden in the first place.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10126
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
    * Is this step still relevant? I don’t think I have the required permissions to do that. — @Gallaecio 
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: Gallaecio
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:10126

Modify twisted.web._newclient.HTTPParser so that, when using
twisted.web.client.HTTPConnectionPool, response headers include connection
headers, such as Content-Length.
```
