### PR TITLE
#11908 replace utcfromtimezone with fromtimezone(x, utc).replace(tzinfo=None)

### DIFF
--- a/src/twisted/newsfragments/11908.bugfix
+++ b/src/twisted/newsfragments/11908.bugfix
@@ -1,0 +1,2 @@
+utcfromtimestamp has been deprecated since Python 3.12,
+use fromtimestamp(x, timezone.utc).replace(tzinfo=None) instead.

--- a/src/twisted/python/_tzhelper.py
+++ b/src/twisted/python/_tzhelper.py
@@ -6,7 +6,12 @@
 Time zone utilities.
 """
 
-from datetime import datetime as DateTime, timedelta as TimeDelta, tzinfo as TZInfo
+from datetime import (
+    datetime as DateTime,
+    timedelta as TimeDelta,
+    timezone,
+    tzinfo as TZInfo,
+)
 from typing import Optional
 
 __all__ = [
@@ -68,9 +73,9 @@ class FixedOffsetTimeZone(TZInfo):
         Create a time zone with a fixed offset corresponding to a time stamp in
         the system's locally configured time zone.
         """
-        offset = DateTime.fromtimestamp(timeStamp) - DateTime.utcfromtimestamp(
-            timeStamp
-        )
+        offset = DateTime.fromtimestamp(timeStamp) - DateTime.fromtimestamp(
+            timeStamp, timezone.utc
+        ).replace(tzinfo=None)
         return cls(offset)
 
     def utcoffset(self, dt: Optional[DateTime]) -> TimeDelta:

--- a/src/twisted/python/log.py
+++ b/src/twisted/python/log.py
@@ -11,7 +11,7 @@ import sys
 import time
 import warnings
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, BinaryIO, Dict, Optional, cast
 
 from zope.interface import Interface
@@ -490,7 +490,9 @@ class FileLogObserver(_GlobalStartStopObserver):
         @return: The number of seconds offset from UTC.  West is positive,
         east is negative.
         """
-        offset = datetime.utcfromtimestamp(when) - datetime.fromtimestamp(when)
+        offset = datetime.fromtimestamp(when, timezone.utc).replace(
+            tzinfo=None
+        ) - datetime.fromtimestamp(when)
         return offset.days * (60 * 60 * 24) + offset.seconds
 
     def formatTime(self, when):
@@ -512,7 +514,9 @@ class FileLogObserver(_GlobalStartStopObserver):
             return datetime.fromtimestamp(when).strftime(self.timeFormat)
 
         tzOffset = -self.getTimezoneOffset(when)
-        when = datetime.utcfromtimestamp(when + tzOffset)
+        when = datetime.fromtimestamp(when + tzOffset, timezone.utc).replace(
+            tzinfo=None
+        )
         tzHour = abs(int(tzOffset / 60 / 60))
         tzMin = abs(int(tzOffset / 60 % 60))
         if tzOffset < 0:


### PR DESCRIPTION
## Scope and purpose

Fixes #11908 
