### PR TITLE
10327 Support coroutine results in maybeDeferred

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -172,7 +172,7 @@ def _isAsyncDefValue(o: Any) -> bool:
     Determine whether to apply "coroutine" handling to a value in
     L{maybeDeferred}.
 
-    @return: C{True} if L{o} came from a function defined using C{async def},
+    @return: C{True} if C{o} came from a function defined using C{async def},
         C{False} otherwise.
     """
     # A note on how we identify such values...
@@ -202,17 +202,18 @@ def maybeDeferred(
 
     Call the given function with the given arguments.  Then:
 
-    - If the returned object is a L{Deferred}, return it.
+      - If the returned object is a L{Deferred}, return it.
 
-    - If the returned object is a L{Failure}, wrap it with L{fail} and return it.
+      - If the returned object is a L{Failure}, wrap it with L{fail} and
+        return it.
 
-    - If the returned object is a L{types.CoroutineType}, wrap it with
-      L{Deferred.fromCoroutine} and return it.
+      - If the returned object is a L{types.CoroutineType}, wrap it with
+        L{Deferred.fromCoroutine} and return it.
 
-    - Otherwise, wrap it in L{succeed} and return it.
+      - Otherwise, wrap it in L{succeed} and return it.
 
-    - If an exception is raised, convert it to a L{Failure}, wrap it in
-      L{fail}, and then return it.
+      - If an exception is raised, convert it to a L{Failure}, wrap it in
+        L{fail}, and then return it.
 
     @param f: The callable to invoke
     @param args: The arguments to pass to C{f}

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -15,7 +15,7 @@ from asyncio import AbstractEventLoop, Future, iscoroutine
 from enum import Enum
 from functools import wraps
 from sys import exc_info, version_info
-from types import GeneratorType, MappingProxyType
+from types import CoroutineType, GeneratorType, MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -167,17 +167,52 @@ def execute(
         return succeed(result)
 
 
+def _isAsyncDefValue(o: Any) -> bool:
+    """
+    Determine whether to apply "coroutine" handling to a value in
+    L{maybeDeferred}.
+
+    @return: C{True} if L{o} came from a function defined using C{async def},
+        C{False} otherwise.
+    """
+    # A note on how we identify such values...
+    #
+    # inspect.iscoroutinefunction(f) should be the simplest and easiest way to
+    # determine if we want to apply coroutine handling.  However, the value
+    # may be returned by a regular function that calls a coroutine function
+    # and returns its result.  It would be confusing if cases like this led to
+    # different handling of the coroutine (even though it is a mistake to have
+    # a regular function call a coroutine function to return its result -
+    # doing so immediately destroys a large part of the value of coroutine
+    # functions: that they can only have a coroutine result).
+    #
+    # There are many ways we could inspect ``o`` to determine if it is a
+    # "coroutine" but these are all mistakes.  The goal is only to determine
+    # whether the value came from ``async def`` or not because these are the
+    # only values we're trying to handle specially in ``maybeDeferred``.  Such
+    # values always have exactly one type:
+    return type(o) is CoroutineType
+
+
 def maybeDeferred(
     f: Callable[..., _T], *args: object, **kwargs: object
 ) -> "Deferred[_T]":
     """
-    Invoke a function that may or may not return a L{Deferred}.
+    Invoke a function that may or may not return a L{Deferred} or coroutine.
 
-    Call the given function with the given arguments.  If the returned
-    object is a L{Deferred}, return it.  If the returned object is a L{Failure},
-    wrap it with L{fail} and return it.  Otherwise, wrap it in L{succeed} and
-    return it.  If an exception is raised, convert it to a L{Failure}, wrap it
-    in L{fail}, and then return it.
+    Call the given function with the given arguments.  Then:
+
+    - If the returned object is a L{Deferred}, return it.
+
+    - If the returned object is a L{Failure}, wrap it with L{fail} and return it.
+
+    - If the returned object is a L{types.CoroutineType}, wrap it with
+      L{Deferred.fromCoroutine} and return it.
+
+    - Otherwise, wrap it in L{succeed} and return it.
+
+    - If an exception is raised, convert it to a L{Failure}, wrap it in
+      L{fail}, and then return it.
 
     @param f: The callable to invoke
     @param args: The arguments to pass to C{f}
@@ -195,6 +230,8 @@ def maybeDeferred(
         return result
     elif isinstance(result, Failure):
         return fail(result)
+    elif _isAsyncDefValue(result):
+        return Deferred.fromCoroutine(result)
     else:
         return succeed(result)
 

--- a/src/twisted/newsfragments/10327.feature
+++ b/src/twisted/newsfragments/10327.feature
@@ -1,0 +1,1 @@
+twisted.internet.defer.maybeDeferred will now schedule a coroutine result as asynchronous operation and return a Deferred that fires with the result of the coroutine.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -30,6 +30,8 @@ from typing import (
     cast,
 )
 
+from hamcrest import assert_that, equal_to, is_
+
 from twisted.internet import defer, reactor
 from twisted.internet.defer import (
     Deferred,
@@ -846,6 +848,50 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         )
         d1.errback(Failure(RuntimeError()))
         self.assertImmediateFailure(d2, RuntimeError)
+
+    def test_maybeDeferredCoroutineSuccess(self) -> None:
+        """
+        When called with a coroutine function L{defer.maybeDeferred} returns a
+        L{defer.Deferred} which has the same result as the coroutine returned
+        by the function.
+        """
+        result = object()
+
+        async def f() -> object:
+            return result
+
+        # Demonstrate that the function itself does not need to be a coroutine
+        # function to trigger the coroutine-handling behavior.
+        def g() -> Coroutine:
+            return f()
+
+        assert_that(
+            self.successResultOf(defer.maybeDeferred(g)),
+            is_(result),
+        )
+
+    def test_maybeDeferredCoroutineFailure(self) -> None:
+        """
+        When called with a coroutine function L{defer.maybeDeferred} returns a
+        L{defer.Deferred} which has a L{Failure} result wrapping the exception
+        raised by the coroutine function.
+        """
+
+        class SomeException(Exception):
+            pass
+
+        async def f() -> None:
+            raise SomeException()
+
+        # Demonstrate that the function itself does not need to be a coroutine
+        # function to trigger the coroutine-handling behavior.
+        def g() -> Coroutine:
+            return f()
+
+        assert_that(
+            self.failureResultOf(defer.maybeDeferred(g)).type,
+            equal_to(SomeException),
+        )
 
     def test_innerCallbacksPreserved(self) -> None:
         """


### PR DESCRIPTION
## Scope and purpose

https://twistedmatrix.com/trac/ticket/10327

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10327
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10327

Support a coroutine result in `maybeDeferred` by applying `Deferred.fromCoroutine`.
This makes it possible to convert functions which may or may not return a `Deferred`
(and which are called by `maybeDeferred`) into functions defined with `async def`
with minimal or no additional effort.

A partial list of APIs in Twisted which this causes to begin supporting coroutines is:

* twisted.internet.task.LoopingCall
* twisted.internet.threads.blockingCallFromThread 
* twisted.protocols.ident.IdentServer.lookup
* twisted.protocols.amp.IResponderLocator.locateResponder 
* twisted.protocols.ftp.FTP.processCommand (ftp_* methods)
* twisted.protocols.postfix.PostfixTCPMapServer's "factory.get"
* twisted.application.internet.ClientService
* twisted.application.service.IService.stopService
* twisted.conch.scripts.cftp.StdioClient (cmd_* methods)
* twisted.conch.ssh.userauth.SSHUserAuthClient.getPublicKey
* twisted.conch.ssh.connection.SSHChannel.requestReceived
* twisted.conch.interfaces.ISFTPServer.openFile
* all twisted.conch.interfaces.ISFTPFile methods
* twisted.cred.credentials.IUsernamePassword.checkPassword
* twisted.cred.credentials.IUsernameHashedPassword.checkPassword
* twisted.cred.credentials.IUsernameDigestHash.checkHash
* twisted.cred.checkers.ICredentialsChecker.requestAvatarId
* twisted.internet.interfaces.IListeningPort.stopListening

* Some APIs in twisted.mail, twisted.names, twisted.spread
* Some APIs in twisted.web.soap, twisted.web.xmlrpc
* Some APIs twisted.words.service
```
