### PR TITLE
10269: Annotate `readBody` as per the docstring

### DIFF
--- a/src/twisted/newsfragments/10269.doc
+++ b/src/twisted/newsfragments/10269.doc
@@ -1,0 +1,1 @@
+Add type annotations for twisted.web.client.readBody.

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -2302,7 +2302,7 @@ def readBody(response: IResponse) -> defer.Deferred[bytes]:
         Cancelling it will close the connection to the server immediately.
     """
 
-    def cancel(deferred):
+    def cancel(deferred: defer.Deferred) -> None:
         """
         Cancel a L{readBody} call, close the connection to the HTTP server
         immediately, if it is still open.
@@ -2313,7 +2313,7 @@ def readBody(response: IResponse) -> defer.Deferred[bytes]:
         if abort is not None:
             abort()
 
-    d = defer.Deferred(cancel)
+    d: defer.Deferred[bytes] = defer.Deferred(cancel)
     protocol = _ReadBodyProtocol(response.code, response.phrase, d)
 
     def getAbort():

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -2288,7 +2288,7 @@ class _ReadBodyProtocol(protocol.Protocol):
             self.deferred.errback(reason)
 
 
-def readBody(response):
+def readBody(response: IResponse) -> defer.Deferred[bytes]:
     """
     Get the body of an L{IResponse} and return it as a byte string.
 


### PR DESCRIPTION
## Scope and purpose

Quick drive-by contribution. The docstring already describes the input and output types for this function. I'd like to make those part of the annotations.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10269
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
  * :question: pypy-3.7-alldeps-nocov-posix is failing. Not sure why? pypy-3.7-alldeps-withcov-posix is succeeding so I wonder if this might be some CI flakiness? (Given that my changes are just type hints, and that there aren't any extra imports, I wouldn't expect there to be any behaviour changes at runtime.) 
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1668 from DMRobertson:annotate-readBody

Author: DMRobertson
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10269

The docstring already describes the input and output types for this function.
Include this information in the type annotations, so type checkers can see this
information and enforce the requirements.
```
