### PR TITLE
10349 Optimize set_verify call to SSL context.

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1654,13 +1654,7 @@ class OpenSSLCertificateOptions:
                 verifyFlags |= SSL.VERIFY_CLIENT_ONCE
             self.trustRoot._addCACertsToContext(ctx)
 
-        # It'd be nice if pyOpenSSL let us pass None here for this behavior (as
-        # the underlying OpenSSL API call allows NULL to be passed).  It
-        # doesn't, so we'll supply a function which does the same thing.
-        def _verifyCallback(conn, cert, errno, depth, preverify_ok):
-            return preverify_ok
-
-        ctx.set_verify(verifyFlags, _verifyCallback)
+        ctx.set_verify(verifyFlags)
         if self.verifyDepth is not None:
             ctx.set_verify_depth(self.verifyDepth)
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -509,7 +509,7 @@ class FakeContext:
         """
         self._mode = mode
 
-    def set_verify(self, flags, callback):
+    def set_verify(self, flags, callback=None):
         self._verify = flags, callback
 
     def set_verify_depth(self, depth):


### PR DESCRIPTION
## Scope and purpose

Since pyOpenSSL 20.0.0, the set_verify method now does not need to be passed a callback if it does the default behavior. This is convenient and also more efficient since CFFI doesn't need to be invoked to wrap the callback.

See https://github.com/pyca/pyopenssl/pull/933 for the change in pyOpenSSL that supports this.

## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10349
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [x] The title of the PR starts with the associated Trac ticket number (without the `#` character).
* [x] I have updated the automated tests and checked that all checks for the PR are green.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
* [ ] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-trac-id

Author: <github_username>, <github_usernames_if_more_authors>
Reviewer: <github_username>, <github_username_if_more_reviewers>
Fixes: ticket:<trac_ticket_number>, ticket:<another_if_more_in_one_PR>

Long description providing a summary of these changes.
(as long as you wish)
```
