### PR TITLE
#11776 Add redirection to moved dev-process page.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,4 @@ For a PR to be accepted:
 * All automated checks must pass
 * The changeset must have 100% patch test coverage
 
-Extensive contribution guidelines are [available online](https://docs.twisted.org/en/latest/core/development/dev-process.html)
+Extensive contribution guidelines are [available online](https://docs.twisted.org/en/latest/development/dev-process.html)

--- a/docs/core/development/dev-process.rst
+++ b/docs/core/development/dev-process.rst
@@ -3,4 +3,4 @@
 Redirecting to new dev process page
 ===================================
 
-The content of this page was moved to :doc:`Twisted naming convention </development/dev-process>`.
+The content of this page was moved to :doc:`Twisted development process </development/dev-process>`.

--- a/docs/core/development/dev-process.rst
+++ b/docs/core/development/dev-process.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Redirecting to new dev process page
+===================================
+
+The content of this page was moved to :doc:`Twisted naming convention </development/dev-process>`.


### PR DESCRIPTION
## Scope and purpose

Fixes #11776

See ticket description.



In the previous https://github.com/twisted/twisted/pull/11577 PR I forgot to create the redirection for dev-process.rst

This is done now.

Also, the CONTRIBUTORS file was updated with the link to the current page


# How to test

## Redirection link

The old page will provide a redirect link to the current canonical URL

The old page can be tested here https://twisted--11777.org.readthedocs.build/en/11777/core/development/dev-process.html


## Contributors link

The CONTRIBUTORS file now has the link to the current canonical URL

https://github.com/twisted/twisted/blob/11776-old-dev-process-redirect/CONTRIBUTING.md

