### PR TITLE
10168: Enable ignore_missing_imports only where it is needed.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -821,7 +821,15 @@ warn_return_any = False
 
 # Don't complain about imports of fake modules used in tests
 
+[mypy-__main__]
+ignore_missing_imports = True
+
 [mypy-automat]
+ignore_missing_imports = True
+
+[mypy-dummy]
+ignore_missing_imports = True
+[mypy-dummy.*]
 ignore_missing_imports = True
 
 [mypy-goodpackage]

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,6 @@
 namespace_packages = True
 plugins=mypy_zope:plugin
 
-ignore_missing_imports = True
-
 # Increase our expectations
 
 check_untyped_defs       = True
@@ -821,3 +819,205 @@ allow_incomplete_defs = True
 [mypy-twisted.words.protocols.jabber.jid]
 warn_return_any = False
 
+# Don't complain about imports of fake modules used in tests
+
+[mypy-automat]
+ignore_missing_imports = True
+
+[mypy-goodpackage]
+ignore_missing_imports = True
+
+[mypy-twisted.plugins.fakeendpoint]
+ignore_missing_imports = True
+
+[mypy-twisted_private_helper]
+ignore_missing_imports = True
+
+[mypy-twisted_rebuild_fakelib]
+ignore_missing_imports = True
+
+[mypy-twisted_renamed_helper]
+ignore_missing_imports = True
+
+[mypy-twisted_toptobottom_temp]
+ignore_missing_imports = True
+
+[mypy-uberpackage]
+ignore_missing_imports = True
+
+[mypy-utmp]
+ignore_missing_imports = True
+
+# Don't complain about dependencies known to lack type hints
+
+[mypy-appdirs]
+ignore_missing_imports = True
+
+[mypy-bcrypt]
+ignore_missing_imports = True
+
+[mypy-CFNetwork]
+ignore_missing_imports = True
+
+[mypy-constantly]
+ignore_missing_imports = True
+
+[mypy-CoreFoundation]
+ignore_missing_imports = True
+
+[mypy-cryptography.*]
+ignore_missing_imports = True
+
+[mypy-cStringIO]
+ignore_missing_imports = True
+
+[mypy-cython_test_exception_raiser]
+ignore_missing_imports = True
+
+[mypy-gi]
+ignore_missing_imports = True
+[mypy-gi.*]
+ignore_missing_imports = True
+
+[mypy-gobject]
+ignore_missing_imports = True
+
+[mypy-gtk]
+ignore_missing_imports = True
+
+[mypy-h2]
+ignore_missing_imports = True
+[mypy-h2.*]
+ignore_missing_imports = True
+
+[mypy-hamcrest]
+ignore_missing_imports = True
+
+[mypy-hpack.*]
+ignore_missing_imports = True
+
+[mypy-hyperframe]
+ignore_missing_imports = True
+
+[mypy-idna]
+ignore_missing_imports = True
+
+[mypy-incremental]
+ignore_missing_imports = True
+
+[mypy-kinterbasdb]
+ignore_missing_imports = True
+
+[mypy-mypackage]
+ignore_missing_imports = True
+[mypy-mypackage.*]
+ignore_missing_imports = True
+
+[mypy-MySQLdb]
+ignore_missing_imports = True
+
+[mypy-OpenSSL]
+ignore_missing_imports = True
+[mypy-OpenSSL.*]
+ignore_missing_imports = True
+
+[mypy-package]
+ignore_missing_imports = True
+
+[mypy-pb]
+ignore_missing_imports = True
+
+[mypy-plugindummy]
+ignore_missing_imports = True
+[mypy-plugindummy.*]
+ignore_missing_imports = True
+
+[mypy-priority]
+ignore_missing_imports = True
+
+[mypy-process_tester]
+ignore_missing_imports = True
+
+[mypy-psycopg]
+ignore_missing_imports = True
+
+[mypy-pyasn1.*]
+ignore_missing_imports = True
+
+[mypy-pydoctor]
+ignore_missing_imports = True
+[mypy-pydoctor.*]
+ignore_missing_imports = True
+
+[mypy-pygtk]
+ignore_missing_imports = True
+
+[mypy-pyPgSQL]
+ignore_missing_imports = True
+
+[mypy-pythoncom]
+ignore_missing_imports = True
+
+[mypy-pyui]
+ignore_missing_imports = True
+
+[mypy-pywintypes]
+ignore_missing_imports = True
+
+[mypy-quixote]
+ignore_missing_imports = True
+
+[mypy-serial]
+ignore_missing_imports = True
+[mypy-serial.*]
+ignore_missing_imports = True
+
+[mypy-service_identity]
+ignore_missing_imports = True
+[mypy-service_identity.*]
+ignore_missing_imports = True
+
+[mypy-sets]
+ignore_missing_imports = True
+
+[mypy-SOAPpy]
+ignore_missing_imports = True
+
+[mypy-StringIO]
+ignore_missing_imports = True
+
+[mypy-subunit]
+ignore_missing_imports = True
+
+[mypy-tkinter.*]
+ignore_missing_imports = True
+
+[mypy-twisted_iocpsupport.*]
+ignore_missing_imports = True
+
+[mypy-win32api]
+ignore_missing_imports = True
+[mypy-win32com.shell]
+ignore_missing_imports = True
+[mypy-win32con]
+ignore_missing_imports = True
+[mypy-win32console]
+ignore_missing_imports = True
+[mypy-win32event]
+ignore_missing_imports = True
+[mypy-win32file]
+ignore_missing_imports = True
+[mypy-win32gui]
+ignore_missing_imports = True
+[mypy-win32pipe]
+ignore_missing_imports = True
+[mypy-win32process]
+ignore_missing_imports = True
+[mypy-win32security]
+ignore_missing_imports = True
+
+[mypy-wx]
+ignore_missing_imports = True
+
+[mypy-wxPython.*]
+ignore_missing_imports = True


### PR DESCRIPTION
The current `mypy.ini` file sets `ignore_missing_imports=True` globally.

We should instead disable it specifically for packages that are known to lack type stubs. That ensures that for those where we expect type stubs, the Mypy error is not suppressed if they are missing.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10168
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
