### PR TITLE
10313: Send exit-status/exit-signal on EOF to SSHSession again

### DIFF
--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -180,10 +180,14 @@ class SSHSession(channel.SSHChannel):
             log.warn("Weird extended data: {dataType}", dataType=dataType)
 
     def eofReceived(self):
-        if self.client:
-            self.conn.sendClose(self)
+        # If we have a session, tell it that EOF has been received and
+        # expect it to send a close message (it may need to send other
+        # messages such as exit-status or exit-signal first).  If we don't
+        # have a session, then just send a close message directly.
         if self.session:
             self.session.eofReceived()
+        elif self.client:
+            self.conn.sendClose(self)
 
     def closed(self):
         if self.client and self.client.transport:

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -342,18 +342,24 @@ class StubConnection:
         """
         Record the sent data.
         """
+        if self.closes.get(channel):
+            return
         self.data.setdefault(channel, []).append(data)
 
     def sendExtendedData(self, channel, type, data):
         """
         Record the sent extended data.
         """
+        if self.closes.get(channel):
+            return
         self.extData.setdefault(channel, []).append((type, data))
 
     def sendRequest(self, channel, request, data, wantReply=False):
         """
         Record the sent channel request.
         """
+        if self.closes.get(channel):
+            return
         self.requests.setdefault(channel, []).append((request, data, wantReply))
         if wantReply:
             return defer.succeed(None)
@@ -362,6 +368,8 @@ class StubConnection:
         """
         Record the sent EOF.
         """
+        if self.closes.get(channel):
+            return
         self.eofs[channel] = True
 
     def sendClose(self, channel):


### PR DESCRIPTION
## Scope and purpose

When I tried to upgrade https://git.launchpad.net/turnip (the hosting backend for git.launchpad.net) to a backport of https://github.com/twisted/twisted/pull/1696, I found that its SSH frontend tests failed with a series of extremely opaque errors which boiled down to git saying "fatal: the remote end hung up unexpectedly", and which on detailed comparison were because the "exit-status" channel request wasn't being sent after a "git upload-pack" subprocess exited.

This turns out to be because I drew an incorrect parallelism between SSHSession.eofReceived and SSHSession.closed when fixing https://twistedmatrix.com/trac/ticket/10308: while it is indeed necessary to lose the client transport's connection in SSHSession.closed even if there's a session adapter as well, it's *not* necessary to send a close message in SSHSession.eofReceived if there's a session adapter.  Firstly, the session adapter will typically already send a close message via SSHChannel.loseConnection once it's finished cleaning up (and would presumably have done so prior to the fix for https://twistedmatrix.com/trac/ticket/10308).  Secondly, and more critically, the SSH_MSG_CHANNEL_CLOSE message sent by SSHConnection.sendClose is a request to terminate the channel, and it's supposed to be the last thing that the party sending it sends on that channel; SSHConnection refuses to send any other messages after sending a close message.  As a result, any asynchronous cleanup work done by SSHSession.eofReceived, even a Deferred that fires on the next iteration of the reactor, will fail to send cleanup messages such as "exit-status" or "exit-signal", which the peer may interpret as abrupt termination; that is indeed what git does.

We failed to notice this because the session tests use a StubConnection which behaves differently: it's happy to continue to "send" messages (i.e. record them in its various dicts of messages that would have been sent to a real peer by the code under test) even if the channel has been closed, and thus fails to be an accurate stub.  Fixing the stub immediately exposes the failure in SessionInterfaceTests.test_requestExecWithData.

Reverting part of my previous change means that SSHSession correctly sends "exit-status"/"exit-signal" messages again when a program it started in response to a "shell" or "exec" request exits.  I've also checked that this doesn't cause https://twistedmatrix.com/trac/ticket/10308 to recur; only the change to SSHSession.closed was in fact needed there.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10313
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/conch/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles)) (empty because this regression never made it into a release)
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: cjwatson
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10313

Send exit-status/exit-signal on EOF to SSHSession again
```