### PR TITLE
10231 Fix type annotation for `inlineCallbacks`

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1828,8 +1828,8 @@ class _InternalInlineCallbacksCancelledError(Exception):
 # type note: "..." is used here because we don't have a better way to express
 #     that the same arguments are accepted by the returned callable.
 def inlineCallbacks(
-    f: Callable[..., Generator[Deferred[object], object, None]]
-) -> Callable[..., Deferred[object]]:
+    f: Callable[..., Generator[Deferred[object], object, _T]]
+) -> Callable[..., Deferred[_T]]:
     """
     L{inlineCallbacks} helps you write L{Deferred}-using code that looks like a
     regular sequential function. For example::

--- a/src/twisted/newsfragments/10231.bugfix
+++ b/src/twisted/newsfragments/10231.bugfix
@@ -1,1 +1,1 @@
-twisted.internet.defer.inlineCallbacks has an improved type annotation, to avoidtyping errors when it is used on a function which returns a non-None result.
+twisted.internet.defer.inlineCallbacks has an improved type annotation, to avoid typing errors when it is used on a function which returns a non-None result.

--- a/src/twisted/newsfragments/10231.bugfix
+++ b/src/twisted/newsfragments/10231.bugfix
@@ -1,1 +1,1 @@
-Fix type annotations for inlineCallbacks.
+twisted.internet.defer.inlineCallbacks has an improved type annotation, to avoidtyping errors when it is used on a function which returns a non-None result.

--- a/src/twisted/newsfragments/10231.bugfix
+++ b/src/twisted/newsfragments/10231.bugfix
@@ -1,1 +1,1 @@
-Fix type annotations fro inlineCallbacks.
+Fix type annotations for inlineCallbacks.

--- a/src/twisted/newsfragments/10231.bugfix
+++ b/src/twisted/newsfragments/10231.bugfix
@@ -1,0 +1,1 @@
+Fix type annotations fro inlineCallbacks.


### PR DESCRIPTION
## Scope and purpose

Propagate the ReturnType of the generators wrapped by `inlineCallbacks`. 


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10231
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: richvdh
Reviewer: 
Fixes: ticket:10231

Update the type annotation on `inlineCallbacks`.
```
