### PR TITLE
10211 fix haproxy IPAddress type error

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -538,6 +538,10 @@ check_untyped_defs = False
 [mypy-twisted.protocols.test.test_basic]
 allow_incomplete_defs = True
 
+[mypy-twisted.protocols.haproxy.*]
+allow_untyped_defs = False
+check_untyped_defs = True
+
 [mypy-twisted.python._pydoctor]
 allow_untyped_defs = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -531,16 +531,89 @@ check_untyped_defs = False
 allow_untyped_defs = True
 check_untyped_defs = False
 
-[mypy-twisted.protocols.*]
+[mypy-twisted.protocols.amp]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.basic]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.dict]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.finger]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.ftp]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.htb]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.ident]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.loopback]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.memcache]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.pcp]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.policies]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.portforward]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.postfix]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.shoutcast]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.sip]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.socks]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.stateful]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.tls]
+allow_untyped_defs = True
+check_untyped_defs = False
+
+[mypy-twisted.protocols.wire]
 allow_untyped_defs = True
 check_untyped_defs = False
 
 [mypy-twisted.protocols.test.test_basic]
-allow_incomplete_defs = True
+allow_untyped_defs = True
+check_untyped_defs = False
 
-[mypy-twisted.protocols.haproxy.*]
-allow_untyped_defs = False
-check_untyped_defs = True
+[mypy-twisted.protocols.test.test_tls]
+allow_untyped_defs = True
+check_untyped_defs = False
 
 [mypy-twisted.python._pydoctor]
 allow_untyped_defs = True

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -18,6 +18,7 @@ from zope.interface.verify import verifyClass
 from twisted.python import failure
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import (
+    IProtocol,
     ITransport,
     IConsumer,
     IPushProducer,
@@ -299,6 +300,8 @@ class StringTransportWithDisconnection(StringTransport):
     A L{StringTransport} which on disconnection will trigger the connection
     lost on the attached protocol.
     """
+
+    protocol: IProtocol
 
     def loseConnection(self):
         if self.connected:

--- a/src/twisted/newsfragments/10211.bugfix
+++ b/src/twisted/newsfragments/10211.bugfix
@@ -1,0 +1,1 @@
+haproxy transport wrapper returns a transport.getPeer().host of type bytes, when the type annotation is str

--- a/src/twisted/newsfragments/10211.bugfix
+++ b/src/twisted/newsfragments/10211.bugfix
@@ -1,1 +1,1 @@
-haproxy transport wrapper returns a transport.getPeer().host of type bytes, when the type annotation is str
+haproxy transport wrapper now returns hosts of type str for getPeer() and getHost(), as specified by IPv4Address and IPv6Address documentation. Previously it was returning bytes for the host.``` 

--- a/src/twisted/protocols/haproxy/__init__.py
+++ b/src/twisted/protocols/haproxy/__init__.py
@@ -5,9 +5,6 @@
 """
 HAProxy PROXY protocol implementations.
 """
+__all__ = ["proxyEndpoint"]
 
 from ._wrapper import proxyEndpoint
-
-__all__ = [
-    "proxyEndpoint",
-]

--- a/src/twisted/protocols/haproxy/_exceptions.py
+++ b/src/twisted/protocols/haproxy/_exceptions.py
@@ -7,9 +7,7 @@ HAProxy specific exceptions.
 """
 
 import contextlib
-import sys
-
-from twisted.python import compat
+from typing import Generator, Callable, Type
 
 
 class InvalidProxyHeader(Exception):
@@ -31,19 +29,21 @@ class MissingAddressData(InvalidProxyHeader):
 
 
 @contextlib.contextmanager
-def convertError(sourceType, targetType):
+def convertError(
+    sourceType: Type[BaseException], targetType: Callable[[], BaseException]
+) -> Generator[None, None, None]:
     """
     Convert an error into a different error type.
 
     @param sourceType: The type of exception that should be caught and
         converted.
-    @type sourceType: L{Exception}
+    @type sourceType: L{BaseException}
 
     @param targetType: The type of exception to which the original should be
         converted.
-    @type targetType: L{Exception}
+    @type targetType: L{BaseException}
     """
     try:
-        yield None
-    except sourceType:
-        compat.reraise(targetType(), sys.exc_info()[-1])
+        yield
+    except sourceType as e:
+        raise targetType().with_traceback(e.__traceback__)

--- a/src/twisted/protocols/haproxy/_info.py
+++ b/src/twisted/protocols/haproxy/_info.py
@@ -5,32 +5,28 @@
 """
 IProxyInfo implementation.
 """
-
+from typing import Optional
+import attr
 from zope.interface import implementer
 
+from twisted.internet.interfaces import IAddress
 from ._interfaces import IProxyInfo
 
 
 @implementer(IProxyInfo)
+@attr.s(frozen=True, slots=True, auto_attribs=True)
 class ProxyInfo:
     """
     A data container for parsed PROXY protocol information.
 
     @ivar header: The raw header bytes extracted from the connection.
-    @type header: bytes
+    @type header: C{bytes}
     @ivar source: The connection source address.
     @type source: L{twisted.internet.interfaces.IAddress}
     @ivar destination: The connection destination address.
     @type destination: L{twisted.internet.interfaces.IAddress}
     """
 
-    __slots__ = (
-        "header",
-        "source",
-        "destination",
-    )
-
-    def __init__(self, header, source, destination):
-        self.header = header
-        self.source = source
-        self.destination = destination
+    header: bytes
+    source: Optional[IAddress]
+    destination: Optional[IAddress]

--- a/src/twisted/protocols/haproxy/_interfaces.py
+++ b/src/twisted/protocols/haproxy/_interfaces.py
@@ -5,7 +5,7 @@
 """
 Interfaces used by the PROXY protocol modules.
 """
-
+from typing import Union, Tuple
 import zope.interface
 
 
@@ -32,7 +32,7 @@ class IProxyParser(zope.interface.Interface):
     Streaming parser that handles PROXY protocol headers.
     """
 
-    def feed(data):
+    def feed(data: bytes) -> Union[Tuple[IProxyInfo, bytes], Tuple[None, None]]:
         """
         Consume a chunk of data and attempt to parse it.
 
@@ -47,7 +47,7 @@ class IProxyParser(zope.interface.Interface):
             invalid PROXY header.
         """
 
-    def parse(line):
+    def parse(line: bytes) -> IProxyInfo:
         """
         Parse a bytestring as a full PROXY protocol header line.
 

--- a/src/twisted/protocols/haproxy/_parser.py
+++ b/src/twisted/protocols/haproxy/_parser.py
@@ -5,20 +5,22 @@
 """
 Parser for 'haproxy:' string endpoint.
 """
-
+from typing import Tuple, Mapping
 from zope.interface import implementer
 from twisted.plugin import IPlugin
 
+from twisted.internet import interfaces
 from twisted.internet.endpoints import (
     quoteStringArgument,
     serverFromString,
     IStreamServerEndpointStringParser,
+    _WrapperServerEndpoint,
 )
 
 from . import proxyEndpoint
 
 
-def unparseEndpoint(args, kwargs):
+def unparseEndpoint(args: Tuple[object, ...], kwargs: Mapping[str, object]) -> str:
     """
     Un-parse the already-parsed args and kwargs back into endpoint syntax.
 
@@ -27,7 +29,7 @@ def unparseEndpoint(args, kwargs):
 
     @param kwargs: C{:} and then C{=}-separated keyword arguments
 
-    @type kwargs: L{tuple} of native L{str}
+    @type kwargs: L{Mapping[str, str]}
 
     @return: a string equivalent to the original format which this was parsed
         as.
@@ -56,7 +58,9 @@ class HAProxyServerParser:
 
     prefix = "haproxy"
 
-    def parseStreamServer(self, reactor, *args, **kwargs):
+    def parseStreamServer(
+        self, reactor: interfaces.IReactorCore, *args: object, **kwargs: object
+    ) -> _WrapperServerEndpoint:
         """
         Parse a stream server endpoint from a reactor and string-only arguments
         and keyword arguments.

--- a/src/twisted/protocols/haproxy/_v1parser.py
+++ b/src/twisted/protocols/haproxy/_v1parser.py
@@ -6,7 +6,7 @@
 """
 IProxyParser implementation for version one of the PROXY protocol.
 """
-
+from typing import Union, Tuple
 from zope.interface import implementer
 from twisted.internet import address
 
@@ -41,10 +41,12 @@ class V1Parser:
     )
     NEWLINE = b"\r\n"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.buffer = b""
 
-    def feed(self, data):
+    def feed(
+        self, data: bytes
+    ) -> Union[Tuple[_info.ProxyInfo, bytes], Tuple[None, None]]:
         """
         Consume a chunk of data and attempt to parse it.
 
@@ -72,7 +74,7 @@ class V1Parser:
         return (info, remaining)
 
     @classmethod
-    def parse(cls, line):
+    def parse(cls, line: bytes) -> _info.ProxyInfo:
         """
         Parse a bytestring as a full PROXY protocol header line.
 
@@ -131,12 +133,12 @@ class V1Parser:
 
             return _info.ProxyInfo(
                 originalLine,
-                address.IPv4Address("TCP", sourceAddr, int(sourcePort)),
-                address.IPv4Address("TCP", destAddr, int(destPort)),
+                address.IPv4Address("TCP", sourceAddr.decode(), int(sourcePort)),
+                address.IPv4Address("TCP", destAddr.decode(), int(destPort)),
             )
 
         return _info.ProxyInfo(
             originalLine,
-            address.IPv6Address("TCP", sourceAddr, int(sourcePort)),
-            address.IPv6Address("TCP", destAddr, int(destPort)),
+            address.IPv6Address("TCP", sourceAddr.decode(), int(sourcePort)),
+            address.IPv6Address("TCP", destAddr.decode(), int(destPort)),
         )

--- a/src/twisted/protocols/haproxy/_v2parser.py
+++ b/src/twisted/protocols/haproxy/_v2parser.py
@@ -9,8 +9,10 @@ IProxyParser implementation for version two of the PROXY protocol.
 
 import binascii
 import struct
+from typing import Union, Tuple, Type, Callable
 
 from constantly import Values, ValueConstant  # type: ignore[import]
+from typing_extensions import Literal
 
 from zope.interface import implementer
 from twisted.internet import address
@@ -76,10 +78,12 @@ class V2Parser:
         50: "!108s108s",
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.buffer = b""
 
-    def feed(self, data):
+    def feed(
+        self, data: bytes
+    ) -> Union[Tuple[_info.ProxyInfo, bytes], Tuple[None, None]]:
         """
         Consume a chunk of data and attempt to parse it.
 
@@ -108,7 +112,7 @@ class V2Parser:
         return (info, remaining)
 
     @staticmethod
-    def _bytesToIPv4(bytestring):
+    def _bytesToIPv4(bytestring: bytes) -> bytes:
         """
         Convert packed 32-bit IPv4 address bytes into a dotted-quad ASCII bytes
         representation of that address.
@@ -124,7 +128,7 @@ class V2Parser:
         )
 
     @staticmethod
-    def _bytesToIPv6(bytestring):
+    def _bytesToIPv6(bytestring: bytes) -> bytes:
         """
         Convert packed 128-bit IPv6 address bytes into a colon-separated ASCII
         bytes representation of that address.
@@ -142,7 +146,7 @@ class V2Parser:
         )
 
     @classmethod
-    def parse(cls, line):
+    def parse(cls, line: bytes) -> _info.ProxyInfo:
         """
         Parse a bytestring as a full PROXY protocol header.
 
@@ -192,11 +196,13 @@ class V2Parser:
                 address.UNIXAddress(dest.rstrip(b"\x00")),
             )
 
-        addrType = "TCP"
+        addrType: Union[Literal["TCP"], Literal["UDP"]] = "TCP"
         if netproto is NetProtocol.DGRAM:
             addrType = "UDP"
-        addrCls = address.IPv4Address
-        addrParser = cls._bytesToIPv4
+        addrCls: Union[
+            Type[address.IPv4Address], Type[address.IPv6Address]
+        ] = address.IPv4Address
+        addrParser: Callable[[bytes], bytes] = cls._bytesToIPv4
         if family is NetFamily.INET6:
             addrCls = address.IPv6Address
             addrParser = cls._bytesToIPv6
@@ -207,6 +213,6 @@ class V2Parser:
 
         return _info.ProxyInfo(
             line,
-            addrCls(addrType, addrParser(source), sPort),
-            addrCls(addrType, addrParser(dest), dPort),
+            addrCls(addrType, addrParser(source).decode(), sPort),
+            addrCls(addrType, addrParser(dest).decode(), dPort),
         )

--- a/src/twisted/protocols/haproxy/_wrapper.py
+++ b/src/twisted/protocols/haproxy/_wrapper.py
@@ -6,6 +6,7 @@
 """
 Protocol wrapper that provides HAProxy PROXY protocol support.
 """
+from typing import Optional, Union
 
 from twisted.protocols import policies
 from twisted.internet import interfaces
@@ -14,6 +15,7 @@ from twisted.internet.endpoints import _WrapperServerEndpoint
 from ._exceptions import InvalidProxyHeader
 from ._v1parser import V1Parser
 from ._v2parser import V2Parser
+from . import _info
 
 
 class HAProxyProtocolWrapper(policies.ProtocolWrapper):
@@ -25,43 +27,48 @@ class HAProxyProtocolWrapper(policies.ProtocolWrapper):
     the data provided by the PROXY header.
     """
 
-    def __init__(self, factory, wrappedProtocol):
-        policies.ProtocolWrapper.__init__(self, factory, wrappedProtocol)
-        self._proxyInfo = None
-        self._parser = None
+    def __init__(
+        self, factory: policies.WrappingFactory, wrappedProtocol: interfaces.IProtocol
+    ):
+        super().__init__(factory, wrappedProtocol)
+        self._proxyInfo: Optional[_info.ProxyInfo] = None
+        self._parser: Union[V2Parser, V1Parser, None] = None
 
-    def dataReceived(self, data):
+    def dataReceived(self, data: bytes) -> None:
         if self._proxyInfo is not None:
             return self.wrappedProtocol.dataReceived(data)
 
-        if self._parser is None:
+        parser = self._parser
+        if parser is None:
             if (
                 len(data) >= 16
                 and data[:12] == V2Parser.PREFIX
                 and ord(data[12:13]) & 0b11110000 == 0x20
             ):
-                self._parser = V2Parser()
+                self._parser = parser = V2Parser()
             elif len(data) >= 8 and data[:5] == V1Parser.PROXYSTR:
-                self._parser = V1Parser()
+                self._parser = parser = V1Parser()
             else:
                 self.loseConnection()
                 return None
 
         try:
-            self._proxyInfo, remaining = self._parser.feed(data)
+            self._proxyInfo, remaining = parser.feed(data)
             if remaining:
                 self.wrappedProtocol.dataReceived(remaining)
         except InvalidProxyHeader:
             self.loseConnection()
 
-    def getPeer(self):
+    def getPeer(self) -> interfaces.IAddress:
         if self._proxyInfo and self._proxyInfo.source:
             return self._proxyInfo.source
+        assert self.transport
         return self.transport.getPeer()
 
-    def getHost(self):
+    def getHost(self) -> interfaces.IAddress:
         if self._proxyInfo and self._proxyInfo.destination:
             return self._proxyInfo.destination
+        assert self.transport
         return self.transport.getHost()
 
 
@@ -72,7 +79,7 @@ class HAProxyWrappingFactory(policies.WrappingFactory):
 
     protocol = HAProxyProtocolWrapper
 
-    def logPrefix(self):
+    def logPrefix(self) -> str:
         """
         Annotate the wrapped factory's log prefix with some text indicating
         the PROXY protocol is in use.
@@ -86,7 +93,9 @@ class HAProxyWrappingFactory(policies.WrappingFactory):
         return f"{logPrefix} (PROXY)"
 
 
-def proxyEndpoint(wrappedEndpoint):
+def proxyEndpoint(
+    wrappedEndpoint: interfaces.IStreamServerEndpoint,
+) -> _WrapperServerEndpoint:
     """
     Wrap an endpoint with PROXY protocol support, so that the transport's
     C{getHost} and C{getPeer} methods reflect the attributes of the proxied

--- a/src/twisted/protocols/haproxy/test/test_parser.py
+++ b/src/twisted/protocols/haproxy/test/test_parser.py
@@ -4,7 +4,7 @@
 """
 Tests for L{twisted.protocols.haproxy._parser}.
 """
-
+from typing import Union, Type
 from twisted.trial.unittest import SynchronousTestCase as TestCase
 from twisted.test.proto_helpers import MemoryReactor
 from twisted.internet.endpoints import (
@@ -26,7 +26,7 @@ class UnparseEndpointTests(TestCase):
     escaping properly.
     """
 
-    def check(self, input):
+    def check(self, input: str) -> None:
         """
         Check that the input unparses into the output, raising an assertion
         error if it doesn't.
@@ -38,37 +38,37 @@ class UnparseEndpointTests(TestCase):
         """
         self.assertEqual(unparseEndpoint(*parseEndpoint(input)), input)
 
-    def test_basicUnparse(self):
+    def test_basicUnparse(self) -> None:
         """
         An individual word.
         """
         self.check("word")
 
-    def test_multipleArguments(self):
+    def test_multipleArguments(self) -> None:
         """
         Multiple arguments.
         """
         self.check("one:two")
 
-    def test_keywords(self):
+    def test_keywords(self) -> None:
         """
         Keyword arguments.
         """
         self.check("aleph=one:bet=two")
 
-    def test_colonInArgument(self):
+    def test_colonInArgument(self) -> None:
         """
         Escaped ":".
         """
         self.check("hello\\:colon\\:world")
 
-    def test_colonInKeywordValue(self):
+    def test_colonInKeywordValue(self) -> None:
         """
         Escaped ":" in keyword value.
         """
         self.check("hello=\\:")
 
-    def test_colonInKeywordName(self):
+    def test_colonInKeywordName(self) -> None:
         """
         Escaped ":" in keyword name.
         """
@@ -80,7 +80,15 @@ class HAProxyServerParserTests(TestCase):
     Tests that the parser generates the correct endpoints.
     """
 
-    def onePrefix(self, description, expectedClass):
+    def onePrefix(
+        self,
+        description: str,
+        expectedClass: Union[
+            Type[TCP4ServerEndpoint],
+            Type[TCP6ServerEndpoint],
+            Type[UNIXServerEndpoint],
+        ],
+    ) -> _WrapperServerEndpoint:
         """
         Test the C{haproxy} enpdoint prefix against one sub-endpoint type.
 
@@ -101,23 +109,24 @@ class HAProxyServerParserTests(TestCase):
         reactor = MemoryReactor()
         endpoint = serverFromString(reactor, description)
         self.assertIsInstance(endpoint, _WrapperServerEndpoint)
+        assert isinstance(endpoint, _WrapperServerEndpoint)
         self.assertIsInstance(endpoint._wrappedEndpoint, expectedClass)
         self.assertIs(endpoint._wrapperFactory, HAProxyWrappingFactory)
         return endpoint
 
-    def test_tcp4(self):
+    def test_tcp4(self) -> None:
         """
         Test if the parser generates a wrapped TCP4 endpoint.
         """
         self.onePrefix("haproxy:tcp:8080", TCP4ServerEndpoint)
 
-    def test_tcp6(self):
+    def test_tcp6(self) -> None:
         """
         Test if the parser generates a wrapped TCP6 endpoint.
         """
         self.onePrefix("haproxy:tcp6:8080", TCP6ServerEndpoint)
 
-    def test_unix(self):
+    def test_unix(self) -> None:
         """
         Test if the parser generates a wrapped UNIX endpoint.
         """

--- a/src/twisted/protocols/haproxy/test/test_v1parser.py
+++ b/src/twisted/protocols/haproxy/test/test_v1parser.py
@@ -17,7 +17,7 @@ class V1ParserTests(unittest.TestCase):
     Test L{twisted.protocols.haproxy.V1Parser} behaviour.
     """
 
-    def test_missingPROXYHeaderValue(self):
+    def test_missingPROXYHeaderValue(self) -> None:
         """
         Test that an exception is raised when the PROXY header is missing.
         """
@@ -27,7 +27,7 @@ class V1ParserTests(unittest.TestCase):
             b"NOTPROXY ",
         )
 
-    def test_invalidNetworkProtocol(self):
+    def test_invalidNetworkProtocol(self) -> None:
         """
         Test that an exception is raised when the proto is not TCP or UNKNOWN.
         """
@@ -37,7 +37,7 @@ class V1ParserTests(unittest.TestCase):
             b"PROXY WUTPROTO ",
         )
 
-    def test_missingSourceData(self):
+    def test_missingSourceData(self) -> None:
         """
         Test that an exception is raised when the proto has no source data.
         """
@@ -47,7 +47,7 @@ class V1ParserTests(unittest.TestCase):
             b"PROXY TCP4 ",
         )
 
-    def test_missingDestData(self):
+    def test_missingDestData(self) -> None:
         """
         Test that an exception is raised when the proto has no destination.
         """
@@ -57,7 +57,7 @@ class V1ParserTests(unittest.TestCase):
             b"PROXY TCP4 127.0.0.1 8080 8888",
         )
 
-    def test_fullParsingSuccess(self):
+    def test_fullParsingSuccess(self) -> None:
         """
         Test that parsing is successful for a PROXY header.
         """
@@ -65,12 +65,14 @@ class V1ParserTests(unittest.TestCase):
             b"PROXY TCP4 127.0.0.1 127.0.0.1 8080 8888",
         )
         self.assertIsInstance(info.source, address.IPv4Address)
-        self.assertEqual(info.source.host, b"127.0.0.1")
+        assert isinstance(info.source, address.IPv4Address)
+        assert isinstance(info.destination, address.IPv4Address)
+        self.assertEqual(info.source.host, "127.0.0.1")
         self.assertEqual(info.source.port, 8080)
-        self.assertEqual(info.destination.host, b"127.0.0.1")
+        self.assertEqual(info.destination.host, "127.0.0.1")
         self.assertEqual(info.destination.port, 8888)
 
-    def test_fullParsingSuccess_IPv6(self):
+    def test_fullParsingSuccess_IPv6(self) -> None:
         """
         Test that parsing is successful for an IPv6 PROXY header.
         """
@@ -78,12 +80,14 @@ class V1ParserTests(unittest.TestCase):
             b"PROXY TCP6 ::1 ::1 8080 8888",
         )
         self.assertIsInstance(info.source, address.IPv6Address)
-        self.assertEqual(info.source.host, b"::1")
+        assert isinstance(info.source, address.IPv6Address)
+        assert isinstance(info.destination, address.IPv6Address)
+        self.assertEqual(info.source.host, "::1")
         self.assertEqual(info.source.port, 8080)
-        self.assertEqual(info.destination.host, b"::1")
+        self.assertEqual(info.destination.host, "::1")
         self.assertEqual(info.destination.port, 8888)
 
-    def test_fullParsingSuccess_UNKNOWN(self):
+    def test_fullParsingSuccess_UNKNOWN(self) -> None:
         """
         Test that parsing is successful for a UNKNOWN PROXY header.
         """
@@ -93,7 +97,7 @@ class V1ParserTests(unittest.TestCase):
         self.assertIsNone(info.source)
         self.assertIsNone(info.destination)
 
-    def test_feedParsing(self):
+    def test_feedParsing(self) -> None:
         """
         Test that parsing happens when fed a complete line.
         """
@@ -106,13 +110,17 @@ class V1ParserTests(unittest.TestCase):
         self.assertFalse(remaining)
         info, remaining = parser.feed(b"\r\n")
         self.assertFalse(remaining)
+        assert remaining is not None
+        assert info is not None
         self.assertIsInstance(info.source, address.IPv4Address)
-        self.assertEqual(info.source.host, b"127.0.0.1")
+        assert isinstance(info.source, address.IPv4Address)
+        assert isinstance(info.destination, address.IPv4Address)
+        self.assertEqual(info.source.host, "127.0.0.1")
         self.assertEqual(info.source.port, 8080)
-        self.assertEqual(info.destination.host, b"127.0.0.1")
+        self.assertEqual(info.destination.host, "127.0.0.1")
         self.assertEqual(info.destination.port, 8888)
 
-    def test_feedParsingTooLong(self):
+    def test_feedParsingTooLong(self) -> None:
         """
         Test that parsing fails if no newline is found in 108 bytes.
         """
@@ -129,7 +137,7 @@ class V1ParserTests(unittest.TestCase):
             b" " * 100,
         )
 
-    def test_feedParsingOverflow(self):
+    def test_feedParsingOverflow(self) -> None:
         """
         Test that parsing leaves overflow bytes in the buffer.
         """

--- a/src/twisted/protocols/haproxy/test/test_v2parser.py
+++ b/src/twisted/protocols/haproxy/test/test_v2parser.py
@@ -15,13 +15,13 @@ V2_SIGNATURE = b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"
 
 
 def _makeHeaderIPv6(
-    sig=V2_SIGNATURE,
-    verCom=b"\x21",
-    famProto=b"\x21",
-    addrLength=b"\x00\x24",
-    addrs=((b"\x00" * 15) + b"\x01") * 2,
-    ports=b"\x1F\x90\x22\xB8",
-):
+    sig: bytes = V2_SIGNATURE,
+    verCom: bytes = b"\x21",
+    famProto: bytes = b"\x21",
+    addrLength: bytes = b"\x00\x24",
+    addrs: bytes = ((b"\x00" * 15) + b"\x01") * 2,
+    ports: bytes = b"\x1F\x90\x22\xB8",
+) -> bytes:
     """
     Construct a version 2 IPv6 header with custom bytes.
 
@@ -53,13 +53,13 @@ def _makeHeaderIPv6(
 
 
 def _makeHeaderIPv4(
-    sig=V2_SIGNATURE,
-    verCom=b"\x21",
-    famProto=b"\x11",
-    addrLength=b"\x00\x0C",
-    addrs=b"\x7F\x00\x00\x01\x7F\x00\x00\x01",
-    ports=b"\x1F\x90\x22\xB8",
-):
+    sig: bytes = V2_SIGNATURE,
+    verCom: bytes = b"\x21",
+    famProto: bytes = b"\x11",
+    addrLength: bytes = b"\x00\x0C",
+    addrs: bytes = b"\x7F\x00\x00\x01\x7F\x00\x00\x01",
+    ports: bytes = b"\x1F\x90\x22\xB8",
+) -> bytes:
     """
     Construct a version 2 IPv4 header with custom bytes.
 
@@ -91,17 +91,17 @@ def _makeHeaderIPv4(
 
 
 def _makeHeaderUnix(
-    sig=V2_SIGNATURE,
-    verCom=b"\x21",
-    famProto=b"\x31",
-    addrLength=b"\x00\xD8",
-    addrs=(
+    sig: bytes = V2_SIGNATURE,
+    verCom: bytes = b"\x21",
+    famProto: bytes = b"\x31",
+    addrLength: bytes = b"\x00\xD8",
+    addrs: bytes = (
         b"\x2F\x68\x6F\x6D\x65\x2F\x74\x65\x73\x74\x73\x2F"
         b"\x6D\x79\x73\x6F\x63\x6B\x65\x74\x73\x2F\x73\x6F"
         b"\x63\x6B" + (b"\x00" * 82)
     )
     * 2,
-):
+) -> bytes:
     """
     Construct a version 2 IPv4 header with custom bytes.
 
@@ -133,28 +133,28 @@ class V2ParserTests(unittest.TestCase):
     Test L{twisted.protocols.haproxy.V2Parser} behaviour.
     """
 
-    def test_happyPathIPv4(self):
+    def test_happyPathIPv4(self) -> None:
         """
         Test if a well formed IPv4 header is parsed without error.
         """
         header = _makeHeaderIPv4()
         self.assertTrue(_v2parser.V2Parser.parse(header))
 
-    def test_happyPathIPv6(self):
+    def test_happyPathIPv6(self) -> None:
         """
         Test if a well formed IPv6 header is parsed without error.
         """
         header = _makeHeaderIPv6()
         self.assertTrue(_v2parser.V2Parser.parse(header))
 
-    def test_happyPathUnix(self):
+    def test_happyPathUnix(self) -> None:
         """
         Test if a well formed UNIX header is parsed without error.
         """
         header = _makeHeaderUnix()
         self.assertTrue(_v2parser.V2Parser.parse(header))
 
-    def test_invalidSignature(self):
+    def test_invalidSignature(self) -> None:
         """
         Test if an invalid signature block raises InvalidProxyError.
         """
@@ -165,7 +165,7 @@ class V2ParserTests(unittest.TestCase):
             header,
         )
 
-    def test_invalidVersion(self):
+    def test_invalidVersion(self) -> None:
         """
         Test if an invalid version raises InvalidProxyError.
         """
@@ -176,7 +176,7 @@ class V2ParserTests(unittest.TestCase):
             header,
         )
 
-    def test_invalidCommand(self):
+    def test_invalidCommand(self) -> None:
         """
         Test if an invalid command raises InvalidProxyError.
         """
@@ -187,7 +187,7 @@ class V2ParserTests(unittest.TestCase):
             header,
         )
 
-    def test_invalidFamily(self):
+    def test_invalidFamily(self) -> None:
         """
         Test if an invalid family raises InvalidProxyError.
         """
@@ -198,7 +198,7 @@ class V2ParserTests(unittest.TestCase):
             header,
         )
 
-    def test_invalidProto(self):
+    def test_invalidProto(self) -> None:
         """
         Test if an invalid protocol raises InvalidProxyError.
         """
@@ -209,7 +209,7 @@ class V2ParserTests(unittest.TestCase):
             header,
         )
 
-    def test_localCommandIpv4(self):
+    def test_localCommandIpv4(self) -> None:
         """
         Test that local does not return endpoint data for IPv4 connections.
         """
@@ -218,7 +218,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_localCommandIpv6(self):
+    def test_localCommandIpv6(self) -> None:
         """
         Test that local does not return endpoint data for IPv6 connections.
         """
@@ -227,7 +227,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_localCommandUnix(self):
+    def test_localCommandUnix(self) -> None:
         """
         Test that local does not return endpoint data for UNIX connections.
         """
@@ -236,7 +236,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_proxyCommandIpv4(self):
+    def test_proxyCommandIpv4(self) -> None:
         """
         Test that proxy returns endpoint data for IPv4 connections.
         """
@@ -247,7 +247,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info.destination)
         self.assertIsInstance(info.destination, address.IPv4Address)
 
-    def test_proxyCommandIpv6(self):
+    def test_proxyCommandIpv6(self) -> None:
         """
         Test that proxy returns endpoint data for IPv6 connections.
         """
@@ -258,7 +258,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info.destination)
         self.assertIsInstance(info.destination, address.IPv6Address)
 
-    def test_proxyCommandUnix(self):
+    def test_proxyCommandUnix(self) -> None:
         """
         Test that proxy returns endpoint data for UNIX connections.
         """
@@ -269,7 +269,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info.destination)
         self.assertIsInstance(info.destination, address.UNIXAddress)
 
-    def test_unspecFamilyIpv4(self):
+    def test_unspecFamilyIpv4(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for IPv4 connections.
         """
@@ -278,7 +278,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_unspecFamilyIpv6(self):
+    def test_unspecFamilyIpv6(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for IPv6 connections.
         """
@@ -287,7 +287,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_unspecFamilyUnix(self):
+    def test_unspecFamilyUnix(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for UNIX connections.
         """
@@ -296,7 +296,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_unspecProtoIpv4(self):
+    def test_unspecProtoIpv4(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for IPv4 connections.
         """
@@ -305,7 +305,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_unspecProtoIpv6(self):
+    def test_unspecProtoIpv6(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for IPv6 connections.
         """
@@ -314,7 +314,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_unspecProtoUnix(self):
+    def test_unspecProtoUnix(self) -> None:
         """
         Test that UNSPEC does not return endpoint data for UNIX connections.
         """
@@ -323,7 +323,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertFalse(info.source)
         self.assertFalse(info.destination)
 
-    def test_overflowIpv4(self):
+    def test_overflowIpv4(self) -> None:
         """
         Test that overflow bits are preserved during feed parsing for IPv4.
         """
@@ -334,7 +334,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info)
         self.assertEqual(overflow, testValue)
 
-    def test_overflowIpv6(self):
+    def test_overflowIpv6(self) -> None:
         """
         Test that overflow bits are preserved during feed parsing for IPv6.
         """
@@ -345,7 +345,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info)
         self.assertEqual(overflow, testValue)
 
-    def test_overflowUnix(self):
+    def test_overflowUnix(self) -> None:
         """
         Test that overflow bits are preserved during feed parsing for Unix.
         """
@@ -356,7 +356,7 @@ class V2ParserTests(unittest.TestCase):
         self.assertTrue(info)
         self.assertEqual(overflow, testValue)
 
-    def test_segmentTooSmall(self):
+    def test_segmentTooSmall(self) -> None:
         """
         Test that an initial payload of less than 16 bytes fails.
         """

--- a/src/twisted/protocols/haproxy/test/test_wrapper.py
+++ b/src/twisted/protocols/haproxy/test/test_wrapper.py
@@ -68,7 +68,7 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
         proto.dataReceived(b"2.2.2.2 8080\r\n")
         self.assertFalse(transport.connected)
 
-    def test_preDataRecieved_getPeerHost(self) -> None:
+    def test_preDataReceived_getPeerHost(self) -> None:
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
             address.IPv4Address("TCP", "127.0.0.1", 8080),

--- a/src/twisted/protocols/haproxy/test/test_wrapper.py
+++ b/src/twisted/protocols/haproxy/test/test_wrapper.py
@@ -4,7 +4,7 @@
 """
 Test cases for L{twisted.protocols.haproxy.HAProxyProtocol}.
 """
-
+from typing import Optional
 from twisted.trial import unittest
 from twisted.internet import address
 from twisted.internet.protocol import Protocol, Factory
@@ -18,13 +18,14 @@ class StaticProtocol(Protocol):
     Protocol stand-in that maintains test state.
     """
 
-    def __init__(self):
-        self.source = None
-        self.destination = None
+    def __init__(self) -> None:
+        self.source: Optional[address.IAddress] = None
+        self.destination: Optional[address.IAddress] = None
         self.data = b""
         self.disconnected = False
 
-    def dataReceived(self, data):
+    def dataReceived(self, data: bytes) -> None:
+        assert self.transport
         self.source = self.transport.getPeer()
         self.destination = self.transport.getHost()
         self.data += data
@@ -36,13 +37,13 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
     headers.
     """
 
-    def test_invalidHeaderDisconnects(self):
+    def test_invalidHeaderDisconnects(self) -> None:
         """
         Test if invalid headers result in connectionLost events.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv4Address("TCP", b"127.1.1.1", 8080),
+            address.IPv4Address("TCP", "127.1.1.1", 8080),
         )
         transport = StringTransportWithDisconnection()
         transport.protocol = proto
@@ -50,13 +51,13 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
         proto.dataReceived(b"NOTPROXY anything can go here\r\n")
         self.assertFalse(transport.connected)
 
-    def test_invalidPartialHeaderDisconnects(self):
+    def test_invalidPartialHeaderDisconnects(self) -> None:
         """
         Test if invalid headers result in connectionLost events.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv4Address("TCP", b"127.1.1.1", 8080),
+            address.IPv4Address("TCP", "127.1.1.1", 8080),
         )
         transport = StringTransportWithDisconnection()
         transport.protocol = proto
@@ -65,90 +66,90 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
         proto.dataReceived(b"2.2.2.2 8080\r\n")
         self.assertFalse(transport.connected)
 
-    def test_validIPv4HeaderResolves_getPeerHost(self):
+    def test_validIPv4HeaderResolves_getPeerHost(self) -> None:
         """
         Test if IPv4 headers result in the correct host and peer data.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv4Address("TCP", b"127.0.0.1", 8080),
+            address.IPv4Address("TCP", "127.0.0.1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(b"PROXY TCP4 1.1.1.1 2.2.2.2 8080 8888\r\n")
-        self.assertEqual(proto.getPeer().host, b"1.1.1.1")
+        self.assertEqual(proto.getPeer().host, "1.1.1.1")
         self.assertEqual(proto.getPeer().port, 8080)
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().host,
-            b"1.1.1.1",
+            "1.1.1.1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().port,
             8080,
         )
-        self.assertEqual(proto.getHost().host, b"2.2.2.2")
+        self.assertEqual(proto.getHost().host, "2.2.2.2")
         self.assertEqual(proto.getHost().port, 8888)
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().host,
-            b"2.2.2.2",
+            "2.2.2.2",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().port,
             8888,
         )
 
-    def test_validIPv6HeaderResolves_getPeerHost(self):
+    def test_validIPv6HeaderResolves_getPeerHost(self) -> None:
         """
         Test if IPv6 headers result in the correct host and peer data.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(b"PROXY TCP6 ::1 ::2 8080 8888\r\n")
-        self.assertEqual(proto.getPeer().host, b"::1")
+        self.assertEqual(proto.getPeer().host, "::1")
         self.assertEqual(proto.getPeer().port, 8080)
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().host,
-            b"::1",
+            "::1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().port,
             8080,
         )
-        self.assertEqual(proto.getHost().host, b"::2")
+        self.assertEqual(proto.getHost().host, "::2")
         self.assertEqual(proto.getHost().port, 8888)
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().host,
-            b"::2",
+            "::2",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().port,
             8888,
         )
 
-    def test_overflowBytesSentToWrappedProtocol(self):
+    def test_overflowBytesSentToWrappedProtocol(self) -> None:
         """
         Test if non-header bytes are passed to the wrapped protocol.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(b"PROXY TCP6 ::1 ::2 8080 8888\r\nHTTP/1.1 / GET")
         self.assertEqual(proto.wrappedProtocol.data, b"HTTP/1.1 / GET")
 
-    def test_overflowBytesSentToWrappedProtocolChunks(self):
+    def test_overflowBytesSentToWrappedProtocolChunks(self) -> None:
         """
         Test if header streaming passes extra data appropriately.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
@@ -156,13 +157,13 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
         proto.dataReceived(b"8080 8888\r\nHTTP/1.1 / GET")
         self.assertEqual(proto.wrappedProtocol.data, b"HTTP/1.1 / GET")
 
-    def test_overflowBytesSentToWrappedProtocolAfter(self):
+    def test_overflowBytesSentToWrappedProtocolAfter(self) -> None:
         """
         Test if wrapper writes all data to wrapped protocol after parsing.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
@@ -228,13 +229,13 @@ class HAProxyWrappingFactoryV2Tests(unittest.TestCase):
         + _SOCK_PATH
     )
 
-    def test_invalidHeaderDisconnects(self):
+    def test_invalidHeaderDisconnects(self) -> None:
         """
         Test if invalid headers result in connectionLost events.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         transport.protocol = proto
@@ -242,71 +243,71 @@ class HAProxyWrappingFactoryV2Tests(unittest.TestCase):
         proto.dataReceived(b"\x00" + self.IPV4HEADER[1:])
         self.assertFalse(transport.connected)
 
-    def test_validIPv4HeaderResolves_getPeerHost(self):
+    def test_validIPv4HeaderResolves_getPeerHost(self) -> None:
         """
         Test if IPv4 headers result in the correct host and peer data.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv4Address("TCP", b"127.0.0.1", 8080),
+            address.IPv4Address("TCP", "127.0.0.1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(self.IPV4HEADER)
-        self.assertEqual(proto.getPeer().host, b"127.0.0.1")
+        self.assertEqual(proto.getPeer().host, "127.0.0.1")
         self.assertEqual(proto.getPeer().port, 8080)
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().host,
-            b"127.0.0.1",
+            "127.0.0.1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().port,
             8080,
         )
-        self.assertEqual(proto.getHost().host, b"127.0.0.1")
+        self.assertEqual(proto.getHost().host, "127.0.0.1")
         self.assertEqual(proto.getHost().port, 8888)
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().host,
-            b"127.0.0.1",
+            "127.0.0.1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().port,
             8888,
         )
 
-    def test_validIPv6HeaderResolves_getPeerHost(self):
+    def test_validIPv6HeaderResolves_getPeerHost(self) -> None:
         """
         Test if IPv6 headers result in the correct host and peer data.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv4Address("TCP", b"::1", 8080),
+            address.IPv4Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(self.IPV6HEADER)
-        self.assertEqual(proto.getPeer().host, b"0:0:0:0:0:0:0:1")
+        self.assertEqual(proto.getPeer().host, "0:0:0:0:0:0:0:1")
         self.assertEqual(proto.getPeer().port, 8080)
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().host,
-            b"0:0:0:0:0:0:0:1",
+            "0:0:0:0:0:0:0:1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getPeer().port,
             8080,
         )
-        self.assertEqual(proto.getHost().host, b"0:0:0:0:0:0:0:1")
+        self.assertEqual(proto.getHost().host, "0:0:0:0:0:0:0:1")
         self.assertEqual(proto.getHost().port, 8888)
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().host,
-            b"0:0:0:0:0:0:0:1",
+            "0:0:0:0:0:0:0:1",
         )
         self.assertEqual(
             proto.wrappedProtocol.transport.getHost().port,
             8888,
         )
 
-    def test_validUNIXHeaderResolves_getPeerHost(self):
+    def test_validUNIXHeaderResolves_getPeerHost(self) -> None:
         """
         Test if UNIX headers result in the correct host and peer data.
         """
@@ -328,26 +329,26 @@ class HAProxyWrappingFactoryV2Tests(unittest.TestCase):
             b"/home/tests/mysockets/sock",
         )
 
-    def test_overflowBytesSentToWrappedProtocol(self):
+    def test_overflowBytesSentToWrappedProtocol(self) -> None:
         """
         Test if non-header bytes are passed to the wrapped protocol.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)
         proto.dataReceived(self.IPV6HEADER + b"HTTP/1.1 / GET")
         self.assertEqual(proto.wrappedProtocol.data, b"HTTP/1.1 / GET")
 
-    def test_overflowBytesSentToWrappedProtocolChunks(self):
+    def test_overflowBytesSentToWrappedProtocolChunks(self) -> None:
         """
         Test if header streaming passes extra data appropriately.
         """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
-            address.IPv6Address("TCP", b"::1", 8080),
+            address.IPv6Address("TCP", "::1", 8080),
         )
         transport = StringTransportWithDisconnection()
         proto.makeConnection(transport)

--- a/src/twisted/protocols/haproxy/test/test_wrapper.py
+++ b/src/twisted/protocols/haproxy/test/test_wrapper.py
@@ -69,6 +69,10 @@ class HAProxyWrappingFactoryV1Tests(unittest.TestCase):
         self.assertFalse(transport.connected)
 
     def test_preDataReceived_getPeerHost(self) -> None:
+        """
+        Before any data is received the HAProxy protocol will return the same peer
+        and host as the IP connection.
+        """
         factory = HAProxyWrappingFactory(Factory.forProtocol(StaticProtocol))
         proto = factory.buildProtocol(
             address.IPv4Address("TCP", "127.0.0.1", 8080),

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -17,7 +17,7 @@ from zope.interface import directlyProvides, providedBy
 
 # twisted imports
 from twisted.internet.protocol import ServerFactory, Protocol, ClientFactory
-from twisted.internet import error
+from twisted.internet import error, interfaces
 from twisted.internet.interfaces import ILoggingContext
 from twisted.python import log
 
@@ -49,7 +49,9 @@ class ProtocolWrapper(Protocol):
 
     disconnecting = 0
 
-    def __init__(self, factory, wrappedProtocol):
+    def __init__(
+        self, factory: "WrappingFactory", wrappedProtocol: interfaces.IProtocol
+    ):
         self.wrappedProtocol = wrappedProtocol
         self.factory = factory
 

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -544,7 +544,7 @@ class TestMixin:
     MAX_LENGTH = 50
     closed = 0
 
-    def connectionLost(self, reason: Failure = connectionDone):
+    def connectionLost(self, reason: Failure = connectionDone) -> None:
         self.closed = 1
 
 


### PR DESCRIPTION
## Scope and purpose

the runtime types in haproxy were wrong, so I checked them with mypy


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10211
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
