### PR TITLE
[10325] CI: enable tests that require gobject

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,10 @@ jobs:
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']
+        # By default, tests are executed without extra platform dependencies.
+        platform-deps: ['']
+        # By default, tests are executed directly via tox.
+        tox-wrapper: ['']
         # Tests are executed with the default target which is the full test suite.
         trial-target: ['']
 
@@ -73,6 +77,12 @@ jobs:
           - python-version: pypy-3.7
             tox-env: alldeps-withcov-posix
             trial-target: twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests
+          # We run selected test for GTK reactor inside X virtual framebuffer.
+          - python-version: '3.7'
+            tox-env: alldeps-gtk-withcov-posix
+            trial-target: twisted.internet.test
+            platform-deps: 'gtk_platform'
+            tox-wrapper: 'xvfb-run -a'
 
 
     steps:
@@ -111,9 +121,23 @@ jobs:
       run: |
         python -m pip install --upgrade pip tox coverage
 
+    - name: Install GTK system deps
+      if: matrix.platform-deps == 'gtk_platform'
+      run: |
+        # *-dev dependencies are for pygobject
+        # https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.42.0/setup.py#L129-L134
+        sudo apt-get update
+        sudo apt-get install -y \
+          libgirepository1.0-dev \
+          libglib2.0-dev \
+          libcairo2-dev \
+          libffi-dev \
+          gir1.2-gtk-3.0 \
+          xvfb
+
     - name: Test
       run: |
-        tox ${{ matrix.trial-target }}
+        ${{ matrix.tox-wrapper }} tox ${{ matrix.trial-target }}
 
     - name: Prepare coverage
       if: ${{ !cancelled() && contains(matrix['tox-env'], 'withcov') }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,10 @@ windows_platform =
 osx_platform =
     %(macos_platform)s
 
+gtk_platform =
+    pygobject
+    %(all_non_platform)s
+
 mypy =
     mypy==0.930
     mypy-zope==0.3.4

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ extras =
 
     alldeps-macos: osx_platform
 
+    gtk: gtk_platform
+
     serial: serial
 
     {withcov}: dev


### PR DESCRIPTION
## Scope and purpose

CI: enable tests that require gobject

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10325
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green. - ~~some GTK/GI tests fail during my local testing~~ tests with issues are properly skipped
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: yan12125
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10325

CI: enable tests that require gobject

Via a separate job for GTK tests
```
