### PR TITLE
#11635 Allow mixed types in Headers types

### DIFF
--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -23,7 +23,6 @@ from typing import (
 
 from twisted.python.compat import cmp, comparable
 
-_S = Union[str, bytes]
 _T = TypeVar("_T")
 
 
@@ -232,15 +231,13 @@ class Headers:
                 "bytes or str" % (type(value),)
             )
 
-        _name = _sanitizeLinearWhitespace(self._encodeName(name))
-        if isinstance(value, str):
-            _value = value.encode("utf8")
-        else:
-            _value = value
-        self._rawHeaders[_name] = [
-            *self._rawHeaders.get(_name, ()),
-            _sanitizeLinearWhitespace(_value),
-        ]
+        self._rawHeaders.setdefault(
+            _sanitizeLinearWhitespace(self._encodeName(name)), []
+        ).append(
+            _sanitizeLinearWhitespace(
+                value.encode("utf8") if isinstance(value, str) else value
+            )
+        )
 
     @overload
     def getRawHeaders(self, name: AnyStr) -> Optional[Sequence[AnyStr]]:

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -24,6 +24,7 @@ from typing import (
 
 from twisted.python.compat import cmp, comparable
 
+_S = Union[str, bytes]
 _T = TypeVar("_T")
 
 
@@ -84,7 +85,7 @@ class Headers:
 
     def __init__(
         self,
-        rawHeaders: Optional[Mapping[AnyStr, Sequence[AnyStr]]] = None,
+        rawHeaders: Optional[Mapping[_S, Sequence[_S]]] = None,
     ):
         self._rawHeaders: Dict[bytes, List[bytes]] = {}
         if rawHeaders is not None:
@@ -152,7 +153,7 @@ class Headers:
         """
         self._rawHeaders.pop(self._encodeName(name), None)
 
-    def setRawHeaders(self, name: AnyStr, values: Sequence[AnyStr]) -> None:
+    def setRawHeaders(self, name: _S, values: Sequence[_S]) -> None:
         """
         Sets the raw representation of the given header.
 
@@ -200,7 +201,7 @@ class Headers:
 
         self._rawHeaders[_name] = encodedValues
 
-    def addRawHeader(self, name: AnyStr, value: AnyStr) -> None:
+    def addRawHeader(self, name: _S, value: _S) -> None:
         """
         Add a new raw value for the given header.
 

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -112,7 +112,7 @@ class Headers:
             )
         return NotImplemented
 
-    def _encodeName(self, name: AnyStr) -> bytes:
+    def _encodeName(self, name: _S) -> bytes:
         """
         Encode the name of a header (eg 'Content-Type') to an ISO-8859-1 encoded
         bytestring if required.
@@ -211,7 +211,7 @@ class Headers:
         """
         if not isinstance(name, (bytes, str)):
             raise TypeError(
-                "Header name is an instance of %r, " "not bytes or str" % (type(name),)
+                "Header name is an instance of %r, not bytes or str" % (type(name),)
             )
 
         if not isinstance(value, (bytes, str)):
@@ -221,7 +221,7 @@ class Headers:
             )
 
         # We secretly know getRawHeaders is really returning a list
-        values = cast(List[AnyStr], self.getRawHeaders(name, default=[]))
+        values = cast(List[_S], self.getRawHeaders(name, default=[]))
         values.append(value)
 
         self.setRawHeaders(name, values)

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -85,7 +85,7 @@ class Headers:
 
     def __init__(
         self,
-        rawHeaders: Optional[Mapping[_S, Sequence[_S]]] = None,
+        rawHeaders: Optional[Mapping[_S, Union[Sequence[bytes], Sequence[str]]]] = None,
     ):
         self._rawHeaders: Dict[bytes, List[bytes]] = {}
         if rawHeaders is not None:
@@ -153,7 +153,9 @@ class Headers:
         """
         self._rawHeaders.pop(self._encodeName(name), None)
 
-    def setRawHeaders(self, name: _S, values: Sequence[_S]) -> None:
+    def setRawHeaders(
+        self, name: _S, values: Union[Sequence[bytes], Sequence[str]]
+    ) -> None:
         """
         Sets the raw representation of the given header.
 
@@ -176,7 +178,7 @@ class Headers:
 
         if not isinstance(name, (bytes, str)):
             raise TypeError(
-                "Header name is an instance of %r, " "not bytes or str" % (type(name),)
+                f"Header name is an instance of {type(name)!r}, not bytes or str"
             )
 
         for count, value in enumerate(values):

--- a/src/twisted/web/newsfragments/11635.bugfix
+++ b/src/twisted/web/newsfragments/11635.bugfix
@@ -1,0 +1,1 @@
+The typing of twisted.web.http_headers.Headers() and its methods addRawHeader() and setRawHeaders() now allow mixing str and bytes, matching the runtime behavior.

--- a/src/twisted/web/newsfragments/11635.bugfix
+++ b/src/twisted/web/newsfragments/11635.bugfix
@@ -1,1 +1,1 @@
-The typing of twisted.web.http_headers.Headers() and its methods addRawHeader() and setRawHeaders() now allow mixing str and bytes, matching the runtime behavior.
+The typing of the twisted.web.http_headers.Headers methods addRawHeader() and setRawHeaders() now allow mixing str and bytes, matching the runtime behavior.

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -676,25 +676,6 @@ class MixedHeadersTests(TestCase):
     where that is permitted.
     """
 
-    def test_init(self) -> None:
-        """
-        Mixed L{str} and L{bytes} are accepted by the L{Headers} initializer.
-        """
-        h = Headers(
-            {
-                b"bytes": [b"bytes", b"bytes"],
-                "str": ["str", "str"],
-            }
-        )
-
-        self.assertEqual(
-            {
-                b"Bytes": [b"bytes", b"bytes"],
-                b"Str": [b"str", b"str"],
-            },
-            dict(h.getAllRawHeaders()),
-        )
-
     def test_addRawHeader(self) -> None:
         """
         L{Headers.addRawHeader} accepts mixed L{str} and L{bytes}.
@@ -713,6 +694,10 @@ class MixedHeadersTests(TestCase):
         h = Headers()
         h.setRawHeaders(b"bytes", [b"bytes"])
         h.setRawHeaders("str", ["str"])
+        h.setRawHeaders("mixed-str", [b"bytes", "str"])
+        h.setRawHeaders(b"mixed-bytes", ["str", b"bytes"])
 
         self.assertEqual(h.getRawHeaders(b"Bytes"), [b"bytes"])
         self.assertEqual(h.getRawHeaders("Str"), ["str"])
+        self.assertEqual(h.getRawHeaders("Mixed-Str"), ["bytes", "str"])
+        self.assertEqual(h.getRawHeaders(b"Mixed-Bytes"), [b"str", b"bytes"])

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -692,7 +692,7 @@ class MixedHeadersTests(TestCase):
                 b"Bytes": [b"str", b"bytes"],
                 b"Str": [b"bytes", b"str"],
             },
-            h.getAllRawHeaders(),
+            dict(h.getAllRawHeaders()),
         )
 
     def test_addRawHeader(self) -> None:

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -668,3 +668,51 @@ class UnicodeHeadersTests(TestCase):
         # Verify that the orignal does not have it
         self.assertEqual(h.getRawHeaders("test\u00E1"), ["foo\u2603", "bar"])
         self.assertEqual(h.getRawHeaders(b"test\xe1"), [b"foo\xe2\x98\x83", b"bar"])
+
+
+class MixedHeadersTests(TestCase):
+    """
+    Tests for L{Headers}, mixing L{bytes} and L{str} arguments for methods
+    where that is permitted.
+    """
+
+    def test_init(self) -> None:
+        """
+        Mixed L{str} and L{bytes} are accepted by the L{Headers} initializer.
+        """
+        h = Headers(
+            {
+                b"bytes": ["str", b"bytes"],
+                "str": [b"bytes", "str"],
+            }
+        )
+
+        self.assertEqual(
+            {
+                b"Bytes": [b"str", b"bytes"],
+                b"Str": [b"bytes", b"str"],
+            },
+            h.getAllRawHeaders(),
+        )
+
+    def test_addRawHeader(self) -> None:
+        """
+        L{Headers.addRawHeader} accepts mixed L{str} and L{bytes}.
+        """
+        h = Headers()
+        h.addRawHeader(b"bytes", "str")
+        h.addRawHeader("str", b"bytes")
+
+        self.assertEqual(h.getRawHeaders(b"Bytes"), [b"str"])
+        self.assertEqual(h.getRawHeaders("Str"), ["bytes"])
+
+    def test_setRawHeaders(self) -> None:
+        """
+        L{Headers.setRawHeaders} accepts mixed L{str} and L{bytes}.
+        """
+        h = Headers()
+        h.setRawHeaders(b"bytes", ["str", b"bytes"])
+        h.setRawHeaders("str", ["str", b"bytes"])
+
+        self.assertEqual(h.getRawHeaders(b"Bytes"), [b"str", b"bytes"])
+        self.assertEqual(h.getRawHeaders("Str"), ["str", "bytes"])

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -682,15 +682,15 @@ class MixedHeadersTests(TestCase):
         """
         h = Headers(
             {
-                b"bytes": ["str", b"bytes"],
-                "str": [b"bytes", "str"],
+                b"bytes": [b"bytes", b"bytes"],
+                "str": ["str", "str"],
             }
         )
 
         self.assertEqual(
             {
-                b"Bytes": [b"str", b"bytes"],
-                b"Str": [b"bytes", b"str"],
+                b"Bytes": [b"bytes", b"bytes"],
+                b"Str": [b"str", b"str"],
             },
             dict(h.getAllRawHeaders()),
         )
@@ -711,8 +711,8 @@ class MixedHeadersTests(TestCase):
         L{Headers.setRawHeaders} accepts mixed L{str} and L{bytes}.
         """
         h = Headers()
-        h.setRawHeaders(b"bytes", ["str", b"bytes"])
-        h.setRawHeaders("str", ["str", b"bytes"])
+        h.setRawHeaders(b"bytes", [b"bytes"])
+        h.setRawHeaders("str", ["str"])
 
-        self.assertEqual(h.getRawHeaders(b"Bytes"), [b"str", b"bytes"])
-        self.assertEqual(h.getRawHeaders("Str"), ["str", "bytes"])
+        self.assertEqual(h.getRawHeaders(b"Bytes"), [b"bytes"])
+        self.assertEqual(h.getRawHeaders("Str"), ["str"])


### PR DESCRIPTION
Fixes #11635.

Purpose is to enable typing of Treq.
