### PR TITLE
Revert "10186: Fix cancellation of deferred flattening"

### DIFF
--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -162,7 +162,7 @@ def _fork(d):
     Create a new L{Deferred} based on C{d} that will fire and fail with C{d}'s
     result or error, but will not modify C{d}'s callback type.
     """
-    d2 = Deferred(lambda _: d.cancel)
+    d2 = Deferred(d.cancel)
 
     def callback(result):
         d2.callback(result)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -15,13 +15,7 @@ from textwrap import dedent
 from twisted.test.testutils import XMLAssertionMixin
 from xml.etree.ElementTree import XML
 
-from twisted.internet.defer import (
-    CancelledError,
-    Deferred,
-    gatherResults,
-    passthru,
-    succeed,
-)
+from twisted.internet.defer import Deferred, gatherResults, passthru, succeed
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.error import (
     FlattenerError,
@@ -569,17 +563,3 @@ class FlattenerErrorTests(SynchronousTestCase):
         # The original exception is unmodified and will be logged separately if
         # unhandled.
         self.failureResultOf(failing, RuntimeError)
-
-    def test_cancel(self):
-        """
-        The flattening of a Deferred can be cancelled.
-        """
-        d = Deferred()
-        flattening = flattenString(None, d)
-        self.assertNoResult(flattening)
-
-        flattening.cancel()
-
-        failure = self.failureResultOf(flattening, FlattenerError)
-        exc = failure.value.args[0]
-        self.assertIsInstance(exc, CancelledError)


### PR DESCRIPTION
Reverts twisted/twisted#1590

The fix should have read `lambda _: d.cancel()` instead of `lambda _: d.cancel`. Yet the new test passed, so that wasn't specific enough. And if I fix the code, the test itself starts causing another test case to fail, so it is probably leaving junk behind in the reactor.
