### PR TITLE
10302: Use assertEqual() in test_workertrial to fix PyPy3

### DIFF
--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -69,7 +69,7 @@ class MainTests(TestCase):
         the stdin fd and C{self.writeStream} for the stdout fd.
         """
         if fd == _WORKER_AMP_STDIN:
-            self.assertIdentical("rb", mode)
+            self.assertEqual("rb", mode)
             return self.readStream
         elif fd == _WORKER_AMP_STDOUT:
             self.assertEqual("wb", mode)

--- a/src/twisted/trial/newsfragments/10302.bugfix
+++ b/src/twisted/trial/newsfragments/10302.bugfix
@@ -1,0 +1,1 @@
+_dist.test.test_workertrial now correctly compare strings via assertEqual() and pass on PyPy3


### PR DESCRIPTION
## Scope and purpose

Use assertEqual() rather than assertIdentical() to compare strings
in twisted.trial._dist.test.test_workertrial to fix the test failure
on PyPy3.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10302
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
