### PR TITLE
10186: Fix cancellation of deferred flattening

### DIFF
--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -162,7 +162,7 @@ def _fork(d):
     Create a new L{Deferred} based on C{d} that will fire and fail with C{d}'s
     result or error, but will not modify C{d}'s callback type.
     """
-    d2 = Deferred(d.cancel)
+    d2 = Deferred(lambda _: d.cancel)
 
     def callback(result):
         d2.callback(result)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -15,7 +15,13 @@ from textwrap import dedent
 from twisted.test.testutils import XMLAssertionMixin
 from xml.etree.ElementTree import XML
 
-from twisted.internet.defer import Deferred, gatherResults, passthru, succeed
+from twisted.internet.defer import (
+    CancelledError,
+    Deferred,
+    gatherResults,
+    passthru,
+    succeed,
+)
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.error import (
     FlattenerError,
@@ -563,3 +569,17 @@ class FlattenerErrorTests(SynchronousTestCase):
         # The original exception is unmodified and will be logged separately if
         # unhandled.
         self.failureResultOf(failing, RuntimeError)
+
+    def test_cancel(self):
+        """
+        The flattening of a Deferred can be cancelled.
+        """
+        d = Deferred()
+        flattening = flattenString(None, d)
+        self.assertNoResult(flattening)
+
+        flattening.cancel()
+
+        failure = self.failureResultOf(flattening, FlattenerError)
+        exc = failure.value.args[0]
+        self.assertIsInstance(exc, CancelledError)


### PR DESCRIPTION
## Scope and purpose

Fixes a regression introduced in #1549.

I ran into this problem when mypy flagged it while I was adding type annotations. Those type annotations will come in a future PR, but @glyph preferred this to get fixed quickly.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10186
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green. -> The red test is a known issue unrelated to this PR.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: mthuurne
Reviewer: glyph
Fixes: ticket:10186

Fix cancellation of deferred flattening.
Add a test case to demonstrate the bug.
```
