### PR TITLE
#10289 Fix incorrect use of _T in react signature

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -17,7 +17,7 @@ Have a look at [our developer documentation](https://docs.twisted.org/en/latest/
 
 Below is a non-exaustive list (as a reminder):
 
-* The title of the PR should describe the changes and starts with the associated issue number (including the `#` character for GitHub auto-links).
+* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
 * A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
 * The automated tests were updated.
 * Once all checks are green, request a review by leaving a comment that contains the `please review` words.

--- a/.github/scripts/check-pr-text.py
+++ b/.github/scripts/check-pr-text.py
@@ -43,7 +43,9 @@ if not pr_body:
 
 title_search = re.search(r"^(#\d+) .+", pr_title)
 if not title_search:
-    fail("Title of PR has no issue ID reference.")
+    fail(
+        "Title of PR has no issue ID reference. It must look like “#1234 Foo bar baz”."
+    )
 else:
     print(f"PR title is complaint for {title_search[1]}. Good job.")
 

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -879,7 +879,7 @@ def react(
         ...,
         Union[Deferred[_T], Coroutine["Deferred[_T]", object, _T]],
     ],
-    argv: Iterable[_T] = (),
+    argv: Iterable[object] = (),
     _reactor: Optional[IReactorCore] = None,
 ) -> NoReturn:
     """
@@ -900,10 +900,11 @@ def react(
 
     The following demonstrates the signature of a C{main} function which can be
     used with L{react}::
-          async def main(reactor, username, password):
-              return "ok"
 
-          task.react(main, ("alice", "secret"))
+      async def main(reactor, username, password):
+          return "ok"
+
+      task.react(main, ("alice", "secret"))
 
     @param main: A callable which returns a L{Deferred} or
         coroutine. It should take the reactor as its first

--- a/src/twisted/newsfragments/10289.bugfix
+++ b/src/twisted/newsfragments/10289.bugfix
@@ -1,0 +1,1 @@
+The typing of twisted.internet.task.react no longer constrains the type of argv.


### PR DESCRIPTION
## Scope and purpose

Fixes #10289.

Small PR to give the new process a spin.

I briefly poked at using [`ParamSpec`](https://docs.python.org/3/library/typing.html#typing.ParamSpec) to better type the callable but it looks like our MyPy is too old and I don't feel like shaving that yak right now. This addresses the immediate issue.