### PR TITLE
Deprecate twisted.web.microdom and twisted.web.domhelpers

### DIFF
--- a/src/twisted/web/domhelpers.py
+++ b/src/twisted/web/domhelpers.py
@@ -4,12 +4,22 @@
 
 """
 A library for performing interesting tasks with DOM objects.
-"""
 
+This module is now deprecated.
+"""
+import warnings
 from io import StringIO
+
+from incremental import Version, getVersionString
 
 from twisted.web import microdom
 from twisted.web.microdom import escape, getElementsByTagName, unescape
+
+warningString = "twisted.web.domhelpers was deprecated at {}".format(
+    getVersionString(Version("Twisted", "NEXT", 0, 0))
+)
+warnings.warn(warningString, DeprecationWarning, stacklevel=3)
+
 
 # These modules are imported here as a shortcut.
 escape

--- a/src/twisted/web/microdom.py
+++ b/src/twisted/web/microdom.py
@@ -16,16 +16,26 @@ fine for the documentation generator, which parses a fairly representative
 sample of XML.
 
 Microdom mainly focuses on working with HTML and XHTML.
+
+This module is now deprecated.
 """
 
 # System Imports
 import re
+import warnings
 from io import BytesIO, StringIO
+
+from incremental import Version, getVersionString
 
 # Twisted Imports
 from twisted.python.compat import ioType
 from twisted.python.util import InsensitiveDict
 from twisted.web.sux import ParseError, XMLParser
+
+warningString = "twisted.web.microdom was deprecated at {}".format(
+    getVersionString(Version("Twisted", "NEXT", 0, 0))
+)
+warnings.warn(warningString, DeprecationWarning, stacklevel=3)
 
 
 def getElementsByTagName(iNode, name):

--- a/src/twisted/web/newsfragments/3651.removal
+++ b/src/twisted/web/newsfragments/3651.removal
@@ -1,0 +1,1 @@
+twisted.dom.microdom and twisted.web.domhelpers are now deprecated.

--- a/src/twisted/web/test/test_domhelpers.py
+++ b/src/twisted/web/test/test_domhelpers.py
@@ -5,7 +5,7 @@
 """
 Specific tests for (some of) the methods in L{twisted.web.domhelpers}.
 """
-
+from importlib import reload
 from typing import Any, Optional
 from xml.dom import minidom
 
@@ -259,6 +259,18 @@ class MicroDOMHelpersTests(DOMHelpersTestsMixin, TestCase):
         self.assertEqual(actual, expected)
         actual = domhelpers.gatherTextNodes(doc5.documentElement)
         self.assertEqual(actual, expected)
+
+    def test_deprecation(self):
+        """
+        An import will raise the deprecation warning.
+        """
+        reload(domhelpers)
+        warnings = self.flushWarnings([self.test_deprecation])
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "twisted.web.domhelpers was deprecated at Twisted NEXT",
+            warnings[0]["message"],
+        )
 
 
 class MiniDOMHelpersTests(DOMHelpersTestsMixin, TestCase):

--- a/src/twisted/web/test/test_xml.py
+++ b/src/twisted/web/test/test_xml.py
@@ -5,7 +5,7 @@
 """
 Some fairly inadequate testcases for Twisted XML support.
 """
-
+from importlib import reload
 from io import BytesIO
 
 from twisted.trial.unittest import TestCase
@@ -787,6 +787,18 @@ alert("I hate you");
         )
         xmlOut = document.toxml()
         self.assertEqual(xmlOut, xmlOk)
+
+    def test_deprecation(self):
+        """
+        An import will raise the deprecation warning.
+        """
+        reload(microdom)
+        warnings = self.flushWarnings([self.test_deprecation])
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "twisted.web.microdom was deprecated at Twisted NEXT",
+            warnings[0]["message"],
+        )
 
 
 class BrokenHTMLTests(TestCase):


### PR DESCRIPTION
## Scope and purpose

Fixes #3561

The usage of these modules in Twisted was removed in https://github.com/twisted/twisted/issues/7943 - in 2016

I think it's time to raise deprecation warnings ... and at some point remove this code.