### PR TITLE
#11592 fix typo in ssl howto page

### DIFF
--- a/docs/core/howto/ssl.rst
+++ b/docs/core/howto/ssl.rst
@@ -259,7 +259,7 @@ It will return a collection of flags indicating support for NPN and/or ALPN.
 
 :py:class:`twisted.internet.ssl.CertificateOptions` and :py:func:`twisted.internet.ssl.optionsForClientTLS` allow for selecting the protocols your program is willing to speak after the connection is established.
 
-On the server=side you will have:
+On the server-side you will have:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Scope and purpose

Fixes #11592

this pull request has fixed a typo in ssl howto page in doc.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number (including the `#` character for GitHub auto-links).
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains the `please review` words.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
