### PR TITLE
#11856 Remove the usage of assertRaisesRegexp unit test alias removed in Python 3.12

### DIFF
--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -3715,7 +3715,7 @@ class CoroutineContextVarsTests(unittest.TestCase):
         used as an asynchronous context manager.
         """
         lock = DeferredLock()
-        with self.assertRaisesRegexp(Exception, "some specific exception"):
+        with self.assertRaisesRegex(Exception, "some specific exception"):
             async with lock:
                 self.assertTrue(lock.locked)
                 raise Exception("some specific exception")


### PR DESCRIPTION
## Scope and purpose

Fixes #11856

assertRaisesRegexp alias for assertRaisesRegex was deprecated in Python 3.2 (https://docs.python.org/3.11/library/unittest.html#deprecated-aliases). https://bugs.python.org/issue?@action=redirect&bpo=45162


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
