### PR TITLE
10137: Reject malformed HTTP chunk boundaries

### DIFF
--- a/src/twisted/web/newsfragments/10137.bugfix
+++ b/src/twisted/web/newsfragments/10137.bugfix
@@ -1,0 +1,2 @@
+The server-side HTTP/1.1 chunking implementation now rejects invalid chunk boundaries, preventing unbounded buffering.
+

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1327,9 +1327,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
             lambda b: None,  # pragma: nocov
         )
         self.assertRaises(
-            http._MalformedChunkedDataError,
-            p.dataReceived,
-            b"3\r\nabc!!!!"
+            http._MalformedChunkedDataError, p.dataReceived, b"3\r\nabc!!!!"
         )
 
     def test_malformedChunkEndFinal(self):
@@ -1343,9 +1341,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
             lambda b: None,  # pragma: nocov
         )
         self.assertRaises(
-            http._MalformedChunkedDataError,
-            p.dataReceived,
-            b"3\r\nabc\r\n0\r\n!!"
+            http._MalformedChunkedDataError, p.dataReceived, b"3\r\nabc\r\n0\r\n!!"
         )
 
     def test_finish(self):

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1316,6 +1316,38 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
             http._MalformedChunkedDataError, p.dataReceived, b"-3\r\nabc\r\n"
         )
 
+    def test_malformedChunkEnd(self):
+        r"""
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the chunk is followed by characters
+        other than C{\r\n}.
+        """
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,
+            lambda b: None,  # pragma: nocov
+        )
+        self.assertRaises(
+            http._MalformedChunkedDataError,
+            p.dataReceived,
+            b"3\r\nabc!!!!"
+        )
+
+    def test_malformedChunkEndFinal(self):
+        r"""
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the terminal zero-length chunk is
+        followed by characters other than C{\r\n}.
+        """
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,
+            lambda b: None,  # pragma: nocov
+        )
+        self.assertRaises(
+            http._MalformedChunkedDataError,
+            p.dataReceived,
+            b"3\r\nabc\r\n0\r\n!!"
+        )
+
     def test_finish(self):
         """
         L{_ChunkedTransferDecoder.dataReceived} interprets a zero-length


### PR DESCRIPTION
## Scope and purpose

Following up on https://github.com/twisted/twisted/pull/1551/files#r596460182, reject invalid chunk boundaries.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10137
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
