### PR TITLE
10318 remove spurious test for illegal whitespace in xmlns

### DIFF
--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -308,16 +308,6 @@ class DomishStreamTestsMixin:
         self.stream.parse(xml)
         self.assertEqual(self.elements[0].child2.uri, "")
 
-    def test_namespaceWithWhitespace(self):
-        """
-        Whitespace in an xmlns value is preserved in the resulting node's C{uri}
-        attribute.
-        """
-        xml = b"<root xmlns:foo=' bar baz '><foo:bar foo:baz='quux'/></root>"
-        self.stream.parse(xml)
-        self.assertEqual(self.elements[0].uri, " bar baz ")
-        self.assertEqual(self.elements[0].attributes, {(" bar baz ", "baz"): "quux"})
-
     def test_attributesWithNamespaces(self):
         """
         Attributes with namespace are parsed without Exception.


### PR DESCRIPTION
<!--
## Remove this section

Have a look at [our developer documentation](https://twistedmatrix.com/trac/wiki/TwistedDevelopment#SubmittingaPatch) before submitting your Pull Request.

Note that the Trac ticket, news fragment, and review submission portions of this process apply to *all* pull requests, no matter how small;
if you don't do them, it's likely that nobody will even notice your PR needs a review.
-->

## Scope and purpose

Add a few words about why this PR is needed and what is its scope.

Add any comments about trade-offs (if any) made in this PR and the reasoning behind them.

Add mentions of things that are not covered here and are planed to be done in separate PRs.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10318
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #1709

Author: glyph
Reviewer: 
Fixes: ticket:10318

Eliminate a test that asserts we handle now-illegal whitespace in xmlns attributes
```
