### PR TITLE
10280: Update imap4.py

### DIFF
--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -2370,7 +2370,7 @@ class IMAP4Server(basic.LineReceiver, policies.TimeoutMixin):
             else:
                 failures.append(result.value)
         if failures:
-            self.sendNegativeResponse(tag, "[ALERT] Some messages were not copied")
+            self.sendNegativeResponse(tag, b"[ALERT] Some messages were not copied")
         else:
             self.sendPositiveResponse(tag, b"COPY completed")
 


### PR DESCRIPTION
Ticket 10280
Fails on type error "builtins.TypeError: sequence item 2: expected a bytes-like object, str found"

## Scope and purpose

Needed to correct TypeError in response to client.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: Khymeira
Reviewer: 
Fixes: ticket:10280

Long description providing a summary of these changes.
(as long as you wish)
```
