### PR TITLE
[#11968] Deprecate twisted.words.

### DIFF
--- a/docs/development/compatibility-policy.rst
+++ b/docs/development/compatibility-policy.rst
@@ -457,6 +457,22 @@ but is not raised from `from twisted.old_code.sub.module import SomeClass`.
 
 This is why it's recommended to just use `warnings.warn()` at the top level of the module.
 
+.. code-block:: python
+
+    """
+    The normal docstring of the top-level package.
+
+    This package is now deprecated.
+    """
+    import warnings
+
+    from incremental import Version, getVersionString
+
+    warningString = "twisted.old_code was deprecated at {}".format(
+        getVersionString(Version("Twisted", "NEXT", 0, 0))
+    )
+    warnings.warn(warningString, DeprecationWarning, stacklevel=3)
+
 
 Testing Deprecation Code
 ------------------------

--- a/docs/development/compatibility-policy.rst
+++ b/docs/development/compatibility-policy.rst
@@ -445,12 +445,17 @@ Modules cannot have properties, so module attributes should be deprecated using 
 Modules
 ^^^^^^^
 
-To deprecate an entire module, :py:func:`deprecatedModuleAttribute <twisted.python.deprecate.deprecatedModuleAttribute>` can be used on the parent package's ``__init__.py``.
+To deprecate an entire module there are two options:
 
-There are two other options:
+* Put a `warnings.warn()` call into the top-level code of the module, with `stacklevel=3`.
+* Deprecate all of the attributes of the module and sub-modules using :py:func:`deprecatedModuleAttribute <twisted.python.deprecate.deprecatedModuleAttribute>`.
 
-* Put a warnings.warn() call into the top-level code of the module.
-* Deprecate all of the attributes of the module.
+Using a single `deprecatedModuleAttribute` on the parent module will not work.
+For example if we have `twisted.old_code.sub.module.SomeClass` and you add the deprecation to `twisted` for the name `old_code`,
+a warning is raised for `from twisted import old_code`,
+but is not raised from `from twisted.old_code.sub.module import SomeClass`.
+
+This is why it's recommended to just use `warnings.warn()` at the top level of the module.
 
 
 Testing Deprecation Code

--- a/docs/development/compatibility-policy.rst
+++ b/docs/development/compatibility-policy.rst
@@ -445,33 +445,12 @@ Modules cannot have properties, so module attributes should be deprecated using 
 Modules
 ^^^^^^^
 
-To deprecate an entire module there are two options:
+To deprecate an entire module, :py:func:`deprecatedModuleAttribute <twisted.python.deprecate.deprecatedModuleAttribute>` can be used on the parent package's ``__init__.py``.
 
-* Put a `warnings.warn()` call into the top-level code of the module, with `stacklevel=3`.
-* Deprecate all of the attributes of the module and sub-modules using :py:func:`deprecatedModuleAttribute <twisted.python.deprecate.deprecatedModuleAttribute>`.
+There are two other options:
 
-Using a single `deprecatedModuleAttribute` on the parent module will not work.
-For example if we have `twisted.old_code.sub.module.SomeClass` and you add the deprecation to `twisted` for the name `old_code`,
-a warning is raised for `from twisted import old_code`,
-but is not raised from `from twisted.old_code.sub.module import SomeClass`.
-
-This is why it's recommended to just use `warnings.warn()` at the top level of the module.
-
-.. code-block:: python
-
-    """
-    The normal docstring of the top-level package.
-
-    This package is now deprecated.
-    """
-    import warnings
-
-    from incremental import Version, getVersionString
-
-    warningString = "twisted.old_code was deprecated at {}".format(
-        getVersionString(Version("Twisted", "NEXT", 0, 0))
-    )
-    warnings.warn(warningString, DeprecationWarning, stacklevel=3)
+* Put a warnings.warn() call into the top-level code of the module.
+* Deprecate all of the attributes of the module.
 
 
 Testing Deprecation Code
@@ -594,30 +573,3 @@ Tests which need to use deprecated classes should use the :py:meth:`getDeprecate
             creds = UsernameHashedPassword(b"foo", b"bar")
             self.assertEqual(creds.username, b"foo")
             self.assertEqual(creds.hashed, b"bar")
-
-Deprecation for whole packages or modules can be tested using the `importlib.reload` helper.
-
-.. code-block:: python
-
-    from importlib import reload
-
-    import twisted.words
-    from twisted.trial import unittest
-
-
-    class WordsDeprecationTests(unittest.TestCase):
-        """
-        Ensures that importing twisted.words directly or as a
-        module of twisted raises a deprecation warning.
-        """
-
-        def test_deprecationDirect(self):
-            """
-            A direct import will raise the deprecation warning.
-            """
-            reload(twisted.words)
-            warnings = self.flushWarnings([self.test_deprecationDirect])
-            self.assertEqual(1, len(warnings))
-            self.assertEqual(
-                "twisted.words was deprecated at Twisted NEXT", warnings[0]["message"]
-            )

--- a/docs/development/compatibility-policy.rst
+++ b/docs/development/compatibility-policy.rst
@@ -578,3 +578,30 @@ Tests which need to use deprecated classes should use the :py:meth:`getDeprecate
             creds = UsernameHashedPassword(b"foo", b"bar")
             self.assertEqual(creds.username, b"foo")
             self.assertEqual(creds.hashed, b"bar")
+
+Deprecation for whole packages or modules can be tested using the `importlib.reload` helper.
+
+.. code-block:: python
+
+    from importlib import reload
+
+    import twisted.words
+    from twisted.trial import unittest
+
+
+    class WordsDeprecationTests(unittest.TestCase):
+        """
+        Ensures that importing twisted.words directly or as a
+        module of twisted raises a deprecation warning.
+        """
+
+        def test_deprecationDirect(self):
+            """
+            A direct import will raise the deprecation warning.
+            """
+            reload(twisted.words)
+            warnings = self.flushWarnings([self.test_deprecationDirect])
+            self.assertEqual(1, len(warnings))
+            self.assertEqual(
+                "twisted.words was deprecated at Twisted NEXT", warnings[0]["message"]
+            )

--- a/src/twisted/words/__init__.py
+++ b/src/twisted/words/__init__.py
@@ -5,4 +5,14 @@
 """
 Twisted Words: Client and server implementations for IRC, XMPP, and other chat
 services.
+
+This package is now deprecated.
 """
+import warnings
+
+from incremental import Version, getVersionString
+
+warningString = "twisted.words is deprecated since {}".format(
+    getVersionString(Version("Twisted", "NEXT", 0, 0))
+)
+warnings.warn(warningString, DeprecationWarning, stacklevel=3)

--- a/src/twisted/words/__init__.py
+++ b/src/twisted/words/__init__.py
@@ -12,7 +12,7 @@ import warnings
 
 from incremental import Version, getVersionString
 
-warningString = "twisted.words is deprecated since {}".format(
+warningString = "twisted.words was deprecated at {}".format(
     getVersionString(Version("Twisted", "NEXT", 0, 0))
 )
 warnings.warn(warningString, DeprecationWarning, stacklevel=3)

--- a/src/twisted/words/newsfragments/11968.removal
+++ b/src/twisted/words/newsfragments/11968.removal
@@ -1,0 +1,2 @@
+twisted.words package is now deprecated.
+The XMMP and IRC protocols don't have an active maintainer.

--- a/src/twisted/words/test/test_deprecation.py
+++ b/src/twisted/words/test/test_deprecation.py
@@ -16,7 +16,7 @@ class WordsDeprecationTests(unittest.TestCase):
     module of twisted raises a deprecation warning.
     """
 
-    def test_deprecationDirect(self):
+    def test_deprecationDirect(self) -> None:
         """
         A direct import will raise the deprecation warning.
         """
@@ -27,7 +27,7 @@ class WordsDeprecationTests(unittest.TestCase):
             "twisted.words was deprecated at Twisted NEXT", warnings[0]["message"]
         )
 
-    def test_deprecationRootPackage(self):
+    def test_deprecationRootPackage(self) -> None:
         """
         Importing as sub-module of C{twisted} raises the deprecation warning.
         """

--- a/src/twisted/words/test/test_deprecation.py
+++ b/src/twisted/words/test/test_deprecation.py
@@ -1,0 +1,39 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+from __future__ import annotations
+
+from importlib import reload
+
+import twisted.words
+from twisted import words
+from twisted.trial import unittest
+
+
+class WordsDeprecationTests(unittest.TestCase):
+    """
+    Ensures that importing twisted.words or any sub-package
+    raises a deprecation warning.
+    """
+
+    def test_deprecationDirect(self):
+        """
+        An import direct will raise the deprecation
+        """
+        reload(twisted.words)
+        warnings = self.flushWarnings([self.test_deprecationDirect])
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "twisted.words is deprecated since Twisted NEXT", warnings[0]["message"]
+        )
+
+    def test_deprecationRootPackage(self):
+        """
+        An import direct will raise the deprecation
+        """
+        reload(words)
+        warnings = self.flushWarnings([self.test_deprecationRootPackage])
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "twisted.words is deprecated since Twisted NEXT", warnings[0]["message"]
+        )

--- a/src/twisted/words/test/test_deprecation.py
+++ b/src/twisted/words/test/test_deprecation.py
@@ -12,28 +12,28 @@ from twisted.trial import unittest
 
 class WordsDeprecationTests(unittest.TestCase):
     """
-    Ensures that importing twisted.words or any sub-package
-    raises a deprecation warning.
+    Ensures that importing twisted.words directly or as a
+    module of twisted raises a deprecation warning.
     """
 
     def test_deprecationDirect(self):
         """
-        An import direct will raise the deprecation
+        A direct import will raise the deprecation warning.
         """
         reload(twisted.words)
         warnings = self.flushWarnings([self.test_deprecationDirect])
         self.assertEqual(1, len(warnings))
         self.assertEqual(
-            "twisted.words is deprecated since Twisted NEXT", warnings[0]["message"]
+            "twisted.words was deprecated at Twisted NEXT", warnings[0]["message"]
         )
 
     def test_deprecationRootPackage(self):
         """
-        An import direct will raise the deprecation
+        Importing as sub-module of C{twisted} raises the deprecation warning.
         """
         reload(words)
         warnings = self.flushWarnings([self.test_deprecationRootPackage])
         self.assertEqual(1, len(warnings))
         self.assertEqual(
-            "twisted.words is deprecated since Twisted NEXT", warnings[0]["message"]
+            "twisted.words was deprecated at Twisted NEXT", warnings[0]["message"]
         )


### PR DESCRIPTION
## Scope and purpose

Fixes #11968

This introduces the deprecation warning for twisted.words

It also updates the documentation to covers how to deprecate a whole module

https://twisted--11969.org.readthedocs.build/en/11969/development/compatibility-policy.html#modules

