### PR TITLE
10230 work around bpo-44070 by making filenames absolute before calling spec_from_file_location

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         # When updating the minimum Python version here, also update the
         # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
+        python-version: [3.6, 3.7, 3.8, 3.8.10, 3.9, 3.9.5, 3.10.0-beta.4]
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         # When updating the minimum Python version here, also update the
         # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.6, 3.7, 3.8, 3.8.10, 3.9, 3.9.5, 3.10.0-beta.4]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']

--- a/src/twisted/trial/newsfragments/10230.bugfix
+++ b/src/twisted/trial/newsfragments/10230.bugfix
@@ -1,0 +1,1 @@
+trial.runner.filenameToModule now sets the correct module.__name__ and sys.modules key

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -100,8 +100,20 @@ def filenameToModule(fn):
     @return: A module object.
     @raise ValueError: If C{fn} does not exist.
     """
+    oldFn = fn
+
+    if (3, 8) <= sys.version_info < (3, 10) and not os.path.isabs(fn):
+        # module.__spec__.__file__ is supposed to be absolute in py3.8+
+        # importlib.util.spec_from_file_location does this automatically from
+        # 3.10+
+        # This was backported to 3.8 and 3.9, but then reverted in 3.8.11 and
+        # 3.9.6
+        # See https://twistedmatrix.com/trac/ticket/10230
+        # and https://bugs.python.org/issue44070
+        fn = os.path.join(os.getcwd(), fn)
+
     if not os.path.exists(fn):
-        raise ValueError(f"{fn!r} doesn't exist")
+        raise ValueError(f"{oldFn!r} doesn't exist")
 
     moduleName = reflect.filenameToModuleName(fn)
     try:

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -125,7 +125,7 @@ def filenameToModule(fn):
     return ret
 
 
-def _importFromFile(fn, moduleName=None):
+def _importFromFile(fn, *, moduleName):
     fn = _resolveDirectory(fn)
     if not moduleName:
         moduleName = os.path.splitext(os.path.split(fn)[-1])[0]

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -102,16 +102,18 @@ def filenameToModule(fn):
     """
     if not os.path.exists(fn):
         raise ValueError(f"{fn!r} doesn't exist")
+
+    moduleName = reflect.filenameToModuleName(fn)
     try:
-        ret = reflect.namedAny(reflect.filenameToModuleName(fn))
+        ret = reflect.namedAny(moduleName)
     except (ValueError, AttributeError):
         # Couldn't find module.  The file 'fn' is not in PYTHONPATH
-        return _importFromFile(fn)
+        return _importFromFile(fn, moduleName=moduleName)
 
     # >=3.7 has __file__ attribute as None, previously __file__ was not present
     if getattr(ret, "__file__", None) is None:
         # This isn't a Python module in a package, so import it from a file
-        return _importFromFile(fn)
+        return _importFromFile(fn, moduleName=moduleName)
 
     # ensure that the loaded module matches the file
     retFile = os.path.splitext(ret.__file__)[0] + ".py"
@@ -119,7 +121,7 @@ def filenameToModule(fn):
     same = getattr(os.path, "samefile", samefile)
     if os.path.isfile(fn) and not same(fn, retFile):
         del sys.modules[ret.__name__]
-        ret = _importFromFile(fn)
+        ret = _importFromFile(fn, moduleName=moduleName)
     return ret
 
 

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -103,6 +103,8 @@ class FileTests(packages.SysPathManglingTest):
         sample1 = runner.filenameToModule(
             os.path.join(self.parent, "goodpackage", "test_sample.py")
         )
+        self.assertEqual(sample1.__name__, "goodpackage.test_sample")
+
         self.cleanUpModules()
         self.mangleSysPath(self.newPath)
         from goodpackage import test_sample as sample2  # type: ignore[import]
@@ -129,14 +131,13 @@ class FileTests(packages.SysPathManglingTest):
         self.mangleSysPath(self.oldPath)
         package1 = runner.filenameToModule(os.path.join(self.parent, "goodpackage"))
         self.assertEqual(package1.__name__, "goodpackage")
+
         self.cleanUpModules()
         self.mangleSysPath(self.newPath)
         import goodpackage
 
-        self.assertEqual(
-            os.path.splitext(goodpackage.__file__)[0],
-            os.path.splitext(package1.__file__)[0],
-        )
+        self.assertIsNot(package1, goodpackage)
+        self.assertEqual(package1.__spec__, goodpackage.__spec__)
 
     def test_directoryNotPackage(self):
         """

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -129,9 +129,8 @@ class FileTests(packages.SysPathManglingTest):
         self.mangleSysPath(self.oldPath)
         package1 = runner.filenameToModule(os.path.join(self.parent, "goodpackage"))
         self.assertEqual(package1.__name__, "goodpackage")
-        self.mangleSysPath(self.newPath)
-
         self.cleanUpModules()
+        self.mangleSysPath(self.newPath)
         import goodpackage
 
         self.assertEqual(


### PR DESCRIPTION
## Scope and purpose

fix test_moduleNotInPath and test_packageNotInPath as well as their TODOs'


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10230
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
