### PR TITLE
11764.codecov token

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@
 # the coverage.
 #
 codecov:
+  token: fb52015a-b78e-4d89-a6e0-a4829aea2efa
   require_ci_to_pass: yes
   notify:
     # We have at least 5 builds in GitHub Actions,


### PR DESCRIPTION
## Scope and purpose

Fixes #11764

A lot of support forum posts on the internet say that including your token reduces the frequency of these errors.
