### PR TITLE
10185: Implement 308 redirect for twisted.web.client.HTTPPageGetter

### DIFF
--- a/src/twisted/newsfragments/10185.feature
+++ b/src/twisted/newsfragments/10185.feature
@@ -1,0 +1,1 @@
+Implemented 308 redirect for twisted.web.client.HTTPPageGetter

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -209,6 +209,9 @@ class HTTPPageGetter(http.HTTPClient):
     def handleStatus_303(self):
         self.factory.method = b"GET"
         self.handleStatus_301()
+        
+    def handleStatus_308(self):
+        self.handleStatus_301()
 
     def connectionLost(self, reason):
         """


### PR DESCRIPTION
## Scope and purpose

twisted.web.client.HTTPPageGetter does not implement the function handleStatus_308, so the HTTP client is unable to follow 308 redirects. This patch implements the missing function and allows HTTPPageGetter to follow "308 Permanent Redirect" HTTP status.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10185
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.