### PR TITLE
10247: Make the request argument to twisted.web.iweb.IRenderable.render non-optional

### DIFF
--- a/src/twisted/newsfragments/10247.bugfix
+++ b/src/twisted/newsfragments/10247.bugfix
@@ -1,0 +1,1 @@
+The request argument to twisted.web.iweb.IRenderable.render() is no longer typed as optional.

--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -160,7 +160,7 @@ class Element:
 
     def lookupRenderMethod(
         self, name: str
-    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
+    ) -> Callable[[IRequest, "Tag"], "Flattenable"]:
         """
         Look up and return the named render method.
         """

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -220,7 +220,7 @@ def _fork(d: Deferred[T]) -> Deferred[T]:
 
 
 def _flattenElement(
-    request: Optional[IRequest],
+    request: IRequest,
     root: Flattenable,
     write: Callable[[bytes], object],
     slotData: List[Optional[Mapping[str, Flattenable]]],
@@ -365,7 +365,7 @@ def _flattenElement(
 
 
 async def _flattenTree(
-    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+    request: IRequest, root: Flattenable, write: Callable[[bytes], object]
 ) -> None:
     """
     Make C{root} into an iterable of L{bytes} and L{Deferred} by doing a depth
@@ -407,7 +407,7 @@ async def _flattenTree(
 
 
 def flatten(
-    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+    request: IRequest, root: Flattenable, write: Callable[[bytes], object]
 ) -> Deferred[None]:
     """
     Incrementally write out a string representation of C{root} using C{write}.
@@ -434,7 +434,7 @@ def flatten(
     return ensureDeferred(_flattenTree(request, root, write))
 
 
-def flattenString(request: Optional[IRequest], root: Flattenable) -> Deferred[bytes]:
+def flattenString(request: IRequest, root: Flattenable) -> Deferred[bytes]:
     """
     Collate a string representation of C{root} into a single string.
 

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -23,13 +23,12 @@ cumbersome.
 
 
 from inspect import isgenerator, iscoroutine
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 from warnings import warn
 
 import attr
 
-if TYPE_CHECKING:
-    from twisted.web.template import Flattenable
+from ._flatten import Flattenable
 
 
 @attr.s(hash=False, eq=False, auto_attribs=True)

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -23,12 +23,13 @@ cumbersome.
 
 
 from inspect import isgenerator, iscoroutine
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 from warnings import warn
 
 import attr
 
-from ._flatten import Flattenable
+if TYPE_CHECKING:
+    from ._flatten import Flattenable
 
 
 @attr.s(hash=False, eq=False, auto_attribs=True)

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -513,7 +513,7 @@ class IRenderable(Interface):
 
     def lookupRenderMethod(
         name: str,
-    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
+    ) -> Callable[[IRequest, "Tag"], "Flattenable"]:
         """
         Look up and return the render method associated with the given name.
 
@@ -525,7 +525,7 @@ class IRenderable(Interface):
             was encountered.
         """
 
-    def render(request: Optional[IRequest]) -> "Flattenable":
+    def render(request: IRequest) -> "Flattenable":
         """
         Get the document for this L{IRenderable}.
 

--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -25,8 +25,10 @@ from twisted.python.compat import nativeString
 from twisted.python.reflect import prefixedMethodNames
 from twisted.python.components import proxyForInterface
 
+from twisted.web._flatten import Flattenable
 from twisted.web._responses import FORBIDDEN, NOT_FOUND
 from twisted.web.error import UnsupportedMethod
+from twisted.web.iweb import IRequest
 
 
 class IResource(Interface):
@@ -72,7 +74,7 @@ class IResource(Interface):
         @type path: C{bytes}
         """
 
-    def render(request):
+    def render(request: IRequest) -> Flattenable:
         """
         Render a request. This is called on the leaf resource for a request.
 

--- a/src/twisted/web/test/_util.py
+++ b/src/twisted/web/test/_util.py
@@ -7,6 +7,7 @@ General helpers for L{twisted.web} unit tests.
 
 
 from typing import Type
+from unittest.mock import sentinel
 
 from twisted.internet.defer import Deferred, succeed
 from twisted.web import server
@@ -45,7 +46,7 @@ class FlattenTestCase(SynchronousTestCase):
         def check(result: bytes) -> bytes:
             return self.assertEqual(result, target)  # type: ignore[no-any-return]
 
-        d: Deferred[bytes] = flattenString(None, root)  # type: ignore[arg-type]
+        d: Deferred[bytes] = flattenString(sentinel.request, root)
         d.addCallback(check)
         return d
 

--- a/src/twisted/web/test/_util.py
+++ b/src/twisted/web/test/_util.py
@@ -45,7 +45,7 @@ class FlattenTestCase(SynchronousTestCase):
         def check(result: bytes) -> bytes:
             return self.assertEqual(result, target)  # type: ignore[no-any-return]
 
-        d: Deferred[bytes] = flattenString(None, root)
+        d: Deferred[bytes] = flattenString(None, root)  # type: ignore[arg-type]
         d.addCallback(check)
         return d
 

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from textwrap import dedent
 from types import FunctionType
 from typing import Callable, Dict, List, NoReturn, Optional, cast
+from unittest.mock import sentinel
 
 from twisted.test.testutils import XMLAssertionMixin
 from xml.etree.ElementTree import XML
@@ -306,7 +307,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             "foo-->bar",
             "----------------",
         ]:
-            d = flattenString(None, Comment(c))
+            d = flattenString(sentinel.request, Comment(c))
             d.addCallback(verifyComment)
             results.append(d)
         return gatherResults(results)
@@ -578,7 +579,7 @@ class FlattenerErrorTests(SynchronousTestCase):
             def render(self, request: Optional[IRequest]) -> Flattenable:
                 return failing
 
-        flattening = flattenString(None, [NotActuallyRenderable()])
+        flattening = flattenString(sentinel.request, [NotActuallyRenderable()])
         self.assertNoResult(flattening)
         exc = RuntimeError("example")
         failing.errback(exc)
@@ -623,7 +624,7 @@ class FlattenerErrorTests(SynchronousTestCase):
             err = failure
 
         d: Deferred[object] = Deferred(checkCancel)
-        flattening = flattenString(None, d)
+        flattening = flattenString(sentinel.request, d)
         self.assertNoResult(flattening)
         d.addErrback(saveErr)
 

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -8,6 +8,7 @@ Tests for L{twisted.web.template}
 
 from io import StringIO
 from typing import List, Optional
+from unittest.mock import sentinel
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -154,7 +155,7 @@ class ElementTests(TestCase):
                 return "bar"
 
         foo = ElementWithRenderMethod().lookupRenderMethod("foo")
-        self.assertEqual(foo(None, tags.br), "bar")
+        self.assertEqual(foo(sentinel.request, tags.br), "bar")
 
     def test_render(self) -> None:
         """


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10247
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
