### PR TITLE
10236 restore .whl building

### DIFF
--- a/src/twisted/newsfragments/10236.bugfix
+++ b/src/twisted/newsfragments/10236.bugfix
@@ -1,0 +1,1 @@
+restore .whl building

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@
 minversion=3.21.4
 requires=
     virtualenv>=20.4.2
+    tox-wheel>=0.6.0
 skip_missing_interpreters=True
 envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,
@@ -34,6 +35,7 @@ sources = setup.py src/ docs/conch/examples docs/mail/examples docs/names/exampl
 ;   docs/core/examples
 
 [testenv]
+wheel = True
 ;; dependencies managed by extras in setup.cfg
 extras =
     ; The "nodeps" build still depends on PyHamcrest.

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,9 @@ sources = setup.py src/ docs/conch/examples docs/mail/examples docs/names/exampl
 ;   docs/core/examples
 
 [testenv]
+# Wheel based testing is required as part of our release process.
+# If you remove the wheels from here, then also update the release
+# process to generate its own wheels.
 wheel = True
 ;; dependencies managed by extras in setup.cfg
 extras =


### PR DESCRIPTION
## Scope and purpose

whl building was disabled here https://github.com/twisted/twisted/pull/1587, re-enable it

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10236
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```