### PR TITLE
#8146 #8147 Support systemd named inherited file descriptors

### DIFF
--- a/docs/core/howto/endpoints.rst
+++ b/docs/core/howto/endpoints.rst
@@ -376,11 +376,14 @@ UNIX
    For example, ``unix:address=/var/run/web.sock:lockfile=1``.
 
 systemd
-   Supported arguments: ``domain``, ``index``.
+   Supported arguments: ``domain``, ``name``, and ``index``.
    ``domain`` indicates which socket domain the inherited file descriptor belongs to (eg INET, INET6).
+   ``name`` indicates the name of a file descriptor inherited from systemd.
+   The is set by the systemd configuration for the socket.
    ``index`` indicates an offset into the array of file descriptors which have been inherited from systemd.
+   ``name`` should be preferred over ``index`` because the order of the descriptors can be difficult to predict.
 
-   For example, ``systemd:domain=INET6:index=3``.
+   For example, ``systemd:domain=INET6:name=my-web-server``.
 
    See also :doc:`Deploying Twisted with systemd <systemd>`.
 

--- a/docs/core/howto/listings/systemd/www.example.com.socket
+++ b/docs/core/howto/listings/systemd/www.example.com.socket
@@ -1,5 +1,6 @@
 [Socket]
 ListenStream=0.0.0.0:80
+FileDescriptorName=www
 
 [Install]
 WantedBy=sockets.target

--- a/docs/core/howto/listings/systemd/www.example.com.socket
+++ b/docs/core/howto/listings/systemd/www.example.com.socket
@@ -1,6 +1,6 @@
 [Socket]
 ListenStream=0.0.0.0:80
-FileDescriptorName=www
+FileDescriptorName=my-web-port
 
 [Install]
 WantedBy=sockets.target

--- a/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
+++ b/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
@@ -5,7 +5,7 @@ Description=Example Web Server
 ExecStart=/usr/bin/twistd \
     --nodaemon \
     --pidfile= \
-    web --listen systemd:domain=INET:index=0 --path .
+    web --listen systemd:domain=INET:name=www --path .
 
 NonBlocking=true
 

--- a/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
+++ b/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Example Web Server
+Requires=www.example.com.socket
 
 [Service]
 ExecStart=/usr/bin/twistd \

--- a/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
+++ b/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
@@ -5,7 +5,7 @@ Description=Example Web Server
 ExecStart=/usr/bin/twistd \
     --nodaemon \
     --pidfile= \
-    web --listen systemd:domain=INET:name=www --path .
+    web --listen systemd:domain=INET:name=my-web-port --path .
 
 NonBlocking=true
 

--- a/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
+++ b/docs/core/howto/listings/systemd/www.example.com.socketactivated.service
@@ -8,8 +8,6 @@ ExecStart=/usr/bin/twistd \
     --pidfile= \
     web --listen systemd:domain=INET:name=my-web-port --path .
 
-NonBlocking=true
-
 WorkingDirectory=/srv/www/www.example.com/static
 
 User=nobody

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -282,7 +282,7 @@ ExecStart
 
   The ``domain=INET`` endpoint argument makes ``twistd`` treat the inherited file descriptor as an IPv4 socket.
 
-  The ``index=0`` endpoint argument makes ``twistd`` adopt the first file descriptor inherited from ``systemd``\ .
+  The ``name=www`` endpoint argument makes ``twistd`` adopt the file descriptor inherited from ``systemd`` named ``www``.
 
   Socket activation is also technically possible with other socket families and types, but Twisted currently only accepts IPv4 and IPv6 TCP sockets. See :ref:`limitations` below.
 
@@ -353,7 +353,7 @@ You can verify this by using systemctl to report the status of the service. eg
               Active: active (running) since Tue 2013-01-29 15:02:20 GMT; 3s ago
             Main PID: 25605 (twistd)
               CGroup: name=systemd:/system/www.example.com.service
-                      └─25605 /usr/bin/python /usr/bin/twistd --nodaemon --pidfile= web --port systemd:domain=INET:index=0 --path .
+                      └─25605 /usr/bin/python /usr/bin/twistd --nodaemon --pidfile= web --port systemd:domain=INET:name=www --path .
 
     Jan 29 15:02:20 zorin.lan systemd[1]: Started Example Web Server.
     Jan 29 15:02:20 zorin.lan twistd[25605]: 2013-01-29 15:02:20+0000 [-] Log opened.

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -291,10 +291,6 @@ ExecStart
 
   Socket activation is also technically possible with other socket families and types, but Twisted currently only accepts IPv4 and IPv6 TCP sockets. See :ref:`limitations` below.
 
-NonBlocking
-
-  This must be set to ``true`` to ensure that ``systemd`` passes non-blocking sockets to Twisted.
-
 Requires
 
   The service no longer knows how to bind the listening port for itself.

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -282,7 +282,7 @@ ExecStart
 
   The ``domain=INET`` endpoint argument makes ``twistd`` treat the inherited file descriptor as an IPv4 socket.
 
-  The ``name=www`` endpoint argument makes ``twistd`` adopt the file descriptor inherited from ``systemd`` named ``www``.
+  The ``name=my-web-port`` endpoint argument makes ``twistd`` adopt the file descriptor inherited from ``systemd`` named ``my-web-port``.
 
   Socket activation is also technically possible with other socket families and types, but Twisted currently only accepts IPv4 and IPv6 TCP sockets. See :ref:`limitations` below.
 

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -295,6 +295,11 @@ NonBlocking
 
   This must be set to ``true`` to ensure that ``systemd`` passes non-blocking sockets to Twisted.
 
+Requires
+
+  The service no longer knows how to bind the listening port for itself.
+  The corresponding socket unit must be started so it can pass the listening port on to the ``twistd`` process.
+
 [Install]
 
   In this example, the ``[Install]`` section has been moved to the socket configuration file.

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -358,7 +358,7 @@ You can verify this by using systemctl to report the status of the service. eg
               Active: active (running) since Tue 2013-01-29 15:02:20 GMT; 3s ago
             Main PID: 25605 (twistd)
               CGroup: name=systemd:/system/www.example.com.service
-                      └─25605 /usr/bin/python /usr/bin/twistd --nodaemon --pidfile= web --port systemd:domain=INET:name=www --path .
+                      └─25605 /usr/bin/python /usr/bin/twistd --nodaemon --pidfile= web --port systemd:domain=INET:name=my-web-port --path .
 
     Jan 29 15:02:20 zorin.lan systemd[1]: Started Example Web Server.
     Jan 29 15:02:20 zorin.lan twistd[25605]: 2013-01-29 15:02:20+0000 [-] Log opened.

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -65,15 +65,15 @@ Twisted
 
 Basic Systemd Service Configuration
 -----------------------------------
-The essential configuration file for a ``systemd`` service is the `service <http://www.freedesktop.org/software/systemd/man/systemd.service.html>`_ file.
+The essential configuration file for a ``systemd`` service is the `service file <http://www.freedesktop.org/software/systemd/man/systemd.service.html>`_.
 
 Later in this tutorial, you will learn about some other types of configuration file, which are used to control when and how your service is started.
 
 But we will begin by configuring ``systemd`` to start a Twisted web server immediately on system boot.
 
-Create a systemd.service file
+Create a systemd service file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Create the `service <http://www.freedesktop.org/software/systemd/man/systemd.service.html>`_ file at ``/etc/systemd/system/www.example.com.service`` with the following content:
+Create the `service file <http://www.freedesktop.org/software/systemd/man/systemd.service.html>`_ at ``/etc/systemd/system/www.example.com.service`` with the following content:
 
 :download:`/etc/systemd/system/www.example.com.service <listings/systemd/www.example.com.static.service>`
 
@@ -190,7 +190,7 @@ Later in this tutorial you will learn how to use another special unit - the ``so
 
 Test that the service is automatically restarted
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``Restart=always`` option in the ``systemd.service`` file ensures that ``systemd`` will restart the ``twistd`` process if and when it exits unexpectedly.
+The ``Restart=always`` option in the ``www.example.com.service`` file ensures that ``systemd`` will restart the ``twistd`` process if and when it exits unexpectedly.
 
 You can read about other ``Restart`` options in the `systemd.service man page <http://www.freedesktop.org/software/systemd/man/systemd.service.html>`_.
 
@@ -269,7 +269,7 @@ WantedBy=sockets.target
   This is
   a `special target <http://www.freedesktop.org/software/systemd/man/systemd.special.html#sockets.target>`_ used by all socket activated services. ``systemd`` will automatically bind to all such socket activation ports during boot up.
 
-You also need to modify the ``systemd.service`` file as follows:
+You also need to modify the ``www.example.com.service`` file as follows:
 
 :download:`/etc/systemd/system/www.example.com.service <listings/systemd/www.example.com.socketactivated.service>`
 

--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -269,6 +269,11 @@ WantedBy=sockets.target
   This is
   a `special target <http://www.freedesktop.org/software/systemd/man/systemd.special.html#sockets.target>`_ used by all socket activated services. ``systemd`` will automatically bind to all such socket activation ports during boot up.
 
+FileDescriptorName=my-web-port
+
+  This option names the file descriptor for the socket.
+  The name allows a specific inherited descriptor to be chosen reliably out of set of several inherited descriptors.
+
 You also need to modify the ``www.example.com.service`` file as follows:
 
 :download:`/etc/systemd/system/www.example.com.service <listings/systemd/www.example.com.socketactivated.service>`

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -17,6 +17,7 @@ import os
 import re
 import socket
 import warnings
+from typing import Optional
 from unicodedata import normalize
 
 from zope.interface import directlyProvides, implementer, provider
@@ -35,6 +36,7 @@ from twisted.internet.address import (
 from twisted.internet.interfaces import (
     IHostnameResolver,
     IReactorPluggableNameResolver,
+    IReactorSocket,
     IResolutionReceiver,
     IStreamClientEndpointStringParserWithReactor,
     IStreamServerEndpointStringParser,
@@ -1504,7 +1506,13 @@ class _SystemdParser:
 
     prefix = "systemd"
 
-    def _parseServer(self, reactor, domain, index):
+    def _parseServer(
+        self,
+        reactor: IReactorSocket,
+        domain: str,
+        index: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> AdoptedStreamServerEndpoint:
         """
         Internal parser function for L{_parseServer} to convert the string
         arguments for a systemd server endpoint into structured arguments for
@@ -1513,21 +1521,35 @@ class _SystemdParser:
         @param reactor: An L{IReactorSocket} provider.
 
         @param domain: The domain (or address family) of the socket inherited
-            from systemd.  This is a string like C{"INET"} or C{"UNIX"}, ie the
-            name of an address family from the L{socket} module, without the
-            C{"AF_"} prefix.
-        @type domain: C{str}
+            from systemd.  This is a string like C{"INET"} or C{"UNIX"}, ie
+            the name of an address family from the L{socket} module, without
+            the C{"AF_"} prefix.
 
-        @param index: An offset into the list of file descriptors inherited from
-            systemd.
-        @type index: C{str}
+        @param index: If given, the decimal representation of an integer
+            giving the offset into the list of file descriptors inherited from
+            systemd.  Since the order of descriptors received from systemd is
+            hard to predict, this option should only be used if only one
+            descriptor is being inherited.  Even in that case, C{name} is
+            probably a better idea.  Either C{index} or C{name} must be given.
+
+        @param name: If given, the name (as defined by C{FileDescriptorName}
+            in the C{[Socket]} section of a systemd service definition) of an
+            inherited file descriptor.  Either C{index} or C{name} must be
+            given.
 
         @return: A two-tuple of parsed positional arguments and parsed keyword
             arguments (a tuple and a dictionary).  These can be used to
             construct an L{AdoptedStreamServerEndpoint}.
         """
-        index = int(index)
-        fileno = self._sddaemon.inheritedDescriptors()[index]
+        if (index is None) == (name is None):
+            raise ValueError("Specify exactly one of descriptor index or name")
+
+        if index is not None:
+            fileno = self._sddaemon.inheritedDescriptors()[int(index)]
+        else:
+            assert name is not None
+            fileno = self._sddaemon.inheritedNamedDescriptors()[name]
+
         addressFamily = getattr(socket, "AF_" + domain)
         return AdoptedStreamServerEndpoint(reactor, fileno, addressFamily)
 

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -1537,9 +1537,8 @@ class _SystemdParser:
             inherited file descriptor.  Either C{index} or C{name} must be
             given.
 
-        @return: A two-tuple of parsed positional arguments and parsed keyword
-            arguments (a tuple and a dictionary).  These can be used to
-            construct an L{AdoptedStreamServerEndpoint}.
+        @return: An L{AdoptedStreamServerEndpoint} which will adopt the
+            inherited listening port when it is used to listen.
         """
         if (index is None) == (name is None):
             raise ValueError("Specify exactly one of descriptor index or name")

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -3887,6 +3887,15 @@ class SystemdEndpointPluginTests(unittest.TestCase):
         else:
             self._parseNameStreamServerTest(AF_UNIX, "UNIX")
 
+    def test_indexAndNameMutuallyExclusive(self) -> None:
+        """
+        The endpoint cannot be defined using both C{index} and C{name}.
+        """
+        parser = self._parserClass()
+        parser._sddaemon = ListenFDs([], ())
+        with self.assertRaises(ValueError):
+            parser.parseStreamServer(reactor, domain="INET", index=0, name="foo")
+
 
 class TCP6ServerEndpointPluginTests(unittest.TestCase):
     """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -8,7 +8,7 @@ L{twisted.internet.endpoints}.
 """
 
 from errno import EPERM
-from socket import AF_INET, AF_INET6, IPPROTO_TCP, SOCK_STREAM, gaierror
+from socket import AF_INET, AF_INET6, IPPROTO_TCP, SOCK_STREAM, AddressFamily, gaierror
 from types import FunctionType
 from unicodedata import normalize
 from unittest import skipIf
@@ -3786,10 +3786,12 @@ class SystemdEndpointPluginTests(unittest.TestCase):
             verifyObject(interfaces.IStreamServerEndpointStringParser, parser)
         )
 
-    def _parseStreamServerTest(self, addressFamily, addressFamilyString):
+    def _parseIndexStreamServerTest(
+        self, addressFamily: AddressFamily, addressFamilyString: str
+    ) -> None:
         """
-        Helper for unit tests for L{endpoints._SystemdParser.parseStreamServer}
-        for different address families.
+        Helper for tests for L{endpoints._SystemdParser.parseStreamServer}
+        for different address families with a descriptor identified by index.
 
         Handling of the address family given will be verify.  If there is a
         problem a test-failing exception will be raised.
@@ -3802,10 +3804,11 @@ class SystemdEndpointPluginTests(unittest.TestCase):
         """
         reactor = object()
         descriptors = [5, 6, 7, 8, 9]
+        names = ["5.socket", "6.socket", "foo", "8.socket", "9.socket"]
         index = 3
 
         parser = self._parserClass()
-        parser._sddaemon = ListenFDs(descriptors)
+        parser._sddaemon = ListenFDs(descriptors, names)
 
         server = parser.parseStreamServer(
             reactor, domain=addressFamilyString, index=str(index)
@@ -3814,19 +3817,43 @@ class SystemdEndpointPluginTests(unittest.TestCase):
         self.assertEqual(server.addressFamily, addressFamily)
         self.assertEqual(server.fileno, descriptors[index])
 
-    def test_parseStreamServerINET(self):
+    def _parseNameStreamServerTest(
+        self, addressFamily: AddressFamily, addressFamilyString: str
+    ) -> None:
+        """
+        Like L{_parseIndexStreamServerTest} but for descriptors identified by
+        name.
+        """
+        reactor = object()
+        descriptors = [5, 6, 7, 8, 9]
+        names = ["5.socket", "6.socket", "foo", "8.socket", "9.socket"]
+        name = "foo"
+
+        parser = self._parserClass()
+        parser._sddaemon = ListenFDs(descriptors, names)
+
+        server = parser.parseStreamServer(
+            reactor,
+            domain=addressFamilyString,
+            name=name,
+        )
+        self.assertIs(server.reactor, reactor)
+        self.assertEqual(server.addressFamily, addressFamily)
+        self.assertEqual(server.fileno, descriptors[names.index(name)])
+
+    def test_parseIndexStreamServerINET(self) -> None:
         """
         IPv4 can be specified using the string C{"INET"}.
         """
-        self._parseStreamServerTest(AF_INET, "INET")
+        self._parseIndexStreamServerTest(AF_INET, "INET")
 
-    def test_parseStreamServerINET6(self):
+    def test_parseIndexStreamServerINET6(self) -> None:
         """
         IPv6 can be specified using the string C{"INET6"}.
         """
-        self._parseStreamServerTest(AF_INET6, "INET6")
+        self._parseIndexStreamServerTest(AF_INET6, "INET6")
 
-    def test_parseStreamServerUNIX(self):
+    def test_parseIndexStreamServerUNIX(self) -> None:
         """
         A UNIX domain socket can be specified using the string C{"UNIX"}.
         """
@@ -3835,7 +3862,30 @@ class SystemdEndpointPluginTests(unittest.TestCase):
         except ImportError:
             raise unittest.SkipTest("Platform lacks AF_UNIX support")
         else:
-            self._parseStreamServerTest(AF_UNIX, "UNIX")
+            self._parseIndexStreamServerTest(AF_UNIX, "UNIX")
+
+    def test_parseNameStreamServerINET(self) -> None:
+        """
+        IPv4 can be specified using the string C{"INET"}.
+        """
+        self._parseNameStreamServerTest(AF_INET, "INET")
+
+    def test_parseNameStreamServerINET6(self) -> None:
+        """
+        IPv6 can be specified using the string C{"INET6"}.
+        """
+        self._parseNameStreamServerTest(AF_INET6, "INET6")
+
+    def test_parseNameStreamServerUNIX(self) -> None:
+        """
+        A UNIX domain socket can be specified using the string C{"UNIX"}.
+        """
+        try:
+            from socket import AF_UNIX
+        except ImportError:
+            raise unittest.SkipTest("Platform lacks AF_UNIX support")
+        else:
+            self._parseNameStreamServerTest(AF_UNIX, "UNIX")
 
 
 class TCP6ServerEndpointPluginTests(unittest.TestCase):

--- a/src/twisted/newsfragments/8146.doc
+++ b/src/twisted/newsfragments/8146.doc
@@ -1,0 +1,1 @@
+The ``systemd`` endpoint parser's ``index`` parameter is now documented as leading to non-deterministic results in which descriptor is selected.  The new ``name`` parameter is now documented as preferred.

--- a/src/twisted/newsfragments/8147.feature
+++ b/src/twisted/newsfragments/8147.feature
@@ -1,0 +1,1 @@
+The ``systemd:`` endpoint parser now supports "named" file descriptors.  This is a more reliable mechanism for choosing among several inherited descriptors.

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -80,7 +80,10 @@ class ListenFDs:
         # They may both be missing (consistent with not running under systemd
         # at all) or they may both be present (consistent with running under
         # systemd 227 or newer).  It is not allowed for only one to be present
-        # or for the values to disagree with each other.
+        # or for the values to disagree with each other (per
+        # systemd.socket(5), systemd will use a default value based on the
+        # socket unit name if the socket unit doesn't explicitly define a name
+        # with FileDescriptorName).
         if len(names) != len(descriptors):
             return cls([], ())
 

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -123,6 +123,18 @@ def _parseDescriptors(start: int, environ: Mapping[str, str]) -> List[int]:
         return []
     else:
         descriptors = list(range(start, start + count))
+
+        # Remove the information from the environment so that a second
+        # `ListenFDs` cannot find the same information.  This is a precaution
+        # against some application code accidentally trying to handle the same
+        # inherited descriptor more than once - which probably wouldn't work.
+        #
+        # This precaution is perhaps somewhat questionable since it is up to
+        # the application itself to know whether its handling of the file
+        # descriptor will actually be safe.  Also, nothing stops an
+        # application from getting the same descriptor more than once using
+        # multiple calls to `ListenFDs.inheritedDescriptors()` on the same
+        # `ListenFDs` instance.
         del environ["LISTEN_PID"], environ["LISTEN_FDS"]
         return descriptors
 

--- a/src/twisted/python/test/strategies.py
+++ b/src/twisted/python/test/strategies.py
@@ -8,7 +8,7 @@ Hypothesis strategies for values related to L{twisted.python}.
 from hypothesis.strategies import SearchStrategy, characters, text
 
 
-def systemd_descriptor_names() -> SearchStrategy[str]:
+def systemdDescriptorNames() -> SearchStrategy[str]:
     """
     Build strings that are legal values for the systemd
     I{FileDescriptorName} field.

--- a/src/twisted/python/test/strategies.py
+++ b/src/twisted/python/test/strategies.py
@@ -1,0 +1,26 @@
+from hypothesis.strategies import SearchStrategy, characters, text
+
+
+def systemd_descriptor_names() -> SearchStrategy[str]:
+    """
+    Build strings that are legal values for the systemd
+    I{FileDescriptorName} field.
+    """
+    # systemd.socket(5) says:
+    #
+    # > Names may contain any ASCII character, but must exclude control
+    # > characters and ":", and must be at most 255 characters in length.
+    return text(
+        # The docs don't say there is a min size so I'm guessing...
+        min_size=1,
+        max_size=255,
+        alphabet=characters(
+            # These constraints restrict us to ASCII.
+            min_codepoint=0,
+            max_codepoint=127,
+            # This one excludes control characters.
+            blacklist_categories=("Cc",),
+            # And this excludes the separator.
+            blacklist_characters=(":",),
+        ),
+    )

--- a/src/twisted/python/test/strategies.py
+++ b/src/twisted/python/test/strategies.py
@@ -1,3 +1,10 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Hypothesis strategies for values related to L{twisted.python}.
+"""
+
 from hypothesis.strategies import SearchStrategy, characters, text
 
 

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -69,8 +69,10 @@ class ListenFDsTests(SynchronousTestCase):
 
     def test_secondEnvironment(self) -> None:
         """
-        L{ListenFDs.fromEnvironment} removes information about the inherited
-        file descriptors from the environment mapping.
+        L{ListenFDs.fromEnvironment} removes information about the
+        inherited file descriptors from the environment mapping so that the
+        same inherited file descriptors cannot be handled repeatedly from
+        multiple L{ListenFDs} instances.
         """
         env = initializeEnvironment(3, os.getpid())
         first = ListenFDs.fromEnvironment(environ=env)

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -7,158 +7,163 @@ Tests for L{twisted.python.systemd}.
 
 
 import os
+from typing import Dict, Mapping, Sequence
+
+from hamcrest import assert_that, equal_to, not_
+from hypothesis import given
+from hypothesis.strategies import dictionaries, integers, lists
 
 from twisted.python.systemd import ListenFDs
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
+from .strategies import systemd_descriptor_names
 
 
-class InheritedDescriptorsMixin:
+def initializeEnvironment(count: int, pid: object) -> Dict[str, str]:
     """
-    Mixin for a L{TestCase} subclass which defines test methods for some kind of
-    systemd sd-daemon class.  In particular, it defines tests for a
-    C{inheritedDescriptors} method.
+    Create a copy of the process environment and add I{LISTEN_FDS} and
+    I{LISTEN_PID} (the environment variables set by systemd) to it.
     """
-
-    def test_inheritedDescriptors(self):
-        """
-        C{inheritedDescriptors} returns a list of integers giving the file
-        descriptors which were inherited from systemd.
-        """
-        sddaemon = self.getDaemon(7, 3)
-        self.assertEqual([7, 8, 9], sddaemon.inheritedDescriptors())
-
-    def test_repeated(self):
-        """
-        Any subsequent calls to C{inheritedDescriptors} return the same list.
-        """
-        sddaemon = self.getDaemon(7, 3)
-        self.assertEqual(
-            sddaemon.inheritedDescriptors(), sddaemon.inheritedDescriptors()
-        )
+    result = os.environ.copy()
+    result["LISTEN_FDS"] = str(count)
+    result["LISTEN_FDNAMES"] = ":".join([f"{n}.socket" for n in range(count)])
+    result["LISTEN_PID"] = str(pid)
+    return result
 
 
-class MemoryOnlyMixin:
-    """
-    Mixin for a L{TestCase} subclass which creates creating a fake, in-memory
-    implementation of C{inheritedDescriptors}.  This provides verification that
-    the fake behaves in a compatible way with the real implementation.
-    """
-
-    def getDaemon(self, start, count):
-        """
-        Invent C{count} new I{file descriptors} (actually integers, attached to
-        no real file description), starting at C{start}.  Construct and return a
-        new L{ListenFDs} which will claim those integers represent inherited
-        file descriptors.
-        """
-        return ListenFDs(range(start, start + count))
-
-
-class EnvironmentMixin:
-    """
-    Mixin for a L{TestCase} subclass which creates a real implementation of
-    C{inheritedDescriptors} which is based on the environment variables set by
-    systemd.  To facilitate testing, this mixin will also create a fake
-    environment dictionary and add keys to it to make it look as if some
-    descriptors have been inherited.
-    """
-
-    def initializeEnvironment(self, count, pid):
-        """
-        Create a copy of the process environment and add I{LISTEN_FDS} and
-        I{LISTEN_PID} (the environment variables set by systemd) to it.
-        """
-        result = os.environ.copy()
-        result["LISTEN_FDS"] = str(count)
-        result["LISTEN_PID"] = str(pid)
-        return result
-
-    def getDaemon(self, start, count):
-        """
-        Create a new L{ListenFDs} instance, initialized with a fake environment
-        dictionary which will be set up as systemd would have set it up if
-        C{count} descriptors were being inherited.  The descriptors will also
-        start at C{start}.
-        """
-        fakeEnvironment = self.initializeEnvironment(count, os.getpid())
-        return ListenFDs.fromEnvironment(environ=fakeEnvironment, start=start)
-
-
-class MemoryOnlyTests(MemoryOnlyMixin, InheritedDescriptorsMixin, TestCase):
-    """
-    Apply tests to L{ListenFDs}, explicitly constructed with some fake file
-    descriptors.
-    """
-
-
-class EnvironmentTests(EnvironmentMixin, InheritedDescriptorsMixin, TestCase):
+class ListenFDsTests(SynchronousTestCase):
     """
     Apply tests to L{ListenFDs}, constructed based on an environment dictionary.
     """
 
-    def test_secondEnvironment(self):
+    @given(lists(systemd_descriptor_names(), min_size=0, max_size=10))
+    def test_fromEnvironmentEquivalence(self, names: Sequence[str]) -> None:
         """
-        Only a single L{Environment} can extract inherited file descriptors.
+        The L{ListenFDs} and L{ListenFDs.fromEnvironment} constructors are
+        equivalent for their respective representations of the same
+        information.
+
+        @param names: The names of the file descriptors to represent as
+            inherited in the test environment given to the parser.  The number
+            of descriptors represented will equal the length of this list.
         """
-        fakeEnvironment = self.initializeEnvironment(3, os.getpid())
-        first = ListenFDs.fromEnvironment(environ=fakeEnvironment)
-        second = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        numFDs = len(names)
+        descriptors = list(range(ListenFDs._START, ListenFDs._START + numFDs))
+        fds = ListenFDs.fromEnvironment(
+            {
+                "LISTEN_PID": str(os.getpid()),
+                "LISTEN_FDS": str(numFDs),
+                "LISTEN_FDNAMES": ":".join(names),
+            }
+        )
+        assert_that(fds, equal_to(ListenFDs(descriptors, tuple(names))))
+
+    def test_defaultEnviron(self) -> None:
+        """
+        If the process environment is not explicitly passed to
+        L{ListenFDs.fromEnvironment}, the real process environment dictionary
+        is used.
+        """
+        self.patch(os, "environ", initializeEnvironment(5, os.getpid()))
+        sddaemon = ListenFDs.fromEnvironment()
+        self.assertEqual(list(range(3, 3 + 5)), sddaemon.inheritedDescriptors())
+
+    def test_secondEnvironment(self) -> None:
+        """
+        L{ListenFDs.fromEnvironment} removes information about the inherited
+        file descriptors from the environment mapping.
+        """
+        env = initializeEnvironment(3, os.getpid())
+        first = ListenFDs.fromEnvironment(environ=env)
+        second = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual(list(range(3, 6)), first.inheritedDescriptors())
         self.assertEqual([], second.inheritedDescriptors())
 
-    def test_mismatchedPID(self):
+    def test_mismatchedPID(self) -> None:
         """
-        If the current process PID does not match the PID in the environment, no
-        inherited descriptors are reported.
+        If the current process PID does not match the PID in the environment,
+        no inherited descriptors are reported.
         """
-        fakeEnvironment = self.initializeEnvironment(3, os.getpid() + 1)
-        sddaemon = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        env = initializeEnvironment(3, os.getpid() + 1)
+        sddaemon = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual([], sddaemon.inheritedDescriptors())
 
-    def test_missingPIDVariable(self):
+    def test_missingPIDVariable(self) -> None:
         """
         If the I{LISTEN_PID} environment variable is not present, no inherited
         descriptors are reported.
         """
-        fakeEnvironment = self.initializeEnvironment(3, os.getpid())
-        del fakeEnvironment["LISTEN_PID"]
-        sddaemon = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        env = initializeEnvironment(3, os.getpid())
+        del env["LISTEN_PID"]
+        sddaemon = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual([], sddaemon.inheritedDescriptors())
 
-    def test_nonIntegerPIDVariable(self):
+    def test_nonIntegerPIDVariable(self) -> None:
         """
         If the I{LISTEN_PID} environment variable is set to a string that cannot
         be parsed as an integer, no inherited descriptors are reported.
         """
-        fakeEnvironment = self.initializeEnvironment(3, "hello, world")
-        sddaemon = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        env = initializeEnvironment(3, "hello, world")
+        sddaemon = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual([], sddaemon.inheritedDescriptors())
 
-    def test_missingFDSVariable(self):
+    def test_missingFDSVariable(self) -> None:
         """
-        If the I{LISTEN_FDS} environment variable is not present, no inherited
-        descriptors are reported.
+        If the I{LISTEN_FDS} and I{LISTEN_FDNAMES} environment variables
+        are not present, no inherited descriptors are reported.
         """
-        fakeEnvironment = self.initializeEnvironment(3, os.getpid())
-        del fakeEnvironment["LISTEN_FDS"]
-        sddaemon = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        env = initializeEnvironment(3, os.getpid())
+        del env["LISTEN_FDS"]
+        del env["LISTEN_FDNAMES"]
+        sddaemon = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual([], sddaemon.inheritedDescriptors())
 
-    def test_nonIntegerFDSVariable(self):
+    def test_nonIntegerFDSVariable(self) -> None:
         """
         If the I{LISTEN_FDS} environment variable is set to a string that cannot
         be parsed as an integer, no inherited descriptors are reported.
         """
-        fakeEnvironment = self.initializeEnvironment("hello, world", os.getpid())
-        sddaemon = ListenFDs.fromEnvironment(environ=fakeEnvironment)
+        env = initializeEnvironment(3, os.getpid())
+        env["LISTEN_FDS"] = "hello, world"
+        sddaemon = ListenFDs.fromEnvironment(environ=env)
         self.assertEqual([], sddaemon.inheritedDescriptors())
 
-    def test_defaultEnviron(self):
+    @given(lists(integers(min_value=0, max_value=10), unique=True))
+    def test_inheritedDescriptors(self, descriptors: Sequence[int]) -> None:
         """
-        If the process environment is not explicitly passed to
-        L{Environment.__init__}, the real process environment dictionary is
-        used.
+        L{ListenFDs.inheritedDescriptors} returns a copy of the inherited
+        descriptors list.
         """
-        self.patch(os, "environ", {"LISTEN_PID": str(os.getpid()), "LISTEN_FDS": "5"})
-        sddaemon = ListenFDs.fromEnvironment()
-        self.assertEqual(list(range(3, 3 + 5)), sddaemon.inheritedDescriptors())
+        names = tuple(map(str, descriptors))
+        fds = ListenFDs(descriptors, names)
+        fdsCopy = fds.inheritedDescriptors()
+        assert_that(descriptors, equal_to(fdsCopy))
+        fdsCopy.append(1)
+        assert_that(descriptors, not_(equal_to(fdsCopy)))
+
+    @given(dictionaries(systemd_descriptor_names(), integers(min_value=0), max_size=10))
+    def test_inheritedNamedDescriptors(self, expected: Mapping[str, int]) -> None:
+        """
+        L{ListenFDs.inheritedNamedDescriptors} returns a mapping from the
+        descriptor names to their integer values, with items formed by
+        pairwise combination of the input descriptors and names.
+        """
+        items = list(expected.items())
+        names = [name for name, _ in items]
+        descriptors = [fd for _, fd in items]
+        fds = ListenFDs(descriptors, names)
+        assert_that(fds.inheritedNamedDescriptors(), equal_to(expected))
+
+    @given(lists(integers(min_value=0, max_value=10), unique=True))
+    def test_repeated(self, descriptors: Sequence[int]) -> None:
+        """
+        Any subsequent calls to C{inheritedDescriptors} and
+        C{inheritedNamedDescriptors} return the same list.
+        """
+        names = tuple(map(str, descriptors))
+        sddaemon = ListenFDs(descriptors, names)
+        self.assertEqual(
+            sddaemon.inheritedDescriptors(), sddaemon.inheritedDescriptors()
+        )
+        self.assertEqual(
+            sddaemon.inheritedNamedDescriptors(), sddaemon.inheritedNamedDescriptors()
+        )

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -86,8 +86,11 @@ class ListenFDsTests(SynchronousTestCase):
 
     def test_mismatchedPID(self) -> None:
         """
-        If the current process PID does not match the PID in the environment,
-        no inherited descriptors are reported.
+        If the current process PID does not match the PID in the
+        environment then the systemd variables in the environment were set for
+        a different process (perhaps our parent) and the inherited descriptors
+        are not intended for this process so L{ListenFDs.inheritedDescriptors}
+        returns an empty list.
         """
         env = buildEnvironment(3, os.getpid() + 1)
         sddaemon = ListenFDs.fromEnvironment(environ=env)
@@ -95,8 +98,10 @@ class ListenFDsTests(SynchronousTestCase):
 
     def test_missingPIDVariable(self) -> None:
         """
-        If the I{LISTEN_PID} environment variable is not present, no inherited
-        descriptors are reported.
+        If the I{LISTEN_PID} environment variable is not present then
+        there is no clear indication that any file descriptors were inherited
+        by this process so L{ListenFDs.inheritedDescriptors} returns an empty
+        list.
         """
         env = buildEnvironment(3, os.getpid())
         del env["LISTEN_PID"]

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -15,7 +15,7 @@ from hypothesis.strategies import dictionaries, integers, lists
 
 from twisted.python.systemd import ListenFDs
 from twisted.trial.unittest import SynchronousTestCase
-from .strategies import systemd_descriptor_names
+from .strategies import systemdDescriptorNames
 
 
 def initializeEnvironment(count: int, pid: object) -> Dict[str, str]:
@@ -35,7 +35,7 @@ class ListenFDsTests(SynchronousTestCase):
     Apply tests to L{ListenFDs}, constructed based on an environment dictionary.
     """
 
-    @given(lists(systemd_descriptor_names(), min_size=0, max_size=10))
+    @given(lists(systemdDescriptorNames(), min_size=0, max_size=10))
     def test_fromEnvironmentEquivalence(self, names: Sequence[str]) -> None:
         """
         The L{ListenFDs} and L{ListenFDs.fromEnvironment} constructors are
@@ -142,7 +142,7 @@ class ListenFDsTests(SynchronousTestCase):
         fdsCopy.append(1)
         assert_that(descriptors, not_(equal_to(fdsCopy)))
 
-    @given(dictionaries(systemd_descriptor_names(), integers(min_value=0), max_size=10))
+    @given(dictionaries(systemdDescriptorNames(), integers(min_value=0), max_size=10))
     def test_inheritedNamedDescriptors(self, expected: Mapping[str, int]) -> None:
         """
         L{ListenFDs.inheritedNamedDescriptors} returns a mapping from the


### PR DESCRIPTION
## Scope and purpose

Fixes #8146
Fixes #8147


The unit tests for systemd.py were well-intentioned but sadly misguided (nice try though, jean-paul@2012).  So I kind of rewrote them (a lot of the tests are the same but the infrastructure they fit into is better now).
