### PR TITLE
10315 Remove TRIAL_PYTHONPATH

### DIFF
--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -122,10 +122,9 @@ class DistTrialRunner:
             _WORKER_AMP_STDOUT: "r",
         }
         environ = os.environ.copy()
-        # Add an environment variable containing the raw sys.path, to be used by
-        # subprocesses to make sure it's identical to the parent. See
-        # workertrial._setupPath.
-        environ["TRIAL_PYTHONPATH"] = os.pathsep.join(sys.path)
+        # Add an environment variable containing the raw sys.path, to be used
+        # by subprocesses to try to make it identical to the parent's.
+        environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         for worker in protocols:
             args = [sys.executable, workertrialPath]
             args.extend(arguments)

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -262,7 +262,10 @@ class DistTrialRunnerTests(TestCase):
         self.assertEqual(arguments[0], arguments[1])
         self.assertTrue(os.path.exists(arguments[2]))
         self.assertEqual("foo", arguments[3])
-        self.assertEqual(os.pathsep.join(sys.path), environment["TRIAL_PYTHONPATH"])
+        # The child process runs with PYTHONPATH set to exactly the parent's
+        # import search path so that the child has a good chance of finding
+        # the same source files the parent would have found.
+        self.assertEqual(os.pathsep.join(sys.path), environment["PYTHONPATH"])
 
     def test_run(self):
         """

--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -19,7 +19,7 @@ from twisted.trial._dist import (
     workercommands,
     workertrial,
 )
-from twisted.trial._dist.workertrial import WorkerLogObserver, _setupPath, main
+from twisted.trial._dist.workertrial import WorkerLogObserver, main
 from twisted.trial.unittest import TestCase
 
 
@@ -144,30 +144,3 @@ class MainTests(TestCase):
 
         self.readStream = FakeStream()
         self.assertRaises(IOError, main, self.fdopen)
-
-
-class SetupPathTests(TestCase):
-    """
-    Tests for L{_setupPath} C{sys.path} manipulation.
-    """
-
-    def setUp(self):
-        self.addCleanup(setattr, sys, "path", sys.path[:])
-
-    def test_overridePath(self):
-        """
-        L{_setupPath} overrides C{sys.path} if B{TRIAL_PYTHONPATH} is specified
-        in the environment.
-        """
-        environ = {"TRIAL_PYTHONPATH": os.pathsep.join(["foo", "bar"])}
-        _setupPath(environ)
-        self.assertEqual(["foo", "bar"], sys.path)
-
-    def test_noVariable(self):
-        """
-        L{_setupPath} doesn't change C{sys.path} if B{TRIAL_PYTHONPATH} is not
-        present in the environment.
-        """
-        originalPath = sys.path[:]
-        _setupPath({})
-        self.assertEqual(originalPath, sys.path)

--- a/src/twisted/trial/_dist/test/test_workertrial.py
+++ b/src/twisted/trial/_dist/test/test_workertrial.py
@@ -6,7 +6,6 @@ Tests for L{twisted.trial._dist.workertrial}.
 """
 
 import errno
-import os
 import sys
 from io import BytesIO
 

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -14,20 +14,6 @@ import errno
 import os
 import sys
 
-
-def _setupPath(environ):
-    """
-    Override C{sys.path} with what the parent passed in B{TRIAL_PYTHONPATH}.
-
-    @see: twisted.trial._dist.disttrial.DistTrialRunner.launchWorkerProcesses
-    """
-    if "TRIAL_PYTHONPATH" in environ:
-        sys.path[:] = environ["TRIAL_PYTHONPATH"].split(os.pathsep)
-
-
-_setupPath(os.environ)
-
-
 from twisted.internet.protocol import FileWrapper
 from twisted.python.log import startLoggingWithObserver, textFromEventDict
 from twisted.trial._dist import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT


### PR DESCRIPTION
## Scope and purpose

See https://twistedmatrix.com/trac/ticket/10315 for motivation 

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10315
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [ ] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10315

Switch to the standard PYTHONPATH environment variable for configuring
disttrial worker processes.
```
