### PR TITLE
#12012 Fix loading JQuery for Read The Docs theme.

### DIFF
--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -1,5 +1,0 @@
-// Configure the Gitter sidecar chat button.
-// https://sidecar.gitter.im/
-window.gitter = {'chat': {'options': {
-    'room': 'twisted/twisted'
-  }}}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@ from pprint import pprint
 
 import sphinx_rtd_theme
 
+from twisted import version as twisted_version_object
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -37,17 +39,9 @@ sys.path.insert(0, os.path.abspath(".."))
 # ones.
 extensions = [
     "sphinx.ext.intersphinx",
+    "sphinxcontrib.jquery",
     "pydoctor.sphinx_ext.build_apidocs",
 ]
-
-try:
-    import rst2pdf.pdfbuilder
-
-    extensions.append("rst2pdf.pdfbuilder")
-except ImportError:
-    pass
-
-from twisted import version as twisted_version_object
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -105,14 +99,6 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-
-# These paths are either relative to html_static_path
-# or fully qualified paths (eg. https://...)
-html_js_files = [
-    "js/custom.js",
-    # Here we have a Sphinx HTML injection hack to make the JS script load without blocking.
-    'https://sidecar.gitter.im/dist/sidecar.v1.js" defer hack="',
-]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "Twisteddoc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,8 @@ test = [
 # release scripts and process.
 dev-release = [
     "towncrier ~= 23.6",
-    "pydoctor ~= 23.4.0",
-    "sphinx-rtd-theme ~= 1.2",
-    "readthedocs-sphinx-ext ~= 2.2",
+    "pydoctor ~= 23.9.0",
+    "sphinx-rtd-theme ~= 1.3",
     "sphinx >= 6, <7",
 ]
 

--- a/src/twisted/newsfragments/12012.doc
+++ b/src/twisted/newsfragments/12012.doc
@@ -1,0 +1,3 @@
+The search and version navigation for the documentation hosted on
+Read The Docs was fixed.
+This was a regression introduced with 23.8.0.


### PR DESCRIPTION
## Scope and purpose

Fixes #12012

This tries to fix search page and RTD version navigation issue that was introduced with 23.8.0

## Issue description

You can see that search works for 22.10.0 https://docs.twisted.org/en/twisted-22.10.0/search.html?q=deferLater&check_keywords=yes&area=default

But this fails https://docs.twisted.org/en/twisted-23.8.0/search.html?q=deferLater&check_keywords=yes&area=default

Also clicking on the RTD version, does nothing

![image](https://github.com/twisted/twisted/assets/204609/c92c85ac-975e-4866-92e2-5bec7e70dd99)

## Changes

Explicit use of the jquery extension.

I have updated the RTD sphinx theme and pydoctor versions... while on it.

As a drive-by, I have removed the Gitter embeeded chat box, as it's no longer available.
I have also removed the PDF code, since we don't build the PDF version of the docs.

## How to test

Check the search and RTD version navigation for the docs build generated by this PR

https://twisted--12013.org.readthedocs.build/en/12013/search.html?q=deferLater&check_keywords=yes&area=default