### PR TITLE
#11674 Run only on macOS 12 with latest Python.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,11 +122,6 @@ jobs:
           # Just Python 3.9 with default settings.
           - python-version: '3.9'
 
-          # Oldest macOS and olders Python supported versions.
-          - python-version: '3.7'
-            runs-on: 'macos-11'
-            job-name: 'macos-10-default-tests'
-
           # Newest macOS and newest Python supported versions.
           - python-version: '3.10'
             runs-on: 'macos-12'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,10 +123,8 @@ jobs:
           - python-version: '3.9'
 
           # Oldest macOS and olders Python supported versions.
-          # We pin a specific Python micro release due to a TK library bug.
-          # https://github.com/actions/setup-python/issues/402#issuecomment-1156015780
-          - python-version: '3.7.12'
-            runs-on: 'macos-10.15'
+          - python-version: '3.7'
+            runs-on: 'macos-11'
             job-name: 'macos-10-default-tests'
 
           # Newest macOS and newest Python supported versions.


### PR DESCRIPTION
## Scope and purpose

Fixes #11674

MacOS 10 will be removed soon.. or already removed.

Macos11 with Python 3.7  the minimum version fails with

```
File "/Users/runner/work/twisted/twisted/.tox/alldeps-withcov-posix/lib/python3.7/site-packages/twisted/internet/test/_posixifaces.py", line 31, in <module>
    libc = CDLL(find_library("c") or "")
  File "/Users/runner/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/ctypes/__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
builtins.OSError: dlopen(, 6): no suitable image found.  Did find:
```

stop pretending that we care about macOS and just remove the CI for older versions.
