### PR TITLE
ensure we don't mix together strings and bytes

### DIFF
--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -1651,8 +1651,9 @@ class ESMTP(SMTP):
         for c, v in self.extensions().items():
             if v is not None:
                 if v:
+                    bv = [x.encode() if isinstance(x, str) else x for x in v]
                     # Intentionally omit extensions with empty argument lists
-                    r.append(c + b" " + b" ".join(v))
+                    r.append(c + b" " + b" ".join(bv))
             else:
                 r.append(c)
 


### PR DESCRIPTION
**EDIT:** I've just now made a bug report to go along with this PR: https://github.com/twisted/twisted/issues/11634

see the IRC log here:
https://gitter.im/twisted/twisted?at=631510753a42316d33d54f6b

This change fixed the following crash for me:
```
$ twistd -ny emailserver.tac
:0: UserWarning: You do not have a working installation of the service_identity module: 'No module named 'service_identity''.  Please install it from <https://pypi.python.org/pypi/service_identity> and make sure all of its dependencies are satisfied.  Without the service_identity module, Twisted can perform only rudimentary TLS client hostname verification.  Many valid certificate/hostname mappings may be rejected.
2022-09-04T23:01:21+0200 [-] Loading emailserver.tac...
2022-09-04T23:01:22+0200 [-] Loaded.
2022-09-04T23:01:22+0200 [twisted.scripts._twistd_unix.UnixAppLogger#info] twistd 22.1.0 (/usr/bin/python 3.10.6) starting up.
2022-09-04T23:01:22+0200 [twisted.scripts._twistd_unix.UnixAppLogger#info] reactor class: twisted.internet.epollreactor.EPollReactor.
2022-09-04T23:01:22+0200 [-] ConsoleSMTPFactory starting on 2500
2022-09-04T23:01:22+0200 [builtins.ConsoleSMTPFactory#info] Starting factory <ConsoleSMTPFactory object at 0x7fd169abde40>
2022-09-04T23:01:30+0200 [ESMTP,0,127.0.0.1] Unhandled Error
        Traceback (most recent call last):
          File "/usr/lib/python3.10/site-packages/twisted/python/log.py", line 96, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/usr/lib/python3.10/site-packages/twisted/python/log.py", line 80, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/lib/python3.10/site-packages/twisted/python/context.py", line 117, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib/python3.10/site-packages/twisted/python/context.py", line 82, in callWithContext
            return func(*args, **kw)
        --- <exception caught here> ---
          File "/usr/lib/python3.10/site-packages/twisted/internet/posixbase.py", line 683, in _doReadOrWrite
            why = selectable.doRead()
          File "/usr/lib/python3.10/site-packages/twisted/internet/tcp.py", line 248, in doRead
            return self._dataReceived(data)
          File "/usr/lib/python3.10/site-packages/twisted/internet/tcp.py", line 253, in _dataReceived
            rval = self.protocol.dataReceived(data)
          File "/usr/lib/python3.10/site-packages/twisted/protocols/basic.py", line 440, in dataReceived
            self.lineReceived(line)
          File "/usr/lib/python3.10/site-packages/twisted/mail/smtp.py", line 489, in lineReceived
            return getattr(self, "state_" + self.mode)(line)
          File "/usr/lib/python3.10/site-packages/twisted/mail/smtp.py", line 501, in state_COMMAND
            method(parts[1])
          File "/usr/lib/python3.10/site-packages/twisted/mail/smtp.py", line 1677, in do_EHLO
            + self.listExtensions()
          File "/usr/lib/python3.10/site-packages/twisted/mail/smtp.py", line 1655, in listExtensions
            r.append(c + b" " + b" ".join(v))
        builtins.TypeError: sequence item 0: expected a bytes-like object, str found

^C2022-09-04T23:01:35+0200 [-] Received SIGINT, shutting down.
2022-09-04T23:01:35+0200 [-] (TCP Port 2500 Closed)
2022-09-04T23:01:35+0200 [builtins.ConsoleSMTPFactory#info] Stopping factory <ConsoleSMTPFactory object at 0x7fd169abde40>
2022-09-04T23:01:35+0200 [-] Main loop terminated.
2022-09-04T23:01:35+0200 [twisted.scripts._twistd_unix.UnixAppLogger#info] Server Shut Down.
```
