### PR TITLE
Don't skip all-success on deps failure.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,12 +257,29 @@ jobs:
           fi
 
 
+  # We have this job so that the PR can be blocked on a single job.
+  # In this way, each time a job is modified,
+  # we don't have to go to GitHub UI and reconfigure branch protection.
+  # See GitHub support answer for this hack.
+  # https://gist.github.com/altendky/2e3483a1f7e1ba21cc97de75db9b7d1c
   all-successful:
-    # We have this job so that the PR can be blocked on a single job.
-    # See GitHub support answer for this hack.
-    # https://gist.github.com/altendky/2e3483a1f7e1ba21cc97de75db9b7d1c
+    # Is very important to force running this always, as otherwise it will be
+    #  skipped by default.
+    if: always()
     runs-on: ubuntu-latest
-    needs: [testing, static-checks, release-publish]
+    # Here should be the list of all the other jobs defined in this file.
+    needs:
+      - testing
+      - static-checks
+      - release-publish
     steps:
-    - name: note that all tests succeeded
-      run: echo "🎉"
+      - name: Require all successes
+        shell: python
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)


### PR DESCRIPTION
## Scope and purpose

Fixes #11569 

This applies the changes created by @altendky  from here https://github.com/Chia-Network/chia-blockchain/pull/11880/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R79 

The code was already tested in towncrier here https://github.com/twisted/towncrier/pull/392

Note that this only handles the jobs defined inside our `test.yaml` files

codecov.io, Azure Pipelines, Read The Docs, and pre-commit are external services and are not covered by this change.

In theory, we can enabled probot-settings app and have all the repo settings as YAML 
https://github.com/repository-settings/app

Anyone with push access to the repo will be admin and could change the branch protection via YAML config.

```
Author: adiroiban
Reviewer: 
Fixes #11569

Fail and don't skip CI branch protection when a job fails.
```
