### PR TITLE
10330 use `twisted.internet.defer.execute` instead of `maybeDeferred` in Conch in a couple places

### DIFF
--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -482,7 +482,7 @@ class SSHPublicKeyChecker:
         self._keydb = keydb
 
     def requestAvatarId(self, credentials):
-        d = defer.maybeDeferred(self._sanityCheckKey, credentials)
+        d = defer.execute(self._sanityCheckKey, credentials)
         d.addCallback(self._checkKey, credentials)
         d.addCallback(self._verifyKey, credentials)
         return d

--- a/src/twisted/conch/client/knownhosts.py
+++ b/src/twisted/conch/client/knownhosts.py
@@ -451,7 +451,7 @@ class KnownHostsFile:
             verified or has changed.
         @rtype: L{Deferred}
         """
-        hhk = defer.maybeDeferred(self.hasHostKey, hostname, key)
+        hhk = defer.execute(self.hasHostKey, hostname, key)
 
         def gotHasKey(result):
             if result:


### PR DESCRIPTION
## Scope and purpose

See https://twistedmatrix.com/trac/ticket/10330

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10330
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10330

Change some unnecessary uses of `maybeDeferred` to `execute` in a couple places.
```
