### PR TITLE
10308: Make SSHSession clean up both client and session

### DIFF
--- a/src/twisted/conch/newsfragments/10308.bugfix
+++ b/src/twisted/conch/newsfragments/10308.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.ssh.session.SSHSession now cleans up both the client transport and the ISession adapter if both are set.  Previously, a subsystem's connectionLost method was not called if a environment variable passing request was also sent on the same channel.

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -180,16 +180,16 @@ class SSHSession(channel.SSHChannel):
             log.warn("Weird extended data: {dataType}", dataType=dataType)
 
     def eofReceived(self):
+        if self.client:
+            self.conn.sendClose(self)
         if self.session:
             self.session.eofReceived()
-        elif self.client:
-            self.conn.sendClose(self)
 
     def closed(self):
+        if self.client:
+            self.client.transport.loseConnection()
         if self.session:
             self.session.closed()
-        elif self.client:
-            self.client.transport.loseConnection()
 
     # def closeReceived(self):
     #    self.loseConnection() # don't know what to do with this

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -186,7 +186,7 @@ class SSHSession(channel.SSHChannel):
             self.session.eofReceived()
 
     def closed(self):
-        if self.client:
+        if self.client and self.client.transport:
             self.client.transport.loseConnection()
         if self.session:
             self.session.closed()

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -542,6 +542,25 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         self.assertTrue(self.session.client.transport.close)
         self.session.client.transport.close = False
 
+    def test_client_closed_with_env_subsystem(self):
+        """
+        If the peer requests an environment variable in its setup process
+        followed by requesting a subsystem, SSHSession.closed() should tell
+        the transport connected to the client that the connection was lost.
+        """
+        self.assertTrue(
+            self.session.requestReceived(b"env", common.NS(b"FOO") + common.NS(b"bar"))
+        )
+        self.assertTrue(
+            self.session.requestReceived(
+                b"subsystem", common.NS(b"TestSubsystem") + b"data"
+            )
+        )
+        self.session.client = StubClient()
+        self.session.closed()
+        self.assertTrue(self.session.client.transport.close)
+        self.session.client.transport.close = False
+
     def test_badSubsystemDoesNotCreateClient(self):
         """
         When a subsystem request fails, SSHSession.client should not be set.


### PR DESCRIPTION
## Scope and purpose

If an environment variable passing request and a subsystem request were
both sent on the same channel, then SSHSession only cleaned up the
ISession adapter when receiving EOF or closing the channel, and did not
call loseConnection on the client transport which is the only reasonable
way for a subsystem to be notified when a connection is closed.

SSHSession now cleans up both the client transport and the ISession
adapter if both are set.

I think this should be safe for non-subsystem sessions as well - I can't see a practical downside to doing more careful cleanup here.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10308
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/conch/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: cjwatson
Reviewer: adiroiban
Fixes: ticket:10308

If an environment variable passing request and a subsystem request were
both sent on the same channel, then SSHSession only cleaned up the
ISession adapter when receiving EOF or closing the channel, and did not
call loseConnection on the client transport which is the only reasonable
way for a subsystem to be notified when a connection is closed.

SSHSession now cleans up both the client transport and the ISession
adapter if both are set.
```