### PR TITLE
9654 trial exitfirst and jobs

### DIFF
--- a/src/twisted/scripts/trial.py
+++ b/src/twisted/scripts/trial.py
@@ -511,7 +511,7 @@ class Options(_BasicOptions, usage.Options, app.ReactorSelectionMixin):
     def postOptions(self):
         _BasicOptions.postOptions(self)
         if self["jobs"]:
-            conflicts = ["debug", "profile", "debug-stacktraces", "exitfirst"]
+            conflicts = ["debug", "profile", "debug-stacktraces"]
             for option in conflicts:
                 if self[option]:
                     raise usage.UsageError(
@@ -601,6 +601,7 @@ def _makeRunner(config):
         "uncleanWarnings": config["unclean-warnings"],
         "logfile": config["logfile"],
         "workingDirectory": config["temp-directory"],
+        "exitFirst": config["exitfirst"],
     }
     if config["dry-run"]:
         args["mode"] = runner.TrialRunner.DRY_RUN
@@ -625,7 +626,6 @@ def _makeRunner(config):
             else:
                 args["debugger"] = _wrappedPdb()
 
-        args["exitFirst"] = config["exitfirst"]
         args["profile"] = config["profile"]
         args["forceGarbageCollection"] = config["force-gc"]
 

--- a/src/twisted/trial/_dist/distreporter.py
+++ b/src/twisted/trial/_dist/distreporter.py
@@ -68,7 +68,7 @@ class DistReporter(proxyForInterface(IReporter)):  # type: ignore[misc]
         self, test: ITestCase, error: ReporterFailure, todo: Optional[str] = None
     ) -> None:
         """
-        Queue adding an unexpected failure.
+        Queue adding an expected failure.
         """
         self.running[test.id()].append(
             (self.original.addExpectedFailure, test, error, todo)

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -405,6 +405,8 @@ class DistTrialRunner:
                 # provide a report about which run this is.
                 self._stream.write(f"Test Pass {n + 1}\n")
 
+            result = self._makeResult()
+
             if self._exitFirst:
                 # Keep giving out tests as long as the result object has only
                 # seen success.
@@ -412,7 +414,6 @@ class DistTrialRunner:
             else:
                 casesCondition = lambda _: True
 
-            result = self._makeResult()
             await runTests(
                 startedPool,
                 takeWhile(casesCondition, testCases),

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -32,7 +32,7 @@ from ..runner import TestHolder
 from ..util import _unusedTestDirectory, openTestLog
 from . import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT
 from .distreporter import DistReporter
-from .functional import countingCalls, discardResult, iterateWhile
+from .functional import countingCalls, discardResult, iterateWhile, takeWhile
 from .worker import LocalWorker, LocalWorkerAMP, WorkerAction
 
 
@@ -275,7 +275,10 @@ class DistTrialRunner:
     local worker processes which will run tests.
 
     @ivar _maxWorkers: the number of workers to be spawned.
-    @type _maxWorkers: C{int}
+
+    @ivar _exitFirst: ``True`` to stop the run as soon as a test case fails.
+        ``False`` to run through the whole suite and report all of the results
+        at the end.
 
     @ivar _stream: stream which the reporter will use.
 
@@ -290,6 +293,7 @@ class DistTrialRunner:
     _reporterFactory: Callable[..., IReporter]
     _maxWorkers: int
     _workerArguments: List[str]
+    _exitFirst: bool = False
     _reactor: IDistTrialReactor = field(
         # mypy doesn't understand the converter
         default=None,
@@ -353,7 +357,9 @@ class DistTrialRunner:
             await task(case)
 
     async def runAsync(
-        self, suite: TestSuite, untilFailure: bool = False
+        self,
+        suite: TestSuite,
+        untilFailure: bool = False,
     ) -> DistReporter:
         """
         Spawn local worker processes and load tests. After that, run them.
@@ -399,10 +405,17 @@ class DistTrialRunner:
                 # provide a report about which run this is.
                 self._stream.write(f"Test Pass {n + 1}\n")
 
+            if self._exitFirst:
+                # Keep giving out tests as long as the result object has only
+                # seen success.
+                casesCondition = lambda _: result.original.wasSuccessful()
+            else:
+                casesCondition = lambda _: True
+
             result = self._makeResult()
             await runTests(
                 startedPool,
-                testCases,
+                takeWhile(casesCondition, testCases),
                 result,
                 self._driveWorker,
             )

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -252,7 +252,7 @@ def shouldContinue(untilFailure: bool, result: IReporter) -> bool:
 
 async def runTests(
     pool: StartedWorkerPool,
-    testCases: Sequence[ITestCase],
+    testCases: Iterable[ITestCase],
     result: DistReporter,
     driveWorker: Callable[
         [DistReporter, Sequence[ITestCase], LocalWorkerAMP], Awaitable[None]
@@ -260,7 +260,7 @@ async def runTests(
 ) -> None:
     try:
         # Run the tests using the worker pool.
-        await pool.run(partial(driveWorker, result, iter(testCases)))
+        await pool.run(partial(driveWorker, result, testCases))
     except Exception:
         # Exceptions from test code are handled somewhere else.  An
         # exception here is a bug in the runner itself.  The only

--- a/src/twisted/trial/_dist/functional.py
+++ b/src/twisted/trial/_dist/functional.py
@@ -6,7 +6,7 @@ General functional-style helpers for disttrial.
 """
 
 from functools import partial, wraps
-from typing import Awaitable, Callable, Optional, TypeVar
+from typing import Awaitable, Callable, Iterable, Optional, TypeVar
 
 from twisted.internet.defer import Deferred, succeed
 
@@ -26,6 +26,18 @@ def fromOptional(default: _A, optional: Optional[_A]) -> _A:
     if optional is None:
         return default
     return optional
+
+
+def takeWhile(condition: Callable[[_A], bool], xs: Iterable[_A]) -> Iterable[_A]:
+    """
+    :return: An iterable of the prefix of ``xs`` until ``condition`` returns
+        ``False``.
+    """
+    for x in xs:
+        if condition(x):
+            yield x
+        else:
+            break
 
 
 async def sequence(a: Awaitable[_A], b: Awaitable[_B]) -> _B:

--- a/src/twisted/trial/_dist/functional.py
+++ b/src/twisted/trial/_dist/functional.py
@@ -30,8 +30,8 @@ def fromOptional(default: _A, optional: Optional[_A]) -> _A:
 
 def takeWhile(condition: Callable[[_A], bool], xs: Iterable[_A]) -> Iterable[_A]:
     """
-    :return: An iterable of the prefix of ``xs`` until ``condition`` returns
-        ``False``.
+    :return: An iterable over C{xs} that stops when C{condition} returns
+        ``False`` based on the value of iterated C{xs}.
     """
     for x in xs:
         if condition(x):

--- a/src/twisted/trial/_dist/test/matchers.py
+++ b/src/twisted/trial/_dist/test/matchers.py
@@ -1,0 +1,32 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Hamcrest matchers useful throughout the test suite.
+"""
+
+from hamcrest import equal_to, has_length, has_properties
+from hamcrest.core.matcher import Matcher
+
+
+def matches_result(
+    successes: Matcher = equal_to(0),
+    errors: Matcher = has_length(0),
+    failures: Matcher = has_length(0),
+    skips: Matcher = has_length(0),
+    expectedFailures: Matcher = has_length(0),
+    unexpectedSuccesses: Matcher = has_length(0),
+) -> Matcher:
+    """
+    Match a L{TestCase} instances with matching attributes.
+    """
+    return has_properties(
+        {
+            "successes": successes,
+            "errors": errors,
+            "failures": failures,
+            "skips": skips,
+            "expectedFailures": expectedFailures,
+            "unexpectedSuccesses": unexpectedSuccesses,
+        }
+    )

--- a/src/twisted/trial/_dist/test/test_workerreporter.py
+++ b/src/twisted/trial/_dist/test/test_workerreporter.py
@@ -8,7 +8,7 @@ Tests for L{twisted.trial._dist.workerreporter}.
 
 from unittest import TestCase
 
-from hamcrest import assert_that, equal_to, has_length, has_properties
+from hamcrest import assert_that, equal_to, has_length
 from hamcrest.core.matcher import Matcher
 
 from twisted.test.iosim import connectedServerAndClient
@@ -16,29 +16,7 @@ from twisted.trial._dist.worker import LocalWorkerAMP, WorkerProtocol
 from twisted.trial.reporter import TestResult
 from twisted.trial.test import erroneous, pyunitcases, sample, skipping
 from twisted.trial.unittest import SynchronousTestCase
-
-
-def matches_result(
-    successes: Matcher = equal_to(0),
-    errors: Matcher = has_length(0),
-    failures: Matcher = has_length(0),
-    skips: Matcher = has_length(0),
-    expectedFailures: Matcher = has_length(0),
-    unexpectedSuccesses: Matcher = has_length(0),
-) -> Matcher:
-    """
-    Match a L{TestCase} instances with matching attributes.
-    """
-    return has_properties(
-        {
-            "successes": successes,
-            "errors": errors,
-            "failures": failures,
-            "skips": skips,
-            "expectedFailures": expectedFailures,
-            "unexpectedSuccesses": unexpectedSuccesses,
-        }
-    )
+from .matchers import matches_result
 
 
 def run(case: SynchronousTestCase, target: TestCase) -> TestResult:

--- a/src/twisted/trial/newsfragments/9654.feature
+++ b/src/twisted/trial/newsfragments/9654.feature
@@ -1,0 +1,1 @@
+``trial --jobs=N --exitfirst`` is now supported.

--- a/src/twisted/trial/test/test_script.py
+++ b/src/twisted/trial/test/test_script.py
@@ -514,18 +514,6 @@ class OptionsTests(unittest.TestCase):
             "You can't specify --debug-stacktraces when using --jobs", str(error)
         )
 
-    def test_jobsConflictWithExitFirst(self):
-        """
-        C{parseOptions} raises a C{UsageError} when C{--exitfirst} is passed
-        along C{--jobs} as it's not supported yet.
-
-        @see: U{http://twistedmatrix.com/trac/ticket/6436}
-        """
-        error = self.assertRaises(
-            UsageError, self.options.parseOptions, ["--jobs", "4", "--exitfirst"]
-        )
-        self.assertEqual("You can't specify --exitfirst when using --jobs", str(error))
-
     def test_orderConflictWithRandom(self):
         """
         C{parseOptions} raises a C{UsageError} when C{--order} is passed along


### PR DESCRIPTION
## Scope and purpose

Enables `trial -jN -x ...`

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/9654
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [x] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: exarkun
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:9654

``trial --jobs N --exitfirst ...` is now supported.
```
