### PR TITLE
#11640 run twistd tests

### DIFF
--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -49,7 +49,7 @@ from twisted.test.proto_helpers import MemoryReactor
 from twisted.test.test_process import MockOS
 from twisted.trial.unittest import TestCase
 
-_twistd_unix = requireModule("twistd.scripts._twistd_unix")
+_twistd_unix = requireModule("twisted.scripts._twistd_unix")
 if _twistd_unix:
     from twisted.scripts._twistd_unix import (
         UnixApplicationRunner,
@@ -58,7 +58,7 @@ if _twistd_unix:
     )
 
 
-syslog = requireModule("twistd.python.syslog")
+syslog = requireModule("twisted.python.syslog")
 profile = requireModule("profile")
 pstats = requireModule("pstats")
 cProfile = requireModule("cProfile")


### PR DESCRIPTION
## Scope and purpose

Fixes #11640

Just makes the obvious spelling fix so if the correct dependencies are available the tests can run.
