### PR TITLE
#11638 manhole vs excepthook

### DIFF
--- a/src/twisted/conch/newsfragments/11638.bugfix
+++ b/src/twisted/conch/newsfragments/11638.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.manhole.ManholeInterpreter now captures tracebacks even if sys.excepthook has been modified.

--- a/src/twisted/conch/test/test_manhole.py
+++ b/src/twisted/conch/test/test_manhole.py
@@ -8,6 +8,7 @@
 Tests for L{twisted.conch.manhole}.
 """
 
+import sys
 import traceback
 from typing import Optional
 
@@ -148,9 +149,6 @@ class WriterTests(unittest.TestCase):
 class ManholeLoopbackMixin:
     serverProtocol = manhole.ColoredManhole
 
-    def wfd(self, d):
-        return defer.waitForDeferred(d)
-
     def test_SimpleExpression(self):
         """
         Evaluate simple expression.
@@ -244,10 +242,21 @@ class ManholeLoopbackMixin:
                     + defaultFunctionName.encode("utf-8"),
                     b"Exception: foo bar baz",
                     b">>> done",
-                ]
+                ],
             )
 
-        return done.addCallback(finished)
+        done.addCallback(finished)
+        return done
+
+    def test_ExceptionWithCustomExcepthook(
+        self,
+    ):
+        """
+        Raised exceptions are handled the same way even if L{sys.excepthook}
+        has been modified from its original value.
+        """
+        self.patch(sys, "excepthook", lambda *args: None)
+        return self.test_Exception()
 
     def test_ControlC(self):
         """

--- a/src/twisted/conch/test/test_recvline.py
+++ b/src/twisted/conch/test/test_recvline.py
@@ -473,15 +473,7 @@ class _BaseMixin:
     def _assertBuffer(self, lines):
         receivedLines = self.recvlineClient.__bytes__().splitlines()
         expectedLines = lines + ([b""] * (self.HEIGHT - len(lines) - 1))
-        self.assertEqual(len(receivedLines), len(expectedLines))
-        for i in range(len(receivedLines)):
-            self.assertEqual(
-                receivedLines[i],
-                expectedLines[i],
-                b"".join(receivedLines[max(0, i - 1) : i + 1])
-                + b" != "
-                + b"".join(expectedLines[max(0, i - 1) : i + 1]),
-            )
+        self.assertEqual(receivedLines, expectedLines)
 
     def _trivialTest(self, inputLine, output):
         done = self.recvlineClient.expect(b"done")

--- a/src/twisted/python/monkey.py
+++ b/src/twisted/python/monkey.py
@@ -48,6 +48,8 @@ class MonkeyPatcher:
                 self._originals.append((obj, name, getattr(obj, name)))
             setattr(obj, name, value)
 
+    __enter__ = patch
+
     def restore(self):
         """
         Restore all original values to any patched objects.
@@ -55,6 +57,9 @@ class MonkeyPatcher:
         while self._originals:
             obj, name, value = self._originals.pop()
             setattr(obj, name, value)
+
+    def __exit__(self, excType=None, excValue=None, excTraceback=None):
+        self.restore()
 
     def runWithPatches(self, f, *args, **kw):
         """

--- a/src/twisted/test/test_monkey.py
+++ b/src/twisted/test/test_monkey.py
@@ -152,3 +152,22 @@ class MonkeyPatcherTests(unittest.SynchronousTestCase):
         self.assertRaises(RuntimeError, self.monkeyPatcher.runWithPatches, _)
         self.assertEqual(self.testObject.foo, self.originalObject.foo)
         self.assertEqual(self.testObject.bar, self.originalObject.bar)
+
+    def test_contextManager(self):
+        """
+        L{MonkeyPatcher} is a context manager that applies its patches on
+        entry and restore original values on exit.
+        """
+        self.monkeyPatcher.addPatch(self.testObject, "foo", "patched value")
+        with self.monkeyPatcher:
+            self.assertEqual(self.testObject.foo, "patched value")
+        self.assertEqual(self.testObject.foo, self.originalObject.foo)
+
+    def test_contextManagerPropagatesExceptions(self):
+        """
+        Exceptions propagate through the L{MonkeyPatcher} context-manager
+        exit method.
+        """
+        with self.assertRaises(RuntimeError):
+            with self.monkeyPatcher:
+                raise RuntimeError("something")


### PR DESCRIPTION
## Scope and purpose

Fixes #11638

This makes manhole itself override sys.excepthook while evaluating code so it can control what happens when an exception is raised.
