### PR TITLE
#11599 Fix API reference link

### DIFF
--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -13,10 +13,8 @@ Twisted Core
     examples/index
     specifications/index
 
-
 - :doc:`Developer guides <howto/index>`: documentation on using Twisted Core to develop your own applications
 - :doc:`Examples <examples/index>`: short code examples using Twisted Core
 - :doc:`Specifications <specifications/index>`: specification documents for elements of Twisted Core
 
-
-An `API reference <//twistedmatrix.com/documents/current/api/>`_ is available on the twistedmatrix web site.
+An :py:mod:`API reference <twisted>` is available.

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -14,9 +14,9 @@ Twisted Core
     specifications/index
 
 
-- :doc:`Developer guides <howto/index>` : documentation on using Twisted Core to develop your own applications
-- :doc:`Examples <examples/index>` : short code examples using Twisted Core
-- :doc:`Specifications <specifications/index>` : specification documents for elements of Twisted Core
+- :doc:`Developer guides <howto/index>`: documentation on using Twisted Core to develop your own applications
+- :doc:`Examples <examples/index>`: short code examples using Twisted Core
+- :doc:`Specifications <specifications/index>`: specification documents for elements of Twisted Core
 
 
 An `API reference <//twistedmatrix.com/documents/current/api/>`_ is available on the twistedmatrix web site.


### PR DESCRIPTION
## Scope and purpose

Use an intersphinx-style link rather than an absolute one so that the generated link is relative.

You can see the result [here](https://twisted--11689.org.readthedocs.build/en/11689/core/index.html):

![image](https://user-images.githubusercontent.com/43662/192119194-77b42e9e-f715-4960-a962-ff1b2da9d124.png)

The monospace formatting is unfortunate but such is Sphinx. :shrug: 

Fixes #11599.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
