### PR TITLE
10251: Fix IReactorTCP.connectTCP type parameter type

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -707,7 +707,7 @@ class IReactorTCP(Interface):
         """
 
     def connectTCP(
-        host: bytes,
+        host: str,
         port: int,
         factory: "ClientFactory",
         timeout: float,

--- a/src/twisted/newsfragments/10251.bugfix
+++ b/src/twisted/newsfragments/10251.bugfix
@@ -1,0 +1,1 @@
+The type annotation of the host parameter to twisted.internet.interfaces.IReactorTCP.connectTCP has been corrected from bytes to str.


### PR DESCRIPTION
Correct the type annotation to match real-world implementations as discussed on the mailing list.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10251
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green. (N/A)
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: twm
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10251

Correct the IReactorTCP.connectTCP host parameter type annotation to match
real-world implementations as discussed on the mailing list.
```
