### PR TITLE
[10317] Fix a typo in GlibReactorBaseTests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: 21.7b0
     hooks:
       - id: black
+        additional_dependencies: ['click<8.1']
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2

--- a/src/twisted/internet/test/test_glibbase.py
+++ b/src/twisted/internet/test/test_glibbase.py
@@ -93,7 +93,7 @@ class GlibReactorBaseTests(TestCase):
         no delayed calls for the reactor and hence there is no defined sleep
         period.
         """
-        sut = gireactor.PortableGIReactor(usegtk=False)
+        sut = gireactor.PortableGIReactor(useGtk=False)
         # Double check that reactor has no sleep period.
         self.assertIs(None, sut.timeout())
 

--- a/src/twisted/newsfragments/10317.bugfix
+++ b/src/twisted/newsfragments/10317.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.test.test_glibbase.GlibReactorBaseTests now passes.


### PR DESCRIPTION
## Scope and purpose

Fix a typo in GlibReactorBaseTests

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10317
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1705 from yan12125/10317-fix-GlibReactorBaseTests

Author: yan12125
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10317

Fix a typo in GlibReactorBaseTests
```