### PR TITLE
10249 Use enviroment markers for extra all

### DIFF
--- a/docs/installation/howto/optional.rst
+++ b/docs/installation/howto/optional.rst
@@ -42,11 +42,7 @@ The following optional dependencies are supported:
 
 * **serial** - the `pyserial`_ package to work with serial data.
 
-* **all_non_platform** - installs **tls**, **conch**, **soap**, and **serial** options.
-
-* **macos_platform** - **all_non_platform** options and `pyobjc`_ to work with Objective-C apis.
-
-* **windows_platform** - **all_non_platform** options and `pywin32`_ to work with Windows's apis.
+* **all** - installs **tls**, **conch**, **soap**, and **serial** options.
 
 * **http2** - packages needed for http2 support.
 

--- a/docs/installation/howto/optional.rst
+++ b/docs/installation/howto/optional.rst
@@ -15,62 +15,109 @@ For a deeper explanation of what optional dependencies are and how they are decl
 
 The following optional dependencies are supported:
 
-* **dev** - packages that aid in the development of Twisted itself.
+tls
+   Packages that are needed to work with TLS:
 
-  * `pyflakes`_
-  * `twisted-dev-tools`_
-  * `python-subunit`_
-  * `Sphinx`_
-  * `TwistedChecker`_, only available on python2
-  * `pydoctor`_, only available on python2
+   * pyOpenSSL_
+   * service_identity_
+   * idna_
 
+conch
+   Packages for working with conch/SSH:
 
-* **tls** - packages that are needed to work with TLS.
+   * pyasn1_
+   * cryptography_
+   * bcrypt_
+   * appdirs_
 
-  * `pyOpenSSL`_
-  * `service_identity`_
-  * `idna`_
+conch_nacl
+   ``conch`` options and PyNaCl_ to support Ed25519 keys
+   on systems with OpenSSL < 1.1.1b.
 
-* **conch** - packages for working with conch/SSH.
+serial
+   The pyserial_ package to work with serial data.
+   On Windows, this also requires pywin32_.
 
-  * `pyasn1`_
-  * `cryptography`_
+http2
+   Packages needed for HTTP/2 support:
 
-* **conch_nacl** - **conch** options and `PyNaCl`_ to support Ed25519 keys on systems with OpenSSL < 1.1.1b.
+   * h2_
+   * priority_
 
-* **soap** - the `SOAPpy`_ package to work with SOAP.
+contextvars
+   The contextvars_ backport package to provide `context variables`_ support
+   for Python versions before 3.7.
 
-* **serial** - the `pyserial`_ package to work with serial data.
+all
+   Extras ``tls``, ``conch``, ``serial``, ``http2``, ``contextvars``,
+   and platform-specific interfacing such as pyobjc_ for Objective-C on macOS
+   and pywin32_ for Windows.
 
-* **all** - installs **tls**, **conch**, **soap**, and **serial** options.
+dev_release
+   Packages used in Twisted's release process:
 
-* **http2** - packages needed for http2 support.
+   * towncrier_
+   * pydoctor_
+   * Sphinx_, sphinx-rtd-theme_ and readthedocs-sphinx-ext_
 
-  * `h2`_
-  * `priority`_
+dev
+   Packages that aid in the development of Twisted itself,
+   including those in ``all`, ``dev_release`` and the following:
 
-* **contextvars** - the `contextvars`_ backport package to provide contextvars support for Python versions before 3.7.
+   * pyflakes_
+   * python-subunit_
+   * twistedchecker_
+   * coverage_
 
+mypy
+   Type checking facilities, including ``dev`` packages,
+   ``conch_nacl``, as well as the following:
 
-.. _pip: https://pip.pypa.io/en/latest/quickstart.html
-.. _TwistedChecker: https://pypi.python.org/pypi/TwistedChecker
-.. _pyflakes: https://pypi.python.org/pypi/pyflakes
-.. _twisted-dev-tools: https://pypi.python.org/pypi/twisted-dev-tools
-.. _python-subunit: https://pypi.python.org/pypi/python-subunit
-.. _Sphinx: https://pypi.python.org/pypi/Sphinx/1.3b1
-.. _pydoctor: https://pypi.python.org/pypi/pydoctor
-.. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL
-.. _service_identity: https://pypi.python.org/pypi/service_identity
-.. _pyasn1: https://pypi.python.org/pypi/pyasn1
-.. _cryptography: https://pypi.python.org/pypi/cryptography
+   * mypy_
+   * mypy-zope_
+   * types-setuptools_
+   * types-pyOpenSSL_
+
+.. _pip: https://pip.pypa.io
+.. _python packaging tutorial:
+   https://packaging.python.org/en/latest/installing.html#examples
+.. _setuptools documentation:
+   https://setuptools.readthedocs.io/en/stable/userguide/dependency_management.html#optional-dependencies
+
+.. _pyOpenSSL: https://pypi.org/project/pyOpenSSL
+.. _service_identity: https://pypi.org/project/service_identity
+.. _idna: https://pypi.org/project/idna
+
+.. _pyasn1: https://pypi.org/project/pyasn1
+.. _cryptography: https://pypi.org/project/cryptography
+.. _bcrypt: https://pypi.org/project/bcrypt
+.. _appdirs: https://pypi.org/project/appdirs
+
 .. _PyNaCl: https://pypi.python.org/pypi/PyNaCl
-.. _SOAPpy: https://pypi.python.org/pypi/SOAPpy
-.. _pyserial: https://pypi.python.org/pypi/pyserial
-.. _pyobjc: https://pypi.python.org/pypi/pyobjc
-.. _pywin32: https://pypi.python.org/pypi/pywin32
-.. _`setuptools documentation`: https://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
-.. _`python packaging tutorial`: https://packaging.python.org/en/latest/installing.html#examples
-.. _idna: https://pypi.python.org/pypi/idna
-.. _h2: https://pypi.python.org/pypi/h2
-.. _priority: https://pypi.python.org/pypi/priority
-.. _contextvars: https://pypi.org/project/contextvars/
+
+.. _pyserial: https://pypi.org/project/pyserial
+.. _pywin32: https://pypi.org/project/pywin32
+
+.. _h2: https://pypi.org/project/h2
+.. _priority: https://pypi.org/project/priority
+
+.. _contextvars: https://pypi.org/project/contextvars
+.. _context variables: https://docs.python.org/3/library/contextvars.html
+
+.. _pyobjc: https://pypi.org/project/pyobjc
+
+.. _mypy: https://pypi.org/project/mypy
+.. _mypy-zope: https://pypi.org/project/mypy-zope
+.. _types-setuptools: https://pypi.org/project/types-setuptools
+.. _types-pyOpenSSL: https://pypi.org/project/types-pyOpenSSL
+
+.. _towncrier: https://pypi.org/project/towncrier
+.. _pydoctor: https://pypi.org/project/pydoctor
+.. _Sphinx: https://pypi.org/project/Sphinx
+.. _sphinx-rtd-theme: https://pypi.org/project/sphinx-rtd-theme
+.. _readthedocs-sphinx-ext: https://pypi.org/project/readthedocs-sphinx-ext
+
+.. _pyflakes: https://pypi.org/project/pyflakes
+.. _python-subunit: https://pypi.org/project/python-subunit
+.. _twistedchecker: https://pypi.org/project/twistedchecker
+.. _coverage: https://pypi.org/project/coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,14 +108,22 @@ all_non_platform =
     %(http2)s
     %(contextvars)s
 
+all =
+    pyobjc-core; platform_system == "Darwin"
+    pyobjc-framework-CFNetwork; platform_system == "Darwin"
+    pyobjc-framework-Cocoa; platform_system == "Darwin"
+    pywin32 != 226; platform_system == "Windows"
+    %(test)s
+    %(tls)s
+    %(conch)s
+    %(serial)s
+    %(http2)s
+    %(contextvars)s
+
 macos_platform =
-    pyobjc-core
-    pyobjc-framework-CFNetwork
-    pyobjc-framework-Cocoa
     %(all_non_platform)s
 
 windows_platform =
-    pywin32 != 226
     %(all_non_platform)s
 
 osx_platform =

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ dev_release =
 
 ; All the extra tools used to help with the development process.
 dev =
+    %(all)s
+    %(test)s
     %(dev_release)s
     pyflakes ~= 2.2
     # TODO: support python-subunit in py3.10 https://twistedmatrix.com/trac/ticket/10115
@@ -113,7 +115,6 @@ all =
     pyobjc-framework-CFNetwork; platform_system == "Darwin"
     pyobjc-framework-Cocoa; platform_system == "Darwin"
     pywin32 != 226; platform_system == "Windows"
-    %(test)s
     %(tls)s
     %(conch)s
     %(serial)s
@@ -121,13 +122,13 @@ all =
     %(contextvars)s
 
 macos_platform =
-    %(all_non_platform)s
+    %(all)s
 
 windows_platform =
-    %(all_non_platform)s
+    %(all)s
 
 osx_platform =
-    %(macos_platform)s
+    %(all)s
 
 mypy =
     mypy==0.930
@@ -135,7 +136,6 @@ mypy =
     types-setuptools
     types-pyOpenSSL
     %(dev)s
-    %(all_non_platform)s
     %(conch_nacl)s
 
 [options.packages.find]

--- a/src/twisted/newsfragments/10249.feature
+++ b/src/twisted/newsfragments/10249.feature
@@ -1,0 +1,6 @@
+The ``all_non_platform`` extra has been renamed to ``all``,
+with the former name being a compatibility alias.  Platform-specific extras
+such as ``macos_platform`` and ``windows_platform`` have also been deprecated;
+their dependencies have been moved into the ``all`` extra with appropriate
+environment markers.  Optional dependencies in ``all`` are now also included
+in ``dev`` for convenience.

--- a/tox.ini
+++ b/tox.ini
@@ -49,11 +49,7 @@ extras =
     ; release helpers or documentation generation, and `conch_nacl` so that
     ; we can test conch fallbacks to PyNaCl without requiring most users to
     ; install it.
-    alldeps: all_non_platform, dev_release, conch_nacl
-
-    windows: windows_platform
-
-    alldeps-macos: osx_platform
+    alldeps: all, test, dev_release, conch_nacl
 
     serial: serial
 


### PR DESCRIPTION
## Scope and purpose

This will make it valid to install every extra on any platform.  This sounds odd but it is a [criteria we are experimentally mandate in IPWHL](https://man.sr.ht/~cnx/ipwhl/#dependencies), a WIP downstream repository for Python packages.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10249
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
