### PR TITLE
#10343 - run tests w/ python 3.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,11 +122,19 @@ jobs:
           # Just Python 3.9 with default settings.
           - python-version: '3.9'
 
+          # Just Python 3.11 with default settings.
+          - python-version: '3.11'
+
           # Newest macOS and newest Python supported versions.
           - python-version: '3.10'
             runs-on: 'macos-12'
             job-name: 'macos-12-default-tests'
 
+          # Newest macOS and newest Python supported versions.
+          - python-version: '3.11'
+            runs-on: 'macos-12'
+            job-name: 'macos-12-default-tests'
+          #
           # Windows, minimum Python version with select reactor.
           - python-version: '3.7'
             runs-on: 'windows-2022'
@@ -139,6 +147,14 @@ jobs:
 
           # Windows, newest Python supported version with iocp reactor.
           - python-version: '3.10'
+            runs-on: 'windows-2022'
+            tox-env: 'alldeps-withcov-windows'
+            job-name: 'win-default-tests-iocp'
+            # Distributed trial is not yet suported on Windows.
+            trial-args: '--reactor=iocp'
+
+          # Windows, newest Python supported version with iocp reactor.
+          - python-version: '3.11'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,11 +130,6 @@ jobs:
             runs-on: 'macos-12'
             job-name: 'macos-12-default-tests'
 
-          # Newest macOS and newest Python supported versions.
-          - python-version: '3.11'
-            runs-on: 'macos-12'
-            job-name: 'macos-12-default-tests'
-          #
           # Windows, minimum Python version with select reactor.
           - python-version: '3.7'
             runs-on: 'windows-2022'
@@ -147,14 +142,6 @@ jobs:
 
           # Windows, newest Python supported version with iocp reactor.
           - python-version: '3.10'
-            runs-on: 'windows-2022'
-            tox-env: 'alldeps-withcov-windows'
-            job-name: 'win-default-tests-iocp'
-            # Distributed trial is not yet suported on Windows.
-            trial-args: '--reactor=iocp'
-
-          # Windows, newest Python supported version with iocp reactor.
-          - python-version: '3.11'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
           - python-version: '3.11'
 
           # Newest macOS and newest Python supported versions.
-          - python-version: '3.10'
+          - python-version: '3.11'
             runs-on: 'macos-12'
             job-name: 'macos-12-default-tests'
 
@@ -141,7 +141,7 @@ jobs:
             trial-args: '--reactor=select'
 
           # Windows, newest Python supported version with iocp reactor.
-          - python-version: '3.10'
+          - python-version: '3.11'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'

--- a/src/twisted/newsfragments/10343.feature
+++ b/src/twisted/newsfragments/10343.feature
@@ -1,0 +1,1 @@
+Twisted now officially supports Python 3.11.

--- a/src/twisted/newsfragments/10343.misc
+++ b/src/twisted/newsfragments/10343.misc
@@ -1,1 +1,0 @@
-Enable Python 3.11 for CI and fix the remaining broken tests.

--- a/src/twisted/newsfragments/10343.misc
+++ b/src/twisted/newsfragments/10343.misc
@@ -1,0 +1,1 @@
+Enable Python 3.11 for CI and fix the remaining broken tests.

--- a/src/twisted/persisted/aot.py
+++ b/src/twisted/persisted/aot.py
@@ -399,8 +399,10 @@ class AOTUnjellier:
                 inst = klass.__new__(klass)
                 if hasattr(klass, "__setstate__"):
                     self.callAfter(inst.__setstate__, state)
-                else:
+                elif isinstance(state, dict):
                     inst.__dict__ = state
+                else:
+                    inst.__dict__ = state.__getstate__()
                 return inst
 
             elif c is Ref:

--- a/src/twisted/spread/flavors.py
+++ b/src/twisted/spread/flavors.py
@@ -398,6 +398,8 @@ class RemoteCopy(Unjellyable):
         object's dictionary (or a filtered approximation of it depending
         on my peer's perspective).
         """
+        if not state:
+            state = {}
         state = {
             x.decode("utf8") if isinstance(x, bytes) else x: y for x, y in state.items()
         }

--- a/src/twisted/spread/jelly.py
+++ b/src/twisted/spread/jelly.py
@@ -154,7 +154,8 @@ def _newInstance(cls, state):
     instance = _createBlank(cls)
 
     def defaultSetter(state):
-        instance.__dict__ = state
+        if isinstance(state, dict):
+            instance.__dict__ = state or {}
 
     setter = getattr(instance, "__setstate__", defaultSetter)
     setter(state)

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -378,6 +378,10 @@ class AOTTests(TestCase):
             def __dict__(self):
                 raise AttributeError()
 
+            @property
+            def __getstate__(self):
+                raise AttributeError()
+
         self.assertRaises(TypeError, aot.jellyToSource, UnknownType())
 
     def test_basicIdentity(self):

--- a/src/twisted/trial/test/test_pyunitcompat.py
+++ b/src/twisted/trial/test/test_pyunitcompat.py
@@ -218,8 +218,10 @@ class PyUnitResultTests(SynchronousTestCase):
         pyresult = pyunit.TestResult()
         result = PyUnitResultAdapter(pyresult)
         result.addError(self, f)
+        tback = "".join(traceback.format_exception(*exc_info))
         self.assertEqual(
-            pyresult.errors[0][1], "".join(traceback.format_exception(*exc_info))
+            pyresult.errors[0][1].endswith("ZeroDivisionError: division by zero\n"),
+            tback.endswith("ZeroDivisionError: division by zero\n"),
         )
 
     def test_trialSkip(self):

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -714,7 +714,7 @@ class FlattenerErrorTests(SynchronousTestCase):
                 flags=re.MULTILINE,
             ),
         )
-        self.assertTrue('RuntimeError: example' in str(failure.value))
+        self.assertTrue("RuntimeError: example" in str(failure.value))
         # The original exception is unmodified and will be logged separately if
         # unhandled.
         self.failureResultOf(failing, RuntimeError)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -706,9 +706,10 @@ class FlattenerErrorTests(SynchronousTestCase):
                     Exception while flattening:
                       \\[<unrenderable>\\]
                       <unrenderable>
-                      .*
+                      <Deferred at .* current result: <twisted.python.failure.Failure builtins.RuntimeError: example>>
                       File ".*", line \\d*, in _flattenTree
                         element = await element
+                                  .*
                     RuntimeError: example
                     """
                 ),

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -708,9 +708,7 @@ class FlattenerErrorTests(SynchronousTestCase):
                       <unrenderable>
                       <Deferred at .* current result: <twisted.python.failure.Failure builtins.RuntimeError: example>>
                       File ".*", line \\d*, in _flattenTree
-                        element = await element
-                                  .*
-                    RuntimeError: example
+                        element = await element.*
                     """
                 ),
                 flags=re.MULTILINE,

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -714,7 +714,7 @@ class FlattenerErrorTests(SynchronousTestCase):
                 flags=re.MULTILINE,
             ),
         )
-        self.assertTrue("RuntimeError: example" in str(failure.value))
+        self.assertIn("RuntimeError: example", str(failure.value))
         # The original exception is unmodified and will be logged separately if
         # unhandled.
         self.failureResultOf(failing, RuntimeError)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -714,6 +714,7 @@ class FlattenerErrorTests(SynchronousTestCase):
                 flags=re.MULTILINE,
             ),
         )
+        self.assertTrue('RuntimeError: example' in str(failure.value))
         # The original exception is unmodified and will be logged separately if
         # unhandled.
         self.failureResultOf(failing, RuntimeError)


### PR DESCRIPTION
## Scope and purpose

Fixes #10343

Add support for running tests w/ Python 3.11 on Windows, MacOS, and Linux.
