### PR TITLE
10169 Fix typos in documentation

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -403,8 +403,8 @@ class Deferred(Awaitable[_DeferredResultT]):
 
         @param canceller: a callable used to stop the pending operation
             scheduled by this L{Deferred} when L{Deferred.cancel} is invoked.
-            The canceller will be passed the deferred whose cancelation is
-            requested (i.e., self).
+            The canceller will be passed the deferred whose cancellation is
+            requested (i.e., C{self}).
 
             If a canceller is not given, or does not invoke its argument's
             C{callback} or C{errback} method, L{Deferred.cancel} will
@@ -586,7 +586,7 @@ class Deferred(Awaitable[_DeferredResultT]):
 
         def convertCancelled(value: object) -> object:
             # if C{deferred} was timed out, call the translation function,
-            # if provdied, otherwise just use L{cancelledToTimedOutError}
+            # if provided, otherwise just use L{cancelledToTimedOutError}
             if timedOut[0]:
                 toCall = onTimeoutCancel or _cancelledToTimedOutError
                 return toCall(value, timeout)

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -104,7 +104,7 @@ class LoopingCall:
         elapsed, or if the callable itself blocks for longer than an interval,
         preventing I{itself} from being called.
 
-        When running with an interval if 0, count will be always 1.
+        When running with an interval of 0, count will be always 1.
 
         @param countCallable: A callable that will be invoked each time the
             resulting LoopingCall is run, with an integer specifying the number

--- a/src/twisted/protocols/dict.py
+++ b/src/twisted/protocols/dict.py
@@ -288,7 +288,7 @@ class DictClient(basic.LineReceiver):
         pass
 
     def matchFailed(self, reason):
-        """override to catch resonable failure responses to MATCH"""
+        """override to catch reasonable failure responses to MATCH"""
         pass
 
     def matchDone(self, result):

--- a/src/twisted/protocols/socks.py
+++ b/src/twisted/protocols/socks.py
@@ -132,7 +132,7 @@ class SOCKSv4(protocol.Protocol):
         @param version: The SOCKS protocol version number.
 
         @type code: L{int}
-        @param code: The comand code. 1 means establish a TCP/IP stream
+        @param code: The command code. 1 means establish a TCP/IP stream
             connection, and 2 means establish a TCP/IP port binding.
 
         @type port: L{int}


### PR DESCRIPTION
## Scope and purpose

Collecting a few typo fixes in documentation.

This pulls in the commits from PR #1477 and PR #1497 as well as a couple other minuscule fixes.

## Contributor Checklist:

* [X] The associated [ticket in Trac](https://twistedmatrix.com/trac/ticket/10169)
* [X] I ran `tox -e lint`
* [X] I have created a newsfragment in src/twisted/newsfragments/ 
* [X] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* N/A I have updated the automated tests and checked that all checks for the PR are green.
* [X] I have submitted the associated Trac ticket for review
* [X] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
