### PR TITLE
10287: Type annotate twisted.python.fakepwd

### DIFF
--- a/src/twisted/newsfragments/10287.feature
+++ b/src/twisted/newsfragments/10287.feature
@@ -1,0 +1,1 @@
+Type annotations have been added to the twisted.python.fakepwd module.

--- a/src/twisted/python/fakepwd.py
+++ b/src/twisted/python/fakepwd.py
@@ -6,6 +6,7 @@
 L{twisted.python.fakepwd} provides a fake implementation of the L{pwd} API.
 """
 
+from typing import List
 
 __all__ = ["UserDatabase", "ShadowDatabase"]
 
@@ -17,7 +18,16 @@ class _UserRecord:
     See that module for attribute documentation.
     """
 
-    def __init__(self, name, password, uid, gid, gecos, home, shell):
+    def __init__(
+        self,
+        name: str,
+        password: str,
+        uid: int,
+        gid: int,
+        gecos: str,
+        home: str,
+        shell: str,
+    ) -> None:
         self.pw_name = name
         self.pw_passwd = password
         self.pw_uid = uid
@@ -26,7 +36,7 @@ class _UserRecord:
         self.pw_dir = home
         self.pw_shell = shell
 
-    def __len__(self):
+    def __len__(self) -> int:
         return 7
 
     def __getitem__(self, index):
@@ -50,46 +60,50 @@ class UserDatabase:
         added to this database.
     """
 
-    def __init__(self):
+    _users: List[_UserRecord]
+
+    def __init__(self) -> None:
         self._users = []
 
-    def addUser(self, username, password, uid, gid, gecos, home, shell):
+    def addUser(
+        self,
+        username: str,
+        password: str,
+        uid: int,
+        gid: int,
+        gecos: str,
+        home: str,
+        shell: str,
+    ) -> None:
         """
         Add a new user record to this database.
 
         @param username: The value for the C{pw_name} field of the user
             record to add.
-        @type username: C{str}
 
         @param password: The value for the C{pw_passwd} field of the user
             record to add.
-        @type password: C{str}
 
         @param uid: The value for the C{pw_uid} field of the user record to
             add.
-        @type uid: C{int}
 
         @param gid: The value for the C{pw_gid} field of the user record to
             add.
-        @type gid: C{int}
 
         @param gecos: The value for the C{pw_gecos} field of the user record
             to add.
-        @type gecos: C{str}
 
         @param home: The value for the C{pw_dir} field of the user record to
             add.
-        @type home: C{str}
 
         @param shell: The value for the C{pw_shell} field of the user record to
             add.
-        @type shell: C{str}
         """
         self._users.append(
             _UserRecord(username, password, uid, gid, gecos, home, shell)
         )
 
-    def getpwuid(self, uid):
+    def getpwuid(self, uid: int) -> _UserRecord:
         """
         Return the user record corresponding to the given uid.
         """
@@ -98,16 +112,18 @@ class UserDatabase:
                 return entry
         raise KeyError()
 
-    def getpwnam(self, name):
+    def getpwnam(self, name: str) -> _UserRecord:
         """
         Return the user record corresponding to the given username.
         """
+        if not isinstance(name, str):
+            raise TypeError(f"getpwuam() argument must be str, not {type(name)}")
         for entry in self._users:
             if entry.pw_name == name:
                 return entry
         raise KeyError()
 
-    def getpwall(self):
+    def getpwall(self) -> List[_UserRecord]:
         """
         Return a list of all user records.
         """
@@ -122,8 +138,17 @@ class _ShadowRecord:
     """
 
     def __init__(
-        self, username, password, lastChange, min, max, warn, inact, expire, flag
-    ):
+        self,
+        username: str,
+        password: str,
+        lastChange: int,
+        min: int,
+        max: int,
+        warn: int,
+        inact: int,
+        expire: int,
+        flag: int,
+    ) -> None:
         self.sp_nam = username
         self.sp_pwd = password
         self.sp_lstchg = lastChange
@@ -134,7 +159,7 @@ class _ShadowRecord:
         self.sp_expire = expire
         self.sp_flag = flag
 
-    def __len__(self):
+    def __len__(self) -> int:
         return 9
 
     def __getitem__(self, index):
@@ -162,48 +187,50 @@ class ShadowDatabase:
     @since: 12.0
     """
 
-    def __init__(self):
+    _users: List[_ShadowRecord]
+
+    def __init__(self) -> None:
         self._users = []
 
     def addUser(
-        self, username, password, lastChange, min, max, warn, inact, expire, flag
-    ):
+        self,
+        username: str,
+        password: str,
+        lastChange: int,
+        min: int,
+        max: int,
+        warn: int,
+        inact: int,
+        expire: int,
+        flag: int,
+    ) -> None:
         """
         Add a new user record to this database.
 
         @param username: The value for the C{sp_nam} field of the user record to
             add.
-        @type username: C{str}
 
         @param password: The value for the C{sp_pwd} field of the user record to
             add.
-        @type password: C{str}
 
         @param lastChange: The value for the C{sp_lstchg} field of the user
             record to add.
-        @type lastChange: C{int}
 
         @param min: The value for the C{sp_min} field of the user record to add.
-        @type min: C{int}
 
         @param max: The value for the C{sp_max} field of the user record to add.
-        @type max: C{int}
 
         @param warn: The value for the C{sp_warn} field of the user record to
             add.
-        @type warn: C{int}
 
         @param inact: The value for the C{sp_inact} field of the user record to
             add.
-        @type inact: C{int}
 
         @param expire: The value for the C{sp_expire} field of the user record
             to add.
-        @type expire: C{int}
 
         @param flag: The value for the C{sp_flag} field of the user record to
             add.
-        @type flag: C{int}
         """
         self._users.append(
             _ShadowRecord(
@@ -211,14 +238,16 @@ class ShadowDatabase:
             )
         )
 
-    def getspnam(self, username):
+    def getspnam(self, username: str) -> _ShadowRecord:
         """
         Return the shadow user record corresponding to the given username.
         """
+        if not isinstance(username, str):
+            raise TypeError(f"getspnam() argument must be str, not {type(username)}")
         for entry in self._users:
             if entry.sp_nam == username:
                 return entry
-        raise KeyError
+        raise KeyError(username)
 
     def getspall(self):
         """

--- a/src/twisted/python/test/test_fakepwd.py
+++ b/src/twisted/python/test/test_fakepwd.py
@@ -108,6 +108,12 @@ class UserDatabaseTestsMixin:
             self.assertEqual(entry.pw_dir, dir)
             self.assertEqual(entry.pw_shell, shell)
 
+    def test_getpwnamRejectsBytes(self):
+        """
+        L{getpwnam} rejects a non-L{str} username with L{TypeError}.
+        """
+        self.assertRaises(TypeError, self.database.getpwnam, b"i-am-bytes")
+
     def test_noSuchName(self):
         """
         I{getpwnam} raises L{KeyError} when passed a username which does not
@@ -298,6 +304,13 @@ class ShadowDatabaseTestsMixin:
         exist in the user database.
         """
         self.assertRaises(KeyError, self.database.getspnam, "alice")
+
+    def test_getspnamBytes(self):
+        """
+        I{getspnam} raises L{TypeError} when passed a L{bytes}, just like
+        L{spwd.getspnam}.
+        """
+        self.assertRaises(TypeError, self.database.getspnam, b"i-am-bytes")
 
     def test_recordLength(self):
         """

--- a/src/twisted/python/test/test_fakepwd.py
+++ b/src/twisted/python/test/test_fakepwd.py
@@ -22,6 +22,7 @@ else:
 import os
 from operator import getitem
 
+from twisted.python.compat import _PYPY
 from twisted.python.fakepwd import ShadowDatabase, UserDatabase
 from twisted.trial.unittest import TestCase
 
@@ -110,9 +111,14 @@ class UserDatabaseTestsMixin:
 
     def test_getpwnamRejectsBytes(self):
         """
-        L{getpwnam} rejects a non-L{str} username with L{TypeError}.
+        L{getpwnam} rejects a non-L{str} username with an exception.
         """
-        self.assertRaises(TypeError, self.database.getpwnam, b"i-am-bytes")
+        exc_type = TypeError
+        if _PYPY:
+            # PyPy raises KeyError instead of TypeError. See
+            # https://foss.heptapod.net/pypy/pypy/-/issues/3624
+            exc_type = Exception
+        self.assertRaises(exc_type, self.database.getpwnam, b"i-am-bytes")
 
     def test_noSuchName(self):
         """


### PR DESCRIPTION
## Scope and purpose

We've had some bugs due to `bytes` vs. `str` issues in [#9130](https://twistedmatrix.com/trac/ticket/9130) and [#10286](https://twistedmatrix.com/trac/ticket/10286). This indicates a shortcoming of the fake implementation: it happily passes through `bytes` when it should require `str`. Therefore, add type annotations and a few runtime type checks to better resemble the real `pwd` and `spwd` modules ([#10287](https://twistedmatrix.com/trac/ticket/10287#ticket)).


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10287
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.

    Failures appear unrelated to the content of the change.

* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
