### PR TITLE
10250 update CI and trove to 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         # When updating the minimum Python version here, also update the
         # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.1]
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -13,6 +13,7 @@ parameters:
   - '3.7'
   - '3.8'
   - '3.9'
+  - '3.10.0-rc.1'
 
 - name: windowsReactor
   type: string

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     hyperlink >= 17.1.1
     attrs >= 19.2.0
     typing_extensions >= 3.6.5
-    twisted-iocpsupport >= 1.0.2rc0, <2; platform_system == "Windows"
+    twisted-iocpsupport >= 1.0.2, <2; platform_system == "Windows"
 include_package_data = True
 zip_safe = False
 package_dir = =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev_release =
     pydoctor ~= 21.2.2; python_version >= "3.6"
     sphinx-rtd-theme ~= 0.5
     readthedocs-sphinx-ext ~= 2.1
-    sphinx ~= 3.3
+    sphinx >= 4.1.2, <6
 
 ; All the extra tools used to help with the development process.
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     hyperlink >= 17.1.1
     attrs >= 19.2.0
     typing_extensions >= 3.6.5
-    twisted-iocpsupport ~= 1.0.0; platform_system == "Windows"
+    twisted-iocpsupport >= 1.0.2rc0, <2; platform_system == "Windows"
 include_package_data = True
 zip_safe = False
 package_dir = =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 long_description_content_type = text/x-rst
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ packages = find:
 ; We trust semantic versioning and auto-upgrading to a bugfix release
 ; should be OK.
 test =
-    cython-test-exception-raiser ~= 1.0
+    cython-test-exception-raiser >= 1.0.2, <2
     PyHamcrest >= 1.9.0
 
 ; List of dependencies required to build the documentation and test the

--- a/src/twisted/newsfragments/10250.misc
+++ b/src/twisted/newsfragments/10250.misc
@@ -1,1 +1,1 @@
-official support for Py3.10
+Document official support for Py3.10. (Metadata change only)

--- a/src/twisted/newsfragments/10250.misc
+++ b/src/twisted/newsfragments/10250.misc
@@ -1,0 +1,1 @@
+official support for Py3.10

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ extras =
 deps =
     lint: pre-commit
     ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
-    alldeps: sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
+    alldeps: sphinx @ https://github.com/sphinx-doc/sphinx/archive/514fca7a407f03fae4c788178555a74256936655.tar.gz
 
 ; All environment variables are passed.
 passenv = *
@@ -128,7 +128,7 @@ extras =
 
 deps =
     ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
-    sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
+    sphinx @ https://github.com/sphinx-doc/sphinx/archive/514fca7a407f03fae4c788178555a74256936655.tar.gz
 
 setenv =
     # Set this to `True` to run similar to Read The Docs.
@@ -157,7 +157,7 @@ extras = dev_release
 commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
 deps =
     ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
-    sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
+    sphinx @ https://github.com/sphinx-doc/sphinx/archive/514fca7a407f03fae4c788178555a74256936655.tar.gz
 
 [testenv:mypy]
 description = run Mypy (static type checker)

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@
 ; See README.rst for example tox commands.
 ;
 [tox]
-minversion=3.21.4
+minversion=3.24.1
 requires=
-    virtualenv>=20.4.2
+    virtualenv>=20.7.2
     tox-wheel>=0.6.0
 skip_missing_interpreters=True
 envlist=lint, mypy,

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,8 @@ extras =
 ;; dependencies that are not specified as extras
 deps =
     lint: pre-commit
+    ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
+    alldeps: sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
 
 ; All environment variables are passed.
 passenv = *
@@ -124,8 +126,9 @@ description = Build the full documentation (narrative and apidocs).
 extras =
     dev_release
 
-; It looks like tox don't recognize this a deps script.
-allowlist_externals = sphinx-build
+deps =
+    ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
+    sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
 
 setenv =
     # Set this to `True` to run similar to Read The Docs.
@@ -152,7 +155,9 @@ description = Build the API documentation.
 
 extras = dev_release
 commands = {toxinidir}/bin/admin/build-apidocs {toxinidir}/src/ apidocs
-
+deps =
+    ; bugfix for https://github.com/sphinx-doc/sphinx/pull/9513/ on py310rc1
+    sphinx @ https://github.com/sphinx-doc/sphinx/archive/d194e0f4909b0887b37e2a32787f6b4c0fe8862a.tar.gz
 
 [testenv:mypy]
 description = run Mypy (static type checker)


### PR DESCRIPTION
## Scope and purpose

Twisted 21.7.0 announced tentative support for python 3.10 because only a beta was available to test against. This PR represents no actual source changes, and only downstream tooling changes (twisted-iocpsupport and cython-test-exception-raiser) both upgraded to cibuildwheel 2 for 3.10 wheels.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10250
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
