### PR TITLE
10347: Remove the setEnv warning in manhole_ssh

### DIFF
--- a/src/twisted/conch/newsfragments/10347.bugfix
+++ b/src/twisted/conch/newsfragments/10347.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.ssh.SSHSession.request_env no longer gives a warning if the session does not implement ISessionSetEnv.

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -133,14 +133,6 @@ class SSHSession(channel.SSHChannel):
         if not self.session:
             self.session = ISession(self.avatar)
         if not ISessionSetEnv.providedBy(self.session):
-            log.warn(
-                "Can't handle environment variables for SSH avatar {avatar}: "
-                "{session} does not provide ISessionSetEnv interface. "
-                "It should be decorated with @implementer(ISession, "
-                "ISessionSetEnv) to support env variables.",
-                avatar=self.avatar,
-                session=self.session,
-            )
             return 0
         name, value, data = common.getNS(data, 2)
         try:


### PR DESCRIPTION
## Scope and purpose

On connection, the manhole gave a warning about the TerminalSession object not providing ISessionSetEnv interface. It should just ignore this silently, so the warning has been removed

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10347
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: pmw
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:10347

```
