### PR TITLE
10173  Remove py2.4 sets module support from jelly.py

### DIFF
--- a/src/twisted/spread/jelly.py
+++ b/src/twisted/spread/jelly.py
@@ -86,19 +86,6 @@ from incremental import Version
 _SetTypes = [set]
 _ImmutableSetTypes = [frozenset]
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", category=DeprecationWarning)
-    try:
-        import sets as _sets
-    except ImportError:
-        # sets module is deprecated in Python 2.6, and gone in
-        # Python 3
-        _sets = None
-    else:
-        _SetTypes.append(_sets.Set)
-        _ImmutableSetTypes.append(_sets.ImmutableSet)
-
-
 DictTypes = (dict,)
 
 None_atom = b"None"  # N

--- a/src/twisted/spread/jelly.py
+++ b/src/twisted/spread/jelly.py
@@ -51,14 +51,13 @@ Instance Method: s.center, where s is an instance of UserString.UserString::
     ['module', 'UserString'], 'UserString']], ['dictionary', ['data', 'd']]],
     ['dereference', 1]]
 
-The C{set} builtin and the C{sets.Set} class are serialized to the same
-thing, and unserialized to C{set} if available, else to C{sets.Set}. It means
-that there's a possibility of type switching in the serialization process. The
-solution is to always use C{set}.
-
-The same rule applies for C{frozenset} and C{sets.ImmutableSet}.
+The Python 2.x C{sets.Set} and C{sets.ImmutableSet} classes are
+serialized to the same thing as the builtin C{set} and C{frozenset}
+classes.  (This is only relevant if you are communicating with a
+version of jelly running on an older version of Python.)
 
 @author: Glyph Lefkowitz
+
 """
 
 # System Imports
@@ -81,10 +80,6 @@ from twisted.spread.interfaces import IJellyable, IUnjellyable
 
 from twisted.python.deprecate import deprecatedModuleAttribute
 from incremental import Version
-
-
-_SetTypes = [set]
-_ImmutableSetTypes = [frozenset]
 
 DictTypes = (dict,)
 
@@ -538,9 +533,9 @@ class _Jellier:
                     sxp.append(dictionary_atom)
                     for key, val in obj.items():
                         sxp.append([self.jelly(key), self.jelly(val)])
-                elif objType in _SetTypes:
+                elif objType is set:
                     sxp.extend(self._jellyIterable(set_atom, obj))
-                elif objType in _ImmutableSetTypes:
+                elif objType is frozenset:
                     sxp.extend(self._jellyIterable(frozenset_atom, obj))
                 else:
                     className = qual(obj.__class__).encode("utf-8")

--- a/src/twisted/spread/test/test_jelly.py
+++ b/src/twisted/spread/test/test_jelly.py
@@ -8,7 +8,6 @@ Test cases for L{jelly} object serialization.
 
 import datetime
 import decimal
-from unittest import skipIf
 
 from twisted.spread import banana, jelly, pb
 from twisted.trial import unittest
@@ -331,41 +330,6 @@ class JellyTests(TestCase):
         """
         inputList = [frozenset([1, 2, 3])]
         self._testSecurity(inputList, b"frozenset")
-
-    @skipIf(not jelly._sets, "sets.Set is gone in Python 3 and higher")
-    def test_oldSets(self):
-        """
-        Test jellying C{sets.Set}: it should serialize to the same thing as
-        C{set} jelly, and be unjellied as C{set} if available.
-        """
-        inputList = [jelly._sets.Set([1, 2, 3])]
-        inputJelly = jelly.jelly(inputList)
-        self.assertEqual(inputJelly, jelly.jelly([{1, 2, 3}]))
-        output = jelly.unjelly(inputJelly)
-        # Even if the class is different, it should coerce to the same list
-        self.assertEqual(list(inputList[0]), list(output[0]))
-        if set is jelly._sets.Set:
-            self.assertIsInstance(output[0], jelly._sets.Set)
-        else:
-            self.assertIsInstance(output[0], set)
-
-    @skipIf(not jelly._sets, "sets.ImmutableSets is gone in Python 3 " "and higher")
-    def test_oldImmutableSets(self):
-        """
-        Test jellying C{sets.ImmutableSet}: it should serialize to the same
-        thing as L{frozenset} jelly, and be unjellied as L{frozenset} if
-        available.
-        """
-        inputList = [jelly._sets.ImmutableSet([1, 2, 3])]
-        inputJelly = jelly.jelly(inputList)
-        self.assertEqual(inputJelly, jelly.jelly([frozenset([1, 2, 3])]))
-        output = jelly.unjelly(inputJelly)
-        # Even if the class is different, it should coerce to the same list
-        self.assertEqual(list(inputList[0]), list(output[0]))
-        if frozenset is jelly._sets.ImmutableSet:
-            self.assertIsInstance(output[0], jelly._sets.ImmutableSet)
-        else:
-            self.assertIsInstance(output[0], frozenset)
 
     def test_simple(self):
         """


### PR DESCRIPTION
Pretty straightforward: this code can never be executed any more, nor can the tests for it ever not be skipped.

* [X] The [associated ticket in Trac](https://twistedmatrix.com/trac/ticket/10173#ticket)
* [X] I ran `tox -e lint`
* [X] I have created a newsfragment
* [X] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review
* [X] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: wiml
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10173
Refs: ticket:8616

Remove py2.4 sets module support from jelly.py
```
