### PR TITLE
10150 upgrade mypy-zope to 0.2.13

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -187,8 +187,8 @@ commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
 description = run Mypy (static type checker)
 
 deps =
-    mypy==0.800
-    mypy-zope==0.2.10
+    mypy==0.812
+    mypy-zope==0.2.13
 
 commands =
     mypy                                       \


### PR DESCRIPTION
to fix https://github.com/Shoobx/mypy-zope/issues/34


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10150
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] I have added `twisted/twisted-contributors` teams to the PR `Reviewers`.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_usernames_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
