### PR TITLE
10273 use current_thread() instead of currentThread()

### DIFF
--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -14,6 +14,7 @@ from twisted.internet.interfaces import IReactorThreads
 from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.python.threadable import isInIOThread
 from twisted.python.threadpool import ThreadPool
+from twisted.python.versions import Version
 
 
 class ThreadTestsBuilder(ReactorBuilder):
@@ -219,6 +220,12 @@ class ThreadTestsBuilder(ReactorBuilder):
         reactor.callInThread(check)
         self.runReactor(reactor)
         self.assertEqual([False], results)
+
+    def test_threadPoolCurrentThreadDeprecated(self):
+        self.callDeprecated(
+            version=(Version("Twisted", "NEXT", 0, 0), "ThreadPool.current_thread"),
+            f=ThreadPool.currentThread,
+        )
 
 
 globals().update(ThreadTestsBuilder.makeTestCaseClasses())

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -7,7 +7,6 @@ Tests for implementations of L{IReactorThreads}.
 
 
 import gc
-import threading
 from weakref import ref
 
 from twisted.internet.interfaces import IReactorThreads

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -109,13 +109,13 @@ class ThreadTestsBuilder(ReactorBuilder):
         result = []
 
         def threadCall():
-            result.append(threading.currentThread())
+            result.append(threading.current_thread())
             reactor.stop()
 
         reactor.callLater(0, reactor.callInThread, reactor.callFromThread, threadCall)
         self.runReactor(reactor, 5)
 
-        self.assertEqual(result, [threading.currentThread()])
+        self.assertEqual(result, [threading.current_thread()])
 
     def test_stopThreadPool(self):
         """

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -12,7 +12,7 @@ from weakref import ref
 
 from twisted.internet.interfaces import IReactorThreads
 from twisted.internet.test.reactormixins import ReactorBuilder
-from twisted.python.threadable import isInIOThread
+from twisted.python.threadable import getThreadID, isInIOThread
 from twisted.python.threadpool import ThreadPool
 from twisted.python.versions import Version
 
@@ -110,13 +110,13 @@ class ThreadTestsBuilder(ReactorBuilder):
         result = []
 
         def threadCall():
-            result.append(threading.current_thread())
+            result.append(getThreadID())
             reactor.stop()
 
         reactor.callLater(0, reactor.callInThread, reactor.callFromThread, threadCall)
         self.runReactor(reactor, 5)
 
-        self.assertEqual(result, [threading.current_thread()])
+        self.assertEqual(result, [getThreadID()])
 
     def test_stopThreadPool(self):
         """
@@ -223,7 +223,7 @@ class ThreadTestsBuilder(ReactorBuilder):
 
     def test_threadPoolCurrentThreadDeprecated(self):
         self.callDeprecated(
-            version=(Version("Twisted", "NEXT", 0, 0), "ThreadPool.current_thread"),
+            version=(Version("Twisted", "NEXT", 0, 0), "twisted.python.threadable.getThreadID"),
             f=ThreadPool.currentThread,
         )
 

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -225,7 +225,7 @@ class ThreadTestsBuilder(ReactorBuilder):
         self.callDeprecated(
             version=(
                 Version("Twisted", "NEXT", 0, 0),
-                "twisted.python.threadable.getThreadID",
+                "threading.current_thread",
             ),
             f=ThreadPool.currentThread,
         )

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -223,7 +223,10 @@ class ThreadTestsBuilder(ReactorBuilder):
 
     def test_threadPoolCurrentThreadDeprecated(self):
         self.callDeprecated(
-            version=(Version("Twisted", "NEXT", 0, 0), "twisted.python.threadable.getThreadID"),
+            version=(
+                Version("Twisted", "NEXT", 0, 0),
+                "twisted.python.threadable.getThreadID",
+            ),
             f=ThreadPool.currentThread,
         )
 

--- a/src/twisted/internet/test/test_threads.py
+++ b/src/twisted/internet/test/test_threads.py
@@ -7,11 +7,12 @@ Tests for implementations of L{IReactorThreads}.
 
 
 import gc
+import threading
 from weakref import ref
 
 from twisted.internet.interfaces import IReactorThreads
 from twisted.internet.test.reactormixins import ReactorBuilder
-from twisted.python.threadable import getThreadID, isInIOThread
+from twisted.python.threadable import isInIOThread
 from twisted.python.threadpool import ThreadPool
 from twisted.python.versions import Version
 
@@ -109,13 +110,13 @@ class ThreadTestsBuilder(ReactorBuilder):
         result = []
 
         def threadCall():
-            result.append(getThreadID())
+            result.append(threading.current_thread())
             reactor.stop()
 
         reactor.callLater(0, reactor.callInThread, reactor.callFromThread, threadCall)
         self.runReactor(reactor, 5)
 
-        self.assertEqual(result, [getThreadID()])
+        self.assertEqual(result, [threading.current_thread()])
 
     def test_stopThreadPool(self):
         """

--- a/src/twisted/newsfragments/10273.bugfix
+++ b/src/twisted/newsfragments/10273.bugfix
@@ -1,0 +1,1 @@
+Replaced usage of ``threading.currentThread()`` with ``threading.current_thread()`` to avoid the deprecation warnings introduced for the former in Python 3.10.

--- a/src/twisted/newsfragments/10273.bugfix
+++ b/src/twisted/newsfragments/10273.bugfix
@@ -1,1 +1,2 @@
-Deprecated ``threading.currentThread()`` in favor of ``threading.current_thread()`` to avoid the deprecation warnings introduced for the former in Python 3.10.
+Deprecated ``twisted.python.threading.ThreadPool.currentThread()`` in favor of ``twisted.python.threadable.getThreadID()``.
+Switched ``twisted.python.threading.ThreadPool.currentThread()`` and ``twisted.python.threadable.getThreadID()`` to use `threading.current_thread()`` to avoid the deprecation warnings introduced for ``threading.currentThread()`` in Python 3.10.

--- a/src/twisted/newsfragments/10273.bugfix
+++ b/src/twisted/newsfragments/10273.bugfix
@@ -1,1 +1,1 @@
-Replaced usage of ``threading.currentThread()`` with ``threading.current_thread()`` to avoid the deprecation warnings introduced for the former in Python 3.10.
+Deprecated ``threading.currentThread()`` in favor of ``threading.current_thread()`` to avoid the deprecation warnings introduced for the former in Python 3.10.

--- a/src/twisted/newsfragments/10273.bugfix
+++ b/src/twisted/newsfragments/10273.bugfix
@@ -1,2 +1,2 @@
-Deprecated ``twisted.python.threading.ThreadPool.currentThread()`` in favor of ``twisted.python.threadable.getThreadID()``.
+Deprecated ``twisted.python.threading.ThreadPool.currentThread()`` in favor of ``threading.current_thread()``.
 Switched ``twisted.python.threading.ThreadPool.currentThread()`` and ``twisted.python.threadable.getThreadID()`` to use `threading.current_thread()`` to avoid the deprecation warnings introduced for ``threading.currentThread()`` in Python 3.10.

--- a/src/twisted/python/threadable.py
+++ b/src/twisted/python/threadable.py
@@ -104,7 +104,7 @@ _dummyID = object()
 def getThreadID():
     if threadingmodule is None:
         return _dummyID
-    return threadingmodule.currentThread().ident
+    return threadingmodule.current_thread().ident
 
 
 def isInIOThread():

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -9,7 +9,7 @@ In most cases you can just use C{reactor.callInThread} and friends
 instead of creating a thread pool directly.
 """
 
-from threading import Thread, current_thread, currentThread
+from threading import Thread, current_thread
 from typing import List
 
 from twisted._threads import pool as _pool
@@ -48,10 +48,9 @@ class ThreadPool:
     currentThread = staticmethod(
         deprecated(
             version=Version("Twisted", "NEXT", 0, 0),
-            replacement="ThreadPool.current_thread",
-        )(currentThread)
+            replacement="twisted.python.threadable.getThreadID",
+        )(current_thread)
     )
-    current_thread = staticmethod(current_thread)
     _pool = staticmethod(_pool)
 
     def __init__(self, minthreads=5, maxthreads=20, name=None):

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -45,10 +45,12 @@ class ThreadPool:
     name = None
 
     threadFactory = Thread
-    currentThread = staticmethod(deprecated(
-        version=Version("Twisted", "NEXT", 0, 0),
-        replacement="ThreadPool.current_thread",
-    )(currentThread))
+    currentThread = staticmethod(
+        deprecated(
+            version=Version("Twisted", "NEXT", 0, 0),
+            replacement="ThreadPool.current_thread",
+        )(currentThread)
+    )
     current_thread = staticmethod(current_thread)
     _pool = staticmethod(_pool)
 

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -9,12 +9,14 @@ In most cases you can just use C{reactor.callInThread} and friends
 instead of creating a thread pool directly.
 """
 
-from threading import Thread, current_thread
+from threading import Thread, current_thread, currentThread
 from typing import List
 
 from twisted._threads import pool as _pool
 from twisted.python import context, log
+from twisted.python.deprecate import deprecated
 from twisted.python.failure import Failure
+from twisted.python.versions import Version
 
 WorkerStop = object()
 
@@ -43,6 +45,10 @@ class ThreadPool:
     name = None
 
     threadFactory = Thread
+    currentThread = staticmethod(deprecated(
+        version=Version("Twisted", "NEXT", 0, 0),
+        replacement="ThreadPool.current_thread",
+    )(currentThread))
     current_thread = staticmethod(current_thread)
     _pool = staticmethod(_pool)
 

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -9,7 +9,7 @@ In most cases you can just use C{reactor.callInThread} and friends
 instead of creating a thread pool directly.
 """
 
-from threading import Thread, currentThread
+from threading import Thread, current_thread
 from typing import List
 
 from twisted._threads import pool as _pool
@@ -43,7 +43,7 @@ class ThreadPool:
     name = None
 
     threadFactory = Thread
-    currentThread = staticmethod(currentThread)
+    current_thread = staticmethod(current_thread)
     _pool = staticmethod(_pool)
 
     def __init__(self, minthreads=5, maxthreads=20, name=None):

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -48,7 +48,7 @@ class ThreadPool:
     currentThread = staticmethod(
         deprecated(
             version=Version("Twisted", "NEXT", 0, 0),
-            replacement="twisted.python.threadable.getThreadID",
+            replacement="threading.current_thread",
         )(current_thread)
     )
     _pool = staticmethod(_pool)

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -404,11 +404,11 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         event = threading.Event()
 
         def onResult(success, result):
-            threadIds.append(threadable.getThreadID())
+            threadIds.append(threading.current_thread().ident)
             event.set()
 
         def func():
-            threadIds.append(threadable.getThreadID())
+            threadIds.append(threading.current_thread().ident)
 
         tp = threadpool.ThreadPool(0, 1)
         tp.callInThreadWithCallback(onResult, func)

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -404,11 +404,11 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         event = threading.Event()
 
         def onResult(success, result):
-            threadIds.append(threadable.getThreadID().ident)
+            threadIds.append(threadable.getThreadID())
             event.set()
 
         def func():
-            threadIds.append(threadable.getThreadID().ident)
+            threadIds.append(threadable.getThreadID())
 
         tp = threadpool.ThreadPool(0, 1)
         tp.callInThreadWithCallback(onResult, func)

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -404,11 +404,11 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         event = threading.Event()
 
         def onResult(success, result):
-            threadIds.append(threading.current_thread().ident)
+            threadIds.append(threadable.getThreadID().ident)
             event.set()
 
         def func():
-            threadIds.append(threading.current_thread().ident)
+            threadIds.append(threadable.getThreadID().ident)
 
         tp = threadpool.ThreadPool(0, 1)
         tp.callInThreadWithCallback(onResult, func)

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -404,11 +404,11 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         event = threading.Event()
 
         def onResult(success, result):
-            threadIds.append(threading.currentThread().ident)
+            threadIds.append(threading.current_thread().ident)
             event.set()
 
         def func():
-            threadIds.append(threading.currentThread().ident)
+            threadIds.append(threading.current_thread().ident)
 
         tp = threadpool.ThreadPool(0, 1)
         tp.callInThreadWithCallback(onResult, func)


### PR DESCRIPTION
## Scope and purpose

`current_thread()` was introduced in 2.6 as an alias for `currentThread()`.
The old `currentThread()` spelling raises a `DeprecationWarning` in 3.10.

https://docs.python.org/2.7/library/threading.html#threading.current_thread

```console
$ for v in 2.7 3.5 3.6 3.7 3.8 3.9 3.10; do echo -------------- Python $v; python$v -c 'import threading; print(threading.currentThread())'; done
-------------- Python 2.7
<_MainThread(MainThread, started 139976240273216)>
-------------- Python 3.5
<_MainThread(MainThread, started 140209924052800)>
-------------- Python 3.6
<_MainThread(MainThread, started 139896207542080)>
-------------- Python 3.7
<_MainThread(MainThread, started 139969139185472)>
-------------- Python 3.8
<_MainThread(MainThread, started 140299012052800)>
-------------- Python 3.9
<_MainThread(MainThread, started 140377659451200)>
-------------- Python 3.10
<string>:1: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
<_MainThread(MainThread, started 139908902836032)>
```

Thanks to @whitslack for pointing this out over in https://github.com/pytest-dev/pytest-twisted/issues/146.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10273
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

(yep, this formatting is messed up due to including a code block in the message.  please edit this and then copy the source for use.)

```
Merge pull request #1670 from altendky/10273-altendky-current_thread

Author: altendky
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10273

`current_thread()` was introduced in 2.6 as an alias for `currentThread()`.
The old `currentThread()` spelling raises a `DeprecationWarning` in 3.10.

https://docs.python.org/2.7/library/threading.html#threading.current_thread

```console
$ for v in 2.7 3.5 3.6 3.7 3.8 3.9 3.10; do echo -------------- Python $v; python$v -c 'import threading; print(threading.currentThread())'; done
-------------- Python 2.7
<_MainThread(MainThread, started 139976240273216)>
-------------- Python 3.5
<_MainThread(MainThread, started 140209924052800)>
-------------- Python 3.6
<_MainThread(MainThread, started 139896207542080)>
-------------- Python 3.7
<_MainThread(MainThread, started 139969139185472)>
-------------- Python 3.8
<_MainThread(MainThread, started 140299012052800)>
-------------- Python 3.9
<_MainThread(MainThread, started 140377659451200)>
-------------- Python 3.10
<string>:1: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
<_MainThread(MainThread, started 139908902836032)>
```

Thanks to @whitslack for pointing this out over in https://github.com/pytest-dev/pytest-twisted/issues/146.
```
