### PR TITLE
10273 use current_thread() instead of currentThread()

### DIFF
--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -109,13 +109,13 @@ class ThreadTestsBuilder(ReactorBuilder):
         result = []
 
         def threadCall():
-            result.append(threading.currentThread())
+            result.append(threading.current_thread())
             reactor.stop()
 
         reactor.callLater(0, reactor.callInThread, reactor.callFromThread, threadCall)
         self.runReactor(reactor, 5)
 
-        self.assertEqual(result, [threading.currentThread()])
+        self.assertEqual(result, [threading.current_thread()])
 
     def test_stopThreadPool(self):
         """

--- a/src/twisted/newsfragments/10273.bugfix
+++ b/src/twisted/newsfragments/10273.bugfix
@@ -1,0 +1,1 @@
+Replaced usage of ``threading.currentThread()`` with ``threading.current_thread()`` to avoid the deprecation warnings introduced for the former in Python 3.10.

--- a/src/twisted/python/threadable.py
+++ b/src/twisted/python/threadable.py
@@ -104,7 +104,7 @@ _dummyID = object()
 def getThreadID():
     if threadingmodule is None:
         return _dummyID
-    return threadingmodule.currentThread().ident
+    return threadingmodule.current_thread().ident
 
 
 def isInIOThread():

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -9,7 +9,7 @@ In most cases you can just use C{reactor.callInThread} and friends
 instead of creating a thread pool directly.
 """
 
-from threading import Thread, currentThread
+from threading import Thread, current_thread
 from typing import List
 
 from twisted._threads import pool as _pool
@@ -43,7 +43,7 @@ class ThreadPool:
     name = None
 
     threadFactory = Thread
-    currentThread = staticmethod(currentThread)
+    current_thread = staticmethod(current_thread)
     _pool = staticmethod(_pool)
 
     def __init__(self, minthreads=5, maxthreads=20, name=None):

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -404,11 +404,11 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         event = threading.Event()
 
         def onResult(success, result):
-            threadIds.append(threading.currentThread().ident)
+            threadIds.append(threading.current_thread().ident)
             event.set()
 
         def func():
-            threadIds.append(threading.currentThread().ident)
+            threadIds.append(threading.current_thread().ident)
 
         tp = threadpool.ThreadPool(0, 1)
         tp.callInThreadWithCallback(onResult, func)


### PR DESCRIPTION
## Scope and purpose

`current_thread()` was introduced in 2.6 as an alias for `currentThread()`.
The old `currentThread()` spelling raises a `DeprecationWarning` in 3.10.

https://docs.python.org/2.7/library/threading.html#threading.current_thread

```console
$ for v in 2.7 3.5 3.6 3.7 3.8 3.9 3.10; do echo -------------- Python $v; python$v -c 'import threading; print(threading.currentThread())'; done
-------------- Python 2.7
<_MainThread(MainThread, started 139976240273216)>
-------------- Python 3.5
<_MainThread(MainThread, started 140209924052800)>
-------------- Python 3.6
<_MainThread(MainThread, started 139896207542080)>
-------------- Python 3.7
<_MainThread(MainThread, started 139969139185472)>
-------------- Python 3.8
<_MainThread(MainThread, started 140299012052800)>
-------------- Python 3.9
<_MainThread(MainThread, started 140377659451200)>
-------------- Python 3.10
<string>:1: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
<_MainThread(MainThread, started 139908902836032)>
```

Thanks to @whitslack for pointing this out over in https://github.com/pytest-dev/pytest-twisted/issues/146.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10273
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
