### PR TITLE
10219 remove reraise related py2 compatability hacks

### DIFF
--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -290,7 +290,7 @@ class ConnectionPool:
                 conn.rollback()
             except BaseException:
                 log.err(None, "Rollback failed")
-            raise excValue.with_traceback(excTraceback)
+            raise
 
     def runInteraction(self, interaction, *args, **kw):
         """
@@ -453,7 +453,7 @@ class ConnectionPool:
                 conn.rollback()
             except BaseException:
                 log.err(None, "Rollback failed")
-            raise excValue.with_traceback(excTraceback)
+            raise
 
     def _runQuery(self, trans, *args, **kw):
         trans.execute(*args, **kw)

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -10,7 +10,7 @@ An asynchronous mapping to U{DB-API
 import sys
 
 from twisted.internet import threads
-from twisted.python import reflect, log, compat
+from twisted.python import reflect, log
 
 
 class ConnectionLost(Exception):
@@ -290,7 +290,7 @@ class ConnectionPool:
                 conn.rollback()
             except BaseException:
                 log.err(None, "Rollback failed")
-            compat.reraise(excValue, excTraceback)
+            raise excValue.with_traceback(excTraceback)
 
     def runInteraction(self, interaction, *args, **kw):
         """
@@ -453,7 +453,7 @@ class ConnectionPool:
                 conn.rollback()
             except BaseException:
                 log.err(None, "Rollback failed")
-            compat.reraise(excValue, excTraceback)
+            raise excValue.with_traceback(excTraceback)
 
     def _runQuery(self, trans, *args, **kw):
         trans.execute(*args, **kw)

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -7,7 +7,6 @@ An asynchronous mapping to U{DB-API
 2.0<http://www.python.org/topics/database/DatabaseAPI-2.0.html>}.
 """
 
-import sys
 
 from twisted.internet import threads
 from twisted.python import reflect, log

--- a/src/twisted/enterprise/adbapi.py
+++ b/src/twisted/enterprise/adbapi.py
@@ -285,7 +285,6 @@ class ConnectionPool:
             conn.commit()
             return result
         except BaseException:
-            excType, excValue, excTraceback = sys.exc_info()
             try:
                 conn.rollback()
             except BaseException:
@@ -448,7 +447,6 @@ class ConnectionPool:
             conn.commit()
             return result
         except BaseException:
-            excType, excValue, excTraceback = sys.exc_info()
             try:
                 conn.rollback()
             except BaseException:

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -466,24 +466,12 @@ class Failure(BaseException):
                 return error
         return None
 
-    # It would be nice to use twisted.python.compat.reraise, but that breaks
-    # the stack exploration in _findFailure; possibly this can be fixed in
-    # #5931.
-    if getattr(BaseException, "with_traceback", None):
-        # Python 3
-        def raiseException(self):
-            raise self.value.with_traceback(self.tb)
-
-    else:
-        exec(
-            """def raiseException(self):
-    raise self.type, self.value, self.tb"""
-        )
-
-    raiseException.__doc__ = """
+    def raiseException(self):
+        """
         raise the original exception, preserving traceback
         information if available.
         """
+        raise self.value.with_traceback(self.tb)
 
     @_extraneous
     def throwExceptionIntoGenerator(self, g):


### PR DESCRIPTION
## Scope and purpose

there were two different ways to reraise an error with a traceback - there's now only 1

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10219#
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
