### PR TITLE
[#10201] Update priority for ECDSA KEX.

### DIFF
--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -88,14 +88,20 @@ class _Curve25519SHA256LibSSH:
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH512:
+class _ECDH256:
     """
-    Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
+    Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
     RFC 5656.
+
+    Note that C{ecdh-sha2-nistp256} takes priority over nistp384 or nistp512.
+    This is the same priority from OpenSSH.
+
+    C{ecdh-sha2-nistp256} is considered preety good cryptography.
+    If you need something better consider using C{curve25519-sha256}.
     """
 
     preference = 3
-    hashProcessor = sha512
+    hashProcessor = sha256
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
@@ -110,14 +116,14 @@ class _ECDH384:
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH256:
+class _ECDH512:
     """
-    Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
+    Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
     RFC 5656.
     """
 
     preference = 5
-    hashProcessor = sha256
+    hashProcessor = sha512
 
 
 @implementer(_IGroupExchangeKexAlgorithm)

--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -88,14 +88,14 @@ class _Curve25519SHA256LibSSH:
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH256:
+class _ECDH512:
     """
-    Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
+    Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
     RFC 5656.
     """
 
     preference = 3
-    hashProcessor = sha256
+    hashProcessor = sha512
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
@@ -110,14 +110,14 @@ class _ECDH384:
 
 
 @implementer(_IEllipticCurveExchangeKexAlgorithm)
-class _ECDH512:
+class _ECDH256:
     """
-    Elliptic Curve Key Exchange with SHA-512 as HASH. Defined in
+    Elliptic Curve Key Exchange with SHA-256 as HASH. Defined in
     RFC 5656.
     """
 
     preference = 5
-    hashProcessor = sha512
+    hashProcessor = sha256
 
 
 @implementer(_IGroupExchangeKexAlgorithm)

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -914,6 +914,21 @@ class SSHFactoryTests(unittest.TestCase):
         self.assertIn(b"diffie-hellman-group-exchange-sha1", p2.supportedKeyExchanges)
         self.assertIn(b"diffie-hellman-group-exchange-sha256", p2.supportedKeyExchanges)
 
+    def test_buildProtocolKexECDSA(self):
+        """
+        ECDSA key exchanges are listed with 521 having a higher priority than 256.
+        """
+        f2 = self.makeSSHFactory()
+
+        p2 = f2.buildProtocol(None)
+
+        # The list might contain other algorightm.
+        # For this test just check the order for ECDSA KEX.
+        self.assertIn(
+            b"ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256",
+            b",".join(p2.supportedKeyExchanges),
+        )
+
 
 class MPTests(unittest.TestCase):
     """

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -916,7 +916,7 @@ class SSHFactoryTests(unittest.TestCase):
 
     def test_buildProtocolKexECDSA(self):
         """
-        ECDSA key exchanges are listed with 521 having a higher priority than 256.
+        ECDSA key exchanges are listed with 256 having a higher priority among ECDSA.
         """
         f2 = self.makeSSHFactory()
 
@@ -925,7 +925,7 @@ class SSHFactoryTests(unittest.TestCase):
         # The list might contain other algorightm.
         # For this test just check the order for ECDSA KEX.
         self.assertIn(
-            b"ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256",
+            b"ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521",
             b",".join(p2.supportedKeyExchanges),
         )
 

--- a/src/twisted/newsfragments/10102.bugfix
+++ b/src/twisted/newsfragments/10102.bugfix
@@ -1,2 +1,0 @@
-The priority for SSH ECDSA key exchange algorithm was updated so that is the
-most preferred ecdh-sha2-nistp521 and ecdh-sha2-nistp256 is the less preferred.

--- a/src/twisted/newsfragments/10102.bugfix
+++ b/src/twisted/newsfragments/10102.bugfix
@@ -1,0 +1,2 @@
+The priority for SSH ECDSA key exchange algorithm was updated so that is the
+most preferred ecdh-sha2-nistp521 and ecdh-sha2-nistp256 is the less preferred.


### PR DESCRIPTION
## Scope and purpose

I think that ECDSA 512  should have higher priority than ECDSA 256.

In conch _kex the lower priority is the preferred algorithm.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10201
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author:  adiroiban
Reviewer: alex
Fixes: ticket:10201

Document that ecdh-sha2-nistp521 has lower priority than ecdh-sha2-nistp256 on purpose.
```
