### PR TITLE
#11795 Update the return type of __aexit__

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -15,7 +15,7 @@ from asyncio import AbstractEventLoop, Future, iscoroutine
 from enum import Enum
 from functools import wraps
 from sys import exc_info
-from types import CoroutineType, GeneratorType, MappingProxyType
+from types import CoroutineType, GeneratorType, MappingProxyType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2004,7 +2004,10 @@ class _ConcurrencyPrimitive(ABC, Generic[_DeferredResultT]):
         return self.acquire()
 
     def __aexit__(
-        self, exc_type: bool, exc_val: bool, exc_tb: bool
+        self,
+        __exc_type: Optional[Type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType]
     ) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -2003,7 +2003,7 @@ class _ConcurrencyPrimitive(ABC, Generic[_DeferredResultT]):
         """
         return self.acquire()
 
-    def __aexit__(self, exc_type: bool, exc_val: bool, exc_tb: bool) -> Deferred[bool]:
+    def __aexit__(self, exc_type: bool, exc_val: bool, exc_tb: bool) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the
         # exception, if any.

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -2007,7 +2007,7 @@ class _ConcurrencyPrimitive(ABC, Generic[_DeferredResultT]):
         self,
         __exc_type: Optional[Type[BaseException]],
         __exc_value: Optional[BaseException],
-        __traceback: Optional[TracebackType]
+        __traceback: Optional[TracebackType],
     ) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -2003,7 +2003,9 @@ class _ConcurrencyPrimitive(ABC, Generic[_DeferredResultT]):
         """
         return self.acquire()
 
-    def __aexit__(self, exc_type: bool, exc_val: bool, exc_tb: bool) -> Deferred[Literal[False]]:
+    def __aexit__(
+        self, exc_type: bool, exc_val: bool, exc_tb: bool
+    ) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the
         # exception, if any.

--- a/src/twisted/newsfragments/11795.feature
+++ b/src/twisted/newsfragments/11795.feature
@@ -1,0 +1,1 @@
+twisted.internet.defer._ConcurrencyPrimitive.__aexit__ now has a more precise type annotation.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -3518,6 +3518,7 @@ class CoroutineContextVarsTests(unittest.TestCase):
         L{DeferredLock} can be used as an asynchronous context manager.
         """
         lock = DeferredLock()
+        d = None  # This makes mypy check that async with doesn't suppress exceptions.
         async with lock:
             self.assertTrue(lock.locked)
             d = lock.acquire()


### PR DESCRIPTION
## Scope and purpose

Fixes #11795

Specifying Literal[False] tells the type checker that this context manager doesn't suppress exceptions.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
