### PR TITLE
10184: Add type annotations to twisted.web.template

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,3 +17,4 @@ ignore_errors = True
 exclude_lines =
     if TYPE_CHECKING
     \s*\.\.\.$
+    raise NotImplementedError

--- a/mypy.ini
+++ b/mypy.ini
@@ -796,6 +796,15 @@ check_untyped_defs = False
 [mypy-twisted.test.test_plugin]
 allow_incomplete_defs = True
 
+[mypy-twisted.web.test.test_flatten]
+allow_untyped_defs = False
+
+[mypy-twisted.web.test.test_stan]
+allow_untyped_defs = False
+
+[mypy-twisted.web.test.test_template]
+allow_untyped_defs = False
+
 [mypy-twisted.web.test.test_util]
 allow_incomplete_defs = True
 
@@ -806,6 +815,18 @@ check_untyped_defs = False
 [mypy-twisted.web.*]
 allow_untyped_defs = True
 check_untyped_defs = False
+
+[mypy-twisted.web._element]
+allow_untyped_defs = False
+
+[mypy-twisted.web._flatten]
+allow_untyped_defs = False
+
+[mypy-twisted.web._stan]
+allow_untyped_defs = False
+
+[mypy-twisted.web.template]
+allow_untyped_defs = False
 
 [mypy-twisted.web.util]
 allow_incomplete_defs = True

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1262,9 +1262,17 @@ class DeferredList(Deferred[List[Tuple[bool, _DeferredResultT]]]):  # type: igno
             logged.  This does not prevent C{fireOnOneErrback} from working.
         """
         self._deferredList = list(deferredList)
+
         self.resultList: List[Optional[Tuple[bool, _DeferredResultT]]] = [None] * len(
             self._deferredList
         )
+        """
+        The final result, in progress.
+        Each item in the list corresponds to the L{Deferred} at the same
+        position in L{_deferredList}. It will be L{None} if the L{Deferred}
+        did not complete yet, or a C{(success, result)} pair if it did.
+        """
+
         Deferred.__init__(self)
         if len(self._deferredList) == 0 and not fireOnOneCallback:
             self.callback([])

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -959,7 +959,11 @@ class Deferred(Awaitable[_DeferredResultT]):
     # type note: base class "Awaitable" defined the type as:
     #     Callable[[], Generator[Any, None, _DeferredResultT]]
     #     See: https://github.com/python/typeshed/issues/5125
-    __await__ = __iter__  # type: ignore[assignment]
+    #     When the typeshed patch is included in a mypy release,
+    #     this method can be replaced by `__await__ = __iter__`.
+    def __await__(self) -> Generator[Any, None, _DeferredResultT]:
+        return self.__iter__()  # type: ignore[return-value]
+
     __next__ = send
 
     def asFuture(self, loop: AbstractEventLoop) -> "Future[_DeferredResultT]":

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -3,7 +3,7 @@
 # See LICENSE for details.
 
 
-from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Callable, List, Optional, TypeVar, Union, overload
 from zope.interface import implementer
 
 from twisted.web.iweb import IRenderable, IRequest, ITemplateLoader
@@ -55,7 +55,7 @@ class Expose:
         if not funcObjs:
             raise TypeError("expose() takes at least 1 argument (0 given)")
         for fObj in funcObjs:
-            exposedThrough = getattr(fObj, "exposedThrough", [])
+            exposedThrough: List[Expose] = getattr(fObj, "exposedThrough", [])
             exposedThrough.append(self)
             setattr(fObj, "exposedThrough", exposedThrough)
         return funcObjs[0]

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -21,9 +21,6 @@ class Expose:
     on the class object of which they are methods.
     """
 
-    def __init__(self, doc=None):
-        self.doc = doc
-
     def __call__(self, *funcObjs):
         """
         Add one or more functions to the set of exposed functions.
@@ -79,20 +76,11 @@ class Expose:
             return default
         return method
 
-    @classmethod
-    def _withDocumentation(cls, thunk):
-        """
-        Slight hack to make users of this class appear to have a docstring to
-        documentation generators, by defining them with a decorator.  (This hack
-        should be removed when epydoc can be convinced to use some other method
-        for documenting.)
-        """
-        return cls(thunk.__doc__)
 
-
-# Avoid exposing the ugly, private classmethod name in the docs.  Luckily this
-# namespace is private already so this doesn't leak further.
-exposer = Expose._withDocumentation
+def exposer(thunk):
+    expose = Expose()
+    expose.__doc__ = thunk.__doc__
+    return expose
 
 
 @exposer

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -19,9 +19,6 @@ class Expose:
     Instances of this class can be called with one or more functions as
     positional arguments.  The names of these functions will be added to a list
     on the class object of which they are methods.
-
-    @ivar attributeName: The attribute with which exposed methods will be
-    tracked.
     """
 
     def __init__(self, doc=None):

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -3,12 +3,15 @@
 # See LICENSE for details.
 
 
-from typing import Optional
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
 from zope.interface import implementer
 
-from twisted.web.iweb import IRenderable, ITemplateLoader
+from twisted.web.iweb import IRenderable, IRequest, ITemplateLoader
 from twisted.web.error import MissingRenderMethod, UnexposedMethodError
 from twisted.web.error import MissingTemplateLoader
+
+
+T = TypeVar("T")
 
 
 class Expose:
@@ -21,7 +24,7 @@ class Expose:
     on the class object of which they are methods.
     """
 
-    def __call__(self, *funcObjs):
+    def __call__(self, *funcObjs: Callable) -> Callable:
         """
         Add one or more functions to the set of exposed functions.
 
@@ -52,13 +55,24 @@ class Expose:
         if not funcObjs:
             raise TypeError("expose() takes at least 1 argument (0 given)")
         for fObj in funcObjs:
-            fObj.exposedThrough = getattr(fObj, "exposedThrough", [])
-            fObj.exposedThrough.append(self)
+            exposedThrough = getattr(fObj, "exposedThrough", [])
+            exposedThrough.append(self)
+            setattr(fObj, "exposedThrough", exposedThrough)
         return funcObjs[0]
 
     _nodefault = object()
 
-    def get(self, instance, methodName, default=_nodefault):
+    @overload
+    def get(self, instance: object, methodName: str) -> Callable:
+        ...
+
+    @overload
+    def get(self, instance: object, methodName: str, default: T) -> Union[Callable, T]:
+        ...
+
+    def get(
+        self, instance: object, methodName: str, default: object = _nodefault
+    ) -> object:
         """
         Retrieve an exposed method with the given name from the given instance.
 
@@ -77,14 +91,14 @@ class Expose:
         return method
 
 
-def exposer(thunk):
+def exposer(thunk: Callable) -> Expose:
     expose = Expose()
     expose.__doc__ = thunk.__doc__
     return expose
 
 
 @exposer
-def renderer():
+def renderer() -> None:
     """
     Decorate with L{renderer} to use methods as template render directives.
 
@@ -131,18 +145,19 @@ class Element:
     L{twisted.web.http.Request} being served and second, the tag object which
     "invoked" the render method.
 
-    @type loader: L{ITemplateLoader} provider
     @ivar loader: The factory which will be used to load documents to
         return from C{render}.
     """
 
     loader: Optional[ITemplateLoader] = None
 
-    def __init__(self, loader=None):
+    def __init__(self, loader: Optional[ITemplateLoader] = None):
         if loader is not None:
             self.loader = loader
 
-    def lookupRenderMethod(self, name):
+    def lookupRenderMethod(
+        self, name: str
+    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
         """
         Look up and return the named render method.
         """
@@ -151,7 +166,7 @@ class Element:
             raise MissingRenderMethod(self, name)
         return method
 
-    def render(self, request):
+    def render(self, request: Optional[IRequest]) -> "Flattenable":
         """
         Implement L{IRenderable} to allow one L{Element} to be embedded in
         another's template or rendering output.
@@ -166,3 +181,7 @@ class Element:
         if loader is None:
             raise MissingTemplateLoader(self)
         return loader.load()
+
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable, Tag

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -10,6 +10,9 @@ from twisted.web.iweb import IRenderable, IRequest, ITemplateLoader
 from twisted.web.error import MissingRenderMethod, UnexposedMethodError
 from twisted.web.error import MissingTemplateLoader
 
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable, Tag
+
 
 T = TypeVar("T")
 
@@ -181,7 +184,3 @@ class Element:
         if loader is None:
             raise MissingTemplateLoader(self)
         return loader.load()
-
-
-if TYPE_CHECKING:
-    from twisted.web.template import Flattenable, Tag

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -241,8 +241,13 @@ def _flattenElement(request, root, write, slotData, renderFactory, dataEscaper):
         write(b"-->")
     elif isinstance(root, Tag):
         slotData.append(root.slotData)
-        if root.render is not None:
-            rendererName = root.render
+        rendererName = root.render
+        if rendererName is not None:
+            if renderFactory is None:
+                raise ValueError(
+                    f'Tag wants to be rendered by method "{rendererName}" '
+                    f"but is not contained in any IRenderable"
+                )
             rootClone = root.clone(False)
             rootClone.render = None
             renderMethod = renderFactory.lookupRenderMethod(rendererName)

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -40,9 +40,9 @@ from twisted.web.iweb import IRenderable, IRequest
 
 T = TypeVar("T")
 
-FlattenableRec = Any
+FlattenableRecursive = Any
 """
-For documentation purposes, read C{FlattenableRec} as L{Flattenable}.
+For documentation purposes, read C{FlattenableRecursive} as L{Flattenable}.
 However, since mypy doesn't support recursive type definitions (yet?),
 we'll put Any in the actual definition.
 """
@@ -54,12 +54,12 @@ Flattenable = Union[
     CDATA,
     Comment,
     Tag,
-    Tuple[FlattenableRec, ...],
-    List[FlattenableRec],
-    Generator[FlattenableRec, None, None],
+    Tuple[FlattenableRecursive, ...],
+    List[FlattenableRecursive],
+    Generator[FlattenableRecursive, None, None],
     CharRef,
-    Deferred[FlattenableRec],
-    Coroutine[Deferred[FlattenableRec], object, FlattenableRec],
+    Deferred[FlattenableRecursive],
+    Coroutine[Deferred[FlattenableRecursive], object, FlattenableRecursive],
     IRenderable,
 ]
 """

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -12,17 +12,62 @@ from io import BytesIO
 
 from sys import exc_info
 from types import GeneratorType
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 from traceback import extract_tb
 from inspect import iscoroutine
 
 from twisted.python.compat import nativeString
+
 from twisted.internet.defer import Deferred, ensureDeferred
+from twisted.python.failure import Failure
 from twisted.web._stan import Tag, slot, voidElements, Comment, CDATA, CharRef
 from twisted.web.error import UnfilledSlot, UnsupportedType, FlattenerError
-from twisted.web.iweb import IRenderable
+from twisted.web.iweb import IRenderable, IRequest
 
 
-def escapeForContent(data):
+T = TypeVar("T")
+
+FlattenableRec = Any
+"""
+For documentation purposes, read C{FlattenableRec} as L{Flattenable}.
+However, since mypy doesn't support recursive type definitions (yet?),
+we'll put Any in the actual definition.
+"""
+
+Flattenable = Union[
+    bytes,
+    str,
+    slot,
+    CDATA,
+    Comment,
+    Tag,
+    Tuple[FlattenableRec, ...],
+    List[FlattenableRec],
+    Generator[FlattenableRec, None, None],
+    CharRef,
+    Deferred[FlattenableRec],
+    Coroutine[Deferred[FlattenableRec], object, FlattenableRec],
+    IRenderable,
+]
+"""
+Type alias containing all types that can be flattened by L{flatten()}.
+"""
+
+
+def escapeForContent(data: Union[bytes, str]) -> bytes:
     """
     Escape some character or UTF-8 byte data for inclusion in an HTML or XML
     document, by replacing metacharacters (C{&<>}) with their entity
@@ -30,11 +75,9 @@ def escapeForContent(data):
 
     This is used as an input to L{_flattenElement}'s C{dataEscaper} parameter.
 
-    @type data: C{bytes} or C{unicode}
     @param data: The string to escape.
 
-    @rtype: C{bytes}
-    @return: The quoted form of C{data}.  If C{data} is unicode, return a utf-8
+    @return: The quoted form of C{data}.  If C{data} is L{str}, return a utf-8
         encoded string.
     """
     if isinstance(data, str):
@@ -43,7 +86,7 @@ def escapeForContent(data):
     return data
 
 
-def attributeEscapingDoneOutside(data):
+def attributeEscapingDoneOutside(data: Union[bytes, str]) -> bytes:
     """
     Escape some character or UTF-8 byte data for inclusion in the top level of
     an attribute.  L{attributeEscapingDoneOutside} actually passes the data
@@ -53,18 +96,18 @@ def attributeEscapingDoneOutside(data):
     L{_flattenElement} call so that that generator does not redundantly escape
     its text output.
 
-    @type data: C{bytes} or C{unicode}
     @param data: The string to escape.
 
     @return: The string, unchanged, except for encoding.
-    @rtype: C{bytes}
     """
     if isinstance(data, str):
         return data.encode("utf-8")
     return data
 
 
-def writeWithAttributeEscaping(write):
+def writeWithAttributeEscaping(
+    write: Callable[[bytes], object]
+) -> Callable[[bytes], None]:
     """
     Decorate a C{write} callable so that all output written is properly quoted
     for inclusion within an XML attribute value.
@@ -103,20 +146,18 @@ def writeWithAttributeEscaping(write):
     @return: A callable that writes data with escaping.
     """
 
-    def _write(data):
+    def _write(data: bytes) -> None:
         write(escapeForContent(data).replace(b'"', b"&quot;"))
 
     return _write
 
 
-def escapedCDATA(data):
+def escapedCDATA(data: Union[bytes, str]) -> bytes:
     """
     Escape CDATA for inclusion in a document.
 
-    @type data: L{str} or L{unicode}
     @param data: The string to escape.
 
-    @rtype: L{str}
     @return: The quoted form of C{data}. If C{data} is unicode, return a utf-8
         encoded string.
     """
@@ -125,14 +166,12 @@ def escapedCDATA(data):
     return data.replace(b"]]>", b"]]]]><![CDATA[>")
 
 
-def escapedComment(data):
+def escapedComment(data: Union[bytes, str]) -> bytes:
     """
     Escape a comment for inclusion in a document.
 
-    @type data: L{str} or L{unicode}
     @param data: The string to escape.
 
-    @rtype: C{str}
     @return: The quoted form of C{data}. If C{data} is unicode, return a utf-8
         encoded string.
     """
@@ -144,7 +183,11 @@ def escapedComment(data):
     return data
 
 
-def _getSlotValue(name, slotData, default=None):
+def _getSlotValue(
+    name: str,
+    slotData: Sequence[Optional[Mapping[str, Flattenable]]],
+    default: Optional[Flattenable] = None,
+) -> Flattenable:
     """
     Find the value of the named slot in the given stack of slot data.
     """
@@ -157,18 +200,18 @@ def _getSlotValue(name, slotData, default=None):
         raise UnfilledSlot(name)
 
 
-def _fork(d):
+def _fork(d: Deferred[T]) -> Deferred[T]:
     """
     Create a new L{Deferred} based on C{d} that will fire and fail with C{d}'s
     result or error, but will not modify C{d}'s callback type.
     """
-    d2 = Deferred(lambda _: d.cancel())
+    d2: Deferred[T] = Deferred(lambda _: d.cancel())
 
-    def callback(result):
+    def callback(result: T) -> T:
         d2.callback(result)
         return result
 
-    def errback(failure):
+    def errback(failure: Failure) -> Failure:
         d2.errback(failure)
         return failure
 
@@ -176,7 +219,17 @@ def _fork(d):
     return d2
 
 
-def _flattenElement(request, root, write, slotData, renderFactory, dataEscaper):
+def _flattenElement(
+    request: Optional[IRequest],
+    root: Flattenable,
+    write: Callable[[bytes], object],
+    slotData: List[Optional[Mapping[str, Flattenable]]],
+    renderFactory: Optional[IRenderable],
+    dataEscaper: Callable[[Union[bytes, str]], bytes],
+    # This is annotated as Generator[T, None, None] instead of Iterator[T]
+    # because mypy does not consider an Iterator to be an instance of
+    # GeneratorType.
+) -> Generator[Union[Generator, Deferred[Flattenable]], None, None]:
     """
     Make C{root} slightly more flat by yielding all its immediate contents as
     strings, deferreds or generators that are recursive calls to itself.
@@ -205,25 +258,25 @@ def _flattenElement(request, root, write, slotData, renderFactory, dataEscaper):
         whether the rendering context is within an attribute or not.  See the
         explanation in L{writeWithAttributeEscaping}.
 
-    @return: An iterator that eventually yields L{bytes} that should be written
-        to the output.  However it may also yield other iterators or
-        L{Deferred}s; if it yields another iterator, the caller will iterate
-        it; if it yields a L{Deferred}, the result of that L{Deferred} will
-        either be L{bytes}, in which case it's written, or another generator,
-        in which case it is iterated.  See L{_flattenTree} for the trampoline
-        that consumes said values.
-    @rtype: An iterator which yields L{bytes}, L{Deferred}, and more iterators
-        of the same type.
+    @return: An iterator that eventually writes L{bytes} to C{write}.
+        It can yield other iterators or L{Deferred}s; if it yields another
+        iterator, the caller will iterate it; if it yields a L{Deferred},
+        the result of that L{Deferred} will be another generator, in which
+        case it is iterated.  See L{_flattenTree} for the trampoline that
+        consumes said values.
     """
 
     def keepGoing(
-        newRoot, dataEscaper=dataEscaper, renderFactory=renderFactory, write=write
-    ):
+        newRoot: Flattenable,
+        dataEscaper: Callable[[Union[bytes, str]], bytes] = dataEscaper,
+        renderFactory: Optional[IRenderable] = renderFactory,
+        write: Callable[[bytes], object] = write,
+    ) -> Generator[Union[Generator, Deferred[Generator]], None, None]:
         return _flattenElement(
             request, newRoot, write, slotData, renderFactory, dataEscaper
         )
 
-    def keepGoingAsync(result):
+    def keepGoingAsync(result: Deferred[Flattenable]) -> Deferred[Flattenable]:
         return result.addCallback(keepGoing)
 
     if isinstance(root, (bytes, str)):
@@ -299,7 +352,11 @@ def _flattenElement(request, root, write, slotData, renderFactory, dataEscaper):
     elif isinstance(root, Deferred):
         yield keepGoingAsync(_fork(root))
     elif iscoroutine(root):
-        yield keepGoingAsync(Deferred.fromCoroutine(root))
+        yield keepGoingAsync(
+            Deferred.fromCoroutine(
+                cast(Coroutine[Deferred[Flattenable], object, Flattenable], root)
+            )
+        )
     elif IRenderable.providedBy(root):
         result = root.render(request)
         yield keepGoing(result, renderFactory=root)
@@ -307,7 +364,9 @@ def _flattenElement(request, root, write, slotData, renderFactory, dataEscaper):
         raise UnsupportedType(root)
 
 
-async def _flattenTree(request, root, write):
+async def _flattenTree(
+    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+) -> None:
     """
     Make C{root} into an iterable of L{bytes} and L{Deferred} by doing a depth
     first traversal of the tree.
@@ -325,7 +384,9 @@ async def _flattenTree(request, root, write):
 
     @return: A C{Deferred}-returning coroutine that resolves to C{None}.
     """
-    stack = [_flattenElement(request, root, write, [], None, escapeForContent)]
+    stack: List[Generator] = [
+        _flattenElement(request, root, write, [], None, escapeForContent)
+    ]
     while stack:
         try:
             frame = stack[-1].gi_frame
@@ -345,7 +406,9 @@ async def _flattenTree(request, root, write):
             stack.append(element)
 
 
-def flatten(request, root, write):
+def flatten(
+    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+) -> Deferred[None]:
     """
     Incrementally write out a string representation of C{root} using C{write}.
 
@@ -356,7 +419,7 @@ def flatten(request, root, write):
     @param request: A request object which will be passed to the C{render}
         method of any L{IRenderable} provider which is encountered.
 
-    @param root: An object to be made flatter.  This may be of type L{unicode},
+    @param root: An object to be made flatter.  This may be of type L{str},
         L{bytes}, L{slot}, L{Tag <twisted.web.template.Tag>}, L{tuple},
         L{list}, L{types.GeneratorType}, L{Deferred}, or something that
         provides L{IRenderable}.
@@ -371,7 +434,7 @@ def flatten(request, root, write):
     return ensureDeferred(_flattenTree(request, root, write))
 
 
-def flattenString(request, root):
+def flattenString(request: Optional[IRequest], root: Flattenable) -> Deferred[bytes]:
     """
     Collate a string representation of C{root} into a single string.
 
@@ -379,11 +442,11 @@ def flattenString(request, root):
     the results. See L{flatten} for the exact meanings of C{request} and
     C{root}.
 
-    @return: A L{Deferred} which will be called back with a single string as
-        its result when C{root} has been completely flattened into C{write} or
-        which will be errbacked if an unexpected exception occurs.
+    @return: A L{Deferred} which will be called back with a single UTF-8 encoded
+        string as its result when C{root} has been completely flattened or which
+        will be errbacked if an unexpected exception occurs.
     """
     io = BytesIO()
     d = flatten(request, root, io.write)
     d.addCallback(lambda _: io.getvalue())
-    return d
+    return cast(Deferred[bytes], d)

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -22,12 +22,9 @@ cumbersome.
 """
 
 
-from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import attr
-
-
-T = TypeVar("T")
 
 
 @attr.s(hash=False, eq=False, auto_attribs=True)
@@ -201,9 +198,11 @@ class Tag:
                 self.attributes[k] = v
         return self
 
-    def _clone(self, obj: T, deep: bool) -> T:
+    def _clone(self, obj: "Flattenable", deep: bool) -> "Flattenable":
         """
-        Clone an arbitrary object; used by L{Tag.clone}.
+        Clone a C{Flattenable} object; used by L{Tag.clone}.
+
+        Note that both lists and tuples are cloned into lists.
 
         @param obj: an object with a clone method, a list or tuple, or something
             which should be immutable.
@@ -214,9 +213,9 @@ class Tag:
         @return: a clone of C{obj}.
         """
         if hasattr(obj, "clone"):
-            return obj.clone(deep)  # type: ignore[attr-defined, no-any-return]
+            return obj.clone(deep)  # type: ignore[union-attr]
         elif isinstance(obj, (list, tuple)):
-            return [self._clone(x, deep) for x in obj]  # type: ignore[return-value]
+            return [self._clone(x, deep) for x in obj]
         else:
             return obj
 

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -22,7 +22,9 @@ cumbersome.
 """
 
 
+from inspect import isgenerator, iscoroutine
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from warnings import warn
 
 import attr
 
@@ -219,6 +221,24 @@ class Tag:
             return obj.clone(deep)  # type: ignore[union-attr]
         elif isinstance(obj, (list, tuple)):
             return [self._clone(x, deep) for x in obj]
+        elif isgenerator(obj):
+            warn(
+                "Cloning a Tag which contains a generator is unsafe, "
+                "since the generator can be consumed only once; "
+                "this is deprecated since Twisted NEXT and will raise "
+                "an exception in the future",
+                DeprecationWarning,
+            )
+            return obj
+        elif iscoroutine(obj):
+            warn(
+                "Cloning a Tag which contains a coroutine is unsafe, "
+                "since the coroutine can run only once; "
+                "this is deprecated since Twisted NEXT and will raise "
+                "an exception in the future",
+                DeprecationWarning,
+            )
+            return obj
         else:
             return obj
 

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -292,6 +292,7 @@ voidElements = (
 )
 
 
+@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
 class CDATA:
     """
     A C{<![CDATA[]]>} block from a template.  Given a separate representation in
@@ -299,14 +300,14 @@ class CDATA:
     information.
     """
 
-    def __init__(self, data: str):
-        self.data: str = data
-        """The data between "C{<![CDATA[}" and "C{]]>}"."""
+    data: str
+    """The data between "C{<![CDATA[}" and "C{]]>}"."""
 
     def __repr__(self) -> str:
         return f"CDATA({self.data!r})"
 
 
+@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
 class Comment:
     """
     A C{<!-- -->} comment from a template.  Given a separate representation in
@@ -314,14 +315,14 @@ class Comment:
     information.
     """
 
-    def __init__(self, data: str):
-        self.data: str = data
-        """The data between "C{<!--}" and "C{-->}"."""
+    data: str
+    """The data between "C{<!--}" and "C{-->}"."""
 
     def __repr__(self) -> str:
         return f"Comment({self.data!r})"
 
 
+@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
 class CharRef:
     """
     A numeric character reference.  Given a separate representation in the DOM
@@ -330,9 +331,8 @@ class CharRef:
     @since: 12.0
     """
 
-    def __init__(self, ordinal: int):
-        self.ordinal: int = ordinal
-        """The ordinal value of the unicode character to which this object refers."""
+    ordinal: int
+    """The ordinal value of the unicode character to which this object refers."""
 
     def __repr__(self) -> str:
         return "CharRef(%d)" % (self.ordinal,)

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -24,52 +24,60 @@ cumbersome.
 
 from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
+import attr
+
 
 T = TypeVar("T")
 
 
+@attr.s(hash=False, eq=False, auto_attribs=True)
 class slot:
     """
     Marker for markup insertion in a template.
-
-    @ivar name: The name of this slot.  The key which must be used in
-        L{Tag.fillSlots} to fill it.
-
-    @ivar children: The L{Tag} objects included in this L{slot}'s template.
-
-    @ivar default: The default contents of this slot, if it is left unfilled.
-        If this is L{None}, an L{UnfilledSlot} will be raised, rather than
-        L{None} actually being used.
-
-    @ivar filename: The name of the XML file from which this tag was parsed.
-        If it was not parsed from an XML file, L{None}.
-
-    @ivar lineNumber: The line number on which this tag was encountered in the
-        XML file from which it was parsed.  If it was not parsed from an XML
-        file, L{None}.
-
-    @ivar columnNumber: The column number at which this tag was encountered in
-        the XML file from which it was parsed.  If it was not parsed from an
-        XML file, L{None}.
     """
 
-    def __init__(
-        self,
-        name: str,
-        default: Optional["Flattenable"] = None,
-        filename: Optional[str] = None,
-        lineNumber: Optional[int] = None,
-        columnNumber: Optional[int] = None,
-    ):
-        self.name: str = name
-        self.children: List[Tag] = []
-        self.default: Optional["Flattenable"] = default
-        self.filename: Optional[str] = filename
-        self.lineNumber: Optional[int] = lineNumber
-        self.columnNumber: Optional[int] = columnNumber
+    name: str
+    """
+    The name of this slot.
 
-    def __repr__(self) -> str:
-        return f"slot({self.name!r})"
+    The key which must be used in L{Tag.fillSlots} to fill it.
+    """
+
+    children: List["Tag"] = attr.ib(init=False, factory=list)
+    """
+    The L{Tag} objects included in this L{slot}'s template.
+    """
+
+    default: Optional["Flattenable"] = None
+    """
+    The default contents of this slot, if it is left unfilled.
+
+    If this is L{None}, an L{UnfilledSlot} will be raised, rather than
+    L{None} actually being used.
+    """
+
+    filename: Optional[str] = None
+    """
+    The name of the XML file from which this tag was parsed.
+
+    If it was not parsed from an XML file, L{None}.
+    """
+
+    lineNumber: Optional[int] = None
+    """
+    The line number on which this tag was encountered in the XML file
+    from which it was parsed.
+
+    If it was not parsed from an XML file, L{None}.
+    """
+
+    columnNumber: Optional[int] = None
+    """
+    The column number at which this tag was encountered in the XML file
+    from which it was parsed.
+
+    If it was not parsed from an XML file, L{None}.
+    """
 
 
 class Tag:

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -192,6 +192,10 @@ class Tag:
                 k = k[:-1]
 
             if k == "render":
+                if not isinstance(v, str):
+                    raise TypeError(
+                        f'Value for "render" attribute must be str, got {v!r}'
+                    )
                 self.render = v
             else:
                 self.attributes[k] = v

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -26,6 +26,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import attr
 
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
+
 
 @attr.s(hash=False, eq=False, auto_attribs=True)
 class slot:
@@ -335,7 +338,3 @@ class CharRef:
 
     def __repr__(self) -> str:
         return "CharRef(%d)" % (self.ordinal,)
-
-
-if TYPE_CHECKING:
-    from twisted.web.template import Flattenable

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -80,6 +80,7 @@ class slot:
     """
 
 
+@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
 class Tag:
     """
     A L{Tag} represents an XML tags with a tag name, attributes, and children.
@@ -96,13 +97,13 @@ class Tag:
     For a tag like C{<div></div>}, this would be C{"div"}.
     """
 
-    attributes: Dict[Union[bytes, str], "Flattenable"]
+    attributes: Dict[Union[bytes, str], "Flattenable"] = attr.ib(factory=dict)
     """The attributes of the element."""
 
-    children: List["Flattenable"]
+    children: List["Flattenable"] = attr.ib(factory=list)
     """The contents of this C{Tag}."""
 
-    render: Optional[str]
+    render: Optional[str] = None
     """
     The name of the render method to use for this L{Tag}.
 
@@ -135,7 +136,7 @@ class Tag:
     If it was not parsed from an XML file, L{None}.
     """
 
-    slotData: Optional[Dict[str, "Flattenable"]] = None
+    slotData: Optional[Dict[str, "Flattenable"]] = attr.ib(init=False, default=None)
     """
     The data which can fill slots.
 
@@ -143,33 +144,6 @@ class Tag:
     The values in this dict might be anything that can be present as
     the child of a L{Tag}: strings, lists, L{Tag}s, generators, etc.
     """
-
-    def __init__(
-        self,
-        tagName: Union[bytes, str],
-        attributes: Optional[Dict[Union[bytes, str], "Flattenable"]] = None,
-        children: Optional[List["Flattenable"]] = None,
-        render: Optional[str] = None,
-        filename: Optional[str] = None,
-        lineNumber: Optional[int] = None,
-        columnNumber: Optional[int] = None,
-    ):
-        self.tagName = tagName
-        self.render = render
-        if attributes is None:
-            self.attributes = {}
-        else:
-            self.attributes = attributes
-        if children is None:
-            self.children = []
-        else:
-            self.children = children
-        if filename is not None:
-            self.filename = filename
-        if lineNumber is not None:
-            self.lineNumber = lineNumber
-        if columnNumber is not None:
-            self.columnNumber = columnNumber
 
     def fillSlots(self, **slots: "Flattenable") -> "Tag":
         """

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -18,6 +18,9 @@ from twisted.internet.interfaces import IPushProducer
 from twisted.cred.credentials import IUsernameDigestHash
 from twisted.web.http_headers import Headers
 
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable, Tag
+
 
 class IRequest(Interface):
     """
@@ -825,7 +828,3 @@ __all__ = [
     "IClientRequest",
     "UNKNOWN_LENGTH",
 ]
-
-
-if TYPE_CHECKING:
-    from twisted.web.template import Flattenable, Tag

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -9,7 +9,7 @@ Interface definitions for L{twisted.web}.
     L{IBodyProducer.length} to indicate that the length of the entity
     body is not known in advance.
 """
-from typing import Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from zope.interface import Interface, Attribute
 
@@ -508,11 +508,12 @@ class IRenderable(Interface):
     L{twisted.web.template} templating system.
     """
 
-    def lookupRenderMethod(name):
+    def lookupRenderMethod(
+        name: str,
+    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
         """
         Look up and return the render method associated with the given name.
 
-        @type name: L{str}
         @param name: The value of a render directive encountered in the
             document returned by a call to L{IRenderable.render}.
 
@@ -521,11 +522,10 @@ class IRenderable(Interface):
             was encountered.
         """
 
-    def render(request):
+    def render(request: Optional[IRequest]) -> "Flattenable":
         """
         Get the document for this L{IRenderable}.
 
-        @type request: L{IRequest} provider or L{None}
         @param request: The request in response to which this method is being
             invoked.
 
@@ -539,12 +539,12 @@ class ITemplateLoader(Interface):
     L{twisted.web.template.Element}'s C{loader} attribute.
     """
 
-    def load():
+    def load() -> List["Flattenable"]:
         """
         Load a template suitable for rendering.
 
-        @return: a L{list} of L{list}s, L{unicode} objects, C{Element}s and
-            other L{IRenderable} providers.
+        @return: a L{list} of flattenable objects, such as byte and unicode
+            strings, L{twisted.web.template.Element}s and L{IRenderable} providers.
         """
 
 
@@ -825,3 +825,7 @@ __all__ = [
     "IClientRequest",
     "UNKNOWN_LENGTH",
 ]
+
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable, Tag

--- a/src/twisted/web/newsfragments/10184.feature
+++ b/src/twisted/web/newsfragments/10184.feature
@@ -1,1 +1,2 @@
 twisted.web.template.renderElement() now accepts any IRequest implementer instead of only twisted.web.server.Request.
+Add type hints to twisted.web.template.

--- a/src/twisted/web/newsfragments/10184.feature
+++ b/src/twisted/web/newsfragments/10184.feature
@@ -1,0 +1,1 @@
+twisted.web.template.renderElement() now accepts any IRequest implementer instead of only twisted.web.server.Request.

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -657,7 +657,7 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
             "An error occurred while rendering the response.", failure=failure
         )
         if request.site.displayTracebacks:
-            return flatten(request, _failElement(failure), request.write).encode("utf8")
+            return flatten(request, _failElement(failure), request.write)
         else:
             request.write(
                 b'<div style="font-size:800%;'
@@ -665,6 +665,7 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
                 b"color:#F00"
                 b'">An error occurred while rendering the response.</div>'
             )
+            return None
 
     def finish(result, *, request=request):
         request.finish()

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -23,6 +23,7 @@ __all__ = [
     "TEMPLATE_NAMESPACE",
     "VALID_HTML_TAG_NAMES",
     "Element",
+    "Flattenable",
     "TagLoader",
     "XMLString",
     "XMLFile",
@@ -42,14 +43,30 @@ import warnings
 
 from collections import OrderedDict
 from io import StringIO
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Dict,
+    IO,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from zope.interface import implementer
 
 from xml.sax import make_parser, handler
+from xml.sax.xmlreader import Locator
 
+from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.web._stan import Tag, slot, Comment, CDATA, CharRef
-from twisted.web.iweb import ITemplateLoader
+from twisted.web.iweb import IRenderable, IRequest, ITemplateLoader
 from twisted.logger import Logger
 
 TEMPLATE_NAMESPACE = "http://twistedmatrix.com/ns/twisted.web.template/0.1"
@@ -71,18 +88,18 @@ class _NSContext:
     A mapping from XML namespaces onto their prefixes in the document.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional["_NSContext"] = None):
         """
         Pull out the parent's namespaces, if there's no parent then default to
         XML.
         """
         self.parent = parent
         if parent is not None:
-            self.nss = OrderedDict(parent.nss)
+            self.nss: Dict[Optional[str], Optional[str]] = OrderedDict(parent.nss)
         else:
             self.nss = {"http://www.w3.org/XML/1998/namespace": "xml"}
 
-    def get(self, k, d=None):
+    def get(self, k: Optional[str], d: Optional[str] = None) -> Optional[str]:
         """
         Get a prefix for a namespace.
 
@@ -90,13 +107,13 @@ class _NSContext:
         """
         return self.nss.get(k, d)
 
-    def __setitem__(self, k, v):
+    def __setitem__(self, k: Optional[str], v: Optional[str]) -> None:
         """
         Proxy through to setting the prefix for the namespace.
         """
         self.nss.__setitem__(k, v)
 
-    def __getitem__(self, k):
+    def __getitem__(self, k: Optional[str]) -> Optional[str]:
         """
         Proxy through to getting the prefix for the namespace.
         """
@@ -109,7 +126,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
     Document Object Model.
     """
 
-    def __init__(self, sourceFilename):
+    def __init__(self, sourceFilename: str):
         """
         @param sourceFilename: the filename to load the XML out of.
         """
@@ -117,32 +134,35 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         self.prefixMap = _NSContext()
         self.inCDATA = False
 
-    def setDocumentLocator(self, locator):
+    def setDocumentLocator(self, locator: Locator) -> None:
         """
         Set the document locator, which knows about line and character numbers.
         """
         self.locator = locator
 
-    def startDocument(self):
+    def startDocument(self) -> None:
         """
         Initialise the document.
         """
-        self.document = []
+        # Depending on our active context, the element type can be Tag, slot
+        # or str. Since mypy doesn't understand that context, it would be
+        # a pain to not use Any here.
+        self.document: List[Any] = []
         self.current = self.document
-        self.stack = []
-        self.xmlnsAttrs = []
+        self.stack: List[Any] = []
+        self.xmlnsAttrs: List[Tuple[str, str]] = []
 
-    def endDocument(self):
+    def endDocument(self) -> None:
         """
         Document ended.
         """
 
-    def processingInstruction(self, target, data):
+    def processingInstruction(self, target: str, data: str) -> None:
         """
         Processing instructions are ignored.
         """
 
-    def startPrefixMapping(self, prefix, uri):
+    def startPrefixMapping(self, prefix: Optional[str], uri: str) -> None:
         """
         Set up the prefix mapping, which maps fully qualified namespace URIs
         onto namespace prefixes.
@@ -164,15 +184,22 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         else:
             self.xmlnsAttrs.append(("xmlns:%s" % prefix, uri))
 
-    def endPrefixMapping(self, prefix):
+    def endPrefixMapping(self, prefix: Optional[str]) -> None:
         """
         "Pops the stack" on the prefix mapping.
 
         Gets called after endElementNS.
         """
-        self.prefixMap = self.prefixMap.parent
+        parent = self.prefixMap.parent
+        assert parent is not None, "More prefix mapping ends than starts"
+        self.prefixMap = parent
 
-    def startElementNS(self, namespaceAndName, qname, attrs):
+    def startElementNS(
+        self,
+        namespaceAndName: Tuple[str, str],
+        qname: Optional[str],
+        attrs: Mapping[Tuple[Optional[str], str], str],
+    ) -> None:
         """
         Gets called when we encounter a new xmlns attribute.
 
@@ -192,6 +219,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
             if name == "transparent":
                 name = ""
             elif name == "slot":
+                default: Optional[str]
                 try:
                     # Try to get the default value for the slot
                     default = attrs[(None, "default")]
@@ -199,16 +227,16 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
                     # If there wasn't one, then use None to indicate no
                     # default.
                     default = None
-                el = slot(
+                sl = slot(
                     attrs[(None, "name")],
                     default=default,
                     filename=filename,
                     lineNumber=lineNumber,
                     columnNumber=columnNumber,
                 )
-                self.stack.append(el)
-                self.current.append(el)
-                self.current = el.children
+                self.stack.append(sl)
+                self.current.append(sl)
+                self.current = sl.children
                 return
 
         render = None
@@ -274,7 +302,9 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
                 name = "{}:{}".format(self.prefixMap[ns], name)
         el = Tag(
             name,
-            attributes=OrderedDict(nonTemplateAttrs),
+            attributes=OrderedDict(
+                cast(Mapping[Union[bytes, str], str], nonTemplateAttrs)
+            ),
             render=render,
             filename=filename,
             lineNumber=lineNumber,
@@ -284,19 +314,17 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         self.current.append(el)
         self.current = el.children
 
-    def characters(self, ch):
+    def characters(self, ch: str) -> None:
         """
         Called when we receive some characters.  CDATA characters get passed
         through as is.
-
-        @type ch: C{string}
         """
         if self.inCDATA:
             self.stack[-1].append(ch)
             return
         self.current.append(ch)
 
-    def endElementNS(self, name, qname):
+    def endElementNS(self, name: Tuple[str, str], qname: Optional[str]) -> None:
         """
         A namespace tag is closed.  Pop the stack, if there's anything left in
         it, otherwise return to the document's namespace.
@@ -307,24 +335,24 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         else:
             self.current = self.document
 
-    def startDTD(self, name, publicId, systemId):
+    def startDTD(self, name: str, publicId: str, systemId: str) -> None:
         """
         DTDs are ignored.
         """
 
-    def endDTD(self, *args):
+    def endDTD(self, *args: object) -> None:
         """
         DTDs are ignored.
         """
 
-    def startCDATA(self):
+    def startCDATA(self) -> None:
         """
         We're starting to be in a CDATA element, make a note of this.
         """
         self.inCDATA = True
         self.stack.append([])
 
-    def endCDATA(self):
+    def endCDATA(self) -> None:
         """
         We're no longer in a CDATA element.  Collect up the characters we've
         parsed and put them in a new CDATA object.
@@ -333,19 +361,18 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         comment = "".join(self.stack.pop())
         self.current.append(CDATA(comment))
 
-    def comment(self, content):
+    def comment(self, content: str) -> None:
         """
         Add an XML comment which we've encountered.
         """
         self.current.append(Comment(content))
 
 
-def _flatsaxParse(fl):
+def _flatsaxParse(fl: Union[FilePath, IO[AnyStr], str]) -> List["Flattenable"]:
     """
     Perform a SAX parse of an XML document with the _ToStan class.
 
     @param fl: The XML document to be parsed.
-    @type fl: A file object or filename.
 
     @return: a C{list} of Stan objects.
     """
@@ -368,20 +395,18 @@ def _flatsaxParse(fl):
 @implementer(ITemplateLoader)
 class TagLoader:
     """
-    An L{ITemplateLoader} that loads existing L{IRenderable} providers.
-
-    @ivar tag: The object which will be loaded.
-    @type tag: An L{IRenderable} provider.
+    An L{ITemplateLoader} that loads an existing flattenable object.
     """
 
-    def __init__(self, tag):
+    def __init__(self, tag: "Flattenable"):
         """
         @param tag: The object which will be loaded.
-        @type tag: An L{IRenderable} provider.
         """
-        self.tag = tag
 
-    def load(self):
+        self.tag: "Flattenable" = tag
+        """The object which will be loaded."""
+
+    def load(self) -> List["Flattenable"]:
         return [self.tag]
 
 
@@ -389,29 +414,26 @@ class TagLoader:
 class XMLString:
     """
     An L{ITemplateLoader} that loads and parses XML from a string.
-
-    @ivar _loadedTemplate: The loaded document.
-    @type _loadedTemplate: a C{list} of Stan objects.
     """
 
-    def __init__(self, s):
+    def __init__(self, s: Union[str, bytes]):
         """
         Run the parser on a L{StringIO} copy of the string.
 
         @param s: The string from which to load the XML.
-        @type s: C{str}, or a UTF-8 encoded L{bytes}.
+        @type s: L{str}, or a UTF-8 encoded L{bytes}.
         """
         if not isinstance(s, str):
             s = s.decode("utf8")
 
-        self._loadedTemplate = _flatsaxParse(StringIO(s))
+        self._loadedTemplate: List["Flattenable"] = _flatsaxParse(StringIO(s))
+        """The loaded document."""
 
-    def load(self):
+    def load(self) -> List["Flattenable"]:
         """
         Return the document.
 
         @return: the loaded document.
-        @rtype: a C{list} of Stan objects.
         """
         return self._loadedTemplate
 
@@ -420,40 +442,36 @@ class XMLString:
 class XMLFile:
     """
     An L{ITemplateLoader} that loads and parses XML from a file.
-
-    @ivar _loadedTemplate: The loaded document, or L{None}, if not loaded.
-    @type _loadedTemplate: a C{list} of Stan objects, or L{None}.
-
-    @ivar _path: The L{FilePath}, file object, or filename that is being
-        loaded from.
     """
 
-    def __init__(self, path):
+    def __init__(self, path: FilePath):
         """
         Run the parser on a file.
 
         @param path: The file from which to load the XML.
-        @type path: L{FilePath}
         """
         if not isinstance(path, FilePath):
-            warnings.warn(
+            warnings.warn(  # type: ignore[unreachable]
                 "Passing filenames or file objects to XMLFile is deprecated "
                 "since Twisted 12.1.  Pass a FilePath instead.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-        self._loadedTemplate = None
-        self._path = path
 
-    def _loadDoc(self):
+        self._loadedTemplate: Optional[List["Flattenable"]] = None
+        """The loaded document, or L{None}, if not loaded."""
+
+        self._path: FilePath = path
+        """The file that is being loaded from."""
+
+    def _loadDoc(self) -> List["Flattenable"]:
         """
         Read and parse the XML.
 
         @return: the loaded document.
-        @rtype: a C{list} of Stan objects.
         """
         if not isinstance(self._path, FilePath):
-            return _flatsaxParse(self._path)
+            return _flatsaxParse(self._path)  # type: ignore[unreachable]
         else:
             with self._path.open("r") as f:
                 return _flatsaxParse(f)
@@ -461,12 +479,11 @@ class XMLFile:
     def __repr__(self) -> str:
         return f"<XMLFile of {self._path!r}>"
 
-    def load(self):
+    def load(self) -> List["Flattenable"]:
         """
         Return the document, first loading it if necessary.
 
         @return: the loaded document.
-        @rtype: a C{list} of Stan objects.
         """
         if self._loadedTemplate is None:
             self._loadedTemplate = self._loadDoc()
@@ -615,7 +632,7 @@ class _TagFactory:
     @see: L{tags}
     """
 
-    def __getattr__(self, tagName):
+    def __getattr__(self, tagName: str) -> Tag:
         if tagName == "transparent":
             return Tag("")
         # allow for E.del as E.del_
@@ -628,7 +645,12 @@ class _TagFactory:
 tags = _TagFactory()
 
 
-def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=None):
+def renderElement(
+    request: IRequest,
+    element: IRenderable,
+    doctype: Optional[bytes] = b"<!DOCTYPE html>",
+    _failElement: Optional[Callable[[Failure], "Element"]] = None,
+) -> object:
     """
     Render an element or other L{IRenderable}.
 
@@ -652,12 +674,13 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
 
     d = flatten(request, element, request.write)
 
-    def eb(failure):
+    def eb(failure: Failure) -> Optional[Deferred[None]]:
         _moduleLog.failure(
             "An error occurred while rendering the response.", failure=failure
         )
-        site = getattr(request, "site", None)
+        site: Optional["twisted.web.server.Site"] = getattr(request, "site", None)
         if site is not None and site.displayTracebacks:
+            assert _failElement is not None
             return flatten(request, _failElement(failure), request.write)
         else:
             request.write(
@@ -668,7 +691,7 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
             )
             return None
 
-    def finish(result, *, request=request):
+    def finish(result: object, *, request: IRequest = request) -> object:
         request.finish()
         return result
 
@@ -678,5 +701,5 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
 
 
 from twisted.web._element import Element, renderer
-from twisted.web._flatten import flatten, flattenString
+from twisted.web._flatten import Flattenable, flatten, flattenString
 import twisted.web.util

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -666,8 +666,12 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
                 b'">An error occurred while rendering the response.</div>'
             )
 
+    def finish(result, *, request=request):
+        request.finish()
+        return result
+
     d.addErrback(eb)
-    d.addBoth(lambda _: request.finish())
+    d.addBoth(finish)
     return NOT_DONE_YET
 
 

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -632,7 +632,7 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
     """
     Render an element or other L{IRenderable}.
 
-    @param request: The L{twisted.web.server.Request} being rendered to.
+    @param request: The L{IRequest} being rendered to.
     @param element: An L{IRenderable} which will be rendered.
     @param doctype: A L{bytes} which will be written as the first line of
         the request, or L{None} to disable writing of a doctype.  The argument
@@ -656,7 +656,8 @@ def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=Non
         _moduleLog.failure(
             "An error occurred while rendering the response.", failure=failure
         )
-        if request.site.displayTracebacks:
+        site = getattr(request, "site", None)
+        if site is not None and site.displayTracebacks:
             return flatten(request, _failElement(failure), request.write)
         else:
             request.write(

--- a/src/twisted/web/template.py
+++ b/src/twisted/web/template.py
@@ -630,12 +630,12 @@ tags = _TagFactory()
 
 def renderElement(request, element, doctype=b"<!DOCTYPE html>", _failElement=None):
     """
-    Render an element or other C{IRenderable}.
+    Render an element or other L{IRenderable}.
 
-    @param request: The C{Request} being rendered to.
-    @param element: An C{IRenderable} which will be rendered.
-    @param doctype: A C{bytes} which will be written as the first line of
-        the request, or L{None} to disable writing of a doctype.  The C{string}
+    @param request: The L{twisted.web.server.Request} being rendered to.
+    @param element: An L{IRenderable} which will be rendered.
+    @param doctype: A L{bytes} which will be written as the first line of
+        the request, or L{None} to disable writing of a doctype.  The argument
         should not include a trailing newline and will default to the HTML5
         doctype C{'<!DOCTYPE html>'}.
 

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -275,7 +275,7 @@ class DummyRequest:
         """TODO: make this assert on write() if the header is content-length"""
         self.responseHeaders.addRawHeader(name, value)
 
-    def getSession(self):
+    def getSession(self, sessionInterface=None):
         if self.session:
             return self.session
         assert (
@@ -308,13 +308,13 @@ class DummyRequest:
             raise TypeError("write() only accepts bytes")
         self.written.append(data)
 
-    def notifyFinish(self):
+    def notifyFinish(self) -> Deferred[None]:
         """
         Return a L{Deferred} which is called back with L{None} when the request
         is finished.  This will probably only work if you haven't called
         C{finish} yet.
         """
-        finished = Deferred()
+        finished: Deferred[None] = Deferred()
         self._finishedDeferreds.append(finished)
         return finished
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -11,6 +11,8 @@ import re
 import traceback
 from collections import OrderedDict
 from textwrap import dedent
+from types import FunctionType
+from typing import Any, Callable, Dict, NoReturn, Optional, cast
 
 from twisted.test.testutils import XMLAssertionMixin
 from xml.etree.ElementTree import XML
@@ -29,12 +31,13 @@ from twisted.web.error import (
     UnfilledSlot,
     UnsupportedType,
 )
-from twisted.web.iweb import IRenderable
+from twisted.web.iweb import IRenderable, IRequest, ITemplateLoader
 from twisted.web.template import (
     CDATA,
     CharRef,
     Comment,
     Element,
+    Flattenable,
     Tag,
     TagLoader,
     flattenString,
@@ -51,7 +54,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
     Tests for flattening various things.
     """
 
-    def test_nestedTags(self):
+    def test_nestedTags(self) -> None:
         """
         Test that nested tags flatten correctly.
         """
@@ -60,26 +63,26 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             b'<html hi="there"><body>42</body></html>',
         )
 
-    def test_serializeString(self):
+    def test_serializeString(self) -> None:
         """
         Test that strings will be flattened and escaped correctly.
         """
         self.assertFlattensImmediately("one", b"one"),
         self.assertFlattensImmediately("<abc&&>123", b"&lt;abc&amp;&amp;&gt;123"),
 
-    def test_serializeSelfClosingTags(self):
+    def test_serializeSelfClosingTags(self) -> None:
         """
         The serialized form of a self-closing tag is C{'<tagName />'}.
         """
         self.assertFlattensImmediately(tags.img(), b"<img />")
 
-    def test_serializeAttribute(self):
+    def test_serializeAttribute(self) -> None:
         """
         The serialized form of attribute I{a} with value I{b} is C{'a="b"'}.
         """
         self.assertFlattensImmediately(tags.img(src="foo"), b'<img src="foo" />')
 
-    def test_serializedMultipleAttributes(self):
+    def test_serializedMultipleAttributes(self) -> None:
         """
         Multiple attributes are separated by a single space in their serialized
         form.
@@ -88,7 +91,11 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         tag.attributes = OrderedDict([("src", "foo"), ("name", "bar")])
         self.assertFlattensImmediately(tag, b'<img src="foo" name="bar" />')
 
-    def checkAttributeSanitization(self, wrapData, wrapTag):
+    def checkAttributeSanitization(
+        self,
+        wrapData: Callable[[str], Flattenable],
+        wrapTag: Callable[[Tag], Flattenable],
+    ) -> None:
         """
         Common implementation of L{test_serializedAttributeWithSanitization}
         and L{test_serializedDeferredAttributeWithSanitization},
@@ -96,19 +103,16 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         @param wrapData: A 1-argument callable that wraps around the
             attribute's value so other tests can customize it.
-        @param wrapData: callable taking L{bytes} and returning something
-            flattenable
 
         @param wrapTag: A 1-argument callable that wraps around the outer tag
             so other tests can customize it.
-        @type wrapTag: callable taking L{Tag} and returning L{Tag}.
         """
         self.assertFlattensImmediately(
             wrapTag(tags.img(src=wrapData('<>&"'))),
             b'<img src="&lt;&gt;&amp;&quot;" />',
         )
 
-    def test_serializedAttributeWithSanitization(self):
+    def test_serializedAttributeWithSanitization(self) -> None:
         """
         Attribute values containing C{"<"}, C{">"}, C{"&"}, or C{'"'} have
         C{"&lt;"}, C{"&gt;"}, C{"&amp;"}, or C{"&quot;"} substituted for those
@@ -116,7 +120,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.checkAttributeSanitization(passthru, passthru)
 
-    def test_serializedDeferredAttributeWithSanitization(self):
+    def test_serializedDeferredAttributeWithSanitization(self) -> None:
         """
         Like L{test_serializedAttributeWithSanitization}, but when the contents
         of the attribute are in a L{Deferred
@@ -124,17 +128,22 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.checkAttributeSanitization(succeed, passthru)
 
-    def test_serializedAttributeWithSlotWithSanitization(self):
+    def test_serializedAttributeWithSlotWithSanitization(self) -> None:
         """
         Like L{test_serializedAttributeWithSanitization} but with a slot.
         """
         toss = []
-        self.checkAttributeSanitization(
-            lambda value: toss.append(value) or slot("stuff"),
-            lambda tag: tag.fillSlots(stuff=toss.pop()),
-        )
 
-    def test_serializedAttributeWithTransparentTag(self):
+        def insertSlot(value: str) -> Flattenable:
+            toss.append(value)
+            return slot("stuff")
+
+        def fillSlot(tag: Tag) -> Tag:
+            return tag.fillSlots(stuff=toss.pop())
+
+        self.checkAttributeSanitization(insertSlot, fillSlot)
+
+    def test_serializedAttributeWithTransparentTag(self) -> None:
         """
         Attribute values which are supplied via the value of a C{t:transparent}
         tag have the same substitution rules to them as values supplied
@@ -142,28 +151,33 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.checkAttributeSanitization(tags.transparent, passthru)
 
-    def test_serializedAttributeWithTransparentTagWithRenderer(self):
+    def test_serializedAttributeWithTransparentTagWithRenderer(self) -> None:
         """
         Like L{test_serializedAttributeWithTransparentTag}, but when the
         attribute is rendered by a renderer on an element.
         """
 
         class WithRenderer(Element):
-            def __init__(self, value, loader):
+            def __init__(self, value: str, loader: Optional[ITemplateLoader]):
                 self.value = value
                 super().__init__(loader)
 
             @renderer
-            def stuff(self, request, tag):
+            def stuff(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
                 return self.value
 
         toss = []
-        self.checkAttributeSanitization(
-            lambda value: toss.append(value) or tags.transparent(render="stuff"),
-            lambda tag: WithRenderer(toss.pop(), TagLoader(tag)),
-        )
 
-    def test_serializedAttributeWithRenderable(self):
+        def insertRenderer(value: str) -> Flattenable:
+            toss.append(value)
+            return tags.transparent(render="stuff")
+
+        def render(tag: Tag) -> Flattenable:
+            return WithRenderer(toss.pop(), TagLoader(tag))
+
+        self.checkAttributeSanitization(insertRenderer, render)
+
+    def test_serializedAttributeWithRenderable(self) -> None:
         """
         Like L{test_serializedAttributeWithTransparentTag}, but when the
         attribute is a provider of L{IRenderable} rather than a transparent
@@ -172,22 +186,29 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         @implementer(IRenderable)
         class Arbitrary:
-            def __init__(self, value):
+            def __init__(self, value: Flattenable):
                 self.value = value
 
-            def render(self, request):
+            def render(self, request: Optional[IRequest]) -> Flattenable:
                 return self.value
+
+            def lookupRenderMethod(
+                self, name: str
+            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
+                raise NotImplementedError("Unexpected call")
 
         self.checkAttributeSanitization(Arbitrary, passthru)
 
-    def checkTagAttributeSerialization(self, wrapTag):
+    def checkTagAttributeSerialization(
+        self, wrapTag: Callable[[Tag], Flattenable]
+    ) -> None:
         """
         Common implementation of L{test_serializedAttributeWithTag} and
         L{test_serializedAttributeWithDeferredTag}.
 
         @param wrapTag: A 1-argument callable that wraps around the attribute's
             value so other tests can customize it.
-        @param wrapTag: callable taking L{Tag} and returning something
+        @type wrapTag: callable taking L{Tag} and returning something
             flattenable
         """
         innerTag = tags.a('<>&"')
@@ -204,7 +225,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         # as a tag*.
         self.assertXMLEqual(XML(outer).attrib["src"], inner)
 
-    def test_serializedAttributeWithTag(self):
+    def test_serializedAttributeWithTag(self) -> None:
         """
         L{Tag} objects which are serialized within the context of an attribute
         are serialized such that the text content of the attribute may be
@@ -212,14 +233,14 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.checkTagAttributeSerialization(passthru)
 
-    def test_serializedAttributeWithDeferredTag(self):
+    def test_serializedAttributeWithDeferredTag(self) -> None:
         """
         Like L{test_serializedAttributeWithTag}, but when the L{Tag} is in a
         L{Deferred <twisted.internet.defer.Deferred>}.
         """
         self.checkTagAttributeSerialization(succeed)
 
-    def test_serializedAttributeWithTagWithAttribute(self):
+    def test_serializedAttributeWithTagWithAttribute(self) -> None:
         """
         Similar to L{test_serializedAttributeWithTag}, but for the additional
         complexity where the tag which is the attribute value itself has an
@@ -237,13 +258,13 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             XML(flattened).attrib["src"], b'<a href="&lt;&gt;&amp;&quot;"></a>'
         )
 
-    def test_serializeComment(self):
+    def test_serializeComment(self) -> None:
         """
         Test that comments are correctly flattened and escaped.
         """
         self.assertFlattensImmediately(Comment("foo bar"), b"<!--foo bar-->")
 
-    def test_commentEscaping(self):
+    def test_commentEscaping(self) -> Deferred[Any]:
         """
         The data in a L{Comment} is escaped and mangled in the flattened output
         so that the result is a legal SGML and XML comment.
@@ -258,7 +279,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         @see: U{http://www.w3.org/TR/REC-xml/#sec-comments}
         """
 
-        def verifyComment(c):
+        def verifyComment(c: bytes) -> None:
             self.assertTrue(
                 c.startswith(b"<!--"),
                 f"{c!r} does not start with the comment prefix",
@@ -290,7 +311,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             results.append(d)
         return gatherResults(results)
 
-    def test_serializeCDATA(self):
+    def test_serializeCDATA(self) -> None:
         """
         Test that CDATA is correctly flattened and escaped.
         """
@@ -299,7 +320,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             CDATA("foo ]]> bar"), b"<![CDATA[foo ]]]]><![CDATA[> bar]]>"
         )
 
-    def test_serializeUnicode(self):
+    def test_serializeUnicode(self) -> None:
         """
         Test that unicode is encoded correctly in the appropriate places, and
         raises an error when it occurs in inappropriate place.
@@ -314,7 +335,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             Tag("p", attributes={snowman: ""}), UnicodeEncodeError
         )
 
-    def test_serializeCharRef(self):
+    def test_serializeCharRef(self) -> None:
         """
         A character reference is flattened to a string using the I{&#NNNN;}
         syntax.
@@ -322,14 +343,14 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         ref = CharRef(ord("\N{SNOWMAN}"))
         self.assertFlattensImmediately(ref, b"&#9731;")
 
-    def test_serializeDeferred(self):
+    def test_serializeDeferred(self) -> None:
         """
         Test that a deferred is substituted with the current value in the
         callback chain when flattened.
         """
         self.assertFlattensImmediately(succeed("two"), b"two")
 
-    def test_serializeSameDeferredTwice(self):
+    def test_serializeSameDeferredTwice(self) -> None:
         """
         Test that the same deferred can be flattened twice.
         """
@@ -337,14 +358,14 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         self.assertFlattensImmediately(d, b"three")
         self.assertFlattensImmediately(d, b"three")
 
-    def test_serializeCoroutine(self):
+    def test_serializeCoroutine(self) -> None:
         """
         Test that a coroutine returning a value is substituted with the that
         value when flattened.
         """
         from textwrap import dedent
 
-        namespace = {}
+        namespace: Dict[str, FunctionType] = {}
         exec(
             dedent(
                 """
@@ -358,7 +379,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         self.assertFlattensImmediately(coro("four"), b"four")
 
-    def test_serializeCoroutineWithAwait(self):
+    def test_serializeCoroutineWithAwait(self) -> None:
         """
         Test that a coroutine returning an awaited deferred value is
         substituted with that value when flattened.
@@ -379,14 +400,14 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         self.assertFlattensImmediately(coro("four"), b"four")
 
-    def test_serializeIRenderable(self):
+    def test_serializeIRenderable(self) -> None:
         """
         Test that flattening respects all of the IRenderable interface.
         """
 
         @implementer(IRenderable)
         class FakeElement:
-            def render(ign, ored):
+            def render(ign, ored: object) -> Tag:
                 return tags.p(
                     "hello, ",
                     tags.transparent(render="test"),
@@ -394,13 +415,15 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
                     tags.transparent(render="test"),
                 )
 
-            def lookupRenderMethod(ign, name):
+            def lookupRenderMethod(
+                ign, name: str
+            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
                 self.assertEqual(name, "test")
                 return lambda ign, node: node("world")
 
         self.assertFlattensImmediately(FakeElement(), b"<p>hello, world - world</p>")
 
-    def test_serializeMissingRenderFactory(self):
+    def test_serializeMissingRenderFactory(self) -> None:
         """
         Test that flattening a tag with a C{render} attribute when no render
         factory is available in the context raises an exception.
@@ -408,7 +431,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         self.assertFlatteningRaises(tags.transparent(render="test"), ValueError)
 
-    def test_serializeSlots(self):
+    def test_serializeSlots(self) -> None:
         """
         Test that flattening a slot will use the slot value from the tag.
         """
@@ -418,7 +441,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         self.assertFlatteningRaises(t1, UnfilledSlot)
         self.assertFlattensImmediately(t2, b"<p>hello, world</p>")
 
-    def test_serializeDeferredSlots(self):
+    def test_serializeDeferredSlots(self) -> None:
         """
         Test that a slot with a deferred as its value will be flattened using
         the value from the deferred.
@@ -427,11 +450,11 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         t.fillSlots(test=succeed(tags.em("four>")))
         self.assertFlattensImmediately(t, b"<p><em>four&gt;</em></p>")
 
-    def test_unknownTypeRaises(self):
+    def test_unknownTypeRaises(self) -> None:
         """
         Test that flattening an unknown type of thing raises an exception.
         """
-        self.assertFlatteningRaises(None, UnsupportedType)
+        self.assertFlatteningRaises(None, UnsupportedType)  # type: ignore[arg-type]
 
 
 # Use the co_filename mechanism (instead of the __file__ mechanism) because
@@ -450,7 +473,7 @@ class FlattenerErrorTests(SynchronousTestCase):
     Tests for L{FlattenerError}.
     """
 
-    def test_renderable(self):
+    def test_renderable(self) -> None:
         """
         If a L{FlattenerError} is created with an L{IRenderable} provider root,
         the repr of that object is included in the string representation of the
@@ -458,7 +481,7 @@ class FlattenerErrorTests(SynchronousTestCase):
         """
 
         @implementer(IRenderable)
-        class Renderable:
+        class Renderable:  # type: ignore[misc]
             def __repr__(self) -> str:
                 return "renderable repr"
 
@@ -469,7 +492,7 @@ class FlattenerErrorTests(SynchronousTestCase):
             "RuntimeError: reason\n",
         )
 
-    def test_tag(self):
+    def test_tag(self) -> None:
         """
         If a L{FlattenerError} is created with a L{Tag} instance with source
         location information, the source location is included in the string
@@ -484,7 +507,7 @@ class FlattenerErrorTests(SynchronousTestCase):
             "RuntimeError: reason\n",
         )
 
-    def test_tagWithoutLocation(self):
+    def test_tagWithoutLocation(self) -> None:
         """
         If a L{FlattenerError} is created with a L{Tag} instance without source
         location information, only the tagName is included in the string
@@ -495,17 +518,17 @@ class FlattenerErrorTests(SynchronousTestCase):
             "Exception while flattening:\n" "  Tag <span>\n" "RuntimeError: reason\n",
         )
 
-    def test_traceback(self):
+    def test_traceback(self) -> None:
         """
         If a L{FlattenerError} is created with traceback frames, they are
         included in the string representation of the exception.
         """
         # Try to be realistic in creating the data passed in for the traceback
         # frames.
-        def f():
+        def f() -> None:
             g()
 
-        def g():
+        def g() -> NoReturn:
             raise RuntimeError("reason")
 
         try:
@@ -533,24 +556,26 @@ class FlattenerErrorTests(SynchronousTestCase):
             ),
         )
 
-    def test_asynchronousFlattenError(self):
+    def test_asynchronousFlattenError(self) -> None:
         """
         When flattening a renderer which raises an exception asynchronously,
         the error is reported when it occurs.
         """
-        failing = Deferred()
+        failing: Deferred[object] = Deferred()
 
         @implementer(IRenderable)
         class NotActuallyRenderable:
             "No methods provided; this will fail"
 
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return "<unrenderable>"
 
-            def lookupRenderMethod(self, name):
+            def lookupRenderMethod(
+                self, name: str
+            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
                 ...
 
-            def render(self, request):
+            def render(self, request: Optional[IRequest]) -> Flattenable:
                 return failing
 
         flattening = flattenString(None, [NotActuallyRenderable()])
@@ -579,25 +604,25 @@ class FlattenerErrorTests(SynchronousTestCase):
         # unhandled.
         self.failureResultOf(failing, RuntimeError)
 
-    def test_cancel(self):
+    def test_cancel(self) -> None:
         """
         The flattening of a Deferred can be cancelled.
         """
         cancelCount = 0
         cancelArg = None
 
-        def checkCancel(cancelled):
+        def checkCancel(cancelled: Deferred[object]) -> None:
             nonlocal cancelArg, cancelCount
             cancelArg = cancelled
             cancelCount += 1
 
         err = None
 
-        def saveErr(failure):
+        def saveErr(failure: Failure) -> None:
             nonlocal err
             err = failure
 
-        d = Deferred(checkCancel)
+        d: Deferred[object] = Deferred(checkCancel)
         flattening = flattenString(None, d)
         self.assertNoResult(flattening)
         d.addErrback(saveErr)
@@ -612,7 +637,7 @@ class FlattenerErrorTests(SynchronousTestCase):
         self.assertIs(cancelArg, d)
 
         self.assertIsInstance(err, Failure)
-        self.assertIsInstance(err.value, CancelledError)
+        self.assertIsInstance(cast(Failure, err).value, CancelledError)
 
         exc = failure.value.args[0]
         self.assertIsInstance(exc, CancelledError)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -400,6 +400,14 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
         self.assertFlattensImmediately(FakeElement(), b"<p>hello, world - world</p>")
 
+    def test_serializeMissingRenderFactory(self):
+        """
+        Test that flattening a tag with a C{render} attribute when no render
+        factory is available in the context raises an exception.
+        """
+
+        self.assertFlatteningRaises(tags.transparent(render="test"), ValueError)
+
     def test_serializeSlots(self):
         """
         Test that flattening a slot will use the slot value from the tag.

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -12,7 +12,7 @@ import traceback
 from collections import OrderedDict
 from textwrap import dedent
 from types import FunctionType
-from typing import Any, Callable, Dict, NoReturn, Optional, cast
+from typing import Callable, Dict, List, NoReturn, Optional, cast
 
 from twisted.test.testutils import XMLAssertionMixin
 from xml.etree.ElementTree import XML
@@ -264,7 +264,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.assertFlattensImmediately(Comment("foo bar"), b"<!--foo bar-->")
 
-    def test_commentEscaping(self) -> Deferred[Any]:
+    def test_commentEscaping(self) -> Deferred[List[bytes]]:
         """
         The data in a L{Comment} is escaped and mangled in the flattened output
         so that the result is a legal SGML and XML comment.

--- a/src/twisted/web/test/test_stan.py
+++ b/src/twisted/web/test/test_stan.py
@@ -8,6 +8,7 @@ implementation.
 
 
 import sys
+from typing import NoReturn
 
 from twisted.web.template import Comment, CDATA, CharRef, Flattenable, Tag
 from twisted.trial.unittest import TestCase
@@ -135,8 +136,8 @@ class TagTests(TestCase):
         we deprecate old behavior rather than making it an error immediately.
         """
 
-        async def asyncFunc():
-            return "456"
+        async def asyncFunc() -> NoReturn:
+            raise NotImplementedError
 
         coro = asyncFunc()
         tag = proto("123", coro, "789")

--- a/src/twisted/web/test/test_stan.py
+++ b/src/twisted/web/test/test_stan.py
@@ -7,11 +7,11 @@ implementation.
 """
 
 
-from twisted.web.template import Comment, CDATA, CharRef, Tag
+from twisted.web.template import Comment, CDATA, CharRef, Flattenable, Tag
 from twisted.trial.unittest import TestCase
 
 
-def proto(*a, **kw):
+def proto(*a: Flattenable, **kw: Flattenable) -> Tag:
     """
     Produce a new tag for testing.
     """
@@ -38,19 +38,19 @@ class TagTests(TestCase):
         a string will raise L{TypeError}.
         """
         with self.assertRaises(TypeError) as e:
-            proto(render=83)
+            proto(render=83)  # type: ignore[arg-type]
         self.assertEqual(
             e.exception.args[0], 'Value for "render" attribute must be str, got 83'
         )
 
-    def test_fillSlots(self):
+    def test_fillSlots(self) -> None:
         """
         L{Tag.fillSlots} returns self.
         """
         tag = proto()
         self.assertIdentical(tag, tag.fillSlots(test="test"))
 
-    def test_cloneShallow(self):
+    def test_cloneShallow(self) -> None:
         """
         L{Tag.clone} copies all attributes and children of a tag, including its
         render attribute.  If the shallow flag is C{False}, that's where it
@@ -75,7 +75,7 @@ class TagTests(TestCase):
         self.assertEqual(clone.columnNumber, 12)
         self.assertEqual(clone.render, "aSampleMethod")
 
-    def test_cloneDeep(self):
+    def test_cloneDeep(self) -> None:
         """
         L{Tag.clone} copies all attributes and children of a tag, including its
         render attribute.  In its normal operating mode (where the deep flag is
@@ -109,7 +109,7 @@ class TagTests(TestCase):
         self.assertEqual(clone.columnNumber, 12)
         self.assertEqual(clone.render, "aSampleMethod")
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         """
         L{Tag.clear} removes all children from a tag, but leaves its attributes
         in place.
@@ -119,7 +119,7 @@ class TagTests(TestCase):
         self.assertEqual(tag.children, [])
         self.assertEqual(tag.attributes, {"andSoIs": "this-attribute"})
 
-    def test_suffix(self):
+    def test_suffix(self) -> None:
         """
         L{Tag.__call__} accepts Python keywords with a suffixed underscore as
         the DOM attribute of that literal suffix.
@@ -129,21 +129,21 @@ class TagTests(TestCase):
         tag(class_="a")
         self.assertEqual(tag.attributes, {"class": "a"})
 
-    def test_commentReprPy3(self):
+    def test_commentReprPy3(self) -> None:
         """
         L{Comment.__repr__} returns a value which makes it easy to see what's
         in the comment.
         """
         self.assertEqual(repr(Comment("hello there")), "Comment('hello there')")
 
-    def test_cdataReprPy3(self):
+    def test_cdataReprPy3(self) -> None:
         """
         L{CDATA.__repr__} returns a value which makes it easy to see what's in
         the comment.
         """
         self.assertEqual(repr(CDATA("test data")), "CDATA('test data')")
 
-    def test_charrefRepr(self):
+    def test_charrefRepr(self) -> None:
         """
         L{CharRef.__repr__} returns a value which makes it easy to see what
         character is referred to.

--- a/src/twisted/web/test/test_stan.py
+++ b/src/twisted/web/test/test_stan.py
@@ -23,6 +23,26 @@ class TagTests(TestCase):
     Tests for L{Tag}.
     """
 
+    def test_renderAttribute(self) -> None:
+        """
+        Setting an attribute named C{render} will change the C{render} instance
+        variable instead of adding an attribute.
+        """
+        tag = proto(render="myRenderer")
+        self.assertEqual(tag.render, "myRenderer")
+        self.assertEqual(tag.attributes, {})
+
+    def test_renderAttributeNonString(self) -> None:
+        """
+        Attempting to set an attribute named C{render} to something other than
+        a string will raise L{TypeError}.
+        """
+        with self.assertRaises(TypeError) as e:
+            proto(render=83)
+        self.assertEqual(
+            e.exception.args[0], 'Value for "render" attribute must be str, got 83'
+        )
+
     def test_fillSlots(self):
         """
         L{Tag.fillSlots} returns self.

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -7,15 +7,27 @@ Tests for L{twisted.web.template}
 
 
 from io import StringIO
+from typing import List, Optional
 
+from zope.interface import implementer
 from zope.interface.verify import verifyObject
 
-from twisted.internet.defer import succeed
+from twisted.internet.defer import Deferred, succeed
+from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import TestCase
 from twisted.trial.util import suppress as SUPPRESS
-from twisted.web.template import Element, TagLoader, renderer, tags, XMLFile, XMLString
-from twisted.web.iweb import ITemplateLoader
+from twisted.web.template import (
+    Element,
+    Flattenable,
+    Tag,
+    TagLoader,
+    renderer,
+    tags,
+    XMLFile,
+    XMLString,
+)
+from twisted.web.iweb import IRequest, ITemplateLoader
 
 from twisted.web.error import FlattenerError, MissingTemplateLoader, MissingRenderMethod
 
@@ -41,14 +53,14 @@ class TagFactoryTests(TestCase):
     Tests for L{_TagFactory} through the publicly-exposed L{tags} object.
     """
 
-    def test_lookupTag(self):
+    def test_lookupTag(self) -> None:
         """
         HTML tags can be retrieved through C{tags}.
         """
         tag = tags.a
         self.assertEqual(tag.tagName, "a")
 
-    def test_lookupHTML5Tag(self):
+    def test_lookupHTML5Tag(self) -> None:
         """
         Twisted supports the latest and greatest HTML tags from the HTML5
         specification.
@@ -56,7 +68,7 @@ class TagFactoryTests(TestCase):
         tag = tags.video
         self.assertEqual(tag.tagName, "video")
 
-    def test_lookupTransparentTag(self):
+    def test_lookupTransparentTag(self) -> None:
         """
         To support transparent inclusion in templates, there is a special tag,
         the transparent tag, which has no name of its own but is accessed
@@ -65,14 +77,14 @@ class TagFactoryTests(TestCase):
         tag = tags.transparent
         self.assertEqual(tag.tagName, "")
 
-    def test_lookupInvalidTag(self):
+    def test_lookupInvalidTag(self) -> None:
         """
         Invalid tags which are not part of HTML cause AttributeErrors when
         accessed through C{tags}.
         """
         self.assertRaises(AttributeError, getattr, tags, "invalid")
 
-    def test_lookupXMP(self):
+    def test_lookupXMP(self) -> None:
         """
         As a special case, the <xmp> tag is simply not available through
         C{tags} or any other part of the templating machinery.
@@ -85,7 +97,7 @@ class ElementTests(TestCase):
     Tests for the awesome new L{Element} class.
     """
 
-    def test_missingTemplateLoader(self):
+    def test_missingTemplateLoader(self) -> None:
         """
         L{Element.render} raises L{MissingTemplateLoader} if the C{loader}
         attribute is L{None}.
@@ -94,7 +106,7 @@ class ElementTests(TestCase):
         err = self.assertRaises(MissingTemplateLoader, element.render, None)
         self.assertIdentical(err.element, element)
 
-    def test_missingTemplateLoaderRepr(self):
+    def test_missingTemplateLoaderRepr(self) -> None:
         """
         A L{MissingTemplateLoader} instance can be repr()'d without error.
         """
@@ -107,7 +119,7 @@ class ElementTests(TestCase):
             "Pretty Repr Element", repr(MissingTemplateLoader(PrettyReprElement()))
         )
 
-    def test_missingRendererMethod(self):
+    def test_missingRendererMethod(self) -> None:
         """
         When called with the name which is not associated with a render method,
         L{Element.lookupRenderMethod} raises L{MissingRenderMethod}.
@@ -117,7 +129,7 @@ class ElementTests(TestCase):
         self.assertIdentical(err.element, element)
         self.assertEqual(err.renderName, "foo")
 
-    def test_missingRenderMethodRepr(self):
+    def test_missingRenderMethodRepr(self) -> None:
         """
         A L{MissingRenderMethod} instance can be repr()'d without error.
         """
@@ -130,7 +142,7 @@ class ElementTests(TestCase):
         self.assertIn("Pretty Repr Element", s)
         self.assertIn("expectedMethod", s)
 
-    def test_definedRenderer(self):
+    def test_definedRenderer(self) -> None:
         """
         When called with the name of a defined render method,
         L{Element.lookupRenderMethod} returns that render method.
@@ -138,29 +150,30 @@ class ElementTests(TestCase):
 
         class ElementWithRenderMethod(Element):
             @renderer
-            def foo(self, request, tag):
+            def foo(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
                 return "bar"
 
         foo = ElementWithRenderMethod().lookupRenderMethod("foo")
-        self.assertEqual(foo(None, None), "bar")
+        self.assertEqual(foo(None, tags.br), "bar")
 
-    def test_render(self):
+    def test_render(self) -> None:
         """
         L{Element.render} loads a document from the C{loader} attribute and
         returns it.
         """
 
+        @implementer(ITemplateLoader)
         class TemplateLoader:
-            def load(self):
-                return "result"
+            def load(self) -> List[Flattenable]:
+                return ["result"]
 
         class StubElement(Element):
             loader = TemplateLoader()
 
         element = StubElement()
-        self.assertEqual(element.render(None), "result")
+        self.assertEqual(element.render(None), ["result"])
 
-    def test_misuseRenderer(self):
+    def test_misuseRenderer(self) -> None:
         """
         If the L{renderer} decorator  is called without any arguments, it will
         raise a comprehensible exception.
@@ -168,7 +181,7 @@ class ElementTests(TestCase):
         te = self.assertRaises(TypeError, renderer)
         self.assertEqual(str(te), "expose() takes at least 1 argument (0 given)")
 
-    def test_renderGetDirectlyError(self):
+    def test_renderGetDirectlyError(self) -> None:
         """
         Called directly, without a default, L{renderer.get} raises
         L{UnexposedMethodError} when it cannot find a renderer.
@@ -181,49 +194,56 @@ class XMLFileReprTests(TestCase):
     Tests for L{twisted.web.template.XMLFile}'s C{__repr__}.
     """
 
-    def test_filePath(self):
+    def test_filePath(self) -> None:
         """
         An L{XMLFile} with a L{FilePath} returns a useful repr().
         """
         path = FilePath("/tmp/fake.xml")
         self.assertEqual(f"<XMLFile of {path!r}>", repr(XMLFile(path)))
 
-    def test_filename(self):
+    def test_filename(self) -> None:
         """
         An L{XMLFile} with a filename returns a useful repr().
         """
-        fname = "/tmp/fake.xml"
-        self.assertEqual(f"<XMLFile of {fname!r}>", repr(XMLFile(fname)))
+        fname = "/tmp/fake.xml"  # deprecated
+        self.assertEqual(f"<XMLFile of {fname!r}>", repr(XMLFile(fname)))  # type: ignore[arg-type]
 
     test_filename.suppress = [_xmlFileSuppress]  # type: ignore[attr-defined]
 
-    def test_file(self):
+    def test_file(self) -> None:
         """
         An L{XMLFile} with a file object returns a useful repr().
         """
-        fobj = StringIO("not xml")
-        self.assertEqual(f"<XMLFile of {fobj!r}>", repr(XMLFile(fobj)))
+        fobj = StringIO("not xml")  # deprecated
+        self.assertEqual(f"<XMLFile of {fobj!r}>", repr(XMLFile(fobj)))  # type: ignore[arg-type]
 
     test_file.suppress = [_xmlFileSuppress]  # type: ignore[attr-defined]
 
 
 class XMLLoaderTestsMixin:
-    """
-    @ivar templateString: Simple template to use to exercise the loaders.
 
-    @ivar deprecatedUse: C{True} if this use of L{XMLFile} is deprecated and
-        should emit a C{DeprecationWarning}.
+    deprecatedUse: bool
+    """
+    C{True} if this use of L{XMLFile} is deprecated and should emit
+    a C{DeprecationWarning}.
     """
 
-    loaderFactory = None
     templateString = "<p>Hello, world.</p>"
+    """
+    Simple template to use to exercise the loaders.
+    """
 
-    def test_load(self):
+    def loaderFactory(self) -> ITemplateLoader:
+        raise NotImplementedError
+
+    def test_load(self) -> None:
         """
         Verify that the loader returns a tag with the correct children.
         """
+        assert isinstance(self, TestCase)
         loader = self.loaderFactory()
         (tag,) = loader.load()
+        assert isinstance(tag, Tag)
 
         warnings = self.flushWarnings(offendingFunctions=[self.loaderFactory])
         if self.deprecatedUse:
@@ -240,11 +260,12 @@ class XMLLoaderTestsMixin:
         self.assertEqual(tag.tagName, "p")
         self.assertEqual(tag.children, ["Hello, world."])
 
-    def test_loadTwice(self):
+    def test_loadTwice(self) -> None:
         """
         If {load()} can be called on a loader twice the result should be the
         same.
         """
+        assert isinstance(self, TestCase)
         loader = self.loaderFactory()
         tags1 = loader.load()
         tags2 = loader.load()
@@ -260,7 +281,7 @@ class XMLStringLoaderTests(TestCase, XMLLoaderTestsMixin):
 
     deprecatedUse = False
 
-    def loaderFactory(self):
+    def loaderFactory(self) -> ITemplateLoader:
         """
         @return: an L{XMLString} constructed with C{self.templateString}.
         """
@@ -274,7 +295,7 @@ class XMLFileWithFilePathTests(TestCase, XMLLoaderTestsMixin):
 
     deprecatedUse = False
 
-    def loaderFactory(self):
+    def loaderFactory(self) -> ITemplateLoader:
         """
         @return: an L{XMLString} constructed with a L{FilePath} pointing to a
             file that contains C{self.templateString}.
@@ -291,12 +312,12 @@ class XMLFileWithFileTests(TestCase, XMLLoaderTestsMixin):
 
     deprecatedUse = True
 
-    def loaderFactory(self):
+    def loaderFactory(self) -> ITemplateLoader:
         """
         @return: an L{XMLString} constructed with a file object that contains
             C{self.templateString}.
         """
-        return XMLFile(StringIO(self.templateString))
+        return XMLFile(StringIO(self.templateString))  # type: ignore[arg-type]
 
 
 class XMLFileWithFilenameTests(TestCase, XMLLoaderTestsMixin):
@@ -306,14 +327,14 @@ class XMLFileWithFilenameTests(TestCase, XMLLoaderTestsMixin):
 
     deprecatedUse = True
 
-    def loaderFactory(self):
+    def loaderFactory(self) -> ITemplateLoader:
         """
         @return: an L{XMLString} constructed with a filename that points to a
             file containing C{self.templateString}.
         """
         fp = FilePath(self.mktemp())
         fp.setContent(self.templateString.encode("utf8"))
-        return XMLFile(fp.path)
+        return XMLFile(fp.path)  # type: ignore[arg-type]
 
 
 class FlattenIntegrationTests(FlattenTestCase):
@@ -322,7 +343,7 @@ class FlattenIntegrationTests(FlattenTestCase):
     L{twisted.web._flatten.flatten}.
     """
 
-    def test_roundTrip(self):
+    def test_roundTrip(self) -> None:
         """
         Given a series of parsable XML strings, verify that
         L{twisted.web._flatten.flatten} will flatten the L{Element} back to the
@@ -339,7 +360,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         for xml in fragments:
             self.assertFlattensImmediately(Element(loader=XMLString(xml)), xml)
 
-    def test_entityConversion(self):
+    def test_entityConversion(self) -> None:
         """
         When flattening an HTML entity, it should flatten out to the utf-8
         representation if possible.
@@ -347,14 +368,14 @@ class FlattenIntegrationTests(FlattenTestCase):
         element = Element(loader=XMLString("<p>&#9731;</p>"))
         self.assertFlattensImmediately(element, b"<p>\xe2\x98\x83</p>")
 
-    def test_missingTemplateLoader(self):
+    def test_missingTemplateLoader(self) -> None:
         """
         Rendering an Element without a loader attribute raises the appropriate
         exception.
         """
         self.assertFlatteningRaises(Element(), MissingTemplateLoader)
 
-    def test_missingRenderMethod(self):
+    def test_missingRenderMethod(self) -> None:
         """
         Flattening an L{Element} with a C{loader} which has a tag with a render
         directive fails with L{FlattenerError} if there is no available render
@@ -370,7 +391,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlatteningRaises(element, MissingRenderMethod)
 
-    def test_transparentRendering(self):
+    def test_transparentRendering(self) -> None:
         """
         A C{transparent} element should be eliminated from the DOM and rendered as
         only its children.
@@ -385,7 +406,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"Hello, world.")
 
-    def test_attrRendering(self):
+    def test_attrRendering(self) -> None:
         """
         An Element with an attr tag renders the vaule of its attr tag as an
         attribute of its containing tag.
@@ -402,14 +423,14 @@ class FlattenIntegrationTests(FlattenTestCase):
             element, b'<a href="http://example.com">Hello, world.</a>'
         )
 
-    def test_synchronousDeferredRecursion(self):
+    def test_synchronousDeferredRecursion(self) -> None:
         """
         When rendering a large number of already-fired Deferreds we should not
         encounter any recursion errors or stack-depth issues.
         """
         self.assertFlattensImmediately([succeed("x") for i in range(250)], b"x" * 250)
 
-    def test_errorToplevelAttr(self):
+    def test_errorToplevelAttr(self) -> None:
         """
         A template with a toplevel C{attr} tag will not load; it will raise
         L{AssertionError} if you try.
@@ -424,7 +445,7 @@ class FlattenIntegrationTests(FlattenTestCase):
             """,
         )
 
-    def test_errorUnnamedAttr(self):
+    def test_errorUnnamedAttr(self) -> None:
         """
         A template with an C{attr} tag with no C{name} attribute will not load;
         it will raise L{AssertionError} if you try.
@@ -437,7 +458,7 @@ class FlattenIntegrationTests(FlattenTestCase):
             >hello</t:attr></html>""",
         )
 
-    def test_lenientPrefixBehavior(self):
+    def test_lenientPrefixBehavior(self) -> None:
         """
         If the parser sees a prefix it doesn't recognize on an attribute, it
         will pass it on through to serialization.
@@ -450,7 +471,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         element = Element(loader=XMLString(theInput))
         self.assertFlattensTo(element, theInput.encode("utf8"))
 
-    def test_deferredRendering(self):
+    def test_deferredRendering(self) -> None:
         """
         An Element with a render method which returns a Deferred will render
         correctly.
@@ -458,7 +479,9 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(self, request, tag):
+            def renderMethod(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 return succeed("Hello, world.")
 
         element = RenderfulElement(
@@ -473,7 +496,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"Hello, world.")
 
-    def test_loaderClassAttribute(self):
+    def test_loaderClassAttribute(self) -> None:
         """
         If there is a non-None loader attribute on the class of an Element
         instance but none on the instance itself, the class attribute is used.
@@ -484,7 +507,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         self.assertFlattensImmediately(SubElement(), b"<p>Hello, world.</p>")
 
-    def test_directiveRendering(self):
+    def test_directiveRendering(self) -> None:
         """
         An Element with a valid render directive has that directive invoked and
         the result added to the output.
@@ -493,7 +516,9 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(self, request, tag):
+            def renderMethod(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 renders.append((self, request))
                 return tag("Hello, world.")
 
@@ -507,7 +532,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"<p>Hello, world.</p>")
 
-    def test_directiveRenderingOmittingTag(self):
+    def test_directiveRenderingOmittingTag(self) -> None:
         """
         An Element with a render method which omits the containing tag
         successfully removes that tag from the output.
@@ -515,7 +540,9 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(self, request, tag):
+            def renderMethod(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 return "Hello, world."
 
         element = RenderfulElement(
@@ -530,7 +557,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"Hello, world.")
 
-    def test_elementContainingStaticElement(self):
+    def test_elementContainingStaticElement(self) -> None:
         """
         An Element which is returned by the render method of another Element is
         rendered properly.
@@ -538,7 +565,9 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(self, request, tag):
+            def renderMethod(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 return tag(Element(loader=XMLString("<em>Hello, world.</em>")))
 
         element = RenderfulElement(
@@ -551,7 +580,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"<p><em>Hello, world.</em></p>")
 
-    def test_elementUsingSlots(self):
+    def test_elementUsingSlots(self) -> None:
         """
         An Element which is returned by the render method of another Element is
         rendered properly.
@@ -559,7 +588,9 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(self, request, tag):
+            def renderMethod(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 return tag.fillSlots(test2="world.")
 
         element = RenderfulElement(
@@ -573,7 +604,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"<p>Hello, world.</p>")
 
-    def test_elementContainingDynamicElement(self):
+    def test_elementContainingDynamicElement(self) -> None:
         """
         Directives in the document factory of an Element returned from a render
         method of another Element are satisfied from the correct object: the
@@ -582,7 +613,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class OuterElement(Element):
             @renderer
-            def outerMethod(self, request, tag):
+            def outerMethod(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
                 return tag(
                     InnerElement(
                         loader=XMLString(
@@ -597,7 +628,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class InnerElement(Element):
             @renderer
-            def innerMethod(self, request, tag):
+            def innerMethod(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
                 return "Hello, world."
 
         element = OuterElement(
@@ -610,7 +641,7 @@ class FlattenIntegrationTests(FlattenTestCase):
         )
         self.assertFlattensImmediately(element, b"<p>Hello, world.</p>")
 
-    def test_sameLoaderTwice(self):
+    def test_sameLoaderTwice(self) -> None:
         """
         Rendering the output of a loader, or even the same element, should
         return different output each time.
@@ -628,12 +659,16 @@ class FlattenIntegrationTests(FlattenTestCase):
             loader = sharedLoader
 
             @renderer
-            def classCounter(self, request, tag):
+            def classCounter(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 DestructiveElement.count += 1
                 return tag(str(DestructiveElement.count))
 
             @renderer
-            def instanceCounter(self, request, tag):
+            def instanceCounter(
+                self, request: Optional[IRequest], tag: Tag
+            ) -> Flattenable:
                 self.instanceCount += 1
                 return tag(str(self.instanceCount))
 
@@ -649,22 +684,22 @@ class TagLoaderTests(FlattenTestCase):
     Tests for L{TagLoader}.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.loader = TagLoader(tags.i("test"))
 
-    def test_interface(self):
+    def test_interface(self) -> None:
         """
         An instance of L{TagLoader} provides L{ITemplateLoader}.
         """
         self.assertTrue(verifyObject(ITemplateLoader, self.loader))
 
-    def test_loadsList(self):
+    def test_loadsList(self) -> None:
         """
         L{TagLoader.load} returns a list, per L{ITemplateLoader}.
         """
         self.assertIsInstance(self.loader.load(), list)
 
-    def test_flatten(self):
+    def test_flatten(self) -> None:
         """
         L{TagLoader} can be used in an L{Element}, and flattens as the tag used
         to construct the L{TagLoader} would flatten.
@@ -697,7 +732,7 @@ class TestFailureElement(Element):
         "</p>"
     )
 
-    def __init__(self, failure, loader=None):
+    def __init__(self, failure: Failure, loader: object = None):
         self.failure = failure
 
 
@@ -706,10 +741,10 @@ class FailingElement(Element):
     An element that raises an exception when rendered.
     """
 
-    def render(self, request):
+    def render(self, request: Optional[IRequest]) -> "Flattenable":
         a = 42
         b = 0
-        return a // b
+        return f"{a // b}"
 
 
 class FakeSite:
@@ -720,19 +755,32 @@ class FakeSite:
     displayTracebacks = False
 
 
+@implementer(IRequest)
+class DummyRenderRequest(DummyRequest):  # type: ignore[misc]
+    """
+    A dummy request object that has a C{site} attribute.
+
+    This does not implement the full IRequest interface, but enough of it
+    for this test suite.
+    """
+
+    def __init__(self) -> None:
+        super().__init__([""])
+        self.site = FakeSite()
+
+
 class RenderElementTests(TestCase):
     """
     Test L{renderElement}
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         """
-        Set up a common L{DummyRequest} and L{FakeSite}.
+        Set up a common L{DummyRenderRequest}.
         """
-        self.request = DummyRequest([""])
-        self.request.site = FakeSite()
+        self.request = DummyRenderRequest()
 
-    def test_simpleRender(self):
+    def test_simpleRender(self) -> Deferred[None]:
         """
         L{renderElement} returns NOT_DONE_YET and eventually
         writes the rendered L{Element} to the request before finishing the
@@ -742,7 +790,7 @@ class RenderElementTests(TestCase):
 
         d = self.request.notifyFinish()
 
-        def check(_):
+        def check(_: object) -> None:
             self.assertEqual(
                 b"".join(self.request.written),
                 b"<!DOCTYPE html>\n" b"<p>Hello, world.</p>",
@@ -755,7 +803,7 @@ class RenderElementTests(TestCase):
 
         return d
 
-    def test_simpleFailure(self):
+    def test_simpleFailure(self) -> Deferred[None]:
         """
         L{renderElement} handles failures by writing a minimal
         error message to the request and finishing it.
@@ -764,7 +812,7 @@ class RenderElementTests(TestCase):
 
         d = self.request.notifyFinish()
 
-        def check(_):
+        def check(_: object) -> None:
             flushed = self.flushLoggedErrors(FlattenerError)
             self.assertEqual(len(flushed), 1)
             self.assertEqual(
@@ -785,7 +833,7 @@ class RenderElementTests(TestCase):
 
         return d
 
-    def test_simpleFailureWithTraceback(self):
+    def test_simpleFailureWithTraceback(self) -> Deferred[None]:
         """
         L{renderElement} will render a traceback when rendering of
         the element fails and our site is configured to display tracebacks.
@@ -797,7 +845,7 @@ class RenderElementTests(TestCase):
 
         d = self.request.notifyFinish()
 
-        def check(_):
+        def check(_: object) -> None:
             self.assertEquals(1, len(logObserver))
             f = logObserver[0]["log_failure"]
             self.assertIsInstance(f.value, FlattenerError)
@@ -814,7 +862,7 @@ class RenderElementTests(TestCase):
 
         return d
 
-    def test_nonDefaultDoctype(self):
+    def test_nonDefaultDoctype(self) -> Deferred[None]:
         """
         L{renderElement} will write the doctype string specified by the
         doctype keyword argument.
@@ -823,7 +871,7 @@ class RenderElementTests(TestCase):
 
         d = self.request.notifyFinish()
 
-        def check(_):
+        def check(_: object) -> None:
             self.assertEqual(
                 b"".join(self.request.written),
                 (
@@ -846,7 +894,7 @@ class RenderElementTests(TestCase):
 
         return d
 
-    def test_noneDoctype(self):
+    def test_noneDoctype(self) -> Deferred[None]:
         """
         L{renderElement} will not write out a doctype if the doctype keyword
         argument is L{None}.
@@ -855,7 +903,7 @@ class RenderElementTests(TestCase):
 
         d = self.request.notifyFinish()
 
-        def check(_):
+        def check(_: object) -> None:
             self.assertEqual(b"".join(self.request.written), b"<p>Hello, world.</p>")
 
         d.addCallback(check)


### PR DESCRIPTION
## Scope and purpose

The main goal is to provide type hints to projects using Twisted's template system or that are using just Stan.

Adding the type hints increased the amount of checking mypy can do on Twisted itself and this uncovered two bugs. One was fixed in #1590 + #1593, the other was pretty minor and is fixed in a dedicated commit in this PR.

Things to consider during the review:
(mostly copy-pasted from the commit comments)

Since a lot of functions consume or produce "Stan objects" or "objects can be flattened" and a lot of types can be flattened, I added a type alias for that: `Flattenable`. This may be useful for projects using Twisted as well, so I exported it as a public name from `twisted.web.template`.

The documentation for the `TagLoader` class used to state that it could load `IRenderable` providers, but the implementation actually accepts any flattenable object. The instance variable in which the to-be-loaded object is stored is even named `tag` while the `Tag` class does not implement `IRenderable`. Therefore I assume the docstring was incorrect and changed it to accept `Flattenable` instead. Note that `IRenderable` is a member of `Flattenable`, so the previously documented interface is supported by the annotation.

The `render` attribute of `Tag` will now raise `TypeError` when anything other than a string is assigned to it via `__call__`. Previously, the assignment was accepted but it would break during rendering.

The `request` argument to `twisted.web.template.renderElement()` can now be any `IRequest` implementer instead of only `twisted.web.server.Request`. The only reason it was limited to `server.Request` before was that the `site` attribute was inspected to decide whether to print a minimal or detailed error message. We now pick the minimal message for other request types, to be on the safe side (the detailed message might leak sensitive information).

For the `XMLFile` path, the annotation does not include types for which support is deprecated. I assume projects type checking their code do not want to use a feature that was deprecated 9 years ago.

I removed `@type` and `@rtype` docstring fields that provided no additional value over the type annotations. In quite a few cases, the documented types were incorrect, so this will increase the accuracy of the documentation.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10184
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: mthuurne
Reviewer: wsanchez
Fixes: ticket:10184

Add type annotations to `twisted.web.template`.
```
