### PR TITLE
[10159] Fix codecov.io reporting. Move codecov.io / coveralls reporting outside of tox environments.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,9 +6,8 @@ source = twisted
 [paths]
 source=
    src/twisted
-   build/*/lib/python*/site-packages/twisted
-   build/*/Lib/site-packages/twisted
-   build/pypy*/site-packages/twisted
+   */site-packages/twisted
+   *\site-packages\twisted
 
 [report]
 precision = 2

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,8 @@
 branch = True
 parallel = True
 source = twisted
+omit =
+    .tox/*/tmp/_trial_temp/*
 
 [paths]
 source=

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: "JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -119,7 +119,7 @@ jobs:
       run: |
         python -m coveralls
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 
 
   pypi-publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,6 +109,7 @@ jobs:
 
     - uses: codecov/codecov-action@v1
       if: always()
+      continue-on-error: true
       with:
         files: coverage.xml
         name: lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}
@@ -118,6 +119,7 @@ jobs:
     - name: Publish to Coveralls
       # We want to publish coverage even on failure.
       if: always()
+      continue-on-error: true
       run: |
         python -m coveralls
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,15 +112,14 @@ jobs:
       run: |
         python -m coverage xml -o coverage.xml -i
         python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
-      env:
-        COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 
     - name: Publish coveralls
       # We want to publish coverage even on failure.
       if: contains(matrix['tox-env'], 'withcov') || failure()
       run: |
         python -m coveralls
-
+      env:
+        COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 
 
   pypi-publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,16 +106,16 @@ jobs:
         python --version
         tox -q
 
-    - name: Generate xMl and publish codecov.io
+    - name: Generate XML and publish to Codecov
       # We want to publish coverage even on failure.
-      if: contains(matrix['tox-env'], 'withcov') || failure()
+      if: always()
       run: |
         python -m coverage xml -o coverage.xml -i
         python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
 
-    - name: Publish coveralls
+    - name: Publish to Coveralls
       # We want to publish coverage even on failure.
-      if: contains(matrix['tox-env'], 'withcov') || failure()
+      if: always()
       run: |
         python -m coveralls
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,9 @@ jobs:
       if: always()
       run: |
         python -m coverage xml -o coverage.xml -i
-        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
+        # Bash is the recommended uploader.
+        # See: https://github.com/codecov/example-python#faq
+        bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
 
     - name: Publish to Coveralls
       # We want to publish coverage even on failure.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox codecov coveralls
+        python -m pip install --upgrade pip tox coveralls
         tox --notest
 
     - name: Test
@@ -110,7 +110,6 @@ jobs:
       # We want to publish coverage even on failure.
       if: always()
       run: |
-        python -m coverage xml -o coverage.xml -i
         # Bash is the recommended uploader.
         # See: https://github.com/codecov/example-python#faq
         bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,13 +47,14 @@ jobs:
           # end to end functional test usage for non-distributed trial runs.
           - python-version: 3.6.7
             tox-env: nodeps-withcov-posix
-            trial-args: ''
+            trial-args: '-j 4'
           # `noipv6` is created to make sure all is OK on an OS which doesn't
           # have IPv6 available.
           # Any supported Python version is OK for this job.
           - python-version: 3.6
             tox-env: alldeps-withcov-posix
             noipv6: -noipv6
+            trial-args: '-j 4'
           # On PYPY concurrent test jobs result in random failures so for now
           # run non-distributed tests.
           - python-version: pypy-3.6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,8 +107,7 @@ jobs:
         python --version
         tox -q
 
-    - name: Prepare coverate
-      # We want to publish coverage even on failure.
+    - name: Prepare coverage
       if: always()
       continue-on-error: true
       run: |
@@ -129,11 +128,10 @@ jobs:
         functionalities: gcov,search
 
     - name: Publish to Coveralls
-      # We want to publish coverage even on failure.
       if: always()
       continue-on-error: true
       run: |
-        python -m coveralls
+        python -m coveralls -v
       env:
         COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,19 +106,21 @@ jobs:
         python --version
         tox -q
 
-    - name: Publish coverage
+    - name: Generate xMl and publish codecov.io
       # We want to publish coverage even on failure.
       if: contains(matrix['tox-env'], 'withcov') || failure()
       run: |
         python -m coverage xml -o coverage.xml -i
-        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml &&
-        PID1=$!
-        python -m coveralls &&
-        PID2=$!
-        wait $PID1
-        wait $PID2
+        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
       env:
         COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
+
+    - name: Publish coveralls
+      # We want to publish coverage even on failure.
+      if: contains(matrix['tox-env'], 'withcov') || failure()
+      run: |
+        python -m coveralls
+
 
 
   pypi-publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,7 +112,14 @@ jobs:
       run: |
         python -m coverage xml -o coverage.xml -i
         python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
+
+    - name: Publish coveralls
+      # We want to publish coverage even on failure.
+      if: contains(matrix['tox-env'], 'withcov') || failure()
+      run: |
         python -m coveralls
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
 
   pypi-publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,10 +67,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        # A minimum depth of 2 is required, as the HEAD is the auto-merge commit
-        # and we need the last commit from the PR to report the coverage.
-        fetch-depth: 2
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -111,13 +107,13 @@ jobs:
         python --version
         tox -q
 
-    - name: Generate XML and publish to Codecov
-      # We want to publish coverage even on failure.
+    - uses: codecov/codecov-action@v1
       if: always()
-      run: |
-        # Bash is the recommended uploader.
-        # See: https://github.com/codecov/example-python#faq
-        bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
+      with:
+        files: coverage.xml
+        name: lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}
+        fail_ci_if_error: true
+        functionalities: gcov,search
 
     - name: Publish to Coveralls
       # We want to publish coverage even on failure.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,6 +107,18 @@ jobs:
         python --version
         tox -q
 
+    - name: Prepare coverate
+      # We want to publish coverage even on failure.
+      if: always()
+      continue-on-error: true
+      run: |
+        # sub-process coverage are generated in separate files so we combine them
+        # to get an unified coverage for the local run.
+        # The XML is generate to be used with 3rd party tools like diff-cover.
+        python -m coverage combine
+        python -m coverage xml -o coverage.xml -i
+        python -m coverage report
+
     - uses: codecov/codecov-action@v1
       if: always()
       continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TOXENV: "${{ matrix.tox-env }}"
-      CODECOV_OPTIONS: "-n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}'"
       TRIAL_ARGS: "${{ matrix.trial-args }}"
     name: ${{ matrix.python-version }}${{ matrix.noipv6 }}-${{ matrix.tox-env }}
     strategy:
@@ -99,7 +98,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox codecov coveralls
         tox --notest
 
     - name: Test
@@ -110,7 +109,10 @@ jobs:
     - name: Publish coverage
       # We want to publish coverage even on failure.
       if: contains(matrix['tox-env'], 'withcov') || failure()
-      run: tox -e coverage-prepare,codecov-push,coveralls-push
+      run: |
+        python -m coverage xml -o coverage.xml -i
+        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
+        python -m coveralls
 
 
   pypi-publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # A minimum depth of 2 is required, as the HEAD is the auto-merge commit
+        # and we need the last commit from the PR to report the coverage.
+        fetch-depth: 2
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,13 +111,12 @@ jobs:
       if: contains(matrix['tox-env'], 'withcov') || failure()
       run: |
         python -m coverage xml -o coverage.xml -i
-        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml
-
-    - name: Publish coveralls
-      # We want to publish coverage even on failure.
-      if: contains(matrix['tox-env'], 'withcov') || failure()
-      run: |
-        python -m coveralls
+        python -m codecov -n 'lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}' -X search -X gcov -f coverage.xml &&
+        PID1=$!
+        python -m coveralls &&
+        PID2=$!
+        wait $PID1
+        wait $PID2
       env:
         COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -47,7 +47,7 @@ steps:
    python -c "import os; [ print(e,v) for (e,v) in os.environ.items() ]"
   displayName: 'Get Python Information'
 
-- script: 'python -m pip install -U pip setuptools tox coveralls'
+- script: 'python -m pip install -U pip setuptools tox coverage coveralls'
   displayName: 'Update pip & install tox'
 
 - ${{ if eq(parameters.platform, 'macos') }}:
@@ -65,6 +65,18 @@ steps:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
 - bash: |
+    # sub-process coverage are generated in separate files so we combine them
+    # to get an unified coverage for the local run.
+    # The XML is generate to be used with 3rd party tools like diff-cover.
+    python -m coverage combine
+    python -m coverage xml -o coverage.xml -i
+    python -m coverage report
+
+  displayName: 'Prepare coverage'
+  condition: always()
+  continueOnError: true
+
+- bash: |
     bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
   displayName: 'Report to Codecov'
   condition: always()
@@ -73,12 +85,14 @@ steps:
 # Coveralls has no support for Azure so we pretend to be CircleCI.
 # See https://github.com/lemurheavy/coveralls-public/issues/1272
 - bash: |
-    export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
+    export CI_BRANCH=$SYSTEM_PULLREQUEST_SOURCEBRANCH
+    export CI_PULL_REQUEST=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+    export CI_BUILD_URL=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI/pull/$CI_PULL_REQUEST
     python -m coveralls
   displayName: 'Report to Coveralls'
   condition: always()
   continueOnError: true
   env:
-    CIRCLECI: 1
-    CIRCLE_BUILD_NUM: $(Build.BuildNumber)
+    CI_NAME: 'azure-pipelines'
+    CI_BUILD_NUMBER: $(Build.BuildNumber)
     COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -28,9 +28,6 @@ parameters:
 steps:
 - checkout: self
   clean: true
-  # A minimum depth of 2 is required, as the default is the auto-merge commit
-  # and we need the last commit from the PR to report the coverage.
-  fetchDepth: 2
 
 - task: UsePythonVersion@0
   displayName: "Use Python ${{ parameters.pythonVersion }}"

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -65,7 +65,6 @@ steps:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
 - bash: |
-    python -m coverage xml -o coverage.xml -i
     bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
   displayName: 'Generate XML and report to Codecov'
   condition: always()

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -68,6 +68,7 @@ steps:
     bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
   displayName: 'Report to Codecov'
   condition: always()
+  continueOnError: true
 
 # Coveralls has no support for Azure so we pretend to be CircleCI.
 # See https://github.com/lemurheavy/coveralls-public/issues/1272
@@ -76,6 +77,7 @@ steps:
     python -m coveralls
   displayName: 'Report to Coveralls'
   condition: always()
+  continueOnError: true
   env:
     CIRCLECI: 1
     CIRCLE_BUILD_NUM: $(Build.BuildNumber)

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -63,9 +63,12 @@ steps:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
 - bash: |
+    python -m coverage xml -o coverage.xml -i
     bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
   displayName: 'Report codecov.io'
 
+# Coveralls has no support for Azure so we pretend to be CircleCI.
+# See https://github.com/lemurheavy/coveralls-public/issues/1272
 - bash: |
     export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
     python -m coveralls

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -66,7 +66,7 @@ steps:
 
 - bash: |
     python -m coverage xml -o coverage.xml -i
-    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
   displayName: 'Generate XML and report to Codecov'
   condition: always()
 

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -28,6 +28,9 @@ parameters:
 steps:
 - checkout: self
   clean: true
+  # A minimum depth of 2 is required, as the HEAD is the auto-merge commit
+  # and we need the last commit from the PR to report the coverage.
+  fetchDepth: 2
 
 - task: UsePythonVersion@0
   displayName: "Use Python ${{ parameters.pythonVersion }}"

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -47,7 +47,7 @@ steps:
    python -c "import os; [ print(e,v) for (e,v) in os.environ.items() ]"
   displayName: 'Get Python Information'
 
-- script: 'python -m pip install -U pip setuptools tox coveralls pyyaml'
+- script: 'python -m pip install -U pip setuptools tox coveralls'
   displayName: 'Update pip & install tox'
 
 - ${{ if eq(parameters.platform, 'macos') }}:
@@ -66,15 +66,17 @@ steps:
 
 - bash: |
     python -m coverage xml -o coverage.xml -i
-    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
-  displayName: 'Generate XMl and report codecov.io'
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
+  displayName: 'Generate XML and report to Codecov'
+  condition: always()
 
 # Coveralls has no support for Azure so we pretend to be CircleCI.
 # See https://github.com/lemurheavy/coveralls-public/issues/1272
 - bash: |
     export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
     python -m coveralls
-  displayName: 'Report coveralls'
+  displayName: 'Report to Coveralls'
+  condition: always()
   env:
     CIRCLECI: 1
     CIRCLE_BUILD_NUM: $(Build.BuildNumber)

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -45,7 +45,7 @@ steps:
    python -c "import os; [ print(e,v) for (e,v) in os.environ.items() ]"
   displayName: 'Get Python Information'
 
-- script: 'python -m pip install -U pip setuptools tox'
+- script: 'python -m pip install -U pip setuptools tox coveralls'
   displayName: 'Update pip & install tox'
 
 - ${{ if eq(parameters.platform, 'macos') }}:
@@ -63,6 +63,6 @@ steps:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
 - bash:  |
-    python -m tox -e coverage-prepare,coveralls-push
-    bash <(curl -s https://codecov.io/bash) -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
+    bash <(curl -s https://codecov.io/bash) -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
+    python -m coveralls
   displayName: 'Report coverage'

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -64,19 +64,17 @@ steps:
     env:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
+- bash: |
+    python -m coverage xml -o coverage.xml -i
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
+  displayName: 'Generate XMl and report codecov.io'
+
 # Coveralls has no support for Azure so we pretend to be CircleCI.
 # See https://github.com/lemurheavy/coveralls-public/issues/1272
 - bash: |
-    python -m coverage xml -o coverage.xml -i
-    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov" &&
-    PID1=$!
-
     export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
-    python -m coveralls &&
-    PID2=$!
-    wait $PID1
-    wait $PID2
-  displayName: 'Report coverage'
+    python -m coveralls
+  displayName: 'Report coveralls'
   env:
     CIRCLECI: 1
     CIRCLE_BUILD_NUM: $(Build.BuildNumber)

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -28,6 +28,8 @@ parameters:
 steps:
 - checkout: self
   clean: true
+  # A minimum dept of 2 is required, as for PR head is the auto-merge commit
+  # and we need the last commit from PR to report the coverage.
   fetchDepth: 2
 
 - task: UsePythonVersion@0
@@ -62,17 +64,19 @@ steps:
     env:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
-- bash: |
-    python -m coverage xml -o coverage.xml -i
-    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
-  displayName: 'Report codecov.io'
-
 # Coveralls has no support for Azure so we pretend to be CircleCI.
 # See https://github.com/lemurheavy/coveralls-public/issues/1272
 - bash: |
+    python -m coverage xml -o coverage.xml -i
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov" &&
+    PID1=$!
+
     export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
-    python -m coveralls
-  displayName: 'Report coveralls'
+    python -m coveralls &&
+    PID2=$!
+    wait $PID1
+    wait $PID2
+  displayName: 'Report coverage'
   env:
     CIRCLECI: 1
     CIRCLE_BUILD_NUM: $(Build.BuildNumber)

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -28,7 +28,7 @@ parameters:
 steps:
 - checkout: self
   clean: true
-  fetchDepth: 1
+  fetchDepth: 2
 
 - task: UsePythonVersion@0
   displayName: "Use Python ${{ parameters.pythonVersion }}"
@@ -45,7 +45,7 @@ steps:
    python -c "import os; [ print(e,v) for (e,v) in os.environ.items() ]"
   displayName: 'Get Python Information'
 
-- script: 'python -m pip install -U pip setuptools tox coveralls'
+- script: 'python -m pip install -U pip setuptools tox coveralls pyyaml'
   displayName: 'Update pip & install tox'
 
 - ${{ if eq(parameters.platform, 'macos') }}:
@@ -62,7 +62,15 @@ steps:
     env:
       TWISTED_REACTOR: ${{ parameters.windowsReactor }}
 
-- bash:  |
-    bash <(curl -s https://codecov.io/bash) -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
+- bash: |
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -v -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}-alldeps-withcov"
+  displayName: 'Report codecov.io'
+
+- bash: |
+    export CIRCLE_BRANCH=$BUILD_SOURCEBRANCH
     python -m coveralls
-  displayName: 'Report coverage'
+  displayName: 'Report coveralls'
+  env:
+    CIRCLECI: 1
+    CIRCLE_BUILD_NUM: $(Build.BuildNumber)
+    COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -82,8 +82,12 @@ steps:
   condition: always()
   continueOnError: true
 
-# Coveralls has no support for Azure so we pretend to be CircleCI.
-# See https://github.com/lemurheavy/coveralls-public/issues/1272
+# We are using a 3rd part tools to upload to Coveralls
+# See https://github.com/TheKevJames/coveralls-python
+# It has no support for Azure so we pretend to be CircleCI so that
+# we can differentiate from GitHub Actions.
+# https://github.com/TheKevJames/coveralls-python/blob/04b6a2876e4e7ab2e8cf0778f88ce23f94679931/coveralls/api.py#L147
+# https://github.com/TheKevJames/coveralls-python/blob/04b6a2876e4e7ab2e8cf0778f88ce23f94679931/coveralls/git.py#L31
 - bash: |
     export CI_BRANCH=$SYSTEM_PULLREQUEST_SOURCEBRANCH
     export CI_PULL_REQUEST=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
@@ -93,6 +97,6 @@ steps:
   condition: always()
   continueOnError: true
   env:
-    CI_NAME: 'azure-pipelines'
-    CI_BUILD_NUMBER: $(Build.BuildNumber)
+    CIRCLE_WORKFLOW_ID: $(Build.BuildNumber)
+    CIRCLECI: 1
     COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -66,7 +66,7 @@ steps:
 
 - bash: |
     bash <(curl -s https://codecov.io/bash) -X search -X gcov -f coverage.xml -n "${{ parameters.platform }}-${{ parameters.pythonVersion }}"
-  displayName: 'Generate XML and report to Codecov'
+  displayName: 'Report to Codecov'
   condition: always()
 
 # Coveralls has no support for Azure so we pretend to be CircleCI.

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -28,8 +28,8 @@ parameters:
 steps:
 - checkout: self
   clean: true
-  # A minimum dept of 2 is required, as for PR head is the auto-merge commit
-  # and we need the last commit from PR to report the coverage.
+  # A minimum depth of 2 is required, as the default is the auto-merge commit
+  # and we need the last commit from the PR to report the coverage.
   fetchDepth: 2
 
 - task: UsePythonVersion@0

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -88,7 +88,7 @@ steps:
     export CI_BRANCH=$SYSTEM_PULLREQUEST_SOURCEBRANCH
     export CI_PULL_REQUEST=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
     export CI_BUILD_URL=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI/pull/$CI_PULL_REQUEST
-    python -m coveralls
+    python -m coveralls -v
   displayName: 'Report to Coveralls'
   condition: always()
   continueOnError: true

--- a/tox.ini
+++ b/tox.ini
@@ -89,11 +89,6 @@ commands =
     withcov: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth
     withcov: coverage erase
     withcov: coverage run -p --rcfile={toxinidir}/.coveragerc -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {env:TRIAL_ARGS:} {posargs:twisted}
-    ; sub-process coverage are generated in separate files so we combine them
-    ; to get an unified coverage for the local run.
-    ; The XML is generate to be used with 3rd party tools like diff-cover.
-    withcov: coverage combine
-    withcov: coverage xml -o coverage.xml -i
 
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,11 @@ commands =
     withcov: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth
     withcov: coverage erase
     withcov: coverage run -p --rcfile={toxinidir}/.coveragerc -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {env:TRIAL_ARGS:} {posargs:twisted}
+    ; sub-process coverage are generated in separate files so we combine them
+    ; to get an unified coverage for the local run.
+    ; The XML is generate to be used with 3rd party tools like diff-cover.
     withcov: coverage combine
+    withcov: coverage xml -o coverage.xml -i
 
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,15 +15,6 @@
 ;
 ; See README.rst for example tox commands.
 ;
-; There are also various non-default environments used by the continuous
-; integration system: the `codecov-push` and `coveralls-push` push the coverage
-; results to codecov.io and coveralls.io, respectively. They should be called
-; after running both some number of `-withcov` environments and also
-; `coverage-prepare`.
-;
-; For compatibility with the current infrastructure, `codecov-publish`
-; combines `coverage-prepare` and `codecov-push` into a single step.
-;
 [tox]
 minversion=3.21.4
 requires=
@@ -60,20 +51,10 @@ extras =
 
     serial: serial
 
-    {withcov,coverage-prepare,codecov-publish}: dev
+    {withcov}: dev
 
 ;; dependencies that are not specified as extras
 deps =
-    ; We end up with a bit of deps duplication as we can't install
-    ; coverage deps via `extras` as we run them with `skip_install`.
-    {coverage-prepare,codecov-publish}: coverage ~= 5.5
-
-    {codecov-push,codecov-publish}: codecov ~= 2.1
-
-    coveralls-push: coveralls
-    coveralls-push: PyYAML
-
-
     lint: pre-commit
 
 ; All environment variables are passed.
@@ -90,9 +71,6 @@ setenv =
     {windows,serial}: TWISTED_FORCE_SERIAL_TESTS = 1
 
 skip_install =
-    coverage-prepare: True
-    codecov: True
-    coveralls: True
     lint: True
 
 commands =
@@ -111,16 +89,7 @@ commands =
     withcov: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth
     withcov: coverage erase
     withcov: coverage run -p --rcfile={toxinidir}/.coveragerc -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reactor={env:TWISTED_REACTOR:default} --reporter={env:TRIAL_REPORTER:verbose} {env:TRIAL_ARGS:} {posargs:twisted}
-
-    ; Prepare coverage reports for publication.
-    {coverage-prepare,codecov-publish}: coverage combine
-    {coverage-prepare,codecov-publish}: coverage xml -o coverage.xml -i
-
-    ; Publish coverage reports to codecov.
-    {codecov-push,codecov-publish}: codecov {env:CODECOV_OPTIONS:} -X search -X gcov -f coverage.xml
-
-    ; Publish coverage reports to coveralls.
-    coveralls-push: coveralls
+    withcov: coverage combine
 
     lint: pre-commit {posargs:run --all-files --show-diff-on-failure}
 


### PR DESCRIPTION
## Scope and purpose

Reporting coverage to codecov.io and coveralls should only be needed for CI.

For CI we already have python virtual env created.

That venv can be reused for codecov/coveralls operations so that we don't need to add tox extra complexity for those calls.

It should also make the tox.ini cleaner and move the coverage publish code closer to where it's used.

Coverage reporting also broken with codecov reports for windows linux and mac not merged.
Coveralls reports are not normalized.

## Changes

There is a problem with codecov.io reporting as the coverage is reported for the PR auto-merge commit.
I saw this error for GitHub Coverage and Azure Coverage.

The error is
```
 Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```

`fetch-depth: 2` was enabled for codecov bash uploaded.

---------

Generating XML+ codecov.io publish was taking 40 seconds with the most time taken by XML generation.
Only coveralls publish was also taking 40 seconds.

If coveralls is not used by Twisted devs we can stop publishing it and save 40 seconds with each build.

-------

With coverage publishing handling moved outside of tox.ini there is no speed improvement.
I still prefer the coverage publishing outside of tox as I find it easier to understand how things works.

----------

The coverage config was updated to normalize the path and ignore the trial temp file.

The CI steps were updated to show the status of the local coverage... to help debugging.

----------

Any errors generated during coverage reporting are ignored.
The idea is to reduce random failures.
Once we have the other CI jobs with a solid green we can look at requiring strict rules.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10159
* [NO] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10159

Fix codecov reporting for a PR. Move coverage CI reporting outside of tox.
```
