### PR TITLE
#11846 Deprecate 'alternate' OpenSSH private keys in Twisted Conch.

### DIFF
--- a/src/twisted/conch/newsfragments/11846.removal
+++ b/src/twisted/conch/newsfragments/11846.removal
@@ -1,0 +1,3 @@
+twisted.conch.ssh.keys.Key support for loading "alternate" OpenSSH private keys is now deprecated.
+These are some private keys that at some point were handled by OpenSSH but for which no specification exists.
+For more info about these OpenSSH keys see https://github.com/twisted/twisted/issues/3008.

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -571,7 +571,19 @@ class Key:
             return cls(load_pem_private_key(data, passphrase, default_backend()))
 
         if kind == b"RSA":
-            if len(decodedKey) == 2:  # Alternate RSA key
+            if len(decodedKey) == 2:
+                # Alternate RSA key
+                # See https://github.com/twisted/twisted/issues/3008
+                warnings.warn(
+                    (
+                        "Using this RSA private key was deprecated in "
+                        "Twisted NEXT. You can continue to use the RSA key by "
+                        "converting it to the OpenSSH private key format "
+                        "openssh-key-v1 or newer."
+                    ),
+                    category=DeprecationWarning,
+                    stacklevel=4,
+                )
                 decodedKey = decodedKey[0]
             if len(decodedKey) < 6:
                 raise BadKeyError("RSA key failed to decode properly")


### PR DESCRIPTION
## Scope and purpose

Fixes #11846

Depends #11844  since we need and older pyasn1.

It looks like at some point OpenSSH was handling non-standard PEM keys.
This was done at https://github.com/twisted/twisted/issues/3008

The plan is to remove support for these private keys, so that we can remove our custom PEM handling code and reuse the `cryptography` OpenSSH code for handling OpenSSH PEM files.

