### PR TITLE
10154 Type IAgent

### DIFF
--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from zope.interface import Interface, Attribute
 
+from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IPushProducer
 from twisted.cred.credentials import IUsernameDigestHash
 from twisted.web.http_headers import Headers
@@ -724,7 +725,7 @@ class IAgent(Interface):
         uri: bytes,
         headers: Optional[Headers] = None,
         bodyProducer: Optional[IBodyProducer] = None,
-    ):
+    ) -> Deferred[IResponse]:
         """
         Request the resource at the given location.
 

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -741,20 +741,17 @@ class IAgent(Interface):
             send no extra headers).  An implementation may add its own headers
             to this (for example for client identification or content
             negotiation).
-        @type headers: L{Headers} or L{None}
 
         @param bodyProducer: An object which can generate bytes to make up the
             body of this request (for example, the properly encoded contents of
             a file for a file upload).  Or, L{None} if the request is to have
             no body.
-        @type bodyProducer: L{IBodyProducer} provider
 
         @return: A L{Deferred} that fires with an L{IResponse} provider when
             the header of the response has been received (regardless of the
             response status code) or with a L{Failure} if there is any problem
             which prevents that response from being received (including
             problems that prevent the request from being sent).
-        @rtype: L{Deferred}
         """
 
 

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -9,11 +9,13 @@ Interface definitions for L{twisted.web}.
     L{IBodyProducer.length} to indicate that the length of the entity
     body is not known in advance.
 """
+from typing import Optional
 
 from zope.interface import Interface, Attribute
 
 from twisted.internet.interfaces import IPushProducer
 from twisted.cred.credentials import IUsernameDigestHash
+from twisted.web.http_headers import Headers
 
 
 class IRequest(Interface):
@@ -717,19 +719,22 @@ class IAgent(Interface):
         doSomeRequests(cache)
     """
 
-    def request(method, uri, headers=None, bodyProducer=None):
+    def request(
+        method: bytes,
+        uri: bytes,
+        headers: Optional[Headers] = None,
+        bodyProducer: Optional[IBodyProducer] = None,
+    ):
         """
         Request the resource at the given location.
 
-        @param method: The request method to use, such as C{"GET"}, C{"HEAD"},
-            C{"PUT"}, C{"POST"}, etc.
-        @type method: L{bytes}
+        @param method: The request method to use, such as C{b"GET"}, C{b"HEAD"},
+            C{b"PUT"}, C{b"POST"}, etc.
 
         @param uri: The location of the resource to request.  This should be an
             absolute URI but some implementations may support relative URIs
             (with absolute or relative paths).  I{HTTP} and I{HTTPS} are the
             schemes most likely to be supported but others may be as well.
-        @type uri: L{bytes}
 
         @param headers: The headers to send with the request (or L{None} to
             send no extra headers).  An implementation may add its own headers


### PR DESCRIPTION
## Scope and purpose

Align the types of the example strings in the IAgent docstring with the actual type (`bytes`). Also add some type annotations in the process.

Rendered: https://twisted--1569.org.readthedocs.build/en/1569/api/twisted.web.iweb.IAgent.html

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10154
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.

