### PR TITLE
[10245] Add gitter sidecar chat to documentation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -85,6 +85,7 @@ recursive-include docs *.txt
 recursive-include docs *.users
 recursive-include docs *.xml
 recursive-include docs Makefile
+recursive-include docs/_static/js *.js
 prune docs/_build
 
 # Don't have the real old historic docs

--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -1,3 +1,5 @@
+// Configure the Gitter sidecar chat button.
+// https://sidecar.gitter.im/
 window.gitter = {'chat': {'options': {
     'room': 'twisted/twisted'
   }}}

--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -1,8 +1,3 @@
-window.addEventListener("load", function(){
-
-  // Configure the Gitter sidecar button.
-  var gitter_chat = new window.sidecar.default.Chat({
-    room: 'twisted/twisted'
-  })
-
-})
+window.gitter = {'chat': {'options': {
+    'room': 'twisted/twisted'
+  }}}

--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -1,0 +1,8 @@
+window.addEventListener("load", function(){
+
+  // Configure the Gitter sidecar button.
+  var gitter_chat = new window.sidecar.default.Chat({
+    room: 'twisted/twisted'
+  })
+
+})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,14 @@ html_theme_path = ["_themes"]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_js_files = [
+    "https://sidecar.gitter.im/dist/sidecar.v1.js",
+    "js/custom.js",
+]
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = "Twisteddoc"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,8 @@ html_static_path = ["_static"]
 # or fully qualified paths (eg. https://...)
 html_js_files = [
     "js/custom.js",
-    'https://sidecar.gitter.im/dist/sidecar.v1.js" async defer hack="',
+    # Here we have a Sphinx HTML injection hack to make the JS script load without blocking.
+    'https://sidecar.gitter.im/dist/sidecar.v1.js" defer hack="',
 ]
 
 # Output file base name for HTML help builder.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,8 +119,8 @@ html_static_path = ["_static"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_js_files = [
-    "https://sidecar.gitter.im/dist/sidecar.v1.js",
     "js/custom.js",
+    'https://sidecar.gitter.im/dist/sidecar.v1.js" async defer hack="',
 ]
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
## Scope and purpose

This is an experiment to add a chat link from our documentation.

The result is visible at https://twisted--1649.org.readthedocs.build/en/1649/

The feature is documented here 
https://sidecar.gitter.im/

You can play / develop this over localhost with

```
tox -e narrativedocs
python3 -m http.server 8000 --directory docs/_build/
```

For real time development you can modify the files in docs/_build/_static/js/custom.js

I went with linking the code from https://sidecar.gitter.im/dist/sidecar.v1.js instead of vendoring it.
Not sure what is better.


## Contributor Checklist:

*  [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [NA] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10245

Add Gitter sidecar to documentation pages. 
```
