### PR TITLE
#11631 GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 # Only have a run a single parallel for each branch.
 # Runs for trunk are queues.
 # Older runs for non-trunk branches are cancelled and the jobs are executed
@@ -339,6 +342,8 @@ jobs:
   # process late in the release cycle,
   # The files are published only when a tag is created.
   release-publish:
+    permissions:
+      contents: write
     name: Check release and publish on twisted-* tag
     runs-on: 'ubuntu-20.04'
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -408,7 +408,6 @@ jobs:
           else
             echo "Branch not updated for not stable releases: $GITUB_REF"
           fi
-    
 
   # We have this job so that the PR can be blocked on a single job.
   # In this way, each time a job is modified,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -381,7 +381,7 @@ jobs:
   update-stable-branch:
     permissions:
       contents: write
-    name: Update stable branch - on stable tag
+    name: Update stable branch for RTD - on tag
     runs-on: 'ubuntu-20.04'
     needs: [release-publish]
     if: startsWith(github.ref, 'refs/tags/twisted-')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -374,6 +374,10 @@ jobs:
       with:
         password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
 
+  # Read the Docs has no support for our "twisted-1.2.3" numbering convention
+  # and can't detect which tag is the stable one.
+  # A workaournd is to manually push to a "stable" branch to inform RTD
+  # that this is what we want at the "/en/stable" link.
   update-stable-branch:
     permissions:
       contents: write
@@ -423,6 +427,7 @@ jobs:
       - apidocs
       - static-checks
       - release-publish
+      - update-stable-branch
     steps:
       - name: Require all successes
         shell: python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -437,4 +437,4 @@ jobs:
           import os
           import sys
           results = json.loads(os.environ["RESULTS"])
-          sys.exit(0 if all(result == "success" for result in results) else 1)
+          sys.exit(0 if all(result in ["success", "skipped"] for result in results) else 1)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -342,8 +342,6 @@ jobs:
   # process late in the release cycle,
   # The files are published only when a tag is created.
   release-publish:
-    permissions:
-      contents: write
     name: Check release and publish on twisted-* tag
     runs-on: 'ubuntu-20.04'
     steps:
@@ -376,8 +374,15 @@ jobs:
       with:
         password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
 
+  update-stable-branch:
+    permissions:
+      contents: write
+    name: Update stable branch - on stable tag
+    runs-on: 'ubuntu-20.04'
+    needs: [release-publish]
+    if: startsWith(github.ref, 'refs/tags/twisted-')
+    steps:
     - name: Update stable branch - on stable tag
-      if: startsWith(github.ref, 'refs/tags/twisted-')
       env:
         STABLE_BRANCH: 'stable'
         STABLE_REF_RE: '.*twisted-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
@@ -399,7 +404,7 @@ jobs:
           else
             echo "Branch not updated for not stable releases: $GITUB_REF"
           fi
-
+    
 
   # We have this job so that the PR can be blocked on a single job.
   # In this way, each time a job is modified,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -426,7 +426,6 @@ jobs:
       - apidocs
       - static-checks
       - release-publish
-      - update-stable-branch
     steps:
       - name: Require all successes
         shell: python
@@ -437,4 +436,4 @@ jobs:
           import os
           import sys
           results = json.loads(os.environ["RESULTS"])
-          sys.exit(0 if all(result in ["success", "skipped"] for result in results) else 1)
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/src/twisted/newsfragments/11631.bugfix
+++ b/src/twisted/newsfragments/11631.bugfix
@@ -1,1 +1,1 @@
-test.yaml workflow permissions restricted.
+'test.yaml' workflow permissions restricted.

--- a/src/twisted/newsfragments/11631.bugfix
+++ b/src/twisted/newsfragments/11631.bugfix
@@ -1,1 +1,1 @@
-test.yaml workflow permissions restricted.
+`test.yaml` workflow permissions restricted.

--- a/src/twisted/newsfragments/11631.bugfix
+++ b/src/twisted/newsfragments/11631.bugfix
@@ -1,0 +1,1 @@
+test.yaml workflow permissions restricted.

--- a/src/twisted/newsfragments/11631.bugfix
+++ b/src/twisted/newsfragments/11631.bugfix
@@ -1,1 +1,1 @@
-'test.yaml' workflow permissions restricted.
+test.yaml workflow permissions restricted.


### PR DESCRIPTION
Fixes #11631

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.