### PR TITLE
#11888 Enable GitHub Actions test run for Python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
           - python-version: '3.10'
 
           # Latest Python 3.12 with default settings.
-          - python-version: '3.12'
+          - python-version: '3.12.0-beta.3'
 
           # Newest macOS and newest Python supported versions.
           - python-version: '3.11'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,8 +68,8 @@ jobs:
       matrix:
         # The Python version on which the job is executed.
         # We need at least one value here, so we go with latest Python version
-        # that we support..
-        python-version: ['3.10']
+        # that we support.
+        python-version: ['3.11']
         # Just use the default OS.
         runs-on: ['']
         # Human readable short description for this job.
@@ -124,8 +124,11 @@ jobs:
           # Just Python 3.9 with default settings.
           - python-version: '3.9'
 
-          # Just Python 3.11 with default settings.
-          - python-version: '3.11'
+          # Just Python 3.10 with default settings.
+          - python-version: '3.10'
+
+          # Latest Python 3.12 with default settings.
+          - python-version: '3.12'
 
           # Newest macOS and newest Python supported versions.
           - python-version: '3.11'

--- a/src/twisted/newsfragments/11888.feature
+++ b/src/twisted/newsfragments/11888.feature
@@ -1,0 +1,1 @@
+Support was added for Python 3.12 beta release.


### PR DESCRIPTION
## Scope and purpose

Fixes #11888

For now, it will be beta release.

This can be used as an integration PR and bug/issue discover PR.

Fixes for 3.12 issues should be done in separate PRs

## Changes

Enable GHA for 3.12

Use 3.11 as the default run