### PR TITLE
[9660][twisted/internet/_glibbase] Fix Typeerror in simulate for py3

### DIFF
--- a/src/twisted/internet/_glibbase.py
+++ b/src/twisted/internet/_glibbase.py
@@ -354,8 +354,8 @@ class PortableGlibReactorBase(selectreactor.SelectReactor):
         if self._simtag is not None:
             self._source_remove(self._simtag)
         self.iterate()
-        timeout = min(self.timeout(), 0.01)
-        if timeout is None:
+        timeout = self.timeout()
+        if timeout is None or timeout > 0.01:
             timeout = 0.01
         self._simtag = self._timeout_add(
             int(timeout * 1000),

--- a/src/twisted/internet/test/test_glibbase.py
+++ b/src/twisted/internet/test/test_glibbase.py
@@ -65,3 +65,36 @@ class EnsureNotImportedTests(TestCase):
         )
         self.assertEqual(modules, {"m2": module})
         self.assertEqual(e.args, ("A message.",))
+
+
+try:
+    from twisted.internet import gireactor as _gireactor
+except ImportError:
+    gireactor = None
+else:
+    gireactor = _gireactor
+
+missingGlibReactor = None
+if gireactor is None:
+    missingGlibReactor = "gi reactor not available"
+
+
+class GlibReactorBaseTests(TestCase):
+    """
+    Tests for the private C{twisted.internet._glibbase.GlibReactorBase}
+    done via the public C{twisted.internet.gireactor.PortableGIReactor}
+    """
+
+    skip = missingGlibReactor
+
+    def test_simulate(self):
+        """
+        C{simulate} can be called without raising any errors when there are
+        no delayed calls for the reactor and hence there is no defined sleep
+        period.
+        """
+        sut = gireactor.PortableGIReactor(usegtk=False)
+        # Double check that reactor has no sleep period.
+        self.assertIs(None, sut.timeout())
+
+        sut.simulate()

--- a/src/twisted/newsfragments/9660.bugfix
+++ b/src/twisted/newsfragments/9660.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.glibbase.simulate no longer raises TypeError with no timeout on Python 3.

--- a/src/twisted/newsfragments/9660.bugfix
+++ b/src/twisted/newsfragments/9660.bugfix
@@ -1,1 +1,1 @@
-twisted.internet._glibbase.PortableGlibReactorBase.simulate no longer raises TypeError when there are no delayed called. This was a regression introduced with the migration to Python3 in which the builtin `min` function no longer accepts `None` as an argument.
+twisted.internet.gireactor.PortableGIReactor.simulate and twisted.internet.gtk2reactor.PortableGtkReactor.simulate no longer raises TypeError when there are no delayed called. This was a regression introduced with the migration to Python3 in which the builtin `min` function no longer accepts `None` as an argument.

--- a/src/twisted/newsfragments/9660.bugfix
+++ b/src/twisted/newsfragments/9660.bugfix
@@ -1,1 +1,1 @@
-twisted.internet.glibbase.simulate no longer raises TypeError with no timeout on Python 3.
+twisted.internet._glibbase.PortableGlibReactorBase.simulate no longer raises TypeError when there are no delayed called. This was a regression introduced with the migration to Python3 in which the builtin `min` function no longer accepts `None` as an argument.


### PR DESCRIPTION
## Scope and purpose

Fixes a Type error when calling simpulate() in a glib reactor.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9660
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1679 from doadin/patch-3

Author: Doadin
Reviewer:
Fixes: ticket: 9660

```
