### PR TITLE
#10310 Avoid circular reference with `Deferred._canceller`

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -797,6 +797,11 @@ class Deferred(Awaitable[_DeferredResultT]):
                 self._debugInfo = DebugInfo()
             self._debugInfo.invoker = traceback.format_stack()[:-2]
         self.called = True
+
+        # Clear the canceller to avoid any circular references. This is safe to
+        # do as the canceller does not get called after the deferred has fired
+        self._canceller = None
+
         self.result = result
         self._runCallbacks()
 

--- a/src/twisted/newsfragments/10310.misc
+++ b/src/twisted/newsfragments/10310.misc
@@ -1,1 +1,1 @@
-Fix circular references when using a `Deferred` with a canceller that references the `Deferred`, e.g. `DelayedCall` and `inlineCallbacks`.
+When using a `Deferred` with a canceller that references the `Deferred` (ex. `DelayedCall` and `inlineCallbacks`), a canceller reference from the `Derefferd` is removed a soon as the `Deferred` is called. In this way, the canceller should have a higher change of being garbage collected.

--- a/src/twisted/newsfragments/10310.misc
+++ b/src/twisted/newsfragments/10310.misc
@@ -1,0 +1,1 @@
+Fix circular references when using a `Deferred` with a canceller that references the `Deferred`, e.g. `DelayedCall` and `inlineCallbacks`.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1700,6 +1700,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
 
         deferred.callback(None)
 
+        # We manually remove the reference from the local
+        # function scope, to avoid interfering with the test.
         del deferred
         del canceller
 

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1684,8 +1684,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
     @pyunit.skipIf(_PYPY, "GC works differently on PyPy.")
     def test_canceller_circular_reference(self) -> None:
         """
-        Test that a circular reference between a `Deferred` and its canceller
-        is broken when the deferred is resolved.
+        A circular reference between a `Deferred` and its canceller
+        is broken when the deferred is called.
         """
 
         # Create a canceller and weak reference to track if its been freed.
@@ -1707,15 +1707,19 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.assertIsNone(weakCanceller())
 
 
-class _TestCircularCanceller:
+class DummyCanceller:
     """
-    c.f. L{DeferredTest.test_canceller_circular_reference}
+    A callable that does nothing.
+    It is intended to be used just to get an object reference
+    to support GC related tests.
     """
 
     deferred: Optional[Deferred[Any]] = None
 
-    def __call__(self, deferred: Deferred[Any]) -> None:
-        pass
+    def __call__(self, deferred: Deferred[Any]) -> None:  # pragma: no cover
+        """
+        This is not expected to be called as part of the current test suite.
+        """
 
 
 def _setupRaceState(numDeferreds: int) -> tuple[list[int], list[Deferred[object]]]:

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1757,9 +1757,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         deferred: Deferred[Any] = Deferred(canceller)
         canceller.deferred = deferred
 
-        deferred.callback(None)
-
         deferred.addCallback(lambda _: Deferred())
+        deferred.callback(None)
 
         del deferred
         del canceller

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1712,6 +1712,8 @@ class _TestCircularCanceller:
     c.f. L{DeferredTest.test_canceller_circular_reference}
     """
 
+    deferred: Optional[Deferred[Any]] = None
+
     def __call__(self, deferred: Deferred[Any]) -> None:
         pass
 

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1696,6 +1696,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # deferred to the canceller to create the circular reference.
         deferred: Deferred[Any] = Deferred(canceller)
         canceller.deferred = deferred
+        weakDeferred = weakref.ref(deferred)
 
         deferred.callback(None)
 
@@ -1705,6 +1706,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # Once all local references have been dropped, the canceller should have
         # been freed.
         self.assertIsNone(weakCanceller())
+        self.assertIsNone(weakDeferred())
 
     @pyunit.skipIf(_PYPY, "GC works differently on PyPy.")
     def test_canceller_circular_reference_errback(self) -> None:
@@ -1721,6 +1723,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # deferred to the canceller to create the circular reference.
         deferred: Deferred[Any] = Deferred(canceller)
         canceller.deferred = deferred
+        weakDeferred = weakref.ref(deferred)
 
         failure = Failure(Exception("The test demands failures."))
         deferred.errback(failure)
@@ -1735,6 +1738,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # Once all local references have been dropped, the canceller should have
         # been freed.
         self.assertIsNone(weakCanceller())
+        self.assertIsNone(weakDeferred())
 
     @pyunit.skipIf(_PYPY, "GC works differently on PyPy.")
     def test_canceller_circular_reference_non_final(self) -> None:


### PR DESCRIPTION
Fixes #10310

This is to avoid circular references where the canceller holds a reference to the deferred (which is often the case).

It's safe to clear the `_canceller` after the Deferred has finished since we only call `_canceller` if the Deferred hasn't finished. Note that https://github.com/twisted/twisted/issues/10310#issuecomment-1168428766 suggests that its not safe to make this change, however the only place I can see that `_canceller` is used is behind a check against `.called`:

https://github.com/twisted/twisted/blob/c462c5f7d940260ea3ca553c8653d0d227bbf468/src/twisted/internet/defer.py#L768-L771

I can't see anywhere where we reset `called`, and the docs fairly clearly state it will remain `True`.