### PR TITLE
#11841 fix pending futures

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1874,8 +1874,10 @@ def _inlineCallbacks(
             status.deferred.callback(callbackValue)
             return
 
-        is_not_done_future = isfuture(result) and not result.done()
-        if isinstance(result, Deferred) or is_not_done_future:
+        if isfuture(result) and not result.done():
+            result = Deferred.fromFuture(result)
+
+        if isinstance(result, Deferred):
             # a deferred was yielded, get the result.
             def gotResult(r: object) -> None:
                 if waiting[0]:
@@ -1884,8 +1886,6 @@ def _inlineCallbacks(
                 else:
                     _inlineCallbacks(r, gen, status, context)
 
-            if is_not_done_future:
-                result = Deferred.fromFuture(result)
             result.addBoth(gotResult)
             if waiting[0]:
                 # Haven't called back yet, set flag so that we get reinvoked

--- a/src/twisted/newsfragments/11841.bugfix
+++ b/src/twisted/newsfragments/11841.bugfix
@@ -1,0 +1,1 @@
+`defer.Deferred.fromCoroutine` now correctly processes pending futures.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -17,8 +17,8 @@ from asyncio import (
     AbstractEventLoop,
     CancelledError,
     Future,
-    new_event_loop as _new_event_loop,
     ensure_future,
+    new_event_loop as _new_event_loop,
 )
 from typing import (
     TYPE_CHECKING,
@@ -1685,6 +1685,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         L{Deferred.fromCoroutine} should properly process pending futures
         """
         result = object()
+
         async def test() -> object:
             return result
 
@@ -1697,7 +1698,6 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             self.successResultOf(d),
             is_(result),
         )
-
 
 
 def _setupRaceState(numDeferreds: int) -> tuple[list[int], list[Deferred[object]]]:


### PR DESCRIPTION
It should fix #11841. 

The main problem if `corouting.send` returns future in pending status which means we must back to the event loop and wait until it will be resolved. Otherwise, we will see the error "await wasn't used with future" which comes from the `send` code: https://github.com/python/cpython/blob/3.11/Modules/_asynciomodule.c#L1609 .

We are doing the same thing if we receive `Deferred` but for some reason ignored asyncio futures. This PR does the same thing for pending futures as for `Deferred`. 

Most problems come from `asyncio.ensure_future` function, which used by aiohttp. Without these changes not possible to use aiohttp inside Twisted even if you are using asyncio reactor and it reduces compatibility with tons of libraries. 