### PR TITLE
Update h2 dependency to allow v4 (h2>=3.0, <5.0)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ serial =
     pywin32 != 226; platform_system == "Windows"
 
 http2 =
-    h2 >= 3.0, < 4.0
+    h2 >= 3.0, < 5.0
     priority >= 1.1.0, < 2.0
 
 contextvars =

--- a/src/twisted/web/newsfragments/10182.feature
+++ b/src/twisted/web/newsfragments/10182.feature
@@ -1,0 +1,1 @@
+Twisted is now compatible with h2 4.x.x.

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -36,7 +36,7 @@ try:
     import h2  # type: ignore[import]
     import h2.errors  # type: ignore[import]
     import h2.exceptions  # type: ignore[import]
-    import hyperframe  # type: ignore[import]
+    import hyperframe
     import priority  # type: ignore[import]
     from hpack.hpack import Decoder, Encoder  # type: ignore[import]
 


### PR DESCRIPTION
## Scope and purpose

Current h2 version is 4.1. Updating dependency requirements to allow h2 version 4.

Ticket: https://twistedmatrix.com/trac/ticket/10182
