### PR TITLE
10277: Remove ObjectModelIntegrationTests

### DIFF
--- a/src/twisted/internet/test/test_core.py
+++ b/src/twisted/internet/test/test_core.py
@@ -6,7 +6,6 @@ Tests for implementations of L{IReactorCore}.
 """
 
 
-import inspect
 import signal
 import time
 from types import FrameType
@@ -18,43 +17,6 @@ from twisted.internet.error import ReactorAlreadyRunning, ReactorNotRestartable
 from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
-
-
-class ObjectModelIntegrationMixin:
-    """
-    Helpers for tests about the object model of reactor-related objects.
-    """
-
-    def assertFullyNewStyle(self, instance: object) -> None:
-        """
-        Assert that the given object is an instance of a new-style class and
-        that there are no classic classes in the inheritance hierarchy of
-        that class.
-
-        This is a beneficial condition because PyPy is better able to
-        optimize attribute lookup on such classes.
-        """
-        testCase = cast(SynchronousTestCase, self)
-        testCase.assertIsInstance(instance, object)
-        mro = inspect.getmro(type(instance))
-        for subclass in mro:
-            testCase.assertTrue(
-                issubclass(subclass, object), f"{subclass!r} is not new-style"
-            )
-
-
-class ObjectModelIntegrationTests(ReactorBuilder, ObjectModelIntegrationMixin):
-    """
-    Test details of object model integration against all reactors.
-    """
-
-    def test_newstyleReactor(self) -> None:
-        """
-        Checks that all reactors on a platform have method resolution order
-        containing only new style classes.
-        """
-        reactor = self.buildReactor()
-        self.assertFullyNewStyle(reactor)
 
 
 class SystemEventTestsBuilder(ReactorBuilder):
@@ -352,4 +314,3 @@ class SystemEventTestsBuilder(ReactorBuilder):
 
 
 globals().update(SystemEventTestsBuilder.makeTestCaseClasses())
-globals().update(ObjectModelIntegrationTests.makeTestCaseClasses())

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -80,7 +80,6 @@ from twisted.internet.test.reactormixins import (
     needsRunningReactor,
     stopOnError,
 )
-from twisted.internet.test.test_core import ObjectModelIntegrationMixin
 from twisted.logger import Logger
 from twisted.python import log
 from twisted.python.failure import Failure
@@ -1389,15 +1388,6 @@ class StreamTransportTestsMixin(LogObserverMixin):
 
         self.assertIn(expectedMessage, loggedMessages)
 
-    def test_allNewStyle(self):
-        """
-        The L{IListeningPort} object is an instance of a class with no
-        classic classes in its hierarchy.
-        """
-        reactor = self.buildReactor()
-        port = self.getListeningPort(reactor, ServerFactory())
-        self.assertFullyNewStyle(port)
-
     @skipIf(SKIP_EMFILE, "Reserved EMFILE file descriptor not supported on Windows.")
     def test_closePeerOnEMFILE(self):
         """
@@ -1765,7 +1755,6 @@ class TCPPortTestsBuilder(
     ReactorBuilder,
     ListenTCPMixin,
     TCPPortTestsMixin,
-    ObjectModelIntegrationMixin,
     StreamTransportTestsMixin,
 ):
     pass
@@ -1775,7 +1764,6 @@ class TCPFDPortTestsBuilder(
     ReactorBuilder,
     SocketTCPMixin,
     TCPPortTestsMixin,
-    ObjectModelIntegrationMixin,
     StreamTransportTestsMixin,
 ):
     pass

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -30,7 +30,6 @@ from twisted.internet.test.connectionmixins import (
     EndpointCreator,
 )
 from twisted.internet.test.reactormixins import ReactorBuilder
-from twisted.internet.test.test_core import ObjectModelIntegrationMixin
 from twisted.internet.test.test_tcp import (
     AbortConnectionMixin,
     ConnectToTCPListenerMixin,
@@ -310,7 +309,6 @@ class SSLClientTestsMixin(
 class TLSPortTestsBuilder(
     TLSMixin,
     ContextGeneratingMixin,
-    ObjectModelIntegrationMixin,
     BadContextTestsMixin,
     ConnectToTCPListenerMixin,
     StreamTransportTestsMixin,

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -50,7 +50,6 @@ from twisted.internet.test.connectionmixins import (
     runProtocolsWithReactor,
 )
 from twisted.internet.test.reactormixins import ReactorBuilder
-from twisted.internet.test.test_core import ObjectModelIntegrationMixin
 from twisted.internet.test.test_tcp import (
     MyClientFactory,
     MyServerFactory,
@@ -818,7 +817,6 @@ class UNIXPortTestsBuilder(
     ListenUNIXMixin,
     UNIXPortTestsMixin,
     ReactorBuilder,
-    ObjectModelIntegrationMixin,
     StreamTransportTestsMixin,
 ):
     """
@@ -830,7 +828,6 @@ class UNIXFDPortTestsBuilder(
     SocketUNIXMixin,
     UNIXPortTestsMixin,
     ReactorBuilder,
-    ObjectModelIntegrationMixin,
     StreamTransportTestsMixin,
 ):
     """

--- a/src/twisted/newsfragments/10277.misc
+++ b/src/twisted/newsfragments/10277.misc
@@ -1,0 +1,1 @@
+Remove twisted.internet.test.test_core.ObjectModelIntegrationTests, which is no longer necessary.


### PR DESCRIPTION
## Scope and purpose

`twisted.internet.test.test_core.ObjectModelIntegrationMixin.assertFullyNewStyle` never raises in Python 3, because there are no old-style classes any more.

This PR removes `assertFullyNewStyle`.
…which seems to render `ObjectModelIntegrationMixin` useless, as that was its only method.
…which seems to render `ObjectModelIntegrationTests` useless, as its only test is a test to assert that classes are new-style.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10277
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
