### PR TITLE
10144 Limit ChunkedTransferDecoder buffering

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1786,7 +1786,7 @@ class _IdentityTransferDecoder:
             raise _DataLoss()
 
 
-maxChunkSizeLineLength = 4096
+maxChunkSizeLineLength = 1024
 
 
 class _ChunkedTransferDecoder:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -26,11 +26,10 @@ also useful for HTTP clients (such as the chunked encoding parser).
     header is present in the request) has failed.  This should typically
     indicate that the server has not taken the requested action.
 
-@var MAX_CHUNK_SIZE_LINE_LENGTH: Maximum allowable length of the
-    CRLF-terminated line that indicates the size of a chunk and the extensions
-    associated with it, as in the HTTP 1.1 chunked I{Transfer-Encoding} (RFC
-    7230 section 4.1). This limits how much data may be buffered when decoding
-    the line.
+@var maxChunkSizeLineLength: Maximum allowable length of the CRLF-terminated
+    line that indicates the size of a chunk and the extensions associated with
+    it, as in the HTTP 1.1 chunked I{Transfer-Encoding} (RFC 7230 section 4.1).
+    This limits how much data may be buffered when decoding the line.
 """
 
 __all__ = [
@@ -1787,7 +1786,7 @@ class _IdentityTransferDecoder:
             raise _DataLoss()
 
 
-MAX_CHUNK_SIZE_LINE_LENGTH = 4096
+maxChunkSizeLineLength = 4096
 
 
 class _ChunkedTransferDecoder:
@@ -1849,16 +1848,16 @@ class _ChunkedTransferDecoder:
             C{self._buffer}.  C{False} when more data is required.
 
         @raises _MalformedChunkedDataError: when the chunk size cannot be
-            decoded or the length of the line exceeds L{MAX
+            decoded or the length of the line exceeds L{maxChunkSizeLineLength}.
         """
         eolIndex = self._buffer.find(b"\r\n", self._start)
 
-        if eolIndex >= MAX_CHUNK_SIZE_LINE_LENGTH or (
-            eolIndex == -1 and len(self._buffer) > MAX_CHUNK_SIZE_LINE_LENGTH
+        if eolIndex >= maxChunkSizeLineLength or (
+            eolIndex == -1 and len(self._buffer) > maxChunkSizeLineLength
         ):
             raise _MalformedChunkedDataError(
                 "Chunk size line exceeds maximum of {} bytes.".format(
-                    MAX_CHUNK_SIZE_LINE_LENGTH
+                    maxChunkSizeLineLength
                 )
             )
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1826,6 +1826,17 @@ class _ChunkedTransferDecoder:
         read. For C{'BODY'}, the contents of a chunk are being read. For
         C{'FINISHED'}, the last chunk has been completely read and no more
         input is valid.
+
+    @ivar _buffer: Accumulated received data for the current state. At each
+        state transition this is truncated at the front so that index 0 is
+        where the next state shall begin.
+
+    @ivar _start: While in the C{'CHUNK_LENGTH'} state, tracks the index into
+        the buffer at which search for CRLF should resume. Resuming the search
+        at this position avoids doing quadratic work if the chunk length line
+        arrives over many calls to C{dataReceived}.
+
+        Not used in any other state.
     """
 
     state = "CHUNK_LENGTH"

--- a/src/twisted/web/newsfragments/10144.bugfix
+++ b/src/twisted/web/newsfragments/10144.bugfix
@@ -1,0 +1,1 @@
+The server-side HTTP/1.1 chunking implementation now limits the length of the chunk size line (which includes chunk extensions) to twisted.web.http.MAX_CHUNK_SIZE_LINE_LENGTH, 4 KiB, so that it may not consume an unbounded amount of memory.

--- a/src/twisted/web/newsfragments/10144.bugfix
+++ b/src/twisted/web/newsfragments/10144.bugfix
@@ -1,1 +1,1 @@
-The server-side HTTP/1.1 chunking implementation now limits the length of the chunk size line (which includes chunk extensions) to twisted.web.http.MAX_CHUNK_SIZE_LINE_LENGTH, 4 KiB, so that it may not consume an unbounded amount of memory.
+The server-side HTTP/1.1 chunking implementation now limits the length of the chunk size line (which includes chunk extensions) to twisted.web.http.maxChunkSizeLineLength — 4 KiB — so that it may not consume an unbounded amount of memory.

--- a/src/twisted/web/newsfragments/10144.bugfix
+++ b/src/twisted/web/newsfragments/10144.bugfix
@@ -1,1 +1,1 @@
-The server-side HTTP/1.1 chunking implementation now limits the length of the chunk size line (which includes chunk extensions) to twisted.web.http.maxChunkSizeLineLength — 4 KiB — so that it may not consume an unbounded amount of memory.
+The server-side HTTP/1.1 chunking implementation now limits the length of the chunk size line (which includes chunk extensions) to twisted.web.http.maxChunkSizeLineLength — 1 KiB — so that it may not consume an unbounded amount of memory.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1289,6 +1289,38 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         p.dataReceived(b"3; x-foo=bar\r\nabc\r\n")
         self.assertEqual(L, [b"abc"])
 
+    def test_oversizedChunkSizeLine(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the chunk size line exceeds 4 KiB.
+        """
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,  # pragma: nocov
+            lambda b: None,  # pragma: nocov
+        )
+        self.assertRaises(
+            http._MalformedChunkedDataError,
+            p.dataReceived,
+            b"3;" + b"." * 4096 + b"\r\nabc\r\n",
+        )
+
+    def test_oversizedChunkSizeLinePartial(self):
+        """
+        L{_ChunkedTransferDecoder.dataReceived} raises
+        L{_MalformedChunkedDataError} when the amount of data buffered while
+        looking for the end of the chunk size line exceeds 4 KiB so
+        that buffering does not continue without bound.
+        """
+        p = http._ChunkedTransferDecoder(
+            lambda b: None,  # pragma: nocov
+            lambda b: None,  # pragma: nocov
+        )
+        self.assertRaises(
+            http._MalformedChunkedDataError,
+            p.dataReceived,
+            b"." * 4097,
+        )
+
     def test_malformedChunkSize(self):
         """
         L{_ChunkedTransferDecoder.dataReceived} raises

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1300,7 +1300,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         self.assertRaises(
             http._MalformedChunkedDataError,
             p.dataReceived,
-            b"3;" + b"." * 4096 + b"\r\nabc\r\n",
+            b"3;" + b"." * http.maxChunkSizeLineLength + b"\r\nabc\r\n",
         )
 
     def test_oversizedChunkSizeLinePartial(self):
@@ -1314,7 +1314,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         self.assertRaises(
             http._MalformedChunkedDataError,
             p.dataReceived,
-            b"." * 4097,
+            b"." * (http.maxChunkSizeLineLength + 1),
         )
 
     def test_malformedChunkSize(self):

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1293,6 +1293,8 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         """
         L{_ChunkedTransferDecoder.dataReceived} raises
         L{_MalformedChunkedDataError} when the chunk size line exceeds 4 KiB.
+        This applies even when the data has already been received and buffered
+        so that behavior is consistent regardless of how bytes are framed.
         """
         p = http._ChunkedTransferDecoder(
             lambda b: None,  # pragma: nocov

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1296,10 +1296,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         This applies even when the data has already been received and buffered
         so that behavior is consistent regardless of how bytes are framed.
         """
-        p = http._ChunkedTransferDecoder(
-            lambda b: None,  # pragma: nocov
-            lambda b: None,  # pragma: nocov
-        )
+        p = http._ChunkedTransferDecoder(None, None)
         self.assertRaises(
             http._MalformedChunkedDataError,
             p.dataReceived,
@@ -1313,10 +1310,7 @@ class ChunkedTransferEncodingTests(unittest.TestCase):
         looking for the end of the chunk size line exceeds 4 KiB so
         that buffering does not continue without bound.
         """
-        p = http._ChunkedTransferDecoder(
-            lambda b: None,  # pragma: nocov
-            lambda b: None,  # pragma: nocov
-        )
+        p = http._ChunkedTransferDecoder(None, None)
         self.assertRaises(
             http._MalformedChunkedDataError,
             p.dataReceived,


### PR DESCRIPTION
## Scope and purpose

Following up on #1551, #1550, and #1562, this PR imposes a length limit on the chunk size line. That is, the first line in the `chunk` production:

     chunk          = chunk-size [ chunk-ext ] CRLF
                      chunk-data CRLF

Previously, `_ChunkedTransferDecoder` would buffer an unbounded amount while searching for the terminal CRLF. The new limit, 4 KiB, doesn't meaningfully limit the size of the chunk that can be encoded, but restricts the amount of extension data that can be associated with the chunk.

The 4 KiB limit is an arbitrary one intended to maximize compatibility should extensions be present. The decoder discards extensions, as allowed by [the RFC](https://tools.ietf.org/html/rfc7230#section-4.1), so size is the only concern here.. As far as I know extensions are useless and unused in the wild, so I'm open to setting the limit lower. I put the limit in a global constant (rather than a class variable) so that it could be overridden without touching private symbols, if necessary.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10144
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.

