### PR TITLE
[10213] Document the usage of Libera.chat.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,8 @@ This documentation contains how-tos, code examples, and an API reference.
 
 Help is also available on the `Twisted mailing list <https://twistedmatrix.com/cgi-bin/mailman/listinfo/twisted-python>`_.
 
-There is also a pair of very lively IRC channels, ``#twisted`` (for general Twisted questions) and ``#twisted.web`` (for Twisted Web), on ``chat.freenode.net``.
+There is also a pair of very lively IRC channels, ``#twisted`` (for general Twisted questions) and ``#twisted.web`` (for Twisted Web),
+on `irc.libera.chat <https://web.libera.chat/>_`.
 
 
 Unit Tests

--- a/docs/core/howto/tutorial/protocol.rst
+++ b/docs/core/howto/tutorial/protocol.rst
@@ -242,7 +242,7 @@ function, ``getIRCbot`` , which returns
 a ``ClientFactory`` .  This factory in turn will
 instantiate the ``IRCReplyBot`` protocol.  The IRCBot is
 configured in the last line to connect
-to ``irc.freenode.org`` with a nickname
+to ``irc.libera.chat`` with a nickname
 of ``fingerbot`` .
 
 

--- a/src/twisted/newsfragments/10213.doc
+++ b/src/twisted/newsfragments/10213.doc
@@ -1,0 +1,1 @@
+Twisted IRC channels are now hosted by Libera.Chat.


### PR DESCRIPTION
## Scope and purpose

We no longer use freenode but libera.chat

I have only updated the freenode references from RST files and not from the example .py files.

Not sure if we should do a freenode purge. I can do that if you think that is a good idea.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10213
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10213

Remove freenode from the documentation/README and use Libera.chat.
```
