### PR TITLE
10333 improve disttrial error representation

### DIFF
--- a/src/twisted/trial/_dist/distreporter.py
+++ b/src/twisted/trial/_dist/distreporter.py
@@ -20,8 +20,7 @@ from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from ..itrial import IReporter, ITestCase
 
-Traceback = TracebackType
-ReporterFailure = Union[Failure, Tuple[type, Exception, Traceback]]
+ReporterFailure = Union[Failure, Tuple[type, Exception, TracebackType]]
 
 
 @implementer(IReporter)

--- a/src/twisted/trial/_dist/distreporter.py
+++ b/src/twisted/trial/_dist/distreporter.py
@@ -11,7 +11,8 @@ test is over.
 @since: 12.3
 """
 
-from typing import Any, Optional, Tuple, Union
+from types import TracebackType
+from typing import Optional, Tuple, Union
 
 from zope.interface import implementer
 
@@ -19,7 +20,7 @@ from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from ..itrial import IReporter, ITestCase
 
-Traceback = Any
+Traceback = TracebackType
 ReporterFailure = Union[Failure, Tuple[type, Exception, Traceback]]
 
 

--- a/src/twisted/trial/_dist/distreporter.py
+++ b/src/twisted/trial/_dist/distreporter.py
@@ -11,10 +11,16 @@ test is over.
 @since: 12.3
 """
 
+from typing import Any, Optional, Tuple, Union
+
 from zope.interface import implementer
 
 from twisted.python.components import proxyForInterface
-from twisted.trial.itrial import IReporter
+from twisted.python.failure import Failure
+from ..itrial import IReporter, ITestCase
+
+Traceback = Any
+ReporterFailure = Union[Failure, Tuple[type, Exception, Traceback]]
 
 
 @implementer(IReporter)
@@ -34,13 +40,13 @@ class DistReporter(proxyForInterface(IReporter)):  # type: ignore[misc]
         self.running[test.id()] = []
         self.running[test.id()].append((self.original.startTest, test))
 
-    def addFailure(self, test, fail):
+    def addFailure(self, test: ITestCase, fail: ReporterFailure) -> None:
         """
         Queue adding a failure.
         """
         self.running[test.id()].append((self.original.addFailure, test, fail))
 
-    def addError(self, test, error):
+    def addError(self, test: ITestCase, error: ReporterFailure) -> None:
         """
         Queue error adding.
         """
@@ -58,7 +64,9 @@ class DistReporter(proxyForInterface(IReporter)):  # type: ignore[misc]
         """
         self.running[test.id()].append((self.original.addUnexpectedSuccess, test, todo))
 
-    def addExpectedFailure(self, test, error, todo=None):
+    def addExpectedFailure(
+        self, test: ITestCase, error: ReporterFailure, todo: Optional[str] = None
+    ) -> None:
         """
         Queue adding an unexpected failure.
         """

--- a/src/twisted/trial/_dist/test/test_distreporter.py
+++ b/src/twisted/trial/_dist/test/test_distreporter.py
@@ -7,6 +7,7 @@ Tests for L{twisted.trial._dist.distreporter}.
 
 from io import StringIO
 
+from twisted.python.failure import Failure
 from twisted.trial._dist.distreporter import DistReporter
 from twisted.trial.reporter import TreeReporter
 from twisted.trial.unittest import TestCase
@@ -39,7 +40,7 @@ class DistReporterTests(TestCase):
         """
         self.distReporter.startTest(self.test)
         self.assertEqual(self.stream.getvalue(), "")
-        self.distReporter.addError(self.test, "error")
+        self.distReporter.addError(self.test, Failure(Exception("error")))
         self.assertEqual(self.stream.getvalue(), "")
         self.distReporter.stopTest(self.test)
         self.assertNotEqual(self.stream.getvalue(), "")
@@ -50,9 +51,11 @@ class DistReporterTests(TestCase):
         the test.
         """
         self.distReporter.startTest(self.test)
-        self.distReporter.addFailure(self.test, "foo")
-        self.distReporter.addError(self.test, "bar")
+        self.distReporter.addFailure(self.test, Failure(Exception("foo")))
+        self.distReporter.addError(self.test, Failure(Exception("bar")))
         self.distReporter.addSkip(self.test, "egg")
         self.distReporter.addUnexpectedSuccess(self.test, "spam")
-        self.distReporter.addExpectedFailure(self.test, "err", "foo")
+        self.distReporter.addExpectedFailure(
+            self.test, Failure(Exception("err")), "foo"
+        )
         self.assertEqual(len(self.distReporter.running[self.test.id()]), 6)

--- a/src/twisted/trial/_dist/test/test_distreporter.py
+++ b/src/twisted/trial/_dist/test/test_distreporter.py
@@ -17,12 +17,12 @@ class DistReporterTests(TestCase):
     Tests for L{DistReporter}.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.stream = StringIO()
         self.distReporter = DistReporter(TreeReporter(self.stream))
         self.test = TestCase()
 
-    def test_startSuccessStop(self):
+    def test_startSuccessStop(self) -> None:
         """
         Success output only gets sent to the stream after the test has stopped.
         """
@@ -33,7 +33,7 @@ class DistReporterTests(TestCase):
         self.distReporter.stopTest(self.test)
         self.assertNotEqual(self.stream.getvalue(), "")
 
-    def test_startErrorStop(self):
+    def test_startErrorStop(self) -> None:
         """
         Error output only gets sent to the stream after the test has stopped.
         """
@@ -44,7 +44,7 @@ class DistReporterTests(TestCase):
         self.distReporter.stopTest(self.test)
         self.assertNotEqual(self.stream.getvalue(), "")
 
-    def test_forwardedMethods(self):
+    def test_forwardedMethods(self) -> None:
         """
         Calling methods of L{DistReporter} add calls to the running queue of
         the test.

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -25,6 +25,7 @@ from twisted.trial._dist.worker import (
     LocalWorker,
     LocalWorkerAMP,
     LocalWorkerTransport,
+    WorkerException,
     WorkerProtocol,
 )
 from twisted.trial.reporter import TestResult
@@ -157,7 +158,10 @@ class LocalWorkerAMPTests(TestCase):
         d.addCallback(lambda result: results.append(result["success"]))
         self.pumpTransports()
 
-        self.assertEqual(self.testCase, self.result.errors[0][0])
+        case, failure = self.result.errors[0]
+        self.assertEqual(self.testCase, case)
+        self.assertEqual(failure.type, ValueError)
+        self.assertEqual(failure.value, WorkerException("error"))
         self.assertTrue(results)
 
     def test_runErrorWithFrames(self):
@@ -177,10 +181,11 @@ class LocalWorkerAMPTests(TestCase):
         d.addCallback(lambda result: results.append(result["success"]))
         self.pumpTransports()
 
-        self.assertEqual(self.testCase, self.result.errors[0][0])
-        self.assertEqual(
-            [("file.py", "invalid code", 3, [], [])], self.result.errors[0][1].frames
-        )
+        case, failure = self.result.errors[0]
+        self.assertEqual(self.testCase, case)
+        self.assertEqual(failure.type, ValueError)
+        self.assertEqual(failure.value, WorkerException("error"))
+        self.assertEqual([("file.py", "invalid code", 3, [], [])], failure.frames)
         self.assertTrue(results)
 
     def test_runFailure(self):
@@ -199,7 +204,10 @@ class LocalWorkerAMPTests(TestCase):
         d.addCallback(lambda result: results.append(result["success"]))
         self.pumpTransports()
 
-        self.assertEqual(self.testCase, self.result.failures[0][0])
+        case, failure = self.result.failures[0]
+        self.assertEqual(self.testCase, case)
+        self.assertEqual(failure.type, RuntimeError)
+        self.assertEqual(failure.value, WorkerException("fail"))
         self.assertTrue(results)
 
     def test_runSkip(self):

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -10,7 +10,7 @@ This module implements the worker classes.
 """
 
 import os
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from zope.interface import implementer
 
@@ -93,7 +93,10 @@ class LocalWorkerAMP(AMP):
     managercommands.AddSuccess.responder(addSuccess)
 
     def _buildFailure(
-        self, error: WorkerException, errorClass: str, frames: list
+        self,
+        error: WorkerException,
+        errorClass: str,
+        frames: List[str],
     ) -> Failure:
         """
         Helper to build a C{Failure} with some traceback.
@@ -117,7 +120,11 @@ class LocalWorkerAMP(AMP):
         return failure
 
     def addError(
-        self, testName: str, error: str, errorClass: str, frames: list
+        self,
+        testName: str,
+        error: str,
+        errorClass: str,
+        frames: List[str],
     ) -> Dict[str, bool]:
         """
         Add an error to the reporter.
@@ -135,7 +142,11 @@ class LocalWorkerAMP(AMP):
     managercommands.AddError.responder(addError)
 
     def addFailure(
-        self, testName: str, fail: str, failClass: str, frames: list
+        self,
+        testName: str,
+        fail: str,
+        failClass: str,
+        frames: List[str],
     ) -> Dict[str, bool]:
         """
         Add a failure to the reporter.

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -124,7 +124,11 @@ class LocalWorkerAMP(AMP):
 
         :param error: A message describing the error.
         """
-        failure = self._buildFailure(error, errorClass, frames)
+        # Wrap the error message in ``WorkerException`` because it is not
+        # possible to transfer arbitrary exception values over the AMP
+        # connection to the main process but we must give *some* Exception
+        # (not a str) to the test result object.
+        failure = self._buildFailure(WorkerException(error), errorClass, frames)
         self._result.addError(self._testCase, failure)
         return {"success": True}
 
@@ -136,7 +140,8 @@ class LocalWorkerAMP(AMP):
         """
         Add a failure to the reporter.
         """
-        failure = self._buildFailure(fail, failClass, frames)
+        # See addError for info about use of WorkerException here.
+        failure = self._buildFailure(WorkerException(fail), failClass, frames)
         self._result.addFailure(self._testCase, failure)
         return {"success": True}
 

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -10,6 +10,7 @@ This module implements the worker classes.
 """
 
 import os
+from typing import Dict, Optional
 
 from zope.interface import implementer
 
@@ -78,7 +79,9 @@ class LocalWorkerAMP(AMP):
 
     managercommands.AddSuccess.responder(addSuccess)
 
-    def _buildFailure(self, error, errorClass, frames):
+    def _buildFailure(
+        self, error: WorkerException, errorClass: str, frames: list
+    ) -> Failure:
         """
         Helper to build a C{Failure} with some traceback.
 
@@ -100,9 +103,13 @@ class LocalWorkerAMP(AMP):
             )
         return failure
 
-    def addError(self, testName, error, errorClass, frames):
+    def addError(
+        self, testName: str, error: str, errorClass: str, frames: list
+    ) -> Dict[str, bool]:
         """
         Add an error to the reporter.
+
+        :param error: A message describing the error.
         """
         failure = self._buildFailure(error, errorClass, frames)
         self._result.addError(self._testCase, failure)
@@ -110,7 +117,9 @@ class LocalWorkerAMP(AMP):
 
     managercommands.AddError.responder(addError)
 
-    def addFailure(self, testName, fail, failClass, frames):
+    def addFailure(
+        self, testName: str, fail: str, failClass: str, frames: list
+    ) -> Dict[str, bool]:
         """
         Add a failure to the reporter.
         """
@@ -129,7 +138,9 @@ class LocalWorkerAMP(AMP):
 
     managercommands.AddSkip.responder(addSkip)
 
-    def addExpectedFailure(self, testName, error, todo):
+    def addExpectedFailure(
+        self, testName: str, error: str, todo: Optional[str]
+    ) -> Dict[str, bool]:
         """
         Add an expected failure to the reporter.
         """

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -14,6 +14,8 @@ from typing import Dict, Optional
 
 from zope.interface import implementer
 
+from attrs import frozen
+
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IAddress, ITransport
 from twisted.internet.protocol import ProcessProtocol
@@ -31,6 +33,17 @@ from twisted.trial._dist.workerreporter import WorkerReporter
 from twisted.trial.runner import TestLoader, TrialSuite
 from twisted.trial.unittest import Todo
 from ..util import openTestLog
+
+
+@frozen(auto_exc=False)
+class WorkerException(Exception):
+    """
+    An exception was reported by a test running in a worker process.
+
+    :ivar message: An error message describing the exception.
+    """
+
+    message: str
 
 
 class WorkerProtocol(AMP):

--- a/src/twisted/trial/_dist/workerreporter.py
+++ b/src/twisted/trial/_dist/workerreporter.py
@@ -9,6 +9,8 @@ Test reporter forwarding test results over trial distributed AMP commands.
 @since: 12.3
 """
 
+from typing import List
+
 from twisted.python.failure import Failure
 from twisted.python.reflect import qual
 from twisted.trial._dist import managercommands
@@ -43,12 +45,14 @@ class WorkerReporter(TestResult):
             return Failure(error[1], error[0], error[2])
         return error
 
-    def _getFrames(self, failure):
+    def _getFrames(self, failure: Failure) -> List[str]:
         """
         Extract frames from a C{Failure} instance.
         """
-        frames = []
+        frames: List[str] = []
         for frame in failure.frames:
+            # The code object's name, the code object's filename, and the line
+            # number.
             frames.extend([frame[0], frame[1], str(frame[2])])
         return frames
 
@@ -69,7 +73,7 @@ class WorkerReporter(TestResult):
         failure = self._getFailure(error)
         error = failure.getErrorMessage()
         errorClass = qual(failure.type)
-        frames = [frame for frame in self._getFrames(failure)]
+        frames = self._getFrames(failure)
         self.ampProtocol.callRemote(
             managercommands.AddError,
             testName=testName,
@@ -87,7 +91,7 @@ class WorkerReporter(TestResult):
         failure = self._getFailure(fail)
         fail = failure.getErrorMessage()
         failClass = qual(failure.type)
-        frames = [frame for frame in self._getFrames(failure)]
+        frames = self._getFrames(failure)
         self.ampProtocol.callRemote(
             managercommands.AddFailure,
             testName=testName,

--- a/src/twisted/trial/newsfragments/10333.bugfix
+++ b/src/twisted/trial/newsfragments/10333.bugfix
@@ -1,0 +1,1 @@
+``trial -jN ...`` will now pass errors and failures to ``IReporter`` methods as instances of ``WorkerException`` instead of ``str``.

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -107,7 +107,8 @@ class TestResult(pyunit.TestResult):
         """
         Convert a C{sys.exc_info()}-style tuple to a L{Failure}, if necessary.
         """
-        if isinstance(error, tuple) and len(error) == 3:
+        is_exc_info_tuple = isinstance(error, tuple) and len(error) == 3
+        if is_exc_info_tuple:
             return Failure(error[1], error[0], error[2])
         elif isinstance(error, Failure):
             return error

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -109,7 +109,9 @@ class TestResult(pyunit.TestResult):
         """
         if isinstance(error, tuple):
             return Failure(error[1], error[0], error[2])
-        return error
+        elif isinstance(error, Failure):
+            return error
+        raise TypeError(f"Cannot convert {error} to a Failure")
 
     def startTest(self, test):
         """

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -107,7 +107,7 @@ class TestResult(pyunit.TestResult):
         """
         Convert a C{sys.exc_info()}-style tuple to a L{Failure}, if necessary.
         """
-        if isinstance(error, tuple):
+        if isinstance(error, tuple) and len(error) == 3:
             return Failure(error[1], error[0], error[2])
         elif isinstance(error, Failure):
             return error

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -102,6 +102,21 @@ class TestResultTests(unittest.SynchronousTestCase):
         self.assertEqual(excValue, failure.value)
         self.assertEqual(self.failureException, failure.type)
 
+    def test_somethingElse(self):
+        """
+        L{reporter.TestResult.addError} raises L{TypeError} if it is called with
+        an error that is neither a L{sys.exc_info}-like three-tuple nor a
+        L{Failure}.
+        """
+        with self.assertRaises(TypeError):
+            self.result.addError(self, "an error")
+        with self.assertRaises(TypeError):
+            self.result.addError(self, Exception("an error"))
+        with self.assertRaises(TypeError):
+            self.result.addError(self, (Exception, Exception("an error"), None, "extra"))
+        with self.assertRaises(TypeError):
+            self.result.addError(self, (Exception, Exception("an error")))
+
 
 class ReporterRealtimeTests(TestResultTests):
     def setUp(self):

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -113,7 +113,9 @@ class TestResultTests(unittest.SynchronousTestCase):
         with self.assertRaises(TypeError):
             self.result.addError(self, Exception("an error"))
         with self.assertRaises(TypeError):
-            self.result.addError(self, (Exception, Exception("an error"), None, "extra"))
+            self.result.addError(
+                self, (Exception, Exception("an error"), None, "extra")
+            )
         with self.assertRaises(TypeError):
             self.result.addError(self, (Exception, Exception("an error")))
 


### PR DESCRIPTION
## Scope and purpose

See https://tm.tl/10333

I opted to wrap the string error messages in a new `WorkerException`.  I don't see how the original exception value can be more faithfully represented given the limitations of the protocol between worker and controller processes.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10333
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10333

"disttrial" (`trial -jN ...`) now constructs Failures with an Exception instance
instead of a str for the `value` attribute.

Previously an `IReporter` would see exception instances when running
without `trial -jN ...` and a str when running with `trial -jN ...`.  Now the
`IReporter` will see an exception instance in both cases, but not necessarily
the same exception instance.
```
