### PR TITLE
10255 add changelog to project_urls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ project_urls =
     Source=https://github.com/twisted/twisted
     Issues=https://twistedmatrix.com/trac/report
     Twitter=https://twitter.com/twistedmatrix
+    Changelog=https://github.com/twisted/twisted/blob/HEAD/NEWS.rst
 license = MIT
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10255
* [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
