### PR TITLE
10320 discard async cleanups when running them

### DIFF
--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -199,7 +199,8 @@ class TestCase(SynchronousTestCase):
         object.
         """
         failures = []
-        for func, args, kwargs in self._cleanups[::-1]:
+        while len(self._cleanups) > 0:
+            func, args, kwargs = self._cleanups.pop()
             try:
                 yield func(*args, **kwargs)
             except Exception:

--- a/src/twisted/trial/newsfragments/10320.bugfix
+++ b/src/twisted/trial/newsfragments/10320.bugfix
@@ -1,2 +1,1 @@
-
 twisted.trial.unittest.TestCase now discards cleanup functions after running them.  Notably, this prevents them from being run an ever growing number of times with `trial -u ...`.

--- a/src/twisted/trial/newsfragments/10320.bugfix
+++ b/src/twisted/trial/newsfragments/10320.bugfix
@@ -1,0 +1,2 @@
+
+twisted.trial.unittest.TestCase now discards cleanup functions after running them.  Notably, this prevents them from being run an ever growing number of times with `trial -u ...`.

--- a/src/twisted/trial/test/test_tests.py
+++ b/src/twisted/trial/test/test_tests.py
@@ -962,6 +962,21 @@ class AddCleanupMixin:
         self.assertEqual(error1.getErrorMessage(), "bar")
         self.assertEqual(error2.getErrorMessage(), "foo")
 
+    def test_cleanupRunsOnce(self):
+        """
+        A function registered as a cleanup is run once.
+        """
+        cleanups = []
+        self.test.addCleanup(lambda: cleanups.append(stage))
+        # It should get run this time.
+        stage = "first"
+        self.test.run(self.result)
+        # It should not get run the next time since it has not been
+        # re-registered.
+        stage = "second"
+        self.test.run(self.result)
+        self.assertEqual(cleanups, ["first"])
+
 
 class SynchronousAddCleanupTests(AddCleanupMixin, unittest.SynchronousTestCase):
     """


### PR DESCRIPTION
## Scope and purpose

See https://twistedmatrix.com/trac/ticket/10320

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10320
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:103200

Prevent cleanups from accumulating on TestCase.
```
