### PR TITLE
9437 Update NEWS file for new issues/tickets link.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,10 @@
+This file contains the release notes for the Twisted.
+
+It only contains high-level changes that are of interest to Twisted library users.
+Users of Twisted should check the notes before planning an upgrade.
+
 Ticket numbers in this file can be looked up by visiting
-http://twistedmatrix.com/trac/ticket/<number>
+https://twisted.org/trac/ticket/<number>
 
 .. towncrier release notes start
 


### PR DESCRIPTION
## Scope and purpose

Fixes #9437

This was started to use HTTPS URL.

But we now have a different URL for ticket IDS.


## Contributor Checklist:

* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://docs.twistedmatrix.com/en/stable/core/development/policy/coding-standard.html)
* [x] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://github.com/twisted/trac-wiki-archive/blob/trunk//ReviewProcess.mediawiki#News_files))
* [x] The title of the PR starts with the associated issue number (without the `#` character).
* [NA] I have updated the automated tests and checked that all checks for the PR are green.
* [X] The merge commit will use the below format
  The first line is automatically generated by GitHub based on PR ID and branch name.
  The other lines generated by GitHub should be replaced.

```
Merge pull request #123 from twisted/4356-branch-name-with-issue-id

Author: adiroiban
Reviewer: 
Fixes #9437

Update the link that can be used to resolve ticket ID in release notes.
```
