### PR TITLE
#11999 Use the Black pre-commit mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,8 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://github.com/psf/black
+  # See https://black.readthedocs.io/en/stable/integrations/source_version_control.html
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1
     hooks:
       - id: black


### PR DESCRIPTION
## Scope and purpose

Fixes #11999.

See [Black docs](https://black.readthedocs.io/en/stable/integrations/source_version_control.html).
