### PR TITLE
11830 make process tests more reliable

### DIFF
--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -18,7 +18,8 @@ import signal
 import stat
 import sys
 import traceback
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from collections import defaultdict
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 
 _PS_CLOSE: int
 _PS_DUP2: int
@@ -629,6 +630,83 @@ def _listOpenFDs():
     return detector._listOpenFDs()
 
 
+def _getFileActions(
+    fdState: List[Tuple[int, bool]],
+    childToParentFD: Dict[int, int],
+    doClose: int,
+    doDup2: int,
+) -> List[Tuple[int, ...]]:
+    """
+    Get the C{file_actions} parameter for C{posix_spawn} based on the
+    parameters describing the current process state.
+
+    @param fdState: A list of 2-tuples of (file descriptor, close-on-exec
+        flag).
+
+    @param doClose: the integer to use for the 'close' instruction
+
+    @param doDup2: the integer to use for the 'dup2' instruction
+    """
+    fdStateDict = dict(fdState)
+    parentToChildren: Dict[int, List[int]] = defaultdict(list)
+    for inChild, inParent in childToParentFD.items():
+        parentToChildren[inParent].append(inChild)
+    allocated = set(fdStateDict)
+    allocated |= set(childToParentFD.values())
+    allocated |= set(childToParentFD.keys())
+    nextFD = 0
+
+    def allocateFD() -> int:
+        nonlocal nextFD
+        while nextFD in allocated:
+            nextFD += 1
+        allocated.add(nextFD)
+        return nextFD
+
+    result: List[Tuple[int, ...]] = []
+    relocations = {}
+    for inChild, inParent in sorted(childToParentFD.items()):
+        # The parent FD will later be reused by a child FD.
+        parentToChildren[inParent].remove(inChild)
+        if parentToChildren[inChild]:
+            new = relocations[inChild] = allocateFD()
+            result.append((doDup2, inChild, new))
+        if inParent in relocations:
+            result.append((doDup2, relocations[inParent], inChild))
+            if not parentToChildren[inParent]:
+                result.append((doClose, relocations[inParent]))
+        else:
+            if inParent == inChild:
+                if fdStateDict[inParent]:
+                    # If the child is attempting to inherit the parent as-is,
+                    # and it is not close-on-exec, the job is already done; we
+                    # can bail.  Otherwise...
+
+                    tempFD = allocateFD()
+                    # The child wants to inherit the parent as-is, so the
+                    # handle must be heritable.. dup2 makes the new descriptor
+                    # inheritable by default, *but*, per the man page, “if
+                    # fildes and fildes2 are equal, then dup2() just returns
+                    # fildes2; no other changes are made to the existing
+                    # descriptor”, so we need to dup it somewhere else and dup
+                    # it back before closing the temporary place we put it.
+                    result.extend(
+                        [
+                            (doDup2, inParent, tempFD),
+                            (doDup2, tempFD, inChild),
+                            (doClose, tempFD),
+                        ]
+                    )
+            else:
+                result.append((doDup2, inParent, inChild))
+
+    for eachFD, uninheritable in fdStateDict.items():
+        if eachFD not in childToParentFD and not uninheritable:
+            result.append((doClose, eachFD))
+
+    return result
+
+
 @implementer(IProcessTransport)
 class Process(_BaseProcess):
     """
@@ -791,33 +869,16 @@ class Process(_BaseProcess):
         ):
             return False
         fdmap = kwargs.get("fdmap")
-        dupSources = set(fdmap.values())
-        shouldEventuallyClose = _listOpenFDs()
-        closeBeforeDup = []
-        closeAfterDup = []
-        for eachFD in shouldEventuallyClose:
+        fdState = []
+        for eachFD in _listOpenFDs():
             try:
                 isCloseOnExec = fcntl.fcntl(eachFD, fcntl.F_GETFD, fcntl.FD_CLOEXEC)
             except OSError:
                 pass
             else:
-                if eachFD not in fdmap and not isCloseOnExec:
-                    (closeAfterDup if eachFD in dupSources else closeBeforeDup).append(
-                        (_PS_CLOSE, eachFD)
-                    )
-
+                fdState.append((eachFD, isCloseOnExec))
         if environment is None:
             environment = {}
-
-        fileActions = (
-            closeBeforeDup
-            + [
-                (_PS_DUP2, parentFD, childFD)
-                for (childFD, parentFD) in fdmap.items()
-                if childFD != parentFD
-            ]
-            + closeAfterDup
-        )
 
         setSigDef = [
             everySignal
@@ -829,7 +890,9 @@ class Process(_BaseProcess):
             executable,
             args,
             environment,
-            file_actions=fileActions,
+            file_actions=_getFileActions(
+                fdState, fdmap, doClose=_PS_CLOSE, doDup2=_PS_DUP2
+            ),
             setsigdef=setSigDef,
         )
         self.status = -1

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -82,7 +82,7 @@ def onlyOnPOSIX(testMethod):
 
     @return: the C{testMethod} argument.
     """
-    if os.name == "posix":
+    if os.name != "posix":
         testMethod.skip = "Test only applies to POSIX platforms."
     return testMethod
 

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -396,14 +396,6 @@ class ProcessTestsBuilderBase(ReactorBuilder):
         self.assertEqual(result, [b"Foo" + os.linesep.encode("ascii")])
 
     @skipIf(platform.isWindows(), "Test only applies to POSIX platforms.")
-    # If you see this comment and are running on macOS, try to see if this pass on your environment.
-    # Only run this test on Linux and macOS local tests and Linux CI platforms.
-    # This should be used for POSIX tests that are expected to pass on macOS but which fail due to lack of macOS developers.
-    # We still want to run it on local development macOS environments to help developers discover and fix this issue.
-    @skipIf(
-        platform.isMacOSX() and os.environ.get("CI", "").lower() == "true",
-        "Skipped on macOS CI env.",
-    )
     def test_openFileDescriptors(self):
         """
         Processes spawned with spawnProcess() close all extraneous file

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -23,7 +23,6 @@ from twisted.internet import utils
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 from twisted.internet.error import ProcessDone, ProcessTerminated
 from twisted.internet.interfaces import IProcessTransport, IReactorProcess
-from twisted.internet.process import _getFileActions
 from twisted.internet.protocol import ProcessProtocol
 from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.python.compat import networkString
@@ -51,6 +50,7 @@ except ImportError:
     _uidgidSkipReason = "Cannot change UID/GID on Windows"
 else:
     process = _process
+    from twisted.internet.process import _getFileActions
 
 
 def _getRealMaxOpenFiles() -> int:
@@ -1134,6 +1134,7 @@ CLOSE = 9999
 DUP2 = 10101
 
 
+@onlyOnPOSIX
 class GetFileActionsTests(SynchronousTestCase):
     """
     Tests to make sure that the file actions computed for posix_spawn are

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -446,14 +446,20 @@ sys.stdout.flush()"""
 
         reactor = self.buildReactor()
 
-        reactor.callWhenRunning(
-            reactor.spawnProcess,
-            GatheringProtocol(),
-            pyExe,
-            [pyExe, b"-Wignore", b"-c", source],
-            env=properEnv,
-            usePTY=self.usePTY,
-        )
+        def doSpawn() -> None:
+            try:
+                reactor.spawnProcess(
+                    GatheringProtocol(),
+                    pyExe,
+                    [pyExe, b"-Wignore", b"-c", source],
+                    env=properEnv,
+                    usePTY=self.usePTY,
+                )
+            except BaseException:
+                err()
+                reactor.stop()
+
+        reactor.callWhenRunning(doSpawn)
 
         self.runReactor(reactor)
         reportedChildFDs = set(eval(output.getvalue()))


### PR DESCRIPTION
## Scope and purpose

Fixes #11830

this splits out the file_actions calculation to its own function so tricky edge cases can be tested independently, and it fixes some getrlimit bugginess on macOS

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
