### PR TITLE
#10345 - Remove deprecated inspect.getargspec from sendmail tests.

### DIFF
--- a/src/twisted/mail/test/test_smtp.py
+++ b/src/twisted/mail/test/test_smtp.py
@@ -1771,7 +1771,8 @@ class SendmailTests(TestCase):
         The default C{reactor} parameter of L{twisted.mail.smtp.sendmail} is
         L{twisted.internet.reactor}.
         """
-        args, varArgs, keywords, defaults = inspect.getargspec(smtp.sendmail)
+        fullSpec = inspect.getfullargspec(smtp.sendmail)
+        defaults = fullSpec[3]
         self.assertEqual(reactor, defaults[2])
 
     def _honorsESMTPArguments(self, username, password):

--- a/src/twisted/newsfragments/10345.misc
+++ b/src/twisted/newsfragments/10345.misc
@@ -1,0 +1,1 @@
+Fix SendmailTests for python 3.11.


### PR DESCRIPTION
## Scope and purpose

Fixes #10345 

Replace usage of inspect.getargspec() with inspect.getfullargspec() for Python 3.11 compatibility.

