### PR TITLE
10322 deduplicate test.log opening code

### DIFF
--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -18,6 +18,7 @@ from twisted.internet.interfaces import IAddress, ITransport
 from twisted.internet.protocol import ProcessProtocol
 from twisted.protocols.amp import AMP
 from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
 from twisted.python.reflect import namedObject
 from twisted.trial._dist import (
     _WORKER_AMP_STDIN,
@@ -28,6 +29,7 @@ from twisted.trial._dist import (
 from twisted.trial._dist.workerreporter import WorkerReporter
 from twisted.trial.runner import TestLoader, TrialSuite
 from twisted.trial.unittest import Todo
+from ..util import openTestLog
 
 
 class WorkerProtocol(AMP):
@@ -259,14 +261,10 @@ class LocalWorker(ProcessProtocol):
             os.makedirs(self._logDirectory)
         self._outLog = open(os.path.join(self._logDirectory, "out.log"), "wb")
         self._errLog = open(os.path.join(self._logDirectory, "err.log"), "wb")
-        # Log data is received via AMP which is UTF-8 unicode.
-        # The log file should be written using a Unicode encoding, and not
-        # the default system encoding which might not be Unicode compatible.
-        self._testLog = open(
-            os.path.join(self._logDirectory, self._logFile),
-            "w",
-            encoding="utf-8",
-            errors="strict",
+        self._testLog = openTestLog(
+            FilePath(
+                os.path.join(self._logDirectory, self._logFile),
+            ),
         )
         self._ampProtocol.setTestStream(self._testLog)
         logDirectory = self._logDirectory

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -845,7 +845,7 @@ class TrialRunner:
         if self.logfile == "-":
             logFile = sys.stdout
         else:
-            logFile = open(self.logfile, "a")
+            logFile = util.openTestLog(filepath.FilePath(self.logfile))
         self._logFileObject = logFile
         self._logFileObserver = log.FileLogObserver(logFile)
         log.startLoggingWithObserver(self._logFileObserver.emit, 0)

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -18,8 +18,8 @@ Maintainer: Jonathan Lange
     asynchronous (ie, Deferred-returning) test methods, in seconds.
 """
 
-
 from random import randrange
+from typing import TextIO
 
 from twisted.internet import interfaces, utils
 from twisted.python.failure import Failure
@@ -387,3 +387,12 @@ def _listToPhrase(things, finalDelimiter, delimiter=", "):
             finalDelimiter,
             strThings[-1],
         )
+
+
+def openTestLog(path: FilePath) -> TextIO:
+    """
+    Open the given path such that test log messages can be written to it.
+    """
+    # Always use UTF-8 because, considering all platforms, the system default
+    # encoding can not reliably encode all code points.
+    return open(path.path, "a", encoding="utf-8", errors="strict")


### PR DESCRIPTION
## Scope and purpose

See https://twistedmatrix.com/trac/ticket/10322

I opted to make both codepaths open the file in append mode to avoid accidental data loss and to make them both always use UTF-8 instead of letting one of them rely on the platform to choose to make the behavior more consistent.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10322
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10322

Remove duplication and inconsistencies in trial's two `test.log` opening codepaths.
```
