### PR TITLE
remove pyasn1 from conch and everywhere else

### DIFF
--- a/docs/installation/howto/optional.rst
+++ b/docs/installation/howto/optional.rst
@@ -33,7 +33,6 @@ The following optional dependencies are supported:
 
 * **conch** - packages for working with conch/SSH.
 
-  * `pyasn1`_
   * `cryptography`_
 
 * **conch-nacl** - **conch** options and `PyNaCl`_ to support Ed25519 keys on systems with OpenSSL < 1.1.1b.
@@ -65,7 +64,6 @@ The following optional dependencies are supported:
 .. _pydoctor: https://pypi.python.org/pypi/pydoctor
 .. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL
 .. _service_identity: https://pypi.python.org/pypi/service_identity
-.. _pyasn1: https://pypi.python.org/pypi/pyasn1
 .. _cryptography: https://pypi.python.org/pypi/cryptography
 .. _PyNaCl: https://pypi.python.org/pypi/PyNaCl
 .. _SOAPpy: https://pypi.python.org/pypi/SOAPpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ tls = [
 ]
 
 conch = [
-    "pyasn1 >= 0.4",
     "cryptography >= 3.3",
     "appdirs >= 1.4.0",
     "bcrypt >= 3.1.3",

--- a/src/twisted/conch/newsfragments/11843.removal
+++ b/src/twisted/conch/newsfragments/11843.removal
@@ -1,1 +1,5 @@
 PyAsn1 has been removed as a conch dependency.
+
+twisted.conch.ssh.keys.Key no longer supports loading "alternate" OpenSSH private keys.
+These are some private keys that at some point were handled by OpenSSH but for which no specification exists.
+For more info about these OpenSSH keys see https://github.com/twisted/twisted/issues/3008.

--- a/src/twisted/conch/newsfragments/11843.removal
+++ b/src/twisted/conch/newsfragments/11843.removal
@@ -1,0 +1,1 @@
+PyAsn1 has been removed as a conch dependency.

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -8,7 +8,6 @@ Handling of RSA, DSA, ECDSA, and Ed25519 keys.
 
 
 import binascii
-import itertools
 import struct
 import unicodedata
 import warnings
@@ -27,12 +26,6 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
     load_ssh_public_key,
 )
-from pyasn1.codec.ber import (  # type: ignore[import]
-    decoder as berDecoder,
-    encoder as berEncoder,
-)
-from pyasn1.error import PyAsn1Error  # type: ignore[import]
-from pyasn1.type import univ  # type: ignore[import]
 
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_to_bytes
@@ -516,90 +509,21 @@ class Key:
         """
         lines = data.strip().splitlines()
         kind = lines[0][11:-17]
-        if lines[1].startswith(b"Proc-Type: 4,ENCRYPTED"):
-            if not passphrase:
-                raise EncryptedKeyError(
-                    "Passphrase must be provided " "for an encrypted key"
-                )
-
-            # Determine cipher and initialization vector
+        # cryptography considers an empty byte string a passphrase, but
+        # twisted considers that to be "no password". So we need to convert
+        # to None on empty.
+        if not passphrase:
+            passphrase = None
+        if kind in (b"EC", b"RSA", b"DSA"):
             try:
-                _, cipherIVInfo = lines[2].split(b" ", 1)
-                cipher, ivdata = cipherIVInfo.rstrip().split(b",", 1)
+                key = load_pem_private_key(data, passphrase, default_backend())
+            except TypeError:
+                raise EncryptedKeyError(
+                    "Passphrase must be provided for an encrypted key"
+                )
             except ValueError:
-                raise BadKeyError(f"invalid DEK-info {lines[2]!r}")
-
-            if cipher in (b"AES-128-CBC", b"AES-256-CBC"):
-                algorithmClass = algorithms.AES
-                keySize = int(cipher.split(b"-")[1]) // 8
-                if len(ivdata) != 32:
-                    raise BadKeyError("AES encrypted key with a bad IV")
-            elif cipher == b"DES-EDE3-CBC":
-                algorithmClass = algorithms.TripleDES
-                keySize = 24
-                if len(ivdata) != 16:
-                    raise BadKeyError("DES encrypted key with a bad IV")
-            else:
-                raise BadKeyError(f"unknown encryption type {cipher!r}")
-
-            # Extract keyData for decoding
-            iv = bytes(
-                bytearray(int(ivdata[i : i + 2], 16) for i in range(0, len(ivdata), 2))
-            )
-            ba = md5(passphrase + iv[:8]).digest()
-            bb = md5(ba + passphrase + iv[:8]).digest()
-            decKey = (ba + bb)[:keySize]
-            b64Data = decodebytes(b"".join(lines[3:-1]))
-
-            decryptor = Cipher(
-                algorithmClass(decKey), modes.CBC(iv), backend=default_backend()
-            ).decryptor()
-            keyData = decryptor.update(b64Data) + decryptor.finalize()
-
-            removeLen = ord(keyData[-1:])
-            keyData = keyData[:-removeLen]
-        else:
-            b64Data = b"".join(lines[1:-1])
-            keyData = decodebytes(b64Data)
-
-        try:
-            decodedKey = berDecoder.decode(keyData)[0]
-        except PyAsn1Error as asn1Error:
-            raise BadKeyError(f"Failed to decode key (Bad Passphrase?): {asn1Error}")
-
-        if kind == b"EC":
-            return cls(load_pem_private_key(data, passphrase, default_backend()))
-
-        if kind == b"RSA":
-            if len(decodedKey) == 2:  # Alternate RSA key
-                decodedKey = decodedKey[0]
-            if len(decodedKey) < 6:
-                raise BadKeyError("RSA key failed to decode properly")
-
-            n, e, d, p, q, dmp1, dmq1, iqmp = (int(value) for value in decodedKey[1:9])
-            return cls(
-                rsa.RSAPrivateNumbers(
-                    p=p,
-                    q=q,
-                    d=d,
-                    dmp1=dmp1,
-                    dmq1=dmq1,
-                    iqmp=iqmp,
-                    public_numbers=rsa.RSAPublicNumbers(e=e, n=n),
-                ).private_key(default_backend())
-            )
-        elif kind == b"DSA":
-            p, q, g, y, x = (int(value) for value in decodedKey[1:6])
-            if len(decodedKey) < 6:
-                raise BadKeyError("DSA key failed to decode properly")
-            return cls(
-                dsa.DSAPrivateNumbers(
-                    x=x,
-                    public_numbers=dsa.DSAPublicNumbers(
-                        y=y, parameter_numbers=dsa.DSAParameterNumbers(p=p, q=q, g=g)
-                    ),
-                ).private_key(backend=default_backend())
-            )
+                raise BadKeyError("Failed to decode key (Bad Passphrase?)")
+            return cls(key)
         else:
             raise BadKeyError(f"unknown key type {kind}")
 
@@ -1563,74 +1487,23 @@ class Key:
         @param passphrase: The passphrase to encrypt the key with, or L{None}
         if it is not encrypted.
         """
-        if self.type() == "EC":
-            # EC keys has complex ASN.1 structure hence we do this this way.
-            if not passphrase:
-                # unencrypted private key
-                encryptor = serialization.NoEncryption()
-            else:
-                encryptor = serialization.BestAvailableEncryption(passphrase)
-
+        if not passphrase:
+            # unencrypted private key
+            encryptor = serialization.NoEncryption()
+        else:
+            encryptor = serialization.BestAvailableEncryption(passphrase)
+        if self.type() != "Ed25519":
             return self._keyObject.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
                 encryptor,
             )
-        elif self.type() == "Ed25519":
+        else:
+            # TODO: why not just support serialization here
+            assert self.type() == "Ed25519"
             raise ValueError(
                 "cannot serialize Ed25519 key to OpenSSH PEM format; use v1 " "instead"
             )
-
-        data = self.data()
-        lines = [
-            b"".join(
-                (b"-----BEGIN ", self.type().encode("ascii"), b" PRIVATE KEY-----")
-            )
-        ]
-        if self.type() == "RSA":
-            p, q = data["p"], data["q"]
-            iqmp = rsa.rsa_crt_iqmp(p, q)
-            objData = (
-                0,
-                data["n"],
-                data["e"],
-                data["d"],
-                p,
-                q,
-                data["d"] % (p - 1),
-                data["d"] % (q - 1),
-                iqmp,
-            )
-        else:
-            objData = (0, data["p"], data["q"], data["g"], data["y"], data["x"])
-        asn1Sequence = univ.Sequence()
-        for index, value in zip(itertools.count(), objData):
-            asn1Sequence.setComponentByPosition(index, univ.Integer(value))
-        asn1Data = berEncoder.encode(asn1Sequence)
-        if passphrase:
-            iv = randbytes.secureRandom(8)
-            hexiv = "".join([f"{ord(x):02X}" for x in iterbytes(iv)])
-            hexiv = hexiv.encode("ascii")
-            lines.append(b"Proc-Type: 4,ENCRYPTED")
-            lines.append(b"DEK-Info: DES-EDE3-CBC," + hexiv + b"\n")
-            ba = md5(passphrase + iv).digest()
-            bb = md5(ba + passphrase + iv).digest()
-            encKey = (ba + bb)[:24]
-            padLen = 8 - (len(asn1Data) % 8)
-            asn1Data += bytes((padLen,)) * padLen
-
-            encryptor = Cipher(
-                algorithms.TripleDES(encKey), modes.CBC(iv), backend=default_backend()
-            ).encryptor()
-
-            asn1Data = encryptor.update(asn1Data) + encryptor.finalize()
-
-        b64Data = encodebytes(asn1Data).replace(b"\n", b"")
-        lines += [b64Data[i : i + 64] for i in range(0, len(b64Data), 64)]
-        lines.append(
-            b"".join((b"-----END ", self.type().encode("ascii"), b" PRIVATE KEY-----"))
-        )
-        return b"\n".join(lines)
 
     def _toString_OPENSSH(self, subtype=None, comment=None, passphrase=None):
         """

--- a/src/twisted/conch/test/keydata.py
+++ b/src/twisted/conch/test/keydata.py
@@ -283,38 +283,6 @@ Zrcid5rr3dXSMEbK4tdeQZvPtUg1Uaol3N7bNClIIdvWdPx+5S9T95wJcLnkoHam
 rXp0IjScTxfLP+Cq5V6lJ94/pX8Ppoj1FdZfNxeS4NYFSRA7kvY=
 -----END RSA PRIVATE KEY-----"""
 
-# Some versions of OpenSSH generate these (slightly different keys): the PKCS#1
-# structure is wrapped in an extra ASN.1 SEQUENCE and there's an empty SEQUENCE
-# following it. It is not any standard key format and was probably a bug in
-# OpenSSH at some point.
-privateRSA_openssh_alternate = b"""-----BEGIN RSA PRIVATE KEY-----
-MIIEqDCCBKICAQACggEBANVqrHgj1tYb7CWhUMR3Y1CERQFVQhQqKuDQYO7U6aOt
-Svo5Bl6EVXVfADa/b6oqP4MmN8FpLlv98PPSfdaYzTpAeNXKqBjAEZMkCQyBTI/3
-nO0TFmqkBOlJd8PkVWSzeWieLAjrrOgELSF3BaeO71MwDaXluz1q4gk2b/00031v
-Rv+H2qkpJ6r/rfWF5j4auHodSrHqwFr3MN8fwqTk7z+RSZZA1Rl3LTfDXuydpjpE
-pcKkKd3Vupw9RbPGLBhk1bo936t/zUKsp/EYC6BYFWILpCpuQ8PkBJ81o0eORu0z
-pWW9vDspbgILV9906BO0NzV+g18gJmCm3K2Lxmx5mPcCAwEAAQKCAQAhTAhmoijV
-tPuOD3IbhQkAufJON/AcV0vjUX+eI6fkOphVG+qLepgevNi6sfmJEhhgrOjMC04J
-WkBqui+Z+LMkYIS5zmmVmvni/B9RTScV2ysnre+0aay+fRDrhkdwc7QAh5UVOzf5
-5xTngLtoHhvm3btzY7ln5rInf8/PMJvCmP3ZGDYvNi7xPYF6n+EDLUfbNFFiOd1P
-6ayoi9nW84TEF7lxnQYIQnhNu8Uq9MNYzVUr7b4zXwTqe+YEJGPyLdc9G2zVnGND
-L5KIjT5u2hg32A8lZ4kduUY0XsnOxIvtklozBw/fhgj5kunb6zgINsnNzQoBSFs5
-PnrKxoCp3NQ5AoGBANlwBtjivNR4kVCU1MEbiThsRmRaUaCaBz1IjwNRzGsSjn0a
-sWXncXU54DIFdY0YTK+TsUmxZl94YnrRDMrmTUOznPRrfeYMmNzPIWKO1S4S3gSu
-1yRugzGiFaJEPSKpYiYiubLtVAqdCIOnBw3/GRiO2Ksd2kicMWgRoWZt49gdAoGB
-APtEF4ukNr4eNx2n9mFsBMSq3Xg+B4weMwKuAxSHg3rlnn0IZ6jyqr8ScM9yqafH
-Cx2I1SD9nGPKRzBVTovEz/R/FqSSEnShCcLEbpyMM++l5ffgK61PXBGqGoQ3W/16
-6sPNfLDI5B9UY7XHr9/0Caf8xyX8XOmR15LFmB5W07EjAoGAUa/pkp+UC0qEZT6U
-szuSELV0uIzJ78kOATL6L2gSoQMmrs9RaBRMJpsopAIzCF/hp3CYATR5XlKOxM82
-vB9LVazrwVOEx+FhqErUov9ADYAfEqlQwCoYdZQMBpsWUKhL7EHNe+/3S8l1AmjE
-mLiGiBhaQ+cCM5ciZJODDEUqfO0CgYBpZjfGQN0hxQTzsLg+R5R8dvwt6z85PJXD
-QwFRxEKX8+gWpMbu7NRJEFA4BO47zdfQzMwyaZAHoBtan/4xzR46fnEeGZQaTk8M
-319S1dEXbuzXnLZVnduOIV+8JIi2/K+r8O+kLLDcn4awAxK4i+LdD8DuIz1KUP4v
-uClGWL+2JwKBgGYW+SA00FQlvGExrIL775w1Hn5KVQJolQ0Kk74ev+FA+pCnVHAx
-6Xj84Ga3Inea693V0jBGyuLXXkGbz7VINVGqJdze2zQpSCHb1nT8fuUvU/ecCXC5
-5KB2pq16dCI0nE8Xyz/gquVepSfeP6V/D6aI9RXWXzcXkuDWBUkQO5L2MAA=
------END RSA PRIVATE KEY-----"""
-
 # New format introduced in OpenSSH 6.5
 privateRSA_openssh_new = b"""-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
@@ -653,5 +621,4 @@ __all__ = [
     "publicDSA_openssh",
     "publicRSA_lsh",
     "publicRSA_openssh",
-    "privateRSA_openssh_alternate",
 ]

--- a/src/twisted/conch/test/test_agent.py
+++ b/src/twisted/conch/test/test_agent.py
@@ -18,13 +18,6 @@ else:
     cryptography = _cryptography
 
 try:
-    import pyasn1 as _pyasn1  # type: ignore[import]
-except ImportError:
-    pyasn1 = None
-else:
-    pyasn1 = _pyasn1
-
-try:
     from twisted.conch.ssh import agent as _agent, keys as _keys
 except ImportError:
     keys = agent = None
@@ -51,7 +44,7 @@ class AgentTestBase(unittest.TestCase):
     """
 
     if agent is None or keys is None:
-        skip = "Cannot run without cryptography or PyASN1"
+        skip = "Cannot run without cryptography"
 
     def setUp(self):
         # wire up our client <-> server

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -33,11 +33,10 @@ from twisted.python.procutils import which
 from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
 
-pyasn1 = requireModule("pyasn1")
 cryptography = requireModule("cryptography")
 unix = requireModule("twisted.conch.unix")
 
-if cryptography and pyasn1:
+if cryptography:
     try:
         from twisted.conch.scripts import cftp
         from twisted.conch.scripts.cftp import SSHSession
@@ -50,11 +49,11 @@ if cryptography and pyasn1:
         pass
 
 skipTests = False
-if None in (unix, cryptography, pyasn1, interfaces.IReactorProcess(reactor, None)):
+if None in (unix, cryptography, interfaces.IReactorProcess(reactor, None)):
     skipTests = True
 
 
-@skipIf(skipTests, "don't run w/o spawnProcess or cryptography or pyasn1")
+@skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 class SSHSessionTests(TestCase):
     """
     Tests for L{twisted.conch.scripts.cftp.SSHSession}.
@@ -388,7 +387,7 @@ class InMemoryRemoteFile(BytesIO):
         return BytesIO.getvalue(self)
 
 
-@skipIf(skipTests, "don't run w/o spawnProcess or cryptography or pyasn1")
+@skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 class StdioClientTests(TestCase):
     """
     Tests for L{cftp.StdioClient}.
@@ -931,7 +930,7 @@ class CFTPClientTestBase(SFTPTestBase):
         return SFTPTestBase.tearDown(self)
 
 
-@skipIf(skipTests, "don't run w/o spawnProcess or cryptography or pyasn1")
+@skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 class OurServerCmdLineClientTests(CFTPClientTestBase):
     """
     Functional tests which launch a SFTP server over TCP on localhost and check
@@ -1330,7 +1329,7 @@ class OurServerCmdLineClientTests(CFTPClientTestBase):
         return d
 
 
-@skipIf(skipTests, "don't run w/o spawnProcess or cryptography or pyasn1")
+@skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 class OurServerBatchFileTests(CFTPClientTestBase):
     """
     Functional tests which launch a SFTP server over localhost and checks csftp
@@ -1434,7 +1433,7 @@ exit
         return d
 
 
-@skipIf(skipTests, "don't run w/o spawnProcess or cryptography or pyasn1")
+@skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 @skipIf(not which("ssh"), "no ssh command-line client available")
 @skipIf(not which("sftp"), "no sftp command-line client available")
 class OurServerSftpClientTests(CFTPClientTestBase):

--- a/src/twisted/conch/test/test_checkers.py
+++ b/src/twisted/conch/test/test_checkers.py
@@ -38,14 +38,14 @@ from twisted.python.reflect import requireModule
 from twisted.test.test_process import MockOS
 from twisted.trial.unittest import TestCase
 
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     dependencySkip = None
     from twisted.conch import checkers
     from twisted.conch.error import NotEnoughAuthentication, ValidPublicKey
     from twisted.conch.ssh import keys
     from twisted.conch.test import keydata
 else:
-    dependencySkip = "can't run without cryptography and PyASN1"
+    dependencySkip = "can't run without cryptography"
 
 if getattr(os, "geteuid", None) is not None:
     euidSkip = None

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -22,7 +22,7 @@ from twisted.python.filepath import FilePath
 from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
 
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     from twisted.conch.scripts.ckeygen import (
         _getKeyOrDefault,
         _saveKey,
@@ -38,7 +38,7 @@ if requireModule("cryptography") and requireModule("pyasn1"):
         Key,
     )
 else:
-    skip = "cryptography and pyasn1 required for twisted.conch.scripts.ckeygen"
+    skip = "cryptography required for twisted.conch.scripts.ckeygen"
 
 
 def makeGetpass(*passphrases):

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -38,7 +38,6 @@ try:
 except ImportError:
     pass
 
-pyasn1 = requireModule("pyasn1")
 cryptography = requireModule("cryptography")
 
 if cryptography:
@@ -314,9 +313,6 @@ run()"""
 class ConchServerSetupMixin:
     if not cryptography:
         skip = "can't run without cryptography"
-
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
 
     @staticmethod
     def realmFactory():

--- a/src/twisted/conch/test/test_default.py
+++ b/src/twisted/conch/test/test_default.py
@@ -21,7 +21,7 @@ from twisted.trial.unittest import TestCase
 doSkip = False
 skipReason = ""
 
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     from twisted.conch.client import default
     from twisted.conch.client.agent import SSHAgentClient
     from twisted.conch.client.default import SSHUserAuthClient
@@ -29,7 +29,7 @@ if requireModule("cryptography") and requireModule("pyasn1"):
     from twisted.conch.ssh.keys import Key
 else:
     doSkip = True
-    skipReason = "cryptography and PyASN1 required for twisted.conch.client.default."
+    skipReason = "cryptography required for twisted.conch.client.default."
     skip = skipReason  # no SSL available, skip the entire module
 
 if platform.isWindows():

--- a/src/twisted/conch/test/test_endpoints.py
+++ b/src/twisted/conch/test/test_endpoints.py
@@ -41,7 +41,7 @@ from twisted.python.log import msg
 from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
 
-if requireModule("cryptography") and requireModule("pyasn1.type"):
+if requireModule("cryptography"):
     from twisted.conch.avatar import ConchUser
     from twisted.conch.checkers import InMemorySSHKeyDB, SSHPublicKeyChecker
     from twisted.conch.client.knownhosts import ConsoleUI, KnownHostsFile
@@ -69,7 +69,7 @@ if requireModule("cryptography") and requireModule("pyasn1.type"):
         publicRSA_openssh,
     )
 else:
-    skip = "can't run w/o cryptography and pyasn1"
+    skip = "can't run w/o cryptography"
     SSHFactory = object  # type: ignore[assignment,misc]
     SSHUserAuthServer = object  # type: ignore[assignment,misc]
     SSHConnection = object  # type: ignore[assignment,misc]

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -20,11 +20,10 @@ cryptography = requireModule("cryptography")
 if cryptography is None:
     skipCryptography = "Cannot run without cryptography."
 
-pyasn1 = requireModule("pyasn1")
 _keys_pynacl = requireModule("twisted.conch.ssh._keys_pynacl")
 
 
-if cryptography and pyasn1:
+if cryptography:
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
@@ -49,8 +48,6 @@ class KeyTests(unittest.TestCase):
 
     if cryptography is None:
         skip = skipCryptography
-    if pyasn1 is None:
-        skip = "Cannot run without PyASN1"
 
     def setUp(self):
         self.rsaObj = keys.Key._fromRSAComponents(
@@ -279,10 +276,6 @@ class KeyTests(unittest.TestCase):
             keys.Key.fromString(
                 keydata.privateRSA_openssh_encrypted, passphrase=b"encrypted"
             ),
-            keys.Key.fromString(keydata.privateRSA_openssh),
-        )
-        self.assertEqual(
-            keys.Key.fromString(keydata.privateRSA_openssh_alternate),
             keys.Key.fromString(keydata.privateRSA_openssh),
         )
         self._testPublicPrivateFromString(
@@ -1155,10 +1148,9 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         L{keys.Key.toString} serializes an RSA key in OpenSSH format.
         """
         key = keys.Key.fromString(keydata.privateRSA_agentv3)
-        self.assertEqual(key.toString("openssh"), keydata.privateRSA_openssh)
-        self.assertEqual(
-            key.toString("openssh", passphrase=b"encrypted"),
-            keydata.privateRSA_openssh_encrypted,
+        self.assertEqual(key.toString("openssh").strip(), keydata.privateRSA_openssh)
+        self.assertTrue(
+            key.toString("openssh", passphrase=b"encrypted").find(b"DEK-Info") > 0
         )
         self.assertEqual(
             key.public().toString("openssh"), keydata.publicRSA_openssh[:-8]
@@ -1191,7 +1183,7 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
         L{keys.Key.toString} serializes a DSA key in OpenSSH format.
         """
         key = keys.Key.fromString(keydata.privateDSA_lsh)
-        self.assertEqual(key.toString("openssh"), keydata.privateDSA_openssh)
+        self.assertEqual(key.toString("openssh").strip(), keydata.privateDSA_openssh)
         self.assertEqual(
             key.public().toString("openssh", comment=b"comment"),
             keydata.publicDSA_openssh,

--- a/src/twisted/conch/test/test_knownhosts.py
+++ b/src/twisted/conch/test/test_knownhosts.py
@@ -21,7 +21,7 @@ from twisted.python.reflect import requireModule
 from twisted.test.testutils import ComparisonTestsMixin
 from twisted.trial.unittest import TestCase
 
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     from twisted.conch.client import default
     from twisted.conch.client.knownhosts import (
         ConsoleUI,
@@ -33,7 +33,7 @@ if requireModule("cryptography") and requireModule("pyasn1"):
     from twisted.conch.ssh.keys import BadKeyError, Key
     from twisted.conch.test import keydata
 else:
-    skip = "cryptography and PyASN1 required for twisted.conch.knownhosts."
+    skip = "cryptography required for twisted.conch.knownhosts."
 
 
 sampleEncodedKey = (

--- a/src/twisted/conch/test/test_manhole_tap.py
+++ b/src/twisted/conch/test/test_manhole_tap.py
@@ -15,9 +15,8 @@ from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
 
 cryptography = requireModule("cryptography")
-pyasn1 = requireModule("pyasn1")
 
-if cryptography and pyasn1:
+if cryptography:
     from twisted.conch import manhole_ssh, manhole_tap
 
 
@@ -28,9 +27,6 @@ class MakeServiceTests(TestCase):
 
     if not cryptography:
         skip = "can't run without cryptography"
-
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
 
     usernamePassword = (b"iamuser", b"thisispassword")
 

--- a/src/twisted/conch/test/test_openssh_compat.py
+++ b/src/twisted/conch/test/test_openssh_compat.py
@@ -17,11 +17,11 @@ from twisted.trial.unittest import TestCase
 
 doSkip = False
 skipReason = ""
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     from twisted.conch.openssh_compat.factory import OpenSSHFactory
 else:
     doSkip = True
-    skipReason = "Cannot run without cryptography or PyASN1"
+    skipReason = "Cannot run without cryptography"
 
 if not hasattr(os, "geteuid"):
     doSkip = True

--- a/src/twisted/conch/test/test_scripts.py
+++ b/src/twisted/conch/test/test_scripts.py
@@ -14,10 +14,6 @@ from twisted.trial.unittest import TestCase
 doSkip = False
 skipReason = ""
 
-if not requireModule("pyasn1"):
-    doSkip = True
-    skipReason = "Cannot run without PyASN1"
-
 if not requireModule("cryptography"):
     doSkip = True
     cryptoSkip = "can't run w/o cryptography"

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -26,7 +26,6 @@ from twisted.python.reflect import requireModule
 from twisted.trial import unittest
 
 cryptography = requireModule("cryptography")
-pyasn1 = requireModule("pyasn1")
 
 if cryptography:
     from twisted.conch import avatar, error
@@ -312,7 +311,7 @@ class SuperEchoTransport:
         self.proto.processEnded(failure.Failure(ProcessTerminated(0, None, None)))
 
 
-if cryptography is not None and pyasn1 is not None:
+if cryptography is not None:
     from twisted.conch import checkers
     from twisted.conch.ssh import (
         channel,
@@ -554,9 +553,6 @@ class SSHProtocolTests(unittest.TestCase):
 
     if not cryptography:
         skip = "can't run without cryptography"
-
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
 
     def _ourServerOurClientTest(self, name=b"session", **kwargs):
         """
@@ -866,9 +862,6 @@ class SSHFactoryTests(unittest.TestCase):
     if not cryptography:
         skip = "can't run without cryptography"
 
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
-
     def makeSSHFactory(self, primes=None):
         sshFactory = factory.SSHFactory()
         sshFactory.getPrimes = lambda: primes
@@ -980,9 +973,6 @@ class MPTests(unittest.TestCase):
 
     if not cryptography:
         skip = "can't run without cryptography"
-
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
 
     if cryptography:
         getMP = staticmethod(common.getMP)

--- a/src/twisted/conch/test/test_tap.py
+++ b/src/twisted/conch/test/test_tap.py
@@ -16,11 +16,10 @@ from twisted.python.reflect import requireModule
 from twisted.trial.unittest import TestCase
 
 cryptography = requireModule("cryptography")
-pyasn1 = requireModule("pyasn1")
 unix = requireModule("twisted.conch.unix")
 
 
-if cryptography and pyasn1 and unix:
+if cryptography and unix:
     from twisted.conch import tap
     from twisted.conch.openssh_compat.factory import OpenSSHFactory
 
@@ -32,9 +31,6 @@ class MakeServiceTests(TestCase):
 
     if not cryptography:
         skip = "can't run without cryptography"
-
-    if not pyasn1:
-        skip = "Cannot run without PyASN1"
 
     if not unix:
         skip = "can't run on non-posix computers"

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -26,11 +26,10 @@ from twisted.python.reflect import requireModule
 from twisted.test import proto_helpers
 from twisted.trial.unittest import TestCase
 
-pyasn1 = requireModule("pyasn1")
 cryptography = requireModule("cryptography")
 
 dependencySkip: Optional[str]
-if pyasn1 and cryptography:
+if cryptography:
     dependencySkip = None
     from cryptography.exceptions import UnsupportedAlgorithm
     from cryptography.hazmat.backends import default_backend
@@ -42,9 +41,7 @@ if pyasn1 and cryptography:
 
     X25519_SUPPORTED = default_backend().x25519_supported()
 else:
-    if not pyasn1:
-        dependencySkip = "Cannot run without PyASN1"
-    elif not cryptography:
+    if not cryptography:
         dependencySkip = "can't run without cryptography"
     X25519_SUPPORTED = False
 

--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -23,7 +23,7 @@ from twisted.python.reflect import requireModule
 from twisted.trial import unittest
 
 keys: Optional[ModuleType] = None
-if requireModule("cryptography") and requireModule("pyasn1"):
+if requireModule("cryptography"):
     from twisted.conch.checkers import SSHProtocolChecker
     from twisted.conch.ssh import keys, transport, userauth
     from twisted.conch.ssh.common import NS
@@ -903,7 +903,7 @@ class SSHUserAuthClientTests(unittest.TestCase):
 class LoopbackTests(unittest.TestCase):
 
     if keys is None:
-        skip = "cannot run without cryptography or PyASN1"
+        skip = "cannot run without cryptography"
 
     class Factory:
         class Service:
@@ -962,7 +962,7 @@ class LoopbackTests(unittest.TestCase):
 
 class ModuleInitializationTests(unittest.TestCase):
     if keys is None:
-        skip = "cannot run without cryptography or PyASN1"
+        skip = "cannot run without cryptography"
 
     def test_messages(self):
         # Several message types have value 60, check that MSG_USERAUTH_PK_OK

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -419,7 +419,6 @@ class FileDBCheckerTests(TestCase):
 
 @skipIf(not pwd, "Required module not available: pwd")
 @skipIf(not requireModule("cryptography"), "cryptography is not available")
-@skipIf(not requireModule("pyasn1"), "pyasn1 is not available")
 class SSHCheckerTests(TestCase):
     """
     Tests for the C{--auth=sshkey:...} checker.  The majority of the

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,6 @@ deps =
     mindeps: service_identity == 18.1.0
     mindeps: idna == 2.4
     # Conch
-    mindeps: pyasn1 == 0.4.8
     mindeps: cryptography == 3.3
     mindeps: appdirs == 1.4.0
     mindeps: bcrypt == 3.1.3


### PR DESCRIPTION
This PR removes pyasn1 from the dependencies of conch. However, there is one consequence: broken OpenSSH RSA keys from https://github.com/twisted/twisted/issues/3008 are no longer supported.