### PR TITLE
[#10328] Remove coveralls as not used. Update codecov.io reporting version.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -21,7 +21,7 @@ Add mentions of things that are not covered here and are planed to be done in se
 * [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
 * [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
 * [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
-* [ ] The title of the PR starts with the associated Trac ticket number prefixed by the `#` character. To auto-create link in GitHub.
+* [ ] The title of the PR starts with the associated Trac ticket number (without the `#` character).
 * [ ] I have updated the automated tests and checked that all checks for the PR are green.
 * [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
 * [ ] The merge commit will use the below format

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -21,7 +21,7 @@ Add mentions of things that are not covered here and are planed to be done in se
 * [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
 * [ ] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
 * [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
-* [ ] The title of the PR starts with the associated Trac ticket number (without the `#` character).
+* [ ] The title of the PR starts with the associated Trac ticket number prefixed by the `#` character. To auto-create link in GitHub.
 * [ ] I have updated the automated tests and checked that all checks for the PR are green.
 * [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
 * [ ] The merge commit will use the below format

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,7 +110,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox coverage coveralls
+        python -m pip install --upgrade pip tox coverage
 
     - name: Test
       run: |
@@ -126,21 +126,13 @@ jobs:
         python -m coverage xml -o coverage.xml -i
         python -m coverage report --skip-covered
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       if: ${{ !cancelled() && contains(matrix['tox-env'], 'withcov') }}
       with:
         files: coverage.xml
         name: lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}
         fail_ci_if_error: true
         functionalities: gcov,search
-
-    - name: Publish to Coveralls
-      if: ${{ !cancelled() && contains(matrix['tox-env'], 'withcov') }}
-      continue-on-error: true
-      run: |
-        python -m coveralls -v
-      env:
-        COVERALLS_REPO_TOKEN: 'JFDTIRUVOQ8jCM3zcajrZALlpKXyiXGAX'
 
   static-checks:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,13 +126,12 @@ jobs:
         python -m coverage xml -o coverage.xml -i
         python -m coverage report --skip-covered
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v2
       if: ${{ !cancelled() && contains(matrix['tox-env'], 'withcov') }}
       with:
         files: coverage.xml
         name: lnx-${{ matrix.python-version }}-${{ matrix.tox-env }}${{ matrix.noipv6 }}
         fail_ci_if_error: true
-        functionalities: gcov,search
 
   static-checks:
     runs-on: ubuntu-20.04

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,9 +8,9 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    # We have at least 10 builds in GitHub Actions and 12 in Azure
-    # and lint + mypy + docs + ReadTheDocs
-    after_n_builds: 15
+    # We have at least 5 builds in GitHub Actions,
+    # so try not to send the reports too soon with partial results.
+    after_n_builds: 5
     wait_for_ci: yes
 
 coverage:


### PR DESCRIPTION
## Scope and purpose

This tries to get CI green ... spring is coming :)

Update codecov actions script to v2 . V3 was failing.
Removed coveralls reporting as we were not using it.


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10328
* [NA] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [X] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [X] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [X] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [X] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroibam
Reviewer: 
Fixes: ticket:10238

Fix the CI build system to have green runs.
Use codecov action v2 to publish coverage.
Remove publishing to coveralls.
```
