### PR TITLE
[10171] Fix coverage run random failures on PYPY due to SQLite error.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ dev =
     # TODO: support python-subunit in py3.10 https://twistedmatrix.com/trac/ticket/10115
     python-subunit ~= 1.4; python_version < "3.10"
     twistedchecker ~= 0.7
-    coverage ~= 5.5
+    #WIP: coverage ~= 5.5
 
 tls =
     pyopenssl >= 16.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,9 @@ dev =
     # TODO: support python-subunit in py3.10 https://twistedmatrix.com/trac/ticket/10115
     python-subunit ~= 1.4; python_version < "3.10"
     twistedchecker ~= 0.7
-    #WIP: coverage ~= 5.5
+    # To be pinned to a minor version once PYPY `coverage run` error is fixed.
+    # See: https://twistedmatrix.com/trac/ticket/10171
+    coverage
 
 tls =
     pyopenssl >= 16.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,10 @@ extras =
 ;; dependencies that are not specified as extras
 deps =
     lint: pre-commit
+    # For now we use a dev version of coverage with a fix for `coverage run`
+    # on PYPY.
+    # This should be moved
+    # See: https://twistedmatrix.com/trac/ticket/10171
     withcov: https://github.com/nedbat/coveragepy/archive/refs/heads/nedbat/another-1010.zip
 
 ; All environment variables are passed.

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ extras =
 ;; dependencies that are not specified as extras
 deps =
     lint: pre-commit
+    withcov: https://github.com/nedbat/coveragepy/archive/refs/heads/nedbat/another-1010.zip
 
 ; All environment variables are passed.
 passenv = *


### PR DESCRIPTION
## Scope and purpose

Coverage runs on PYPY fails

https://github.com/twisted/twisted/pull/1577/checks?check_run_id=2274177993#step:9:751

Experimental fix discussed here https://github.com/nedbat/coveragepy/issues/1010

This is the Twisted integration branch.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10171
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10171

Fix coverage run on PYPY due to SQLite error.
```
