### PR TITLE
#11875 Expose new method seek in _InputStream class

### DIFF
--- a/src/twisted/web/newsfragments/11875.feature
+++ b/src/twisted/web/newsfragments/11875.feature
@@ -1,0 +1,3 @@
+twisted.web.wsgi now exposes new seek metod in class _InputStream
+
+The new seek method in class _InputStream (twisted.web.wsgi) allows you to move the position in the stream allowing you to skip part of the stream or read the stream or (parts of) more than once.

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -216,6 +216,14 @@ class _InputStream:
             return self._wrapped.readlines()
         return self._wrapped.readlines(size)
 
+    def seek(self, pos):
+        """
+        Pass through to the underlying C{seek}.
+
+        This is called in a WSGI application thread, not the I/O thread.
+        """
+        self._wrapped.seek(pos)
+
     def __iter__(self):
         """
         Pass through to the underlying C{__iter__}.


### PR DESCRIPTION
Fixes #11875

In our application we do `environ["wsgi.input"].read()` to parse the request payload. In some case we then rewrite the request and on some others we leave the request as is. When we leave it as-is we will need to access `environ["wsgi.input"]` later down the line but since the cursor is at the end of the stream when we read it again it's empty. We need to be able to place the cursor back at the beginning like this: `environ["wsgi.input"].seek(0)`.