### PR TITLE
10106: Fix bug "TypeError: SelectorEventLoop required, instead got: <uvloop.Loop ...>"

### DIFF
--- a/src/twisted/newsfragments/10106.bugfix
+++ b/src/twisted/newsfragments/10106.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.asyncioreactor.AsyncioSelectorReactor will no longer raise a TypeError like "SelectorEventLoop required, instead got: <uvloop.Loop ...>" (broken since 21.2.0).


### PR DESCRIPTION
<!--
## Remove this section

Have a look at [our developer documentation](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch) before submitting your Pull Request.

Note that the Trac ticket, news fragment, and review submission portions of this process apply to *all* pull requests, no matter how small;
if you don't do them, it's likely that nobody will even notice your PR needs a review.
-->

## Scope and purpose

This fixes the bug [#10106](https://twistedmatrix.com/trac/ticket/10106).

The solution is to reject `ProactorEventLoop` instead of only accepting `SelectorEventLoop`.

<!--
Add a few words about why this PR is needed and what is its scope.

Add any comments about trade-offs (if any) made in this PR and the reasoning behind them.

Add mentions of things that are not covered here and are planed to be done in separate PRs.
-->


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10106
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1601 from twisted/10106-andreymz-fix-typeerror-uvloop

Author: AndreyMZ
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10106
```
