### PR TITLE
Fixed missing import of attrs

### DIFF
--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -15,7 +15,7 @@ __all__ = ["ListenFDs"]
 from os import getpid
 from typing import Dict, List, Mapping, Optional, Sequence
 
-from attrs import Factory, define
+from attr import Factory, define
 
 
 @define


### PR DESCRIPTION
File included an import of attrs, incorrect import of which would throw `ModuleNotFoundError: No module named 'attrs'`. Spelling it this way seems to resolve the issue.