### PR TITLE
9915 copyedit threading narrative docs

### DIFF
--- a/docs/core/howto/threading.rst
+++ b/docs/core/howto/threading.rst
@@ -116,7 +116,7 @@ To get a result from some blocking code back into the reactor thread, we can use
     d.addCallback(printResult)
     reactor.run()
 
-Similarly, you want some code running in a non-reactor thread wants to invoke some code in the reactor thread and get its result, you can use :py:func:`blockingCallFromThread <twisted.internet.threads.blockingCallFromThread>`::
+Similarly, if you want some code running in a non-reactor thread to invoke some code in the reactor thread and get its result, you can use :py:func:`twisted.internet.threads.blockingCallFromThread <blockingCallFromThread>`::
 
     from twisted.internet import threads, reactor, defer
     from twisted.web.client import Agent

--- a/docs/core/howto/threading.rst
+++ b/docs/core/howto/threading.rst
@@ -17,7 +17,7 @@ This is not to say that it makes *no* use of threads; there are plenty of APIs w
 One prominent example of this is system hostname resolution: unless you have configured Twisted to use its own DNS client in ``twisted.names``, it will have to use your operating system's blocking APIs to map host names to IP addresses, in the reactor's thread pool.
 However, this is something you only need to know about for resource-tuning purposes, like setting the number of threads to use; otherwise, it is an implementation detail you can ignore.
 
-It is a common mistake is to think that because Twisted can manage multiple connections once, things are happening in multiple threads, and so you need to carefully manage locks.
+It is a common mistake is to think that because Twisted can manage multiple connections at once, things are happening in multiple threads, and so you need to carefully manage locks.
 Lucky for you, Twisted does most things in one thread!
 This document will explain how to interact with existing APIs which need to be run within their own threads because they block.
 If you're just using Twisted's own APIs, the rule for threads is simply "don't use them".


### PR DESCRIPTION
I made a pass over threading.rst and corrected issues I noticed.

This also includes some typo fixes from #1226.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9915
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
