### PR TITLE
10321 Fix test worker test.log corruption

### DIFF
--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -329,7 +329,9 @@ class LocalWorkerTests(TestCase):
         L{AMP} protocol if the right file descriptor, otherwise forwards to
         C{ProcessProtocol.childDataReceived}.
         """
-        localWorker = self.tidyLocalWorker(SpyDataLocalWorkerAMP(), ".", "test.log")
+        localWorker = self.tidyLocalWorker(
+            SpyDataLocalWorkerAMP(), self.mktemp(), "test.log"
+        )
         localWorker._outLog = BytesIO()
         localWorker.childDataReceived(4, b"foo")
         localWorker.childDataReceived(1, b"bar")
@@ -372,7 +374,9 @@ class LocalWorkerTests(TestCase):
         L{LocalWorker.outReceived} logs the output into its C{_outLog} log
         file.
         """
-        localWorker = self.tidyLocalWorker(SpyDataLocalWorkerAMP(), ".", "test.log")
+        localWorker = self.tidyLocalWorker(
+            SpyDataLocalWorkerAMP(), self.mktemp(), "test.log"
+        )
         localWorker._outLog = BytesIO()
         data = b"The quick brown fox jumps over the lazy dog"
         localWorker.outReceived(data)
@@ -383,7 +387,9 @@ class LocalWorkerTests(TestCase):
         L{LocalWorker.errReceived} logs the errors into its C{_errLog} log
         file.
         """
-        localWorker = self.tidyLocalWorker(SpyDataLocalWorkerAMP(), ".", "test.log")
+        localWorker = self.tidyLocalWorker(
+            SpyDataLocalWorkerAMP(), self.mktemp(), "test.log"
+        )
         localWorker._errLog = BytesIO()
         data = b"The quick brown fox jumps over the lazy dog"
         localWorker.errReceived(data)
@@ -427,7 +433,9 @@ class LocalWorkerTests(TestCase):
         L{LocalWorker.connectionLost} closes the log streams.
         """
 
-        localWorker = self.tidyLocalWorker(SpyDataLocalWorkerAMP(), ".", "test.log")
+        localWorker = self.tidyLocalWorker(
+            SpyDataLocalWorkerAMP(), self.mktemp(), "test.log"
+        )
         localWorker.connectionLost(None)
         self.assertTrue(localWorker._outLog.closed)
         self.assertTrue(localWorker._errLog.closed)
@@ -438,10 +446,9 @@ class LocalWorkerTests(TestCase):
         L{LocalWorker.processEnded} calls C{connectionLost} on itself and on
         the L{AMP} protocol.
         """
-
         transport = FakeTransport()
         protocol = SpyDataLocalWorkerAMP()
-        localWorker = LocalWorker(protocol, ".", "test.log")
+        localWorker = LocalWorker(protocol, self.mktemp(), "test.log")
         localWorker.makeConnection(transport)
         localWorker.processEnded(Failure(CONNECTION_DONE))
         self.assertTrue(localWorker._outLog.closed)
@@ -478,6 +485,6 @@ class LocalWorkerTests(TestCase):
 
         protocol = SpyDataLocalWorkerAMP()
         protocol.callRemote = failCallRemote
-        self.tidyLocalWorker(protocol, ".", "test.log")
+        self.tidyLocalWorker(protocol, self.mktemp(), "test.log")
 
         self.assertEqual([], self.flushLoggedErrors(RuntimeError))


### PR DESCRIPTION
## Scope and purpose

See https://twistedmatrix.com/trac/ticket/10321

I would love to implement something to protect test.log from accidentally mangling by application code but I haven't been able to think of any good ideas about how one might go about this.  So instead this just fixes the application code.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10321
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10321

Stop corrupting test.log from some of the disttrial unit tests.
```
