### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/src/twisted/newsfragments/11821.bugfix
+++ b/src/twisted/newsfragments/11821.bugfix
@@ -1,0 +1,2 @@
+BadZipfile (with a small f) has been deprecated since Python 3.2,
+use BadZipFile (big F) instead, added in 3.2.

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -175,7 +175,7 @@ class ZipstreamTests(unittest.TestCase):
 
     def test_invalidHeader(self):
         """
-        A zipfile entry with the wrong magic number should raise BadZipfile for
+        A zipfile entry with the wrong magic number should raise BadZipFile for
         readfile(), but that should not affect other files in the archive.
         """
         fn = self.makeZipFile(["test contents", "more contents"])
@@ -186,14 +186,14 @@ class ZipstreamTests(unittest.TestCase):
             scribble.seek(zeroOffset, 0)
             scribble.write(b"0" * 4)
         with zipstream.ChunkingZipFile(fn) as czf:
-            self.assertRaises(zipfile.BadZipfile, czf.readfile, "0")
+            self.assertRaises(zipfile.BadZipFile, czf.readfile, "0")
             with czf.readfile("1") as zfe:
                 self.assertEqual(zfe.read(), b"more contents")
 
     def test_filenameMismatch(self):
         """
         A zipfile entry with a different filename than is found in the central
-        directory should raise BadZipfile.
+        directory should raise BadZipFile.
         """
         fn = self.makeZipFile([b"test contents", b"more contents"])
         with zipfile.ZipFile(fn, "r") as zf:
@@ -204,14 +204,14 @@ class ZipstreamTests(unittest.TestCase):
             scribble.write(info.FileHeader())
 
         with zipstream.ChunkingZipFile(fn) as czf:
-            self.assertRaises(zipfile.BadZipfile, czf.readfile, "0")
+            self.assertRaises(zipfile.BadZipFile, czf.readfile, "0")
             with czf.readfile("1") as zfe:
                 self.assertEqual(zfe.read(), b"more contents")
 
     def test_unsupportedCompression(self):
         """
         A zipfile which describes an unsupported compression mechanism should
-        raise BadZipfile.
+        raise BadZipFile.
         """
         fn = self.mktemp()
         with zipfile.ZipFile(fn, "w") as zf:
@@ -223,7 +223,7 @@ class ZipstreamTests(unittest.TestCase):
             zi.compress_type = 1234
 
         with zipstream.ChunkingZipFile(fn) as czf:
-            self.assertRaises(zipfile.BadZipfile, czf.readfile, "0")
+            self.assertRaises(zipfile.BadZipFile, czf.readfile, "0")
 
     def test_extraData(self):
         """

--- a/src/twisted/python/zipstream.py
+++ b/src/twisted/python/zipstream.py
@@ -33,7 +33,7 @@ class ChunkingZipFile(zipfile.ZipFile):
 
         fheader = self.fp.read(zipfile.sizeFileHeader)
         if fheader[0:4] != zipfile.stringFileHeader:
-            raise zipfile.BadZipfile("Bad magic number for file header")
+            raise zipfile.BadZipFile("Bad magic number for file header")
 
         fheader = struct.unpack(zipfile.structFileHeader, fheader)
         fname = self.fp.read(fheader[zipfile._FH_FILENAME_LENGTH])
@@ -48,7 +48,7 @@ class ChunkingZipFile(zipfile.ZipFile):
             fname_str = fname.decode("cp437")
 
         if fname_str != zinfo.orig_filename:
-            raise zipfile.BadZipfile(
+            raise zipfile.BadZipFile(
                 'File name in directory "%s" and header "%s" differ.'
                 % (zinfo.orig_filename, fname_str)
             )
@@ -58,7 +58,7 @@ class ChunkingZipFile(zipfile.ZipFile):
         elif zinfo.compress_type == zipfile.ZIP_DEFLATED:
             return DeflatedZipFileEntry(self, zinfo.compress_size)
         else:
-            raise zipfile.BadZipfile(
+            raise zipfile.BadZipFile(
                 "Unsupported compression method %d for file %s"
                 % (zinfo.compress_type, name)
             )


### PR DESCRIPTION
## Scope and purpose

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
