### PR TITLE
10291 fix trunk build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,8 +68,6 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: pypy-3.6
-            tox-env: alldeps-nocov-posix
           - python-version: pypy-3.7
             tox-env: alldeps-nocov-posix
           # We still run some tests with coverage

--- a/azure-pipelines/run_test_steps.yml
+++ b/azure-pipelines/run_test_steps.yml
@@ -9,7 +9,6 @@ parameters:
 - name: pythonVersion
   type: string
   values:
-  - '3.6'
   - '3.7'
   - '3.8'
   - '3.9'


### PR DESCRIPTION
## Scope and purpose

build is red, now its not

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10291
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1681 from twisted/10291-fix_build

Author: glyph
Reviewer: 
Fixes: ticket:10291

Tests are now passing again; some python3.6 builds and the pypy3.6 build were dropped.
```
