### PR TITLE
[10206] Use ed25519_supported to detect support for curve25519-sha256.

### DIFF
--- a/src/twisted/conch/ssh/_kex.py
+++ b/src/twisted/conch/ssh/_kex.py
@@ -276,7 +276,7 @@ def getSupportedKeyExchanges():
                 ec.ECDH(), _curveTable[keyAlgorithmDsa]
             )
         elif keyAlgorithm.startswith(b"curve25519-sha256"):
-            supported = backend.x25519_supported()
+            supported = backend.ed25519_supported()
         else:
             supported = True
         if not supported:

--- a/src/twisted/newsfragments/10206.bugfix
+++ b/src/twisted/newsfragments/10206.bugfix
@@ -1,0 +1,2 @@
+twisted.conch.ssh._kex.getSupportedKeyExchanges() will now return than
+curve25519-sha256 is supported only for OpenSSL 1.1.1b or greater.


### PR DESCRIPTION
## Scope and purpose

This is a fix to explicitly check for ED25119 support as part of  curve25519-sha256 key exchange algorithm support detection.

I think that `backend.x25519_supported()` was used due to an error.
In theory both ed25519 and x25519 are supported since 1.1.1 
See the python cryptography issue for more details https://github.com/pyca/cryptography/issues/5164 and links to OpenSSL bugs.

This was not detected and i think that all the tests were always executed with latest OpenSSL.

This bug is observed on Ubuntu 18.04 

No test was added as we don't have any test suite for Ubuntu 18.04 that is executed with a cryptography compiled to use the OS openssl library. 


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10206
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10206

 Use backend.ed25519_supported() to detect support for curve25519-sha256.
```
