### PR TITLE
10171 upgrade coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,9 +67,7 @@ dev =
     # TODO: support python-subunit in py3.10 https://twistedmatrix.com/trac/ticket/10115
     python-subunit ~= 1.4; python_version < "3.10"
     twistedchecker ~= 0.7
-    # To be pinned to a minor version once PYPY `coverage run` error is fixed.
-    # See: https://twistedmatrix.com/trac/ticket/10171
-    coverage
+    coverage >= 6b1, <7
 
 tls =
     pyopenssl >= 16.0.0

--- a/src/twisted/newsfragments/10171.misc
+++ b/src/twisted/newsfragments/10171.misc
@@ -1,0 +1,1 @@
+use coverage 6b1

--- a/tox.ini
+++ b/tox.ini
@@ -54,11 +54,6 @@ extras =
 ;; dependencies that are not specified as extras
 deps =
     lint: pre-commit
-    # For now we use a dev version of coverage with a fix for `coverage run`
-    # on PYPY.
-    # This should be moved
-    # See: https://twistedmatrix.com/trac/ticket/10171
-    withcov: https://github.com/nedbat/coveragepy/archive/refs/heads/nedbat/another-1010.tar.gz
 
 ; All environment variables are passed.
 passenv = *


### PR DESCRIPTION

## Scope and purpose
the another-1010 coveragepy branch got removed because the changes were integrated into a pypi.org release

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10171
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
