### PR TITLE
10299 Put PATH back in the environment, at least.

### DIFF
--- a/src/twisted/python/test/test_release.py
+++ b/src/twisted/python/test/test_release.py
@@ -49,10 +49,16 @@ if sys.platform != "win32":
 else:
     skip = "Release toolchain only supported on POSIX."
 
-# This should match the GitHub Actions environment used by pre-comnmit.ci to push changes to the auto-updated branches.
-PRECOMMIT_CI_ENVIRON = {"GITHUB_HEAD_REF": "pre-commit-ci-update-config"}
+# This should match the GitHub Actions environment used by pre-commit.ci to push changes to the auto-updated branches.
+PRECOMMIT_CI_ENVIRON = {
+    "GITHUB_HEAD_REF": "pre-commit-ci-update-config",
+    "PATH": os.environ["PATH"],
+}
 # This should match the GHA environment for non pre-commit.ci PRs.
-GENERIC_CI_ENVIRON = {"GITHUB_HEAD_REF": "1234-some-branch-name"}
+GENERIC_CI_ENVIRON = {
+    "GITHUB_HEAD_REF": "1234-some-branch-name",
+    "PATH": os.environ["PATH"],
+}
 
 
 class ExternalTempdirTestCase(TestCase):


### PR DESCRIPTION
## Scope and purpose


CheckNewsfragmentScriptTests.setUp almost completely wipes the environment then the tests try to run git as a child process. This means the runCommand calls in the test methods have to find git with no PATH set which is unreliable at best.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10299<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10299

Fix a spurious failure in twisted.python.test.test_release in some environments.
```
