### PR TITLE
10172 Bump required version of mypy-zope to 0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -118,7 +118,7 @@ osx_platform =
 
 mypy =
     mypy==0.812
-    mypy-zope==0.2.13
+    mypy-zope==0.3.0
     %(dev)s
     %(all_non_platform)s
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1144,7 +1144,7 @@ class ReactorBase(PluggableResolverMixin):
             self.installNameResolver(_GAIResolver(self, self.getThreadPool))
             self.usingThreads = True
 
-        def callFromThread(
+        def callFromThread(  # type: ignore[override]
             self, f: Callable[..., Any], *args: object, **kwargs: object
         ) -> None:
             """
@@ -1199,7 +1199,7 @@ class ReactorBase(PluggableResolverMixin):
                 assert self.threadpool is not None
             return self.threadpool
 
-        def callInThread(
+        def callInThread(  # type: ignore[override]
             self, _callable: Callable[..., Any], *args: object, **kwargs: object
         ) -> None:
             """

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1144,6 +1144,9 @@ class ReactorBase(PluggableResolverMixin):
             self.installNameResolver(_GAIResolver(self, self.getThreadPool))
             self.usingThreads = True
 
+        # `IReactorFromThreads` defines the first named argument as
+        # `callable: Callable[..., Any]` but this defines it as `f`
+        # really both should be defined using py3.8 positional only
         def callFromThread(  # type: ignore[override]
             self, f: Callable[..., Any], *args: object, **kwargs: object
         ) -> None:
@@ -1199,6 +1202,9 @@ class ReactorBase(PluggableResolverMixin):
                 assert self.threadpool is not None
             return self.threadpool
 
+        # `IReactorInThreads` defines the first named argument as
+        # `callable: Callable[..., Any]` but this defines it as `_callable`
+        # really both should be defined using py3.8 positional only
         def callInThread(  # type: ignore[override]
             self, _callable: Callable[..., Any], *args: object, **kwargs: object
         ) -> None:

--- a/src/twisted/newsfragments/10172.misc
+++ b/src/twisted/newsfragments/10172.misc
@@ -1,0 +1,1 @@
+Bump required version of mypy-zope to 0.3.0

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -337,6 +337,8 @@ def proxyForInterface(iface, originalAttribute="original"):
     for name in iface:
         contents[name] = _ProxyDescriptor(name, originalAttribute)
     proxy = type("(Proxy for {})".format(reflect.qual(iface)), (object,), contents)
+    # mypy-zope declarations.classImplements only works when passing
+    # a concrete class type
     declarations.classImplements(proxy, iface)  # type: ignore[misc]
     return proxy
 

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -337,7 +337,7 @@ def proxyForInterface(iface, originalAttribute="original"):
     for name in iface:
         contents[name] = _ProxyDescriptor(name, originalAttribute)
     proxy = type("(Proxy for {})".format(reflect.qual(iface)), (object,), contents)
-    declarations.classImplements(proxy, iface)
+    declarations.classImplements(proxy, iface)  # type: ignore[misc]
     return proxy
 
 


### PR DESCRIPTION
## Scope and purpose

mypy-zope 0.3.0 adds support for using the @overload decorator in interfaces ( see ​https://github.com/Shoobx/mypy-zope/issues/46 ), which is needed in at least one place in Twisted.

mypy-zope is also stricter on interface definitions, and so I've had to type: ignore those places


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10172
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```