### PR TITLE
[#10304] Remove py36 from CI and remove 3.6 specific code branches.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
           # end to end functional test usage for non-distributed trial runs.
           # When updating the minimum Python version here, also update the
           # `python_requires` from `setup.cfg`.
-          - python-version: '3.7.0'
+          - python-version: '3.7.1'
             tox-env: nodeps-withcov-posix
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.
@@ -240,18 +240,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: [testing, static-checks, release-publish]
     steps:
-
-    - name: Fail the job if testing is not success
-      if: ${{ needs.testing.result != 'success'}}
-      run: exit 1
-
-    - name: Fail the job if static-checks is not success
-      if: ${{ needs.static-checks.result != 'success'}}
-      run: exit 1
-
-    - name: Fail the job if release-publish is not success
-      if: ${{ needs.release-publish.result != 'success'}}
-      run: exit 1
-
     - name: note that all tests succeeded
       run: echo "🎉"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,11 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run on the minimum micro Python version that we can get on CI.
-        # When updating the minimum Python version here, also update the
-        # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.1]
+        python-version: [3.8, 3.9, 3.10]
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']
@@ -49,28 +46,30 @@ jobs:
         trial-target: ['']
 
         include:
-
+          # `noipv6` is created to make sure all is OK on an OS which doesn't
+          # have IPv6 available.
+          # Any supported Python version is OK for this job.
+          - python-version: 3.7
+            tox-env: alldeps-withcov-posix
+            noipv6: -noipv6
           # `nodeps` is created to make sure we don't have import errors in the
           # runtime and production code.
           # The minimum supported Python version should be used to maximize
           # coverage of code that otherwise depends on backports.
           # Distributed test run is disabled here so that we also have
           # end to end functional test usage for non-distributed trial runs.
-          - python-version: 3.6.7
+          # When updating the minimum Python version here, also update the
+          # `python_requires` from `setup.cfg`.
+          - python-version: 3.7.0
             tox-env: nodeps-withcov-posix
-          # `noipv6` is created to make sure all is OK on an OS which doesn't
-          # have IPv6 available.
-          # Any supported Python version is OK for this job.
-          - python-version: 3.6
-            tox-env: alldeps-withcov-posix
-            noipv6: -noipv6
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
           - python-version: pypy-3.7
             tox-env: alldeps-nocov-posix
-          # We still run some tests with coverage
+          # We still run some tests with coverage,
+          # as there are test with specific code branches for pypy.
           - python-version: pypy-3.7
             tox-env: alldeps-withcov-posix
             trial-target: twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run on latest minor release of each major python version.
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
         tox-env: ['alldeps-withcov-posix']
         # By default, tests are executed without disabling IPv6.
         noipv6: ['']
@@ -49,7 +49,7 @@ jobs:
           # `noipv6` is created to make sure all is OK on an OS which doesn't
           # have IPv6 available.
           # Any supported Python version is OK for this job.
-          - python-version: 3.7
+          - python-version: '3.7'
             tox-env: alldeps-withcov-posix
             noipv6: -noipv6
           # `nodeps` is created to make sure we don't have import errors in the
@@ -60,7 +60,7 @@ jobs:
           # end to end functional test usage for non-distributed trial runs.
           # When updating the minimum Python version here, also update the
           # `python_requires` from `setup.cfg`.
-          - python-version: 3.7.0
+          - python-version: '3.7.0'
             tox-env: nodeps-withcov-posix
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.
@@ -234,9 +234,24 @@ jobs:
 
 
   all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    # We have this job so that the PR can be blocked on a single job.
+    # See GitHub support answer for this hack.
+    # https://gist.github.com/altendky/2e3483a1f7e1ba21cc97de75db9b7d1c
     runs-on: ubuntu-latest
     needs: [testing, static-checks, release-publish]
     steps:
+
+    - name: Fail the job if testing is not success
+      if: ${{ needs.testing.result != 'success'}}
+      run: exit 1
+
+    - name: Fail the job if static-checks is not success
+      if: ${{ needs.static-checks.result != 'success'}}
+      run: exit 1
+
+    - name: Fail the job if release-publish is not success
+      if: ${{ needs.release-publish.result != 'success'}}
+      run: exit 1
+
     - name: note that all tests succeeded
       run: echo "🎉"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ long_description_content_type = text/x-rst
 
 [options]
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-python_requires = >=3.7.0
+python_requires = >=3.7.1
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1
@@ -79,7 +79,7 @@ tls =
 
 conch =
     pyasn1
-    cryptography >= 2.6
+    cryptography >= 2.6, < 37.0
     appdirs >= 1.4.0
     bcrypt >= 3.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ license = MIT
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ long_description_content_type = text/x-rst
 
 [options]
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-python_requires = >=3.6.7
+python_requires = >=3.7.0
 install_requires =
     zope.interface >= 4.4.2
     constantly >= 15.1

--- a/src/twisted/cred/test/test_cred.py
+++ b/src/twisted/cred/test/test_cred.py
@@ -266,11 +266,6 @@ class HashedPasswordOnDiskDatabaseTests(unittest.TestCase):
 
     def hash(self, u: bytes, p: bytes, s: bytes) -> bytes:
         hashed_password = crypt(p.decode("ascii"), s.decode("ascii"))  # type: ignore[misc]
-        # workaround for pypy3 3.6.9 and above which returns bytes from crypt.crypt()
-        # This is fixed in pypy3 7.3.5.
-        # See L{https://foss.heptapod.net/pypy/pypy/-/issues/3395}
-        if isinstance(hashed_password, bytes):
-            return hashed_password
         return hashed_password.encode("ascii")
 
     def testGoodCredentials(self):

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop, Future, iscoroutine
 from enum import Enum
 from functools import wraps
-from sys import exc_info, version_info
+from sys import exc_info
 from types import CoroutineType, GeneratorType, MappingProxyType
 from typing import (
     TYPE_CHECKING,
@@ -1708,11 +1708,7 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            if version_info < (3, 7):
-                # The contextvars backport and our no-op shim add an extra frame.
-                appCodeTrace = appCodeTrace.tb_next
-                assert appCodeTrace is not None
-            elif _PYPY:
+            if _PYPY:
                 # PyPy as of 3.7 adds an extra frame.
                 appCodeTrace = appCodeTrace.tb_next
                 assert appCodeTrace is not None

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1086,8 +1086,7 @@ class IReactorProcess(Interface):
         L{bytes} using the encoding given by L{sys.getfilesystemencoding}, to be
         used with the "narrow" OS APIs.  On Python 3 on Windows, L{bytes}
         arguments will be decoded up to L{unicode} using the encoding given by
-        L{sys.getfilesystemencoding} (C{mbcs} before Python 3.6, C{utf8}
-        thereafter) and given to Windows's native "wide" APIs.
+        L{sys.getfilesystemencoding} (C{utf8}) and given to Windows's native "wide" APIs.
 
         @param processProtocol: An object which will be notified of all events
             related to the created process.

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -630,10 +630,6 @@ class POP3ClientModuleStructureTests(TestCase):
         ]
 
         for pc in publicClasses:
-            if sys.version_info < (3, 7) and pc == "List":
-                # typing.List shows up in publicClasses on
-                # Python < 3.7, so skip it.
-                continue
             if not pc == "POP3Client":
                 self.assertTrue(
                     hasattr(twisted.mail.pop3, pc),

--- a/src/twisted/newsfragments/10304.removal
+++ b/src/twisted/newsfragments/10304.removal
@@ -1,0 +1,2 @@
+Python 3.6 is no longer supported.
+Twisted 22.4.0 was the last version with support for Python 3.6.

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3341,31 +3341,19 @@ class SelectVerifyImplementationTests(SynchronousTestCase):
             if warning["category"] == UserWarning
         )
 
-        importErrors = [
-            # Python 3.6.3
-            "'import of service_identity halted; None in sys.modules'",
-            # Python 3
-            "'import of 'service_identity' halted; None in sys.modules'",
-            # Python 2
-            "'No module named service_identity'",
-        ]
+        expectedMessage = (
+            "You do not have a working installation of the "
+            "service_identity module: "
+            "'import of service_identity halted; None in sys.modules'.  "
+            "Please install it from "
+            "<https://pypi.python.org/pypi/service_identity> "
+            "and make sure all of its dependencies are satisfied.  "
+            "Without the service_identity module, Twisted can perform only"
+            " rudimentary TLS client hostname verification.  Many valid "
+            "certificate/hostname mappings may be rejected."
+        )
 
-        expectedMessages = []
-        for importError in importErrors:
-            expectedMessages.append(
-                "You do not have a working installation of the "
-                "service_identity module: {message}.  Please install it from "
-                "<https://pypi.python.org/pypi/service_identity> "
-                "and make sure all of its dependencies are satisfied.  "
-                "Without the service_identity module, Twisted can perform only"
-                " rudimentary TLS client hostname verification.  Many valid "
-                "certificate/hostname mappings may be rejected.".format(
-                    message=importError
-                )
-            )
-
-        self.assertIn(warning["message"], expectedMessages)
-
+        self.assertEqual(warning["message"], expectedMessage)
         # Make sure we're abusing the warning system to a sufficient
         # degree: there is no filename or line number that makes sense for
         # this warning to "blame" for the problem.  It is a system

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -9,13 +9,12 @@ Test HTTP support.
 import base64
 import calendar
 import random
-import sys
 from io import BytesIO
 from itertools import cycle
 from typing import Sequence, Union
 from unittest import skipIf
 from urllib.parse import clear_cache  # type: ignore[attr-defined]
-from urllib.parse import parse_qs, urlparse, urlunsplit
+from urllib.parse import urlparse, urlunsplit
 
 from zope.interface import directlyProvides, providedBy, provider
 from zope.interface.verify import verifyObject
@@ -2569,18 +2568,6 @@ ok
 
 
 class QueryArgumentsTests(unittest.TestCase):
-    # FIXME: https://twistedmatrix.com/trac/ticket/10096
-    # Re-enable once the implementation is updated.
-    @skipIf(sys.version_info >= (3, 6, 13), "newer py3.6 parse_qs treat ; differently")
-    def testParseqs(self):
-        self.assertEqual(parse_qs(b"a=b&d=c;+=f"), http.parse_qs(b"a=b&d=c;+=f"))
-        self.assertRaises(ValueError, http.parse_qs, b"blah", strict_parsing=True)
-        self.assertEqual(
-            parse_qs(b"a=&b=c", keep_blank_values=1),
-            http.parse_qs(b"a=&b=c", keep_blank_values=1),
-        )
-        self.assertEqual(parse_qs(b"a=&b=c"), http.parse_qs(b"a=&b=c"))
-
     def test_urlparse(self):
         """
         For a given URL, L{http.urlparse} should behave the same as L{urlparse},


### PR DESCRIPTION
## Scope and purpose

To simplify the CI and development process we will remove support for py3.6

As a drive-by, the CI now runs 3.10 instead of 3.10.0-rc.1

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10304
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: adiroiban
Reviewer: 
Fixes: ticket:10304

Remove the support for Python 3.6.
The cryptography library update is blocked before 37.0, as with 37.0 the current test suite fails.
The cryptography version is pinned to make our existing tests happy.
```
