### PR TITLE
[Fix #10309] Refactor SSH version string parsing.

### DIFF
--- a/src/twisted/conch/newsfragments/10309.bugfix
+++ b/src/twisted/conch/newsfragments/10309.bugfix
@@ -1,0 +1,5 @@
+twisted.conch.ssh.SSHTransportBase now implements stricter checks for
+the peer SSH version string as defined in RFC 4253 section 4.2.
+The version string length is limited to 255 character and null characters are not allowed.
+It also rejects any connection that doesn't start with `SSH-` and no longer
+ignores the lines received before the version string.


### PR DESCRIPTION
## Scope and purpose

This is a refactoring of the SSH peer version string handling.

In 98387b39e9f0b21462f6abc7a1325dc370fcdeb1 we did a quick and dirty fix.

The goal of this PR is to look at providing a better fix.

The main issue with the previous fix, is that in theory a SSH peer can send with the first package the followings :

* SSH version string
* supported ciphers.

Now... the SSH version string is limited to 253 byte... but the supported ciphers can be provided in a packet that is more than 4K in length.
Especially if the peer support a lot of cipher and cipher aliases.

----------

I don't know why conch SSH was implemented to ignore the lines received before 'SSH-`.
I don't thinks that this is OK.
The test was implemented in https://github.com/twisted/twisted/commit/775318c4be8d4c9dce31abde0ae96b0e20f9afac


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10309
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10309

Refactor the SSH version string exchange to no longer ignore data sent before the version string.
The SSH version string no longer accepts null characters.
The SSH version string is now limited to 253 characters.
```

reviewers: @twisted/twisted-contributors
