### PR TITLE
#12005 Fixing license for PyPI so that it appears there

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dynamic = [
     "optional-dependencies",
 ]
 description = "An asynchronous networking framework written in Python"
-license = "MIT"
+license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
 requires-python = ">=3.8.0"
 authors = [

--- a/src/twisted/newsfragments/12005.misc
+++ b/src/twisted/newsfragments/12005.misc
@@ -1,0 +1,1 @@
+This modifies the pyproject.toml so that the license appears correctly on the PyPI repository


### PR DESCRIPTION
## Scope and purpose

Fixes #12005
This modifies the file so that the license appears correctly on the PyPI repository

