### PR TITLE
DRAFT remove use of @defer.inlineCallbacks

### DIFF
--- a/docs/core/examples/echoclient_ssl.py
+++ b/docs/core/examples/echoclient_ssl.py
@@ -8,18 +8,17 @@ from twisted.python.modules import getModule
 import echoclient
 
 
-@defer.inlineCallbacks
-def main(reactor):
+async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling("public.pem").getContent()
     authority = ssl.Certificate.loadPEM(certData)
     options = ssl.optionsForClientTLS("example.com", authority)
     endpoint = endpoints.SSL4ClientEndpoint(reactor, "localhost", 8000, options)
-    echoClient = yield endpoint.connect(factory)
+    echoClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     echoClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 
 if __name__ == "__main__":

--- a/docs/core/examples/ssl_clientauth_client.py
+++ b/docs/core/examples/ssl_clientauth_client.py
@@ -8,8 +8,7 @@ from twisted.python.modules import getModule
 import echoclient
 
 
-@defer.inlineCallbacks
-def main(reactor):
+async def main(reactor):
     factory = protocol.Factory.forProtocol(echoclient.EchoClient)
     certData = getModule(__name__).filePath.sibling("public.pem").getContent()
     authData = getModule(__name__).filePath.sibling("server.pem").getContent()
@@ -17,11 +16,11 @@ def main(reactor):
     authority = ssl.Certificate.loadPEM(certData)
     options = ssl.optionsForClientTLS("example.com", authority, clientCertificate)
     endpoint = endpoints.SSL4ClientEndpoint(reactor, "localhost", 8000, options)
-    echoClient = yield endpoint.connect(factory)
+    echoClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     echoClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 
 if __name__ == "__main__":

--- a/docs/core/examples/starttls_client.py
+++ b/docs/core/examples/starttls_client.py
@@ -16,19 +16,18 @@ class StartTLSClient(LineReceiver):
             self.transport.loseConnection()
 
 
-@defer.inlineCallbacks
-def main(reactor):
+async def main(reactor):
     factory = protocol.Factory.forProtocol(StartTLSClient)
     certData = getModule(__name__).filePath.sibling("server.pem").getContent()
     factory.options = ssl.optionsForClientTLS(
         "example.com", ssl.PrivateCertificate.loadPEM(certData)
     )
     endpoint = endpoints.HostnameEndpoint(reactor, "localhost", 8000)
-    startTLSClient = yield endpoint.connect(factory)
+    startTLSClient = await endpoint.connect(factory)
 
     done = defer.Deferred()
     startTLSClient.connectionLost = lambda reason: done.callback(None)
-    yield done
+    await done
 
 
 if __name__ == "__main__":

--- a/src/twisted/conch/test/test_filetransfer.py
+++ b/src/twisted/conch/test/test_filetransfer.py
@@ -571,17 +571,16 @@ class OurServerOurClientTests(SFTPTestBase):
             },
         )
 
-    @defer.inlineCallbacks
-    def test_openDirectoryIteratorDeprecated(self):
+    async def test_openDirectoryIteratorDeprecated(self):
         """
         Using client.openDirectory as an iterator is deprecated.
         """
         d = self.client.openDirectory(b"")
         self._emptyBuffers()
-        openDir = yield d
+        openDir = await d
         oneFile = openDir.next()
         self._emptyBuffers()
-        yield oneFile
+        await oneFile
 
         warnings = self.flushWarnings()
         message = (
@@ -592,8 +591,7 @@ class OurServerOurClientTests(SFTPTestBase):
         self.assertEqual(DeprecationWarning, warnings[0]["category"])
         self.assertEqual(message, warnings[0]["message"])
 
-    @defer.inlineCallbacks
-    def test_closedConnectionCancelsRequests(self):
+    async def test_closedConnectionCancelsRequests(self):
         """
         If there are requests outstanding when the connection
         is closed for any reason, they should fail.
@@ -601,7 +599,7 @@ class OurServerOurClientTests(SFTPTestBase):
 
         d = self.client.openFile(b"testfile1", filetransfer.FXF_READ, {})
         self._emptyBuffers()
-        fh = yield d
+        fh = await d
 
         # Intercept the handling of the read request on the server side
         gotReadRequest = []

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -336,26 +336,24 @@ class CheckersMixin:
         which are expected to be unauthorized.
     """
 
-    @defer.inlineCallbacks
-    def test_positive(self):
+    async def test_positive(self):
         """
         The given credentials are accepted by all the checkers, and give
         the expected C{avatarID}s
         """
         for chk in self.getCheckers():
             for (cred, avatarId) in self.getGoodCredentials():
-                r = yield chk.requestAvatarId(cred)
+                r = await chk.requestAvatarId(cred)
                 self.assertEqual(r, avatarId)
 
-    @defer.inlineCallbacks
-    def test_negative(self):
+    async def test_negative(self):
         """
         The given credentials are rejected by all the checkers.
         """
         for chk in self.getCheckers():
             for cred in self.getBadCredentials():
-                d = chk.requestAvatarId(cred)
-                yield self.assertFailure(d, error.UnauthorizedLogin)
+                with self.raises(error.UnauthorizedLogin):
+                    await chk.requestAvatarId(cred)
 
 
 class HashlessFilePasswordDBMixin:

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -54,11 +54,12 @@ try:
 
     _contextvarsSupport = True
 
-except ImportError:
+except ModuleNotFoundError:
     _contextvarsSupport = False
 
     class _NoContext:
         @staticmethod
+        @_extraneous
         def run(f: Callable[..., object], *args: object, **kwargs: object) -> object:
             return f(*args, **kwargs)
 
@@ -68,6 +69,16 @@ except ImportError:
 
 else:
     _copy_context = __copy_context  # type: ignore[assignment]
+
+    from contextvars import Context as __Context
+
+    # only pypy3.7+ and the py3.6- contextvars.Context.run has a __code__
+    # object, because on cPython 3.7+ it's a builtin and doesn't appear
+    # in Tracebacks anyway.
+    try:
+        _extraneous(__Context.run)
+    except AttributeError:
+        pass
 
 log = Logger()
 

--- a/src/twisted/internet/utils.py
+++ b/src/twisted/internet/utils.py
@@ -9,6 +9,7 @@ Utility methods.
 
 import warnings
 import sys
+import contextlib
 from functools import wraps
 
 from twisted.internet import protocol, defer
@@ -189,6 +190,17 @@ def _resetWarningFilters(passthrough, addedFilters):
         except ValueError:
             pass
     return passthrough
+
+
+@contextlib.contextmanager
+def suppressWarningsCM(supressedWarnings):
+    for args, kwargs in supressedWarnings:
+        warnings.filterwarnings(*args, **kwargs)
+    addedFilters = warnings.filters[: len(supressedWarnings)]
+    try:
+        yield
+    finally:
+        _resetWarningFilters(None, addedFilters)
 
 
 def runWithWarningsSuppressed(suppressedWarnings, f, *a, **kw):

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -9,6 +9,7 @@ Test case for twisted.mail.imap4
 
 import base64
 import codecs
+import contextlib
 import functools
 import locale
 import os
@@ -1895,6 +1896,17 @@ class IMAP4HelperMixin:
         self.server.transport.loseConnection()
         log.err(failure, "Problem with " + str(self))
 
+    @contextlib.contextmanager
+    def clientCmgr(self):
+        try:
+            try:
+                yield
+            finally:
+                self._cbStopClient(None)
+        except Exception:
+            self._ebGeneral(failure.Failure())
+            raise
+
     def loopback(self):
         return loopback.loopbackAsync(self.server, self.client)
 
@@ -2655,34 +2667,27 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
         self.assertEqual(self.statused, None)
         self.assertEqual(self.failure.value.args, (b"Could not open mailbox",))
 
-    def testFullAppend(self):
+    async def testFullAppend(self):
         infile = util.sibpath(__file__, "rfc822.message")
         SimpleServer.theAccount.addMailbox("root/subthing")
 
-        def login():
-            return self.client.login(b"testuser", b"password-test")
-
-        @defer.inlineCallbacks
-        def append():
+        async def fullAppend():
+            await self.connected
+            await self.client.login(b"testuser", b"password-test")
             with open(infile, "rb") as message:
-                result = yield self.client.append(
+                await self.client.append(
                     "root/subthing",
                     message,
                     ("\\SEEN", "\\DELETED"),
                     "Tue, 17 Jun 2003 11:22:16 -0600 (MDT)",
                 )
-                defer.returnValue(result)
 
-        d1 = self.connected.addCallback(strip(login))
-        d1.addCallbacks(strip(append), self._ebGeneral)
-        d1.addCallbacks(self._cbStopClient, self._ebGeneral)
-        d2 = self.loopback()
+        with self.clientCmgr():
+            await defer.gatherResults(
+                defer.Deferred.fromCoroutine(fullAppend()),
+                defer.Deferred.fromCoroutine(self.aloopback()),
+            )
 
-        d = defer.gatherResults([d1, d2])
-
-        return d.addCallback(self._cbTestFullAppend, infile)
-
-    def _cbTestFullAppend(self, ignored, infile):
         mb = SimpleServer.theAccount.mailboxes["ROOT/SUBTHING"]
         self.assertEqual(1, len(mb.messages))
         self.assertEqual(
@@ -2692,17 +2697,15 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
         with open(infile, "rb") as f:
             self.assertEqual(f.read(), mb.messages[0][0].getvalue())
 
-    def testPartialAppend(self):
+    async def testPartialAppend(self):
         infile = util.sibpath(__file__, "rfc822.message")
         SimpleServer.theAccount.addMailbox("PARTIAL/SUBTHING")
 
-        def login():
-            return self.client.login(b"testuser", b"password-test")
-
-        @defer.inlineCallbacks
-        def append():
+        async def partialAppend():
+            await self.connected
+            await self.client.login(b"testuser", b"password-test")
             with open(infile, "rb") as message:
-                result = yield self.client.sendCommand(
+                await self.client.sendCommand(
                     imap4.Command(
                         b"APPEND",
                         # Using networkString is cheating!  In this
@@ -2719,16 +2722,13 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
                         message,
                     )
                 )
-                defer.returnValue(result)
 
-        d1 = self.connected.addCallback(strip(login))
-        d1.addCallbacks(strip(append), self._ebGeneral)
-        d1.addCallbacks(self._cbStopClient, self._ebGeneral)
-        d2 = self.loopback()
-        d = defer.gatherResults([d1, d2])
-        return d.addCallback(self._cbTestPartialAppend, infile)
+        with self.clientCmgr():
+            await defer.gatherResults(
+                defer.Deferred.fromCoroutine(partialAppend()),
+                defer.Deferred.fromCoroutine(self.aloopback()),
+            )
 
-    def _cbTestPartialAppend(self, ignored, infile):
         mb = SimpleServer.theAccount.mailboxes["PARTIAL/SUBTHING"]
         self.assertEqual(1, len(mb.messages))
         self.assertEqual((["\\SEEN"], b"Right now", 0), mb.messages[0][1:])
@@ -7119,6 +7119,9 @@ class TLSTests(IMAP4HelperMixin, TestCase):
     def loopback(self):
         return loopback.loopbackTCP(self.server, self.client, noisy=False)
 
+    async def aloopback(self):
+        return await self.loopback()
+
     def testAPileOfThings(self):
         SimpleServer.theAccount.addMailbox(b"inbox")
         called = []
@@ -7250,18 +7253,20 @@ class TLSTests(IMAP4HelperMixin, TestCase):
             b"PLAIN": imap4.PLAINCredentials,
         }
 
-        @defer.inlineCallbacks
-        def assertLOGINandPLAIN():
-            capabilities = yield self.client.getCapabilities()
+        async def _assertLOGINandPLAIN():
+            capabilities = await self.client.getCapabilities()
             self.assertIn(b"AUTH", capabilities)
             self.assertIn(b"LOGIN", capabilities[b"AUTH"])
             self.assertIn(b"PLAIN", capabilities[b"AUTH"])
 
-        self.connected.addCallback(strip(assertLOGINandPLAIN))
+        def assertLOGINandPLAIN(ignore):
+            return defer.Deferred.fromCoroutine(_assertLOGINandPLAIN())
+
+        self.connected.addCallback(assertLOGINandPLAIN)
 
         disconnected = self.startTLSAndAssertSession()
 
-        self.connected.addCallback(strip(assertLOGINandPLAIN))
+        self.connected.addCallback(assertLOGINandPLAIN)
 
         self.connected.addCallback(self._cbStopClient)
         self.connected.addErrback(self._ebGeneral)

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -23,7 +23,7 @@ else:
 from unittest import skipIf
 
 from twisted.internet import reactor
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import Deferred
 from twisted.internet.error import ProcessDone
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python.filepath import FilePath
@@ -274,15 +274,14 @@ class SendmsgTests(TestCase):
                 "or maybe send1msg blocked for a while"
             )
 
-    @inlineCallbacks
-    def test_sendSubProcessFD(self):
+    async def test_sendSubProcessFD(self):
         """
         Calling L{sendmsg} with SOL_SOCKET, SCM_RIGHTS, and a platform-endian
         packed file descriptor number should send that file descriptor to a
         different process, where it can be retrieved by using L{recv1msg}.
         """
         sspp = _spawn("pullpipe", self.output.fileno())
-        yield sspp.started
+        await sspp.started
         pipeOut, pipeIn = _makePipe()
         self.addCleanup(pipeOut.close)
         self.addCleanup(pipeIn.close)
@@ -294,7 +293,7 @@ class SendmsgTests(TestCase):
                 [(SOL_SOCKET, SCM_RIGHTS, pack("i", pipeIn.fileno()))],
             )
 
-        yield sspp.stopped
+        await sspp.stopped
         self.assertEqual(read(pipeOut.fileno(), 1024), b"Test fixture data: blonk.\n")
         # Make sure that the pipe is actually closed now.
         self.assertEqual(read(pipeOut.fileno(), 1024), b"")

--- a/src/twisted/test/test_process.py
+++ b/src/twisted/test/test_process.py
@@ -2454,8 +2454,7 @@ class Win32CreateProcessFlagsTests(unittest.TestCase):
     Check the flags passed to CreateProcess.
     """
 
-    @defer.inlineCallbacks
-    def test_flags(self):
+    async def test_flags(self):
         r"""
         Verify that the flags passed to win32process.CreateProcess() prevent a
         new console window from being created. Use the following script
@@ -2532,7 +2531,7 @@ class Win32CreateProcessFlagsTests(unittest.TestCase):
         comspec = str(os.environ["COMSPEC"])
         cmd = [comspec, "/c", exe, scriptPath.path]
         _dumbwin32proc.Process(reactor, processProto, None, cmd, {}, None)
-        yield d
+        await d
         self.assertEqual(flags, [_dumbwin32proc.win32process.CREATE_NO_WINDOW])
 
 

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -99,7 +99,6 @@ class TestCase(SynchronousTestCase):
             v = method()
             return (await v) if isinstance(v, Awaitable) else v
 
-
     def _run(self, methodName, result):
         from twisted.internet import reactor
 
@@ -139,7 +138,7 @@ class TestCase(SynchronousTestCase):
             )
             return defer.fail(exc)
 
-        d = defer.ensureDeferred(self._runCorofnWithWarningsSuppressed)
+        d = defer.Deferred.fromCoroutine(self._runCorofnWithWarningsSuppressed(method))
         call = reactor.callLater(timeout, onTimeout, d)
         d.addBoth(lambda x: call.active() and call.cancel() or x)
         return d
@@ -230,7 +229,7 @@ class TestCase(SynchronousTestCase):
                 result.addError(self, f)
                 self._passed = False
 
-        return defer.ensureDeferred(deferRunCleanups())
+        return defer.Deferred.fromCoroutine(deferRunCleanups())
 
     def _cleanUp(self, result):
         try:

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -117,7 +117,9 @@ class TestCase(SynchronousTestCase):
                 raise defer.TimeoutError(
                     f"{self!r} ({methodName}) still running at {timeout} secs"
                 )
-            return value
+            raise defer.TimeoutError(
+                f"{self!r} ({methodName}) ignored timeout at {timeout} secs"
+            )
 
         return defer.Deferred.fromCoroutine(
             self._runCorofnWithWarningsSuppressed(method)

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -32,7 +32,7 @@ _wait_is_running: List[None] = []
 async def _maybeCoroutine(*args, **kw):
     try:  # simulate `async def _maybeCoroutine(func, /, *args, **kwargs):`
         func, *args = args
-    except ValueError:
+    except ValueError:  # pragma: no cover
         raise TypeError(
             "_maybeCoroutine() missing 1 required positional argument: 'func'"
         ) from None

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -111,6 +111,14 @@ class TestCase(SynchronousTestCase):
             )
             return defer.fail(exc)
 
+        if inspect.isasyncgenfunction(method):
+            exc = TypeError(
+                "{!r} is an async generator function and therefore will never run".format(
+                    method
+                )
+            )
+            return defer.fail(exc)
+
         def _cancelledToTimedOutError(value, timeout):
             if isinstance(value, failure.Failure):
                 value.trap(defer.CancelledError)

--- a/src/twisted/trial/_frames.py
+++ b/src/twisted/trial/_frames.py
@@ -1,0 +1,167 @@
+# -*- test-case-name: twisted.trial.test.test_reporter -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+#
+
+"""
+Format trial tracebacks and trim frames to remove internal paths.
+"""
+
+import importlib
+import os
+import pathlib
+
+
+def _getCvarFrame():
+    try:
+        from contextvars import Context
+    except ModuleNotFoundError:
+        return ("run", "defer")  # defer._NoContext.run
+
+    try:
+        _cvar_mod = Context.run.__module__
+    except AttributeError:
+        return None  # cpython 3.7 Context.run is a builtin
+
+    # pypy3.7 or https://pypi.org/project/contextvars
+    return ("run", pathlib.Path(importlib.import_module(_cvar_mod).__file__).stem)
+
+
+_cvarFrame = _getCvarFrame()
+
+
+def _trimRunnerFrames(frames):
+    def frameInfo(f):
+        return f[0], os.path.splitext(os.path.basename(f[1]))[0]
+
+    syncCase = [("_run", "_synctest")]
+
+    if len(frames) < 1:
+        return frames
+
+    frame0 = frameInfo(frames[0])
+    if [frame0] == syncCase:
+        return frames[1:]
+
+    if len(frames) < 2:
+        return frames
+
+    asyncCase = [
+        ("_inlineCallbacks", "defer"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+    ]
+
+    frame1 = frameInfo(frames[1])
+    if [frame0, frame1] == asyncCase:
+        return frames[2:]
+
+    if len(frames) < 3:
+        return frames
+
+    asyncShimCvarCase = [
+        ("_inlineCallbacks", "defer"),
+        _cvarFrame,
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+    ]
+
+    frame2 = frameInfo(frames[2])
+    if [frame0, frame1, frame2] == asyncShimCvarCase:
+        return frames[3:]
+
+    if len(frames) < 4:
+        return frames
+
+    asyncFailureCase = [
+        ("_inlineCallbacks", "defer"),
+        ("throwExceptionIntoGenerator", "failure"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+        ("_runCallbacks", "defer"),
+    ]
+
+    frame2 = frameInfo(frames[2])
+    frame3 = frameInfo(frames[3])
+    if [frame0, frame1, frame2, frame3] == asyncFailureCase:
+        return frames[4:]
+
+    if len(frames) < 5:
+        return frames
+
+    asyncFailureShimCvarCase = [
+        ("_inlineCallbacks", "defer"),
+        _cvarFrame,
+        ("throwExceptionIntoGenerator", "failure"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+        ("_runCallbacks", "defer"),
+    ]
+
+    frame4 = frameInfo(frames[4])
+    if [frame0, frame1, frame2, frame3, frame4] == asyncFailureShimCvarCase:
+        return frames[5:]
+
+    return frames
+
+
+def _trimFrames(frames):
+    """
+    Trim frames to remove internal paths.
+
+    When a C{SynchronousTestCase} method fails synchronously, the stack
+    looks like this:
+     - [0]: C{SynchronousTestCase._run}
+     - [1:-2]: code in the test method which failed
+     - [-1]: C{_synctest.fail}
+
+    When a C{TestCase} method fails synchronously, the stack looks like
+    this:
+     - [0]: C{defer._inlineCallbacks}
+     - [1]: C{TestCase._runCorofnWithWarningsSuppressed}
+     - [2:-2]: code in the test method which failed
+     - [-1]: C{_synctest.fail}
+
+    When a method fails inside a C{Deferred} (i.e., when the test method
+    returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
+    captured inside the resulting C{Failure} looks like this:
+     - [0]: C{defer._inlineCallbacks}
+     - [1]: C{defer.throwExceptionIntoGenerator}
+     - [2]: C{TestCase._runCorofnWithWarningsSuppressed}
+     - [3]: C{defer._runCallbacks}
+     - [4:-2]: code in the testmethod which failed
+     - [-1]: C{_synctest.fail}
+
+    As a result, we want to trim those frames from the front,
+    and trim the [unittest.fail] from the end.
+
+    There is also another case, when the test method is badly defined and
+    contains extra arguments.
+
+    If it doesn't recognize one of these cases, it just returns the
+    original frames.
+
+    @param frames: The C{list} of frames from the test failure.
+
+    @return: The C{list} of frames to display.
+    """
+    newFrames = _trimRunnerFrames(list(frames))
+
+    if not newFrames:
+        # The method fails before getting called, probably an argument
+        # problem
+        return newFrames
+
+    last = newFrames[-1]
+    if (
+        last[0].startswith("fail")
+        and os.path.splitext(os.path.basename(last[1]))[0] == "_synctest"
+    ):
+        return newFrames[:-1]
+
+    return newFrames
+
+
+def _formatFailureTraceback(*, detail, fail):
+    if isinstance(fail, str):
+        return fail.rstrip() + "\n"
+    fail.frames, frames = _trimFrames(fail.frames), fail.frames
+    result = fail.getTraceback(detail=detail, elideFrameworkCode=True)
+    fail.frames = frames
+    return result

--- a/src/twisted/trial/_frames.py
+++ b/src/twisted/trial/_frames.py
@@ -104,6 +104,8 @@ def _trimRunnerFrames(frames):
 def _trimFrames(frames):
     """
     Trim frames to remove internal paths.
+    
+    TODO: https://twistedmatrix.com/trac/ticket/10220
 
     When a C{SynchronousTestCase} method fails synchronously, the stack
     looks like this:

--- a/src/twisted/trial/_frames.py
+++ b/src/twisted/trial/_frames.py
@@ -104,7 +104,7 @@ def _trimRunnerFrames(frames):
 def _trimFrames(frames):
     """
     Trim frames to remove internal paths.
-    
+
     TODO: https://twistedmatrix.com/trac/ticket/10220
 
     When a C{SynchronousTestCase} method fails synchronously, the stack

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1355,6 +1355,15 @@ class SynchronousTestCase(_Assertions):
             )
             result.addError(self, failure.Failure(exc))
             return True
+
+        if inspect.isasyncgenfunction(method):
+            exc = TypeError(
+                "{!r} is an async generator function and therefore will never run".format(
+                    method
+                )
+            )
+            result.addError(self, failure.Failure(exc))
+            return True
         try:
             with suppressWarningsCM(suppress):
                 method()

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1356,7 +1356,7 @@ class SynchronousTestCase(_Assertions):
             result.addError(self, failure.Failure(exc))
             return True
         try:
-            with supressWarningsCM(supress):
+            with suppressWarningsCM(suppress):
                 method()
         except SkipTest as e:
             result.addSkip(self, self._getSkipReason(method, e))

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -20,7 +20,7 @@ from typing import Optional, Tuple
 
 from twisted.python import failure, log, monkey
 from twisted.python.reflect import fullyQualifiedName
-from twisted.python.util import runWithWarningsSuppressed
+from twisted.internet.utils import suppressWarningsCM
 from twisted.python.deprecate import (
     DEPRECATION_WARNING_FORMAT,
     getDeprecationWarningString,
@@ -1356,7 +1356,8 @@ class SynchronousTestCase(_Assertions):
             result.addError(self, failure.Failure(exc))
             return True
         try:
-            runWithWarningsSuppressed(suppress, method)
+            with supressWarningsCM(supress):
+                method()
         except SkipTest as e:
             result.addSkip(self, self._getSkipReason(method, e))
         except BaseException:

--- a/src/twisted/trial/newsfragments/8977.feature
+++ b/src/twisted/trial/newsfragments/8977.feature
@@ -1,0 +1,1 @@
+Support async def coroutine functions in trial.

--- a/src/twisted/trial/newsfragments/8977.feature
+++ b/src/twisted/trial/newsfragments/8977.feature
@@ -1,1 +1,2 @@
 Support async def coroutine functions in trial.
+``twisted.trial.unittest.TestCase`` now times out Deferreds using the built in cancel mechanism.

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -9,10 +9,7 @@ Defines classes that handle the results of tests.
 """
 
 
-import importlib
-import pathlib
 import sys
-import os
 import time
 import warnings
 import unittest as pyunit
@@ -25,30 +22,12 @@ from twisted.python import reflect, log
 from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from twisted.python.util import untilConcludes
-from twisted.trial import itrial, util
+from . import itrial, util, _frames
 
 try:
     from subunit import TestProtocolClient  # type: ignore[import]
 except ImportError:
     TestProtocolClient = None
-
-
-def _getCvarFrame():
-    try:
-        from contextvars import Context
-    except ModuleNotFoundError:
-        return ("run", "defer")  # defer._NoContext.run
-
-    try:
-        _cvar_mod = Context.run.__module__
-    except AttributeError:
-        return None  # cpython 3.7 Context.run is a builtin
-
-    # pypy3.7 or https://pypi.org/project/contextvars
-    return ("run", pathlib.Path(importlib.import_module(_cvar_mod).__file__).stem)
-
-
-_cvarFrame = _getCvarFrame()
 
 
 def _makeTodo(value):
@@ -370,143 +349,6 @@ class _AdaptedReporter(TestResultDecorator):
         return self._originalReporter.stopTest(self.testAdapter(test))
 
 
-def _trimRunnerFrames(frames):
-    def frameInfo(f):
-        return f[0], os.path.splitext(os.path.basename(f[1]))[0]
-
-    syncCase = [("_run", "_synctest")]
-
-    if len(frames) < 1:
-        return frames
-
-    frame0 = frameInfo(frames[0])
-    if [frame0] == syncCase:
-        return frames[1:]
-
-    if len(frames) < 2:
-        return frames
-
-    asyncCase = [
-        ("_inlineCallbacks", "defer"),
-        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-    ]
-
-    frame1 = frameInfo(frames[1])
-    if [frame0, frame1] == asyncCase:
-        return frames[2:]
-
-    if len(frames) < 3:
-        return frames
-
-    asyncShimCvarCase = [
-        ("_inlineCallbacks", "defer"),
-        _cvarFrame,
-        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-    ]
-
-    frame2 = frameInfo(frames[2])
-    if [frame0, frame1, frame2] == asyncShimCvarCase:
-        return frames[3:]
-
-    if len(frames) < 4:
-        return frames
-
-    asyncFailureCase = [
-        ("_inlineCallbacks", "defer"),
-        ("throwExceptionIntoGenerator", "failure"),
-        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-        ("_runCallbacks", "defer"),
-    ]
-
-    frame2 = frameInfo(frames[2])
-    frame3 = frameInfo(frames[3])
-    if [frame0, frame1, frame2, frame3] == asyncFailureCase:
-        return frames[4:]
-
-    if len(frames) < 5:
-        return frames
-
-    asyncFailureShimCvarCase = [
-        ("_inlineCallbacks", "defer"),
-        _cvarFrame,
-        ("throwExceptionIntoGenerator", "failure"),
-        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-        ("_runCallbacks", "defer"),
-    ]
-
-    frame4 = frameInfo(frames[4])
-    if [frame0, frame1, frame2, frame3, frame4] == asyncFailureShimCvarCase:
-        return frames[5:]
-
-    return frames
-
-
-def _trimFrames(frames):
-    """
-    Trim frames to remove internal paths.
-
-    When a C{SynchronousTestCase} method fails synchronously, the stack
-    looks like this:
-     - [0]: C{SynchronousTestCase._run}
-     - [1:-2]: code in the test method which failed
-     - [-1]: C{_synctest.fail}
-
-    When a C{TestCase} method fails synchronously, the stack looks like
-    this:
-     - [0]: C{defer._inlineCallbacks}
-     - [1]: C{TestCase._runCorofnWithWarningsSuppressed}
-     - [2:-2]: code in the test method which failed
-     - [-1]: C{_synctest.fail}
-
-    When a method fails inside a C{Deferred} (i.e., when the test method
-    returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
-    captured inside the resulting C{Failure} looks like this:
-     - [0]: C{defer._inlineCallbacks}
-     - [1]: C{defer.throwExceptionIntoGenerator}
-     - [2]: C{TestCase._runCorofnWithWarningsSuppressed}
-     - [3]: C{defer._runCallbacks}
-     - [4:-2]: code in the testmethod which failed
-     - [-1]: C{_synctest.fail}
-
-    As a result, we want to trim those frames from the front,
-    and trim the [unittest.fail] from the end.
-
-    There is also another case, when the test method is badly defined and
-    contains extra arguments.
-
-    If it doesn't recognize one of these cases, it just returns the
-    original frames.
-
-    @param frames: The C{list} of frames from the test failure.
-
-    @return: The C{list} of frames to display.
-    """
-    newFrames = _trimRunnerFrames(list(frames))
-
-    if not newFrames:
-        # The method fails before getting called, probably an argument
-        # problem
-        return newFrames
-
-    last = newFrames[-1]
-    if (
-        last[0].startswith("fail")
-        and os.path.splitext(os.path.basename(last[1]))[0] == "_synctest"
-    ):
-        return newFrames[:-1]
-
-    return newFrames
-
-
-def _formatFailureTraceback(*, detail, fail):
-    if isinstance(fail, str):
-        return fail.rstrip() + "\n"
-    fail.frames, frames = _trimFrames(fail.frames), fail.frames
-    result = fail.getTraceback(detail=detail, elideFrameworkCode=True)
-    fail.frames = frames
-    return result
-
-
 @implementer(itrial.IReporter)
 class Reporter(TestResult):
     """
@@ -655,7 +497,7 @@ class Reporter(TestResult):
         )
 
     def _formatFailureTraceback(self, fail):
-        return _formatFailureTraceback(detail=self.tbformat, fail=fail)
+        return _frames._formatFailureTraceback(detail=self.tbformat, fail=fail)
 
     def _groupResults(self, results, formatter):
         """

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -35,7 +35,7 @@ try:
 except ModuleNotFoundError:
     _cvarFrame = ("run", "defer")  # defer._NoContext.run
 else:
-    _cvarFrame = ("run", Context.run.__module__)
+    _cvarFrame = ("run", getattr(Context.run, "__module__", None))
 
 
 def _makeTodo(value):

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -370,6 +370,143 @@ class _AdaptedReporter(TestResultDecorator):
         return self._originalReporter.stopTest(self.testAdapter(test))
 
 
+def _trimRunnerFrames(frames):
+    def frameInfo(f):
+        return f[0], os.path.splitext(os.path.basename(f[1]))[0]
+
+    syncCase = [("_run", "_synctest")]
+
+    if len(frames) < 1:
+        return frames
+
+    frame0 = frameInfo(frames[0])
+    if [frame0] == syncCase:
+        return frames[1:]
+
+    if len(frames) < 2:
+        return frames
+
+    asyncCase = [
+        ("_inlineCallbacks", "defer"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+    ]
+
+    frame1 = frameInfo(frames[1])
+    if [frame0, frame1] == asyncCase:
+        return frames[2:]
+
+    if len(frames) < 3:
+        return frames
+
+    asyncShimCvarCase = [
+        ("_inlineCallbacks", "defer"),
+        _cvarFrame,
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+    ]
+
+    frame2 = frameInfo(frames[2])
+    if [frame0, frame1, frame2] == asyncShimCvarCase:
+        return frames[3:]
+
+    if len(frames) < 4:
+        return frames
+
+    asyncFailureCase = [
+        ("_inlineCallbacks", "defer"),
+        ("throwExceptionIntoGenerator", "failure"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+        ("_runCallbacks", "defer"),
+    ]
+
+    frame2 = frameInfo(frames[2])
+    frame3 = frameInfo(frames[3])
+    if [frame0, frame1, frame2, frame3] == asyncFailureCase:
+        return frames[4:]
+
+    if len(frames) < 5:
+        return frames
+
+    asyncFailureShimCvarCase = [
+        ("_inlineCallbacks", "defer"),
+        _cvarFrame,
+        ("throwExceptionIntoGenerator", "failure"),
+        ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+        ("_runCallbacks", "defer"),
+    ]
+
+    frame4 = frameInfo(frames[4])
+    if [frame0, frame1, frame2, frame3, frame4] == asyncFailureShimCvarCase:
+        return frames[5:]
+
+    return frames
+
+
+def _trimFrames(frames):
+    """
+    Trim frames to remove internal paths.
+
+    When a C{SynchronousTestCase} method fails synchronously, the stack
+    looks like this:
+     - [0]: C{SynchronousTestCase._run}
+     - [1:-2]: code in the test method which failed
+     - [-1]: C{_synctest.fail}
+
+    When a C{TestCase} method fails synchronously, the stack looks like
+    this:
+     - [0]: C{defer._inlineCallbacks}
+     - [1]: C{TestCase._runCorofnWithWarningsSuppressed}
+     - [2:-2]: code in the test method which failed
+     - [-1]: C{_synctest.fail}
+
+    When a method fails inside a C{Deferred} (i.e., when the test method
+    returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
+    captured inside the resulting C{Failure} looks like this:
+     - [0]: C{defer._inlineCallbacks}
+     - [1]: C{defer.throwExceptionIntoGenerator}
+     - [2]: C{TestCase._runCorofnWithWarningsSuppressed}
+     - [3]: C{defer._runCallbacks}
+     - [4:-2]: code in the testmethod which failed
+     - [-1]: C{_synctest.fail}
+
+    As a result, we want to trim those frames from the front,
+    and trim the [unittest.fail] from the end.
+
+    There is also another case, when the test method is badly defined and
+    contains extra arguments.
+
+    If it doesn't recognize one of these cases, it just returns the
+    original frames.
+
+    @param frames: The C{list} of frames from the test failure.
+
+    @return: The C{list} of frames to display.
+    """
+    newFrames = _trimRunnerFrames(list(frames))
+
+    if not newFrames:
+        # The method fails before getting called, probably an argument
+        # problem
+        return newFrames
+
+    last = newFrames[-1]
+    if (
+        last[0].startswith("fail")
+        and os.path.splitext(os.path.basename(last[1]))[0] == "_synctest"
+    ):
+        return newFrames[:-1]
+
+    return newFrames
+
+
+def _formatFailureTraceback(*, detail, fail):
+    if isinstance(fail, str):
+        return fail.rstrip() + "\n"
+    fail.frames, frames = _trimFrames(fail.frames), fail.frames
+    result = fail.getTraceback(detail=detail, elideFrameworkCode=True)
+    fail.frames = frames
+    return result
+
+
 @implementer(itrial.IReporter)
 class Reporter(TestResult):
     """
@@ -517,139 +654,8 @@ class Reporter(TestResult):
             BrokenTestCaseWarning,
         )
 
-    def _trimRunnerFrames(self, frames):
-        def frameInfo(f):
-            return f[0], os.path.splitext(os.path.basename(f[1]))[0]
-
-        syncCase = [("_run", "_synctest")]
-
-        if len(frames) < 1:
-            return frames
-
-        frame0 = frameInfo(frames[0])
-        if [frame0] == syncCase:
-            return frames[1:]
-
-        if len(frames) < 2:
-            return frames
-
-        asyncCase = [
-            ("_inlineCallbacks", "defer"),
-            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-        ]
-
-        frame1 = frameInfo(frames[1])
-        if [frame0, frame1] == asyncCase:
-            return frames[2:]
-
-        if len(frames) < 3:
-            return frames
-
-        asyncShimCvarCase = [
-            ("_inlineCallbacks", "defer"),
-            _cvarFrame,
-            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-        ]
-
-        frame2 = frameInfo(frames[2])
-        if [frame0, frame1, frame2] == asyncShimCvarCase:
-            return frames[3:]
-
-        if len(frames) < 4:
-            return frames
-
-        asyncFailureCase = [
-            ("_inlineCallbacks", "defer"),
-            ("throwExceptionIntoGenerator", "failure"),
-            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-            ("_runCallbacks", "defer"),
-        ]
-
-        frame2 = frameInfo(frames[2])
-        frame3 = frameInfo(frames[3])
-        if [frame0, frame1, frame2, frame3] == asyncFailureCase:
-            return frames[4:]
-
-        if len(frames) < 5:
-            return frames
-
-        asyncFailureShimCvarCase = [
-            ("_inlineCallbacks", "defer"),
-            _cvarFrame,
-            ("throwExceptionIntoGenerator", "failure"),
-            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
-            ("_runCallbacks", "defer"),
-        ]
-
-        frame4 = frameInfo(frames[4])
-        if [frame0, frame1, frame2, frame3, frame4] == asyncFailureShimCvarCase:
-            return frames[5:]
-
-        return frames
-
-    def _trimFrames(self, frames):
-        """
-        Trim frames to remove internal paths.
-
-        When a C{SynchronousTestCase} method fails synchronously, the stack
-        looks like this:
-         - [0]: C{SynchronousTestCase._run}
-         - [1:-2]: code in the test method which failed
-         - [-1]: C{_synctest.fail}
-
-        When a C{TestCase} method fails synchronously, the stack looks like
-        this:
-         - [0]: C{defer._inlineCallbacks}
-         - [1]: C{TestCase._runCorofnWithWarningsSuppressed}
-         - [2:-2]: code in the test method which failed
-         - [-1]: C{_synctest.fail}
-
-        When a method fails inside a C{Deferred} (i.e., when the test method
-        returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
-        captured inside the resulting C{Failure} looks like this:
-         - [0]: C{defer._inlineCallbacks}
-         - [1]: C{defer.throwExceptionIntoGenerator}
-         - [2]: C{TestCase._runCorofnWithWarningsSuppressed}
-         - [3]: C{defer._runCallbacks}
-         - [4:-2]: code in the testmethod which failed
-         - [-1]: C{_synctest.fail}
-
-        As a result, we want to trim those frames from the front,
-        and trim the [unittest.fail] from the end.
-
-        There is also another case, when the test method is badly defined and
-        contains extra arguments.
-
-        If it doesn't recognize one of these cases, it just returns the
-        original frames.
-
-        @param frames: The C{list} of frames from the test failure.
-
-        @return: The C{list} of frames to display.
-        """
-        newFrames = self._trimRunnerFrames(list(frames))
-
-        if not newFrames:
-            # The method fails before getting called, probably an argument
-            # problem
-            return newFrames
-
-        last = newFrames[-1]
-        if (
-            last[0].startswith("fail")
-            and os.path.splitext(os.path.basename(last[1]))[0] == "_synctest"
-        ):
-            return newFrames[:-1]
-
-        return newFrames
-
     def _formatFailureTraceback(self, fail):
-        if isinstance(fail, str):
-            return fail.rstrip() + "\n"
-        fail.frames, frames = self._trimFrames(fail.frames), fail.frames
-        result = fail.getTraceback(detail=self.tbformat, elideFrameworkCode=True)
-        fail.frames = frames
-        return result
+        return _formatFailureTraceback(detail=self.tbformat, fail=fail)
 
     def _groupResults(self, results, formatter):
         """

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -14,6 +14,7 @@ import os
 import time
 import warnings
 import unittest as pyunit
+import importlib
 
 from collections import OrderedDict
 
@@ -29,6 +30,13 @@ try:
     from subunit import TestProtocolClient  # type: ignore[import]
 except ImportError:
     TestProtocolClient = None
+
+try:
+    importlib.import_module("contextvars")
+except ModuleNotFoundError:
+    _cvarFrame = ("run", "defer")  # defer._NoContext.run
+else:
+    _cvarFrame = ("run", "__init__")  # contextvars.Context.run
 
 
 def _makeTodo(value):
@@ -527,7 +535,7 @@ class Reporter(TestResult):
 
         asyncShimCvarCase = [
             ("_inlineCallbacks", "defer"),
-            ("run", "defer"),  # defer._NoContext.run
+            _cvarFrame,
             ("_runCorofnWithWarningsSuppressed", "_asynctest"),
         ]
 
@@ -555,7 +563,7 @@ class Reporter(TestResult):
 
         asyncFailureShimCvarCase = [
             ("_inlineCallbacks", "defer"),
-            ("run", "defer"),
+            _cvarFrame,
             ("throwExceptionIntoGenerator", "failure"),
             ("_runCorofnWithWarningsSuppressed", "_asynctest"),
             ("_runCallbacks", "defer"),

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -14,7 +14,6 @@ import os
 import time
 import warnings
 import unittest as pyunit
-import importlib
 
 from collections import OrderedDict
 
@@ -32,11 +31,11 @@ except ImportError:
     TestProtocolClient = None
 
 try:
-    importlib.import_module("contextvars")
+    from contextvars import Context
 except ModuleNotFoundError:
     _cvarFrame = ("run", "defer")  # defer._NoContext.run
 else:
-    _cvarFrame = ("run", "__init__")  # contextvars.Context.run
+    _cvarFrame = ("run", Context.run.__module__)
 
 
 def _makeTodo(value):

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -522,6 +522,19 @@ class Reporter(TestResult):
         if [frame0, frame1] == asyncCase:
             return frames[2:]
 
+        if len(frames) < 3:
+            return frames
+
+        asyncShimCvarCase = [
+            ("_inlineCallbacks", "defer"),
+            ("run", "defer"),  # defer._NoContext.run
+            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+        ]
+
+        frame2 = frameInfo(frames[2])
+        if [frame0, frame1, frame2] == asyncShimCvarCase:
+            return frames[3:]
+
         if len(frames) < 4:
             return frames
 
@@ -536,6 +549,21 @@ class Reporter(TestResult):
         frame3 = frameInfo(frames[3])
         if [frame0, frame1, frame2, frame3] == asyncFailureCase:
             return frames[4:]
+
+        if len(frames) < 5:
+            return frames
+
+        asyncFailureShimCvarCase = [
+            ("_inlineCallbacks", "defer"),
+            ("run", "defer"),
+            ("throwExceptionIntoGenerator", "failure"),
+            ("_runCorofnWithWarningsSuppressed", "_asynctest"),
+            ("_runCallbacks", "defer"),
+        ]
+
+        frame4 = frameInfo(frames[4])
+        if [frame0, frame1, frame2, frame3, frame4] == asyncFailureShimCvarCase:
+            return frames[5:]
 
         return frames
 

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -126,8 +126,15 @@ class DeferredTests(unittest.TestCase):
         """
         Test case that is decorated with L{defer.inlineCallbacks}.
         """
-        self._touchClass(None)
         yield None
+        self._touchClass(None)
+
+    async def test_passCoroutineFunction(self):
+        """
+        Test case that is a coroutine function
+        """
+        await defer.succeed(None)
+        self._touchClass(None)
 
     def test_fail(self):
         return defer.fail(self.failureException("I fail"))

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -217,6 +217,7 @@ class TimeoutTests(unittest.TestCase):
 
     async def test_cancelSuppression(self):
         """Test case that ignores its timeout"""
+
         async def sleep(delay):
             await task.deferLater(clock=reactor, delay=delay)
 
@@ -232,6 +233,7 @@ class TimeoutTests(unittest.TestCase):
 
     async def test_cancelReplacement(self):
         """Test case that replaces its CancelledError"""
+
         async def sleep(delay):
             await task.deferLater(clock=reactor, delay=delay)
 

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -216,6 +216,7 @@ class TimeoutTests(unittest.TestCase):
     test_errorPropagation.timeout = 0.1  # type: ignore[attr-defined]
 
     async def test_cancelSuppression(self):
+        """Test case that ignores its timeout"""
         async def sleep(delay):
             await task.deferLater(clock=reactor, delay=delay)
 
@@ -230,6 +231,7 @@ class TimeoutTests(unittest.TestCase):
         pass
 
     async def test_cancelReplacement(self):
+        """Test case that replaces its CancelledError"""
         async def sleep(delay):
             await task.deferLater(clock=reactor, delay=delay)
 

--- a/src/twisted/trial/test/test_deferred.py
+++ b/src/twisted/trial/test/test_deferred.py
@@ -220,7 +220,8 @@ class TimeoutTests(TestTester):
         result = self.runTest("test_errorPropagation")
         self.assertFalse(result.wasSuccessful())
         self.assertEqual(result.testsRun, 1)
-        self._wasTimeout(detests.TimeoutTests.timedOut)
+        error = detests.TimeoutTests.timedOut
+        self.assertEqual(error.check(defer.CancelledError), defer.CancelledError)
 
     def test_classTimeout(self):
         loader = pyunit.TestLoader()

--- a/src/twisted/trial/test/test_deferred.py
+++ b/src/twisted/trial/test/test_deferred.py
@@ -133,6 +133,15 @@ class DeferredTests(TestTester):
         self.assertEqual(result.testsRun, 1)
         self.assertTrue(detests.DeferredTests.touched)
 
+    def test_passCoroutineFunction(self):
+        """
+        The body of an async def test gets run.
+        """
+        result = self.runTest("test_passCoroutineFunction")
+        self.assertTrue(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+        self.assertTrue(detests.DeferredTests.touched)
+
     def test_fail(self):
         result = self.runTest("test_fail")
         self.assertFalse(result.wasSuccessful())

--- a/src/twisted/trial/test/test_deferred.py
+++ b/src/twisted/trial/test/test_deferred.py
@@ -223,6 +223,27 @@ class TimeoutTests(TestTester):
         error = detests.TimeoutTests.timedOut
         self.assertEqual(error.check(defer.CancelledError), defer.CancelledError)
 
+    def test_cancelSuppression(self):
+        result = self.runTest("test_cancelSuppression")
+        self.assertFalse(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+        e = result.errors[0][1]
+        self._wasTimeout(e)
+        self.assertEqual(
+            e.getErrorMessage(),
+            "<twisted.trial.test.detests.TimeoutTests "
+            "testMethod=test_cancelSuppression> "
+            "(test_cancelSuppression) ignored timeout at 0.1 secs",
+        )
+
+    def test_cancelReplacement(self):
+        result = self.runTest("test_cancelReplacement")
+        self.assertFalse(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+        e = result.errors[0][1]
+        e.check(detests.TimeoutTests.MyError)
+        self.assertEqual(e.getErrorMessage(), "replaced error")
+
     def test_classTimeout(self):
         loader = pyunit.TestLoader()
         suite = loader.loadTestsFromTestCase(detests.TestClassTimeoutAttribute)

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -21,7 +21,7 @@ from unittest import TestCase as StdlibTestCase
 from twisted.python import log, reflect
 from twisted.python.failure import Failure
 from twisted.python.reflect import qual
-from twisted.trial import itrial, unittest, runner, reporter, util
+from twisted.trial import itrial, unittest, runner, reporter, util, _frames
 from twisted.trial.reporter import _ExitWrapper, UncleanWarningsReporterWrapper
 from twisted.trial.test import erroneous
 from twisted.trial.unittest import makeTodo, SkipTest, Todo
@@ -268,7 +268,7 @@ class TracebackHandlingTests(unittest.SynchronousTestCase):
         bads = result.failures + result.errors
         self.assertEqual(len(bads), 1)
         self.assertEqual(bads[0][0], test)
-        return reporter._trimFrames(bads[0][1].frames)
+        return _frames._trimFrames(bads[0][1].frames)
 
     def checkFrames(self, observedFrames, expectedFrames):
         for observed, expected in zip(observedFrames, expectedFrames):
@@ -304,10 +304,10 @@ class TracebackHandlingTests(unittest.SynchronousTestCase):
         self.checkFrames(frames, [("_later", "twisted/trial/test/erroneous")])
 
     def test_noFrames(self):
-        self.assertEqual([], reporter._trimFrames([]))
+        self.assertEqual([], _frames._trimFrames([]))
 
     def test_oneFrame(self):
-        self.assertEqual(["fake frame"], reporter._trimFrames(["fake frame"]))
+        self.assertEqual(["fake frame"], _frames._trimFrames(["fake frame"]))
 
     def test_exception(self):
         """

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -268,7 +268,7 @@ class TracebackHandlingTests(unittest.SynchronousTestCase):
         bads = result.failures + result.errors
         self.assertEqual(len(bads), 1)
         self.assertEqual(bads[0][0], test)
-        return result._trimFrames(bads[0][1].frames)
+        return reporter._trimFrames(bads[0][1].frames)
 
     def checkFrames(self, observedFrames, expectedFrames):
         for observed, expected in zip(observedFrames, expectedFrames):
@@ -304,12 +304,10 @@ class TracebackHandlingTests(unittest.SynchronousTestCase):
         self.checkFrames(frames, [("_later", "twisted/trial/test/erroneous")])
 
     def test_noFrames(self):
-        result = reporter.Reporter(None)
-        self.assertEqual([], result._trimFrames([]))
+        self.assertEqual([], reporter._trimFrames([]))
 
     def test_oneFrame(self):
-        result = reporter.Reporter(None)
-        self.assertEqual(["fake frame"], result._trimFrames(["fake frame"]))
+        self.assertEqual(["fake frame"], reporter._trimFrames(["fake frame"]))
 
     def test_exception(self):
         """

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -1433,7 +1433,7 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
                 A method which is also a generator function, for testing
                 purposes.
                 """
-                self.fail("this should never be reached")
+                self.fail("this should never be reached")  # pragma: no cover
                 yield
 
         testCase = AsyncGeneratorTestCase("test_async_generator")
@@ -1507,7 +1507,7 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
                 A method which is also a generator function, for testing
                 purposes.
                 """
-                self.fail("this should never be reached")
+                self.fail("this should never be reached")  # pragma: no cover
                 yield
 
         testCase = AsyncGeneratorSynchronousTestCase("test_async_generator")

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -1428,12 +1428,12 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
             A fake TestCase for testing purposes.
             """
 
-            async def test_async_generator(self):
+            async def test_async_generator(self):  # pragma: no cover
                 """
                 A method which is also a generator function, for testing
                 purposes.
                 """
-                self.fail("this should never be reached")  # pragma: no cover
+                self.fail("this should never be reached")
                 yield
 
         testCase = AsyncGeneratorTestCase("test_async_generator")
@@ -1502,12 +1502,12 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
             A fake SynchronousTestCase for testing purposes.
             """
 
-            async def test_async_generator(self):
+            async def test_async_generator(self):  # pragma: no cover
                 """
                 A method which is also a generator function, for testing
                 purposes.
                 """
-                self.fail("this should never be reached")  # pragma: no cover
+                self.fail("this should never be reached")
                 yield
 
         testCase = AsyncGeneratorSynchronousTestCase("test_async_generator")

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -1417,6 +1417,43 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
             result.errors[0][1].value.args[0],
         )
 
+    def test_errorOnAsyncGeneratorFunction(self):
+        """
+        In a TestCase, a test method which is an async generator function is reported
+        as an error, as such a method will never run assertions.
+        """
+
+        class AsyncGeneratorTestCase(unittest.TestCase):
+            """
+            A fake TestCase for testing purposes.
+            """
+
+            async def test_async_generator(self):
+                """
+                A method which is also a generator function, for testing
+                purposes.
+                """
+                self.fail("this should never be reached")
+                yield
+
+        testCase = AsyncGeneratorTestCase("test_async_generator")
+        result = reporter.TestResult()
+        testCase.run(result)
+        self.assertEqual(len(result.failures), 0)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn(
+            "AsyncGeneratorTestCase.test_async_generator",
+            result.errors[0][1].value.args[0],
+        )
+        self.assertIn(
+            "AsyncGeneratorTestCase testMethod=test_async_generator",
+            result.errors[0][1].value.args[0],
+        )
+        self.assertIn(
+            "is an async generator function and therefore will never run",
+            result.errors[0][1].value.args[0],
+        )
+
     def test_synchronousTestCaseErrorOnGeneratorFunction(self):
         """
         In a SynchronousTestCase, a test method which is a generator function
@@ -1451,5 +1488,42 @@ class TrialGeneratorFunctionTests(unittest.SynchronousTestCase):
         )
         self.assertIn(
             "is a generator function and therefore will never run",
+            result.errors[0][1].value.args[0],
+        )
+
+    def test_synchronousTestCaseErrorOnAsyncGeneratorFunction(self):
+        """
+        In a SynchronousTestCase, a test method which is a generator function
+        is reported as an error, as such a method will never run assertions.
+        """
+
+        class AsyncGeneratorSynchronousTestCase(unittest.SynchronousTestCase):
+            """
+            A fake SynchronousTestCase for testing purposes.
+            """
+
+            async def test_async_generator(self):
+                """
+                A method which is also a generator function, for testing
+                purposes.
+                """
+                self.fail("this should never be reached")
+                yield
+
+        testCase = AsyncGeneratorSynchronousTestCase("test_async_generator")
+        result = reporter.TestResult()
+        testCase.run(result)
+        self.assertEqual(len(result.failures), 0)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn(
+            "AsyncGeneratorSynchronousTestCase.test_async_generator",
+            result.errors[0][1].value.args[0],
+        )
+        self.assertIn(
+            "AsyncGeneratorSynchronousTestCase testMethod=test_async_generator",
+            result.errors[0][1].value.args[0],
+        )
+        self.assertIn(
+            "is an async generator function and therefore will never run",
             result.errors[0][1].value.args[0],
         )

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -8,7 +8,7 @@ Tests for L{twisted.words.service}.
 import time
 
 from twisted.cred import portal, credentials, checkers
-from twisted.internet import address, defer, reactor
+from twisted.internet import address, reactor
 from twisted.internet.defer import Deferred, DeferredList, maybeDeferred, succeed
 from twisted.spread import pb
 from twisted.test import proto_helpers
@@ -815,28 +815,27 @@ class PBProtocolTests(unittest.TestCase):
         d.addCallback(lambda ign: self.clientFactory.login(creds, mind))
         return d
 
-    @defer.inlineCallbacks
-    def testGroups(self):
+    async def testGroups(self):
         mindone = TestMind()
-        one = yield self._loggedInAvatar("one", b"p1", mindone)
+        one = await self._loggedInAvatar("one", b"p1", mindone)
 
         mindtwo = TestMind()
-        two = yield self._loggedInAvatar("two", b"p2", mindtwo)
+        two = await self._loggedInAvatar("two", b"p2", mindtwo)
 
         mindThree = TestMind()
-        three = yield self._loggedInAvatar(b"three", b"p3", mindThree)
+        three = await self._loggedInAvatar(b"three", b"p3", mindThree)
 
-        yield self.realm.createGroup("foobar")
-        yield self.realm.createGroup(b"barfoo")
+        await self.realm.createGroup("foobar")
+        await self.realm.createGroup(b"barfoo")
 
-        groupone = yield one.join("foobar")
-        grouptwo = yield two.join(b"barfoo")
+        groupone = await one.join("foobar")
+        grouptwo = await two.join(b"barfoo")
 
-        yield two.join("foobar")
-        yield two.join(b"barfoo")
-        yield three.join("foobar")
+        await two.join("foobar")
+        await two.join(b"barfoo")
+        await three.join("foobar")
 
-        yield groupone.send({b"text": b"hello, monkeys"})
+        await groupone.send({b"text": b"hello, monkeys"})
 
-        yield groupone.leave()
-        yield grouptwo.leave()
+        await groupone.leave()
+        await grouptwo.leave()


### PR DESCRIPTION
<!--
## Remove this section

Have a look at [our developer documentation](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch) before submitting your Pull Request.

Note that the Trac ticket, news fragment, and review submission portions of this process apply to *all* pull requests, no matter how small;
if you don't do them, it's likely that nobody will even notice your PR needs a review.
-->

## Scope and purpose

except for self-tests of inlineCallbacks, in preparation for deprecating it

## Contributor Checklist:

* [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
