### PR TITLE
#11788 Pin tox to latest version 3 for GitHub Actions.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,7 +213,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox coverage
+        python -m pip install --upgrade pip tox=~3.0 coverage
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.
@@ -280,7 +280,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Run the checks
       run: |
@@ -316,7 +316,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Build apidocs
       run: |
@@ -333,7 +333,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Run the checks
       run: |
@@ -358,7 +358,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox pep517
+        python -m pip install --upgrade pip tox~=3.0 pep517
         rm -rf dist/*
         tox -e release-prepare
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,7 +213,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox<4 coverage
+        python -m pip install --upgrade pip tox~=3.0 coverage
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.
@@ -280,7 +280,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox<4
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Run the checks
       run: |
@@ -316,7 +316,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox<4
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Build apidocs
       run: |
@@ -333,7 +333,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox<4
+        python -m pip install --upgrade pip tox~=3.0
 
     - name: Run the checks
       run: |
@@ -358,7 +358,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox<4 pep517
+        python -m pip install --upgrade pip tox~=3.0 pep517
         rm -rf dist/*
         tox -e release-prepare
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,7 +213,7 @@ jobs:
     - uses: twisted/python-info-action@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox=~3.0 coverage
+        python -m pip install --upgrade pip tox<4 coverage
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.
@@ -280,7 +280,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox<4
 
     - name: Run the checks
       run: |
@@ -316,7 +316,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox<4
 
     - name: Build apidocs
       run: |
@@ -333,7 +333,7 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox<4
 
     - name: Run the checks
       run: |
@@ -358,7 +358,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox~=3.0 pep517
+        python -m pip install --upgrade pip tox<4 pep517
         rm -rf dist/*
         tox -e release-prepare
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ minversion=3.24.1
 requires=
     virtualenv>=20.7.2
     tox-wheel>=0.6.0
+    tox < 4
 skip_missing_interpreters=True
 envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,


### PR DESCRIPTION
## Scope and purpose

Fixes #11788

This tries to get our CI green again with the least effort.

In a separate PR we can look at removing our dependence on tox.
