### PR TITLE
Make twisted work properly under fips mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -267,6 +267,61 @@ jobs:
         fail_ci_if_error: true
 
 
+  fips-tests:
+    # Define the host in which the container is deployed
+    runs-on: ubuntu-latest
+
+    # Define container inside which the steps are executed
+    container:
+      image: photon:5.0
+      env:
+        NODE_ENV: development
+        USER: test
+        USER_HOMEDIR: /home/test
+      options: --cpus 2
+
+    # Steps as normal.
+    steps:
+    - name: Setup the container
+      run: |
+        tdnf remove -y toybox
+        tdnf update -y
+        tdnf install -y sed
+        tdnf install -y \
+                coreutils-selinux \
+                openssl-fips-provider \
+                python3-pip \
+                python3-devel \
+                build-essential \
+                git \
+                shadow \
+                tzdata
+
+        pip3 install tox~=3.0
+
+    - uses: actions/checkout@v3
+      with:
+        path: twisted
+
+    - name: Prepare for testenv
+      run: |
+        # run tests from user context
+        # for example, test_checker.py tests fail if run as root
+        useradd -m ${USER}
+        cp -r twisted ${USER_HOMEDIR}
+        chown -R ${USER} ${USER_HOMEDIR}
+
+    - name: Run tests
+      run: |
+        # if docker service is running with LimitNOFILE=infinity
+        # few tests (like test_tcp.py) use everything available
+        # so, don't hog the host's resources while testing by
+        # reducing file limits here.
+        ulimit -S -n 1024
+        ulimit -H -n 1024
+        ulimit -a
+        su - ${USER} -c "cd twisted && tox -e alldeps-nocov-posix"
+
 
   static-checks:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -276,8 +276,6 @@ jobs:
       image: photon:5.0
       env:
         NODE_ENV: development
-        USER: test
-        USER_HOMEDIR: /home/test
       options: --cpus 2
 
     # Steps as normal.
@@ -295,9 +293,10 @@ jobs:
                 build-essential \
                 git \
                 shadow \
-                tzdata
+                tzdata \
+                nodejs
 
-        pip3 install tox~=3.0
+        pip3 install tox~=3.0 coverage
 
     - uses: actions/checkout@v3
       with:
@@ -307,9 +306,9 @@ jobs:
       run: |
         # run tests from user context
         # for example, test_checker.py tests fail if run as root
-        useradd -m ${USER}
-        cp -r twisted ${USER_HOMEDIR}
-        chown -R ${USER} ${USER_HOMEDIR}
+        useradd -m test
+        cp -r twisted /home/test
+        chown -R test /home/test
 
     - name: Run tests
       run: |
@@ -320,7 +319,25 @@ jobs:
         ulimit -S -n 1024
         ulimit -H -n 1024
         ulimit -a
-        su - ${USER} -c "cd twisted && tox -e alldeps-nocov-posix"
+        su - test -c "cd twisted && tox -e alldeps-withcov-posix"
+
+    - name: Prepare for coverage
+      if: ${{ !cancelled() }}
+      run: |
+        # sub-process coverage are generated in separate files so we combine them
+        # to get an unified coverage for the local run.
+        # The XML generated is to be used with 3rd party tools like diff-cover.
+        su - test -c "cd twisted && python -m coverage combine"
+        su - test -c "cd twisted && python -m coverage xml -o coverage.xml -i"
+        su - test -c "cd twisted && python -m coverage report --skip-covered"
+
+    - uses: codecov/codecov-action@v3
+      if: ${{ !cancelled() }}
+      with:
+        files: coverage.xml
+        name: fips-coverage
+        working-directory: /home/test/twisted
+        fail_ci_if_error: true
 
 
   static-checks:

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -8,7 +8,6 @@ Handling of RSA, DSA, ECDSA, and Ed25519 keys.
 
 
 import binascii
-import hashlib
 import struct
 import unicodedata
 import warnings
@@ -31,7 +30,7 @@ from typing_extensions import Literal
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_to_bytes
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes, nativeString
+from twisted.python.compat import iterbytes, nativeString, md5
 from twisted.python.constants import NamedConstant, Names
 from twisted.python.deprecate import _mutuallyExclusiveArguments
 
@@ -46,20 +45,6 @@ except ImportError:
         decode_rfc6979_signature as decode_dss_signature,
         encode_rfc6979_signature as encode_dss_signature,
     )
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 # Curve lookup table

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -8,11 +8,12 @@ Handling of RSA, DSA, ECDSA, and Ed25519 keys.
 
 
 import binascii
+import hashlib
 import struct
 import unicodedata
 import warnings
 from base64 import b64encode, decodebytes, encodebytes
-from hashlib import md5, sha256
+from hashlib import sha256
 
 import bcrypt
 from cryptography import utils
@@ -45,6 +46,20 @@ except ImportError:
         decode_rfc6979_signature as decode_dss_signature,
         encode_rfc6979_signature as encode_dss_signature,
     )
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 # Curve lookup table

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -30,7 +30,7 @@ from typing_extensions import Literal
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_to_bytes
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes, nativeString, md5
+from twisted.python.compat import iterbytes, md5, nativeString
 from twisted.python.constants import NamedConstant, Names
 from twisted.python.deprecate import _mutuallyExclusiveArguments
 

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -13,7 +13,6 @@ Maintainer: Paul Swartz
 
 import binascii
 import hmac
-import hashlib
 import struct
 import zlib
 from hashlib import sha1, sha256, sha384, sha512
@@ -31,24 +30,11 @@ from twisted.conch.ssh.common import MP, NS, ffs, getMP, getNS
 from twisted.internet import defer, protocol
 from twisted.logger import Logger
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes, networkString
+from twisted.python.compat import iterbytes, networkString, md5
 
 # This import is needed if SHA256 hashing is used.
 # from twisted.python.compat import nativeString
 
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 def _mpFromBytes(data):
     """Make an SSH multiple-precision integer from big-endian L{bytes}.

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -30,7 +30,7 @@ from twisted.conch.ssh.common import MP, NS, ffs, getMP, getNS
 from twisted.internet import defer, protocol
 from twisted.logger import Logger
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes, networkString, md5
+from twisted.python.compat import iterbytes, md5, networkString
 
 # This import is needed if SHA256 hashing is used.
 # from twisted.python.compat import nativeString

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -13,9 +13,10 @@ Maintainer: Paul Swartz
 
 import binascii
 import hmac
+import hashlib
 import struct
 import zlib
-from hashlib import md5, sha1, sha256, sha384, sha512
+from hashlib import sha1, sha256, sha384, sha512
 from typing import Dict
 
 from cryptography.exceptions import UnsupportedAlgorithm
@@ -35,6 +36,19 @@ from twisted.python.compat import iterbytes, networkString
 # This import is needed if SHA256 hashing is used.
 # from twisted.python.compat import nativeString
 
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 def _mpFromBytes(data):
     """Make an SSH multiple-precision integer from big-endian L{bytes}.

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -108,10 +108,10 @@ class SSHCiphers:
         b"none": (None, 0, modes.CBC),
     }
     macMap = {
-        b"hmac-sha2-512": sha512,
-        b"hmac-sha2-384": sha384,
-        b"hmac-sha2-256": sha256,
-        b"hmac-sha1": sha1,
+        b"hmac-sha2-512": sha512,  # type: ignore[dict-item]
+        b"hmac-sha2-384": sha384,  # type: ignore[dict-item]
+        b"hmac-sha2-256": sha256,  # type: ignore[dict-item]
+        b"hmac-sha1": sha1,  # type: ignore[dict-item]
         b"hmac-md5": md5,
         b"none": None,
     }

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -7,11 +7,12 @@ Tests for ssh/transport.py and the classes therein.
 
 
 import binascii
+import hashlib
 import re
 import string
 import struct
 import types
-from hashlib import md5, sha1, sha256, sha384, sha512
+from hashlib import sha1, sha256, sha384, sha512
 from typing import Dict, List, Optional, Tuple, Type
 
 from twisted import __version__ as twisted_version
@@ -65,6 +66,19 @@ else:
         def NS(self, arg):
             return b""
 
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 def skipWithoutX25519(f):
     if not X25519_SUPPORTED:

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -7,7 +7,6 @@ Tests for ssh/transport.py and the classes therein.
 
 
 import binascii
-import hashlib
 import re
 import string
 import struct
@@ -21,7 +20,7 @@ from twisted.conch.ssh import _kex, address, service
 from twisted.internet import defer
 from twisted.protocols import loopback
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes
+from twisted.python.compat import iterbytes, md5
 from twisted.python.randbytes import insecureRandom
 from twisted.python.reflect import requireModule
 from twisted.test import proto_helpers
@@ -66,19 +65,6 @@ else:
         def NS(self, arg):
             return b""
 
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 def skipWithoutX25519(f):
     if not X25519_SUPPORTED:

--- a/src/twisted/cred/_digest.py
+++ b/src/twisted/cred/_digest.py
@@ -11,8 +11,8 @@ Calculations for HTTP Digest authentication.
 
 from binascii import hexlify
 from hashlib import sha1
-from twisted.python.compat import md5
 
+from twisted.python.compat import md5
 
 # The digest math
 

--- a/src/twisted/cred/_digest.py
+++ b/src/twisted/cred/_digest.py
@@ -10,7 +10,21 @@ Calculations for HTTP Digest authentication.
 
 
 from binascii import hexlify
-from hashlib import md5, sha1
+from hashlib import sha1
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
+
 
 # The digest math
 

--- a/src/twisted/cred/_digest.py
+++ b/src/twisted/cred/_digest.py
@@ -11,19 +11,7 @@ Calculations for HTTP Digest authentication.
 
 from binascii import hexlify
 from hashlib import sha1
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
+from twisted.python.compat import md5
 
 
 # The digest math

--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -10,7 +10,6 @@ implementations of that interface.
 
 
 import base64
-import hashlib
 import hmac
 import random
 import re
@@ -22,24 +21,10 @@ from zope.interface import Interface, implementer
 
 from twisted.cred import error
 from twisted.cred._digest import calcHA1, calcHA2, calcResponse
-from twisted.python.compat import nativeString, networkString
+from twisted.python.compat import nativeString, networkString, md5
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.randbytes import secureRandom
 from twisted.python.versions import Version
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class ICredentials(Interface):

--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -14,14 +14,13 @@ import hmac
 import random
 import re
 import time
-
 from binascii import hexlify
 
 from zope.interface import Interface, implementer
 
 from twisted.cred import error
 from twisted.cred._digest import calcHA1, calcHA2, calcResponse
-from twisted.python.compat import nativeString, networkString, md5
+from twisted.python.compat import md5, nativeString, networkString
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.randbytes import secureRandom
 from twisted.python.versions import Version

--- a/src/twisted/cred/credentials.py
+++ b/src/twisted/cred/credentials.py
@@ -10,12 +10,13 @@ implementations of that interface.
 
 
 import base64
+import hashlib
 import hmac
 import random
 import re
 import time
+
 from binascii import hexlify
-from hashlib import md5
 
 from zope.interface import Interface, implementer
 
@@ -25,6 +26,20 @@ from twisted.python.compat import nativeString, networkString
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.randbytes import secureRandom
 from twisted.python.versions import Version
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class ICredentials(Interface):

--- a/src/twisted/cred/test/test_cramauth.py
+++ b/src/twisted/cred/test/test_cramauth.py
@@ -5,25 +5,12 @@
 Tests for L{twisted.cred}'s implementation of CRAM-MD5.
 """
 
-import hashlib
 from binascii import hexlify
 from hmac import HMAC
 
 from twisted.cred.credentials import CramMD5Credentials, IUsernameHashedPassword
+from twisted.python.compat import md5
 from twisted.trial.unittest import TestCase
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class CramMD5CredentialsTests(TestCase):

--- a/src/twisted/cred/test/test_cramauth.py
+++ b/src/twisted/cred/test/test_cramauth.py
@@ -56,9 +56,7 @@ class CramMD5CredentialsTests(TestCase):
         """
         c = CramMD5Credentials()
         chal = c.getChallenge()
-        c.response = hexlify(
-            HMAC(b"thewrongsecret", chal, digestmod=md5).digest()
-        )
+        c.response = hexlify(HMAC(b"thewrongsecret", chal, digestmod=md5).digest())
         self.assertFalse(c.checkPassword(b"secret"))
 
     def test_setResponse(self):

--- a/src/twisted/cred/test/test_digestauth.py
+++ b/src/twisted/cred/test/test_digestauth.py
@@ -8,7 +8,6 @@ L{twisted.cred.credentials}.
 
 
 import base64
-
 from binascii import hexlify
 from hashlib import sha1
 
@@ -23,8 +22,7 @@ from twisted.cred.credentials import (
 )
 from twisted.cred.error import LoginFailed
 from twisted.internet.address import IPv4Address
-from twisted.python.compat import md5
-from twisted.python.compat import networkString
+from twisted.python.compat import md5, networkString
 from twisted.trial.unittest import TestCase
 
 

--- a/src/twisted/cred/test/test_digestauth.py
+++ b/src/twisted/cred/test/test_digestauth.py
@@ -8,7 +8,6 @@ L{twisted.cred.credentials}.
 
 
 import base64
-import hashlib
 
 from binascii import hexlify
 from hashlib import sha1
@@ -24,22 +23,9 @@ from twisted.cred.credentials import (
 )
 from twisted.cred.error import LoginFailed
 from twisted.internet.address import IPv4Address
+from twisted.python.compat import md5
 from twisted.python.compat import networkString
 from twisted.trial.unittest import TestCase
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 def b64encode(s):

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -4,10 +4,10 @@
 # See LICENSE for details.
 
 
+import hashlib
 import warnings
 from binascii import hexlify
 from functools import lru_cache
-from hashlib import md5
 
 from zope.interface import Interface, implementer
 
@@ -33,6 +33,20 @@ from twisted.python.deprecate import _mutuallyExclusiveArguments, deprecated
 from twisted.python.failure import Failure
 from twisted.python.randbytes import secureRandom
 from ._idna import _idnaBytes
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class TLSVersion(Names):

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -4,7 +4,6 @@
 # See LICENSE for details.
 
 
-import hashlib
 import warnings
 from binascii import hexlify
 from functools import lru_cache
@@ -28,25 +27,11 @@ from twisted.internet.interfaces import (
     IOpenSSLContextFactory,
 )
 from twisted.python import log, util
-from twisted.python.compat import nativeString
+from twisted.python.compat import nativeString, md5
 from twisted.python.deprecate import _mutuallyExclusiveArguments, deprecated
 from twisted.python.failure import Failure
 from twisted.python.randbytes import secureRandom
 from ._idna import _idnaBytes
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class TLSVersion(Names):

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -27,7 +27,7 @@ from twisted.internet.interfaces import (
     IOpenSSLContextFactory,
 )
 from twisted.python import log, util
-from twisted.python.compat import nativeString, md5
+from twisted.python.compat import md5, nativeString
 from twisted.python.deprecate import _mutuallyExclusiveArguments, deprecated
 from twisted.python.failure import Failure
 from twisted.python.randbytes import secureRandom

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -6,8 +6,6 @@ Tests for implementations of L{IReactorUNIX}.
 """
 
 
-import hashlib
-
 from os import close, fstat, stat, unlink, urandom
 from pprint import pformat
 from socket import AF_INET, SOCK_STREAM, SOL_SOCKET, socket
@@ -57,26 +55,12 @@ from twisted.internet.test.test_tcp import (
     StreamTransportTestsMixin,
     WriteSequenceTestsMixin,
 )
-from twisted.python.compat import nativeString
+from twisted.python.compat import nativeString, md5
 from twisted.python.failure import Failure
 from twisted.python.filepath import _coerceToFilesystemEncoding
 from twisted.python.log import addObserver, err, removeObserver
 from twisted.python.reflect import requireModule
 from twisted.python.runtime import platform
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 sendmsg = requireModule("twisted.python.sendmsg")

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -6,7 +6,8 @@ Tests for implementations of L{IReactorUNIX}.
 """
 
 
-from hashlib import md5
+import hashlib
+
 from os import close, fstat, stat, unlink, urandom
 from pprint import pformat
 from socket import AF_INET, SOCK_STREAM, SOL_SOCKET, socket
@@ -62,6 +63,21 @@ from twisted.python.filepath import _coerceToFilesystemEncoding
 from twisted.python.log import addObserver, err, removeObserver
 from twisted.python.reflect import requireModule
 from twisted.python.runtime import platform
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
+
 
 sendmsg = requireModule("twisted.python.sendmsg")
 sendmsgSkipReason = ""

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -55,13 +55,12 @@ from twisted.internet.test.test_tcp import (
     StreamTransportTestsMixin,
     WriteSequenceTestsMixin,
 )
-from twisted.python.compat import nativeString, md5
+from twisted.python.compat import md5, nativeString
 from twisted.python.failure import Failure
 from twisted.python.filepath import _coerceToFilesystemEncoding
 from twisted.python.log import addObserver, err, removeObserver
 from twisted.python.reflect import requireModule
 from twisted.python.runtime import platform
-
 
 sendmsg = requireModule("twisted.python.sendmsg")
 sendmsgSkipReason = ""

--- a/src/twisted/mail/_cred.py
+++ b/src/twisted/mail/_cred.py
@@ -6,7 +6,6 @@ Credential managers for L{twisted.mail}.
 """
 
 
-import hashlib
 import hmac
 
 from zope.interface import implementer
@@ -14,7 +13,7 @@ from zope.interface import implementer
 from twisted.cred import credentials
 from twisted.mail._except import IllegalClientResponse
 from twisted.mail.interfaces import IChallengeResponse, IClientAuthentication
-from twisted.python.compat import nativeString
+from twisted.python.compat import md5, nativeString
 
 
 @implementer(IClientAuthentication)
@@ -26,7 +25,7 @@ class CramMD5ClientAuthenticator:
         return b"CRAM-MD5"
 
     def challengeResponse(self, secret, chal):
-        response = hmac.HMAC(secret, chal, digestmod=hashlib.md5).hexdigest()
+        response = hmac.HMAC(secret, chal, digestmod=md5).hexdigest()
         return self.user + b" " + response.encode("ascii")
 
 

--- a/src/twisted/mail/_pop3client.py
+++ b/src/twisted/mail/_pop3client.py
@@ -12,7 +12,6 @@ Don't use this module directly.  Use twisted.mail.pop3 instead.
 """
 
 import re
-import hashlib
 from typing import List
 
 from twisted.internet import defer, error, interfaces
@@ -25,23 +24,10 @@ from twisted.mail._except import (
 )
 from twisted.protocols import basic, policies
 from twisted.python import log
+from twisted.python.compat import md5
 
 OK = b"+OK"
 ERR = b"-ERR"
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class _ListSetter:

--- a/src/twisted/mail/_pop3client.py
+++ b/src/twisted/mail/_pop3client.py
@@ -12,7 +12,7 @@ Don't use this module directly.  Use twisted.mail.pop3 instead.
 """
 
 import re
-from hashlib import md5
+import hashlib
 from typing import List
 
 from twisted.internet import defer, error, interfaces
@@ -28,6 +28,20 @@ from twisted.python import log
 
 OK = b"+OK"
 ERR = b"-ERR"
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class _ListSetter:

--- a/src/twisted/mail/maildir.py
+++ b/src/twisted/mail/maildir.py
@@ -8,10 +8,10 @@ Maildir-style mailbox support.
 """
 
 import io
+import hashlib
 import os
 import socket
 import stat
-from hashlib import md5
 from typing import IO
 
 from zope.interface import implementer
@@ -31,6 +31,19 @@ Subject: An Error Occurred
   An internal server error has occurred.  Please contact the
   server administrator.
 """
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class _MaildirNameGenerator:

--- a/src/twisted/mail/maildir.py
+++ b/src/twisted/mail/maildir.py
@@ -8,7 +8,6 @@ Maildir-style mailbox support.
 """
 
 import io
-import hashlib
 import os
 import socket
 import stat
@@ -23,6 +22,7 @@ from twisted.mail import mail, pop3, smtp
 from twisted.persisted import dirdbm
 from twisted.protocols import basic
 from twisted.python import failure, log
+from twisted.python.compat import md5
 
 INTERNAL_ERROR = """\
 From: Twisted.mail Internals
@@ -31,19 +31,6 @@ Subject: An Error Occurred
   An internal server error has occurred.  Please contact the
   server administrator.
 """
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class _MaildirNameGenerator:

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -13,7 +13,6 @@ Post-office Protocol version 3.
 
 import base64
 import binascii
-import hashlib
 import warnings
 from typing import Optional
 
@@ -29,20 +28,7 @@ from twisted.mail.interfaces import (
 )
 from twisted.protocols import basic, policies
 from twisted.python import log
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
+from twisted.python.compat import md5
 
 
 # Authentication

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -13,8 +13,8 @@ Post-office Protocol version 3.
 
 import base64
 import binascii
+import hashlib
 import warnings
-from hashlib import md5
 from typing import Optional
 
 from zope.interface import implementer
@@ -29,6 +29,20 @@ from twisted.mail.interfaces import (
 )
 from twisted.protocols import basic, policies
 from twisted.python import log
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 # Authentication

--- a/src/twisted/mail/test/test_mail.py
+++ b/src/twisted/mail/test/test_mail.py
@@ -9,6 +9,7 @@ import email.message
 import email.parser
 import errno
 import glob
+import hashlib
 import io
 import os
 import pickle
@@ -18,7 +19,6 @@ import sys
 import tempfile
 import textwrap
 import time
-from hashlib import md5
 from unittest import skipIf
 
 from zope.interface import Interface, implementer
@@ -56,6 +56,20 @@ from twisted.python import failure, log
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platformType
 from twisted.trial.unittest import TestCase
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 @skipIf(platformType != "posix", "twisted.mail only works on posix")

--- a/src/twisted/mail/test/test_mail.py
+++ b/src/twisted/mail/test/test_mail.py
@@ -9,7 +9,6 @@ import email.message
 import email.parser
 import errno
 import glob
-import hashlib
 import io
 import os
 import pickle
@@ -53,23 +52,10 @@ from twisted.names import dns
 from twisted.names.dns import Record_CNAME, Record_MX, RRHeader
 from twisted.names.error import DNSNameError
 from twisted.python import failure, log
+from twisted.python.compat import md5
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platformType
 from twisted.trial.unittest import TestCase
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 @skipIf(platformType != "posix", "twisted.mail only works on posix")

--- a/src/twisted/mail/test/test_pop3.py
+++ b/src/twisted/mail/test/test_pop3.py
@@ -7,7 +7,6 @@ Test cases for L{twisted.mail.pop3} module.
 
 
 import base64
-import hashlib
 import hmac
 import itertools
 from collections import OrderedDict
@@ -28,21 +27,8 @@ from twisted.internet.testing import LineSendingProtocol
 from twisted.mail import pop3
 from twisted.protocols import loopback
 from twisted.python import failure
+from twisted.python.compat import md5
 from twisted.trial import unittest, util
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class UtilityTests(unittest.SynchronousTestCase):

--- a/src/twisted/mail/test/test_pop3.py
+++ b/src/twisted/mail/test/test_pop3.py
@@ -7,10 +7,10 @@ Test cases for L{twisted.mail.pop3} module.
 
 
 import base64
+import hashlib
 import hmac
 import itertools
 from collections import OrderedDict
-from hashlib import md5
 from io import BytesIO
 
 from zope.interface import implementer
@@ -29,6 +29,20 @@ from twisted.mail import pop3
 from twisted.protocols import loopback
 from twisted.python import failure
 from twisted.trial import unittest, util
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class UtilityTests(unittest.SynchronousTestCase):

--- a/src/twisted/newsfragments/11883.feature
+++ b/src/twisted/newsfragments/11883.feature
@@ -1,0 +1,1 @@
+Twisted currently doesn't work at all when openssl fips is enabled in the host due to md5 algorithm usage in various places. This patch makes it possible to use Twisted without any problems when fips is enabled. Also added GHA tests for the same.

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -22,6 +22,7 @@ the latest version of Python directly from your code, if possible.
 """
 
 
+import hashlib
 import inspect
 import os
 import platform
@@ -142,6 +143,20 @@ deprecatedModuleAttribute(
     __name__,
     "xrange",
 )
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 @deprecated(Version("Twisted", 21, 2, 0), replacement="d.items()")

--- a/src/twisted/python/compat.py
+++ b/src/twisted/python/compat.py
@@ -145,7 +145,7 @@ deprecatedModuleAttribute(
 )
 
 
-def md5(data=b'', **kwargs):
+def md5(data=b"", **kwargs):
     """
     Wrapper around hashlib.md5
     Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -5,13 +5,27 @@
 Tests for L{twisted.python.zipstream}
 """
 
+import hashlib
 import random
 import struct
 import zipfile
-from hashlib import md5
 
 from twisted.python import filepath, zipstream
 from twisted.trial import unittest
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class FileEntryMixin:

--- a/src/twisted/python/test/test_zipstream.py
+++ b/src/twisted/python/test/test_zipstream.py
@@ -5,27 +5,13 @@
 Tests for L{twisted.python.zipstream}
 """
 
-import hashlib
 import random
 import struct
 import zipfile
 
 from twisted.python import filepath, zipstream
+from twisted.python.compat import md5
 from twisted.trial import unittest
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class FileEntryMixin:

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -29,7 +29,6 @@ To get started, begin with L{PBClientFactory} and L{PBServerFactory}.
 
 
 import random
-import hashlib
 
 from zope.interface import Interface, implementer
 
@@ -45,7 +44,7 @@ from twisted.persisted import styles
 
 # Twisted Imports
 from twisted.python import failure, log, reflect
-from twisted.python.compat import cmp, comparable
+from twisted.python.compat import cmp, comparable, md5
 from twisted.python.components import registerAdapter
 from twisted.spread import banana
 
@@ -79,20 +78,6 @@ from twisted.spread.jelly import _newInstance, globalSecurity, jelly, unjelly
 MAX_BROKER_REFS = 1024
 
 portno = 8787
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class ProtocolError(Exception):

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -29,7 +29,7 @@ To get started, begin with L{PBClientFactory} and L{PBServerFactory}.
 
 
 import random
-from hashlib import md5
+import hashlib
 
 from zope.interface import Interface, implementer
 
@@ -79,6 +79,20 @@ from twisted.spread.jelly import _newInstance, globalSecurity, jelly, unjelly
 MAX_BROKER_REFS = 1024
 
 portno = 8787
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class ProtocolError(Exception):

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -16,8 +16,8 @@ from hamcrest import assert_that, equal_to, has_properties
 from hamcrest.core.matcher import Matcher
 
 from twisted.python import filepath, util
-from twisted.python.modules import getModule
 from twisted.python.compat import md5
+from twisted.python.modules import getModule
 from twisted.python.reflect import ModuleNotFound
 from twisted.trial import reporter, runner, unittest
 from twisted.trial._asyncrunner import _iterateTests

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -6,7 +6,6 @@ Tests for loading tests by name.
 """
 
 
-import hashlib
 import os
 import sys
 import unittest as pyunit
@@ -18,26 +17,13 @@ from hamcrest.core.matcher import Matcher
 
 from twisted.python import filepath, util
 from twisted.python.modules import getModule
+from twisted.python.compat import md5
 from twisted.python.reflect import ModuleNotFound
 from twisted.trial import reporter, runner, unittest
 from twisted.trial._asyncrunner import _iterateTests
 from twisted.trial.itrial import ITestCase
 from twisted.trial.test import packages
 from .matchers import after
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 def testNames(tests):

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -6,10 +6,10 @@ Tests for loading tests by name.
 """
 
 
+import hashlib
 import os
 import sys
 import unittest as pyunit
-from hashlib import md5
 from operator import attrgetter
 from types import ModuleType
 
@@ -24,6 +24,20 @@ from twisted.trial._asyncrunner import _iterateTests
 from twisted.trial.itrial import ITestCase
 from twisted.trial.test import packages
 from .matchers import after
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 def testNames(tests):

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -15,7 +15,7 @@ import time
 
 from zope.interface import Attribute, Interface, implementer
 
-from twisted.python.compat import networkString, md5
+from twisted.python.compat import md5, networkString
 
 
 class ISASLMechanism(Interface):

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -9,28 +9,13 @@ Protocol agnostic implementations of SASL authentication mechanisms.
 
 
 import binascii
-import hashlib
 import os
 import random
 import time
 
 from zope.interface import Attribute, Interface, implementer
 
-from twisted.python.compat import networkString
-
-
-def md5(data=b'', **kwargs):
-    """
-    Wrapper around hashlib.md5
-    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
-    OpenSSL FIPS mode is enabled:
-    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
-    """
-
-    try:
-        return hashlib.md5(data, **kwargs)
-    except ValueError:
-        return hashlib.md5(data, **kwargs, usedforsecurity=False)
+from twisted.python.compat import networkString, md5
 
 
 class ISASLMechanism(Interface):

--- a/src/twisted/words/protocols/jabber/sasl_mechanisms.py
+++ b/src/twisted/words/protocols/jabber/sasl_mechanisms.py
@@ -9,14 +9,28 @@ Protocol agnostic implementations of SASL authentication mechanisms.
 
 
 import binascii
+import hashlib
 import os
 import random
 import time
-from hashlib import md5
 
 from zope.interface import Attribute, Interface, implementer
 
 from twisted.python.compat import networkString
+
+
+def md5(data=b'', **kwargs):
+    """
+    Wrapper around hashlib.md5
+    Attempt call with 'usedforsecurity=False' if we get a ValueError, which happens when
+    OpenSSL FIPS mode is enabled:
+    ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
+    """
+
+    try:
+        return hashlib.md5(data, **kwargs)
+    except ValueError:
+        return hashlib.md5(data, **kwargs, usedforsecurity=False)
 
 
 class ISASLMechanism(Interface):


### PR DESCRIPTION
## Scope and purpose

Fixes #11866

Allow using twisted when openssl fips is enabled.

With this patch, twisted will work the same way it works in non fips environment. Users will not see any difference in the way twisted works even when fips is enabled.

When we install openssl-fips-provider package in a Photon's docker container image, openssl fips gets enabled by default.

Try the below steps if you want to see it in action:

docker run -it --rm photon:5.0 /bin/bash

Inside the container:

tdnf install -y openssl-fips-provider

## the below command should fail
openssl md5 /etc/os-release


## Also, below command will show 1 as output. (but need python >= 3.9)
python3 -c "import _hashlib; print('fips mode: ', _hashlib.get_fips_mode())"

usedforsecurity flag in hashlib module was introduced to temporarily allow fips incompatible algorithms so that things will keep working when there is a hard requirement for md5 like algorithms. This PR does exactly that.

With this fix, Twisted will work the same way when fips is enabled or disabled.