### PR TITLE
#10158 Use stdout/stdin for AMP communication in distrial on Windows.

### DIFF
--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -22,7 +22,6 @@ from twisted.trial._asyncrunner import _iterateTests
 from twisted.trial._dist.worker import LocalWorker, LocalWorkerAMP
 from twisted.trial._dist.distreporter import DistReporter
 from twisted.trial.reporter import UncleanWarningsReporterWrapper
-from twisted.trial._dist import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT
 
 
 class DistTrialRunner:
@@ -115,13 +114,6 @@ class DistTrialRunner:
         @param arguments: Extra arguments passed to the processes.
         """
         workertrialPath = theSystemPath["twisted.trial._dist.workertrial"].filePath.path
-        childFDs = {
-            0: "w",
-            1: "r",
-            2: "r",
-            _WORKER_AMP_STDIN: "w",
-            _WORKER_AMP_STDOUT: "r",
-        }
         environ = os.environ.copy()
         # Add an environment variable containing the raw sys.path, to be used by
         # subprocesses to make sure it's identical to the parent. See
@@ -130,7 +122,7 @@ class DistTrialRunner:
         for worker in protocols:
             args = [sys.executable, workertrialPath]
             args.extend(arguments)
-            spawner(worker, sys.executable, args=args, childFDs=childFDs, env=environ)
+            spawner(worker, sys.executable, args=args, env=environ)
 
     def _driveWorker(self, worker, result, testCases, cooperate):
         """

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -37,7 +37,7 @@ class FakeTransport:
     A simple fake process transport.
     """
 
-    def writeToChild(self, fd, data):
+    def write(self, data):
         """
         Ignore write calls.
         """

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -295,7 +295,7 @@ class FakeTransport:
     dataString = b""
     calls = 0
 
-    def writeToChild(self, fd, data):
+    def write(self, data):
         self.dataString += data
 
     def loseConnection(self):
@@ -321,33 +321,17 @@ class LocalWorkerTests(TestCase):
         worker = LocalWorker(*args, **kwargs)
         worker.makeConnection(FakeTransport())
         self.addCleanup(worker._testLog.close)
-        self.addCleanup(worker._outLog.close)
         self.addCleanup(worker._errLog.close)
         return worker
 
-    def test_childDataReceived(self):
-        """
-        L{LocalWorker.childDataReceived} forwards the received data to linked
-        L{AMP} protocol if the right file descriptor, otherwise forwards to
-        C{ProcessProtocol.childDataReceived}.
-        """
-        localWorker = self.tidyLocalWorker(FakeAMProtocol(), ".", "test.log")
-        localWorker._outLog = BytesIO()
-        localWorker.childDataReceived(4, b"foo")
-        localWorker.childDataReceived(1, b"bar")
-        self.assertEqual(b"foo", localWorker._ampProtocol.dataString)
-        self.assertEqual(b"bar", localWorker._outLog.getvalue())
-
     def test_outReceived(self):
         """
-        L{LocalWorker.outReceived} logs the output into its C{_outLog} log
-        file.
+        L{LocalWorker.outReceived} forward the data to the AMP protocol.
         """
         localWorker = self.tidyLocalWorker(FakeAMProtocol(), ".", "test.log")
-        localWorker._outLog = BytesIO()
-        data = b"The quick brown fox jumps over the lazy dog"
+        data = b"AMP Box Data"
         localWorker.outReceived(data)
-        self.assertEqual(data, localWorker._outLog.getvalue())
+        self.assertEqual(data, localWorker._ampProtocol.dataString)
 
     def test_errReceived(self):
         """
@@ -400,7 +384,6 @@ class LocalWorkerTests(TestCase):
 
         localWorker = self.tidyLocalWorker(FakeAMProtocol(), ".", "test.log")
         localWorker.connectionLost(None)
-        self.assertTrue(localWorker._outLog.closed)
         self.assertTrue(localWorker._errLog.closed)
         self.assertTrue(localWorker._testLog.closed)
 
@@ -415,7 +398,6 @@ class LocalWorkerTests(TestCase):
         localWorker = LocalWorker(protocol, ".", "test.log")
         localWorker.makeConnection(transport)
         localWorker.processEnded(Failure(CONNECTION_DONE))
-        self.assertTrue(localWorker._outLog.closed)
         self.assertTrue(localWorker._errLog.closed)
         self.assertTrue(localWorker._testLog.closed)
         self.assertIdentical(None, protocol.transport)


### PR DESCRIPTION
## Scope and purpose

Fixes #10158

This refactors the distributed trial AMP communication to use stdin/stdout.

In this way, we can have the AMP worker sub-process spawned on Windows.

This is a .misc as in theory it should be only a refactoring without any feature removal.

The PR as it's now, removes the stdout log file `_trial_temp/N/out.log` 
Handling of the sub-process worker stdout in targeted by PR #1571 
So if that PR should be merged first and then this PR can use the new sys.stdout handling .


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10158
* [NO] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10158

Use stdout/stdin communication in distributed trial AMP to simplify the Windows implementation.
```
