### PR TITLE
#11652 migrate community doc page rst

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,39 @@
+Twisted Community
+#################
+
+For interacting with the twisted community members, you have several options:
+
+Mail Lists
+==========
+
+If you want to participate in Twisted's community or development, you probably want to join the main mailing list:
+
+- `twisted-python <https://mail.python.org/mailman3/lists/twisted.python.org/>`_ - the main Twisted discussion list
+
+You can subscribe to the mailing list using the web interface linked above.
+
+ML Archives:
+
+- `Current list archive <https://mail.python.org/archives/list/twisted@python.org/>`_
+- `Other archives <https://github.com/twisted/pipermail>`_
+
+Stack Overflow
+==============
+
+Stack Overflow is a programming Q & A site.  You can find Twisted-related questions there, often with answers:
+
+- https://stackoverflow.com/questions/tagged/twisted
+
+Real-Time Chat
+==============
+
+Server: ``irc.libera.chat`` (more about `the Libera IRC network <https://libera.chat>`_)
+
+For support, you can join this channel:
+
+- `#twisted <irc://irc.libera.chat/twisted>`_  - support for Twisted and its ecosystem
+
+Blogs
+=====
+
+Read `Planet Twisted <https://planet.twistedmatrix.com/>`_.

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -27,9 +27,12 @@ Stack Overflow is a programming Q & A site.  You can find Twisted-related questi
 Real-Time Chat
 ==============
 
-Server: ``irc.libera.chat`` (more about `the Libera IRC network <https://libera.chat>`_)
+You can join the `Twisted Gitter channel <https://gitter.im/twisted/twisted>`_ (or simply click the "Open Chat" button at the bottom-right of this screen).
+Gitter is based on `Matrix <https://matrix.org/>`_, which is itself built with Twisted !
 
-For support, you can join this channel:
+Alternatively you can join the following IRC channel. There are gateways between the Gitter and IRC channels.
+
+Server: ``irc.libera.chat`` (more about `the Libera IRC network <https://libera.chat>`_)
 
 - `#twisted <irc://irc.libera.chat/twisted>`_  - support for Twisted and its ecosystem
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Contents:
    :caption: Quick links
 
    security
+   community
    api/index
    GitHub <https://github.com/twisted/twisted>
    PyPI <https://pypi.org/project/twisted>


### PR DESCRIPTION
## Scope and purpose

Fixes #11652

Add a few words about why this PR is needed and what is its scope.
- Migrate Twisted Community Page to RST from old Trac Wiki.

Add any comments about trade-offs (if any) made in this PR and the reasoning behind them.
- Removed the old IRC channels dev/web and old MLs.

Add mentions of things that are not covered here and are planed to be done in separate PRs.
- Still need to update the twisted.org site to link to the new RTD page.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
