### PR TITLE
#11844 Pin pyasn1 dependency for Twisted Conch to version below 0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ tls = [
 ]
 
 conch = [
-    "pyasn1 >= 0.4",
+    "pyasn1 >= 0.4, < 0.5",
     "cryptography >= 3.3",
     "appdirs >= 1.4.0",
     "bcrypt >= 3.1.3",

--- a/src/twisted/conch/newsfragments/11844.bugfix
+++ b/src/twisted/conch/newsfragments/11844.bugfix
@@ -1,3 +1,2 @@
-The `pyasn1` dependency was updated to depend on version below 0.5.0.
-`pyasn1` intorduce a few changes that so far we know that break the Twisted
-test suite.
+The `pyasn1` dependency was updated to depend on a version below 0.5.0.
+`pyasn1` introduce changes that break the Twisted test suite.

--- a/src/twisted/conch/newsfragments/11844.bugfix
+++ b/src/twisted/conch/newsfragments/11844.bugfix
@@ -1,0 +1,3 @@
+The `pyasn1` dependency was updated to depend on version below 0.5.0.
+`pyasn1` intorduce a few changes that so far we know that break the Twisted
+test suite.


### PR DESCRIPTION
## Scope and purpose

Fixes #11844

The tests are failing with the latest pyans1 version.

Update our deps to depend on older pyasn1.

## Changes

only update the deps declaration.