### PR TITLE
#11600 Fix Libera.Chat link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,9 @@ This documentation contains how-tos, code examples, and an API reference.
 
 Help is also available on the `Twisted mailing list <https://mail.python.org/mailman3/lists/twisted.python.org/>`_.
 
-There is also a pair of very lively IRC channels, ``#twisted`` (for general Twisted questions) and ``#twisted.web`` (for Twisted Web),
-on `irc.libera.chat <https://web.libera.chat/>_`.
+There is also an IRC channel, ``#twisted``,
+on the `Libera.Chat <https://libera.chat/>`_ network.
+A web client is available at `web.libera.chat <https://web.libera.chat/>`_.
 
 
 Unit Tests


### PR DESCRIPTION
## Scope and purpose

Fixes #11600.

Fix a broken link and remove a reference to `#twisted.web`.
