### PR TITLE
#12026 Adjust to deprecation of 3-arg generator.throw()

### DIFF
--- a/src/twisted/newsfragments/12026.bugfix
+++ b/src/twisted/newsfragments/12026.bugfix
@@ -1,0 +1,1 @@
+twisted.python.failure.Failure now throws exception for generators without triggering a deprecation warnings on Python 3.12.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -516,7 +516,7 @@ class Failure(BaseException):
         """
         # Note that the actual magic to find the traceback information
         # is done in _findFailure.
-        return g.throw(self.type, self.value, self.tb)
+        return g.throw(self.value.with_traceback(self.tb))
 
     @classmethod
     def _findFailure(cls):


### PR DESCRIPTION
In Python 3.12, the 3-arg signature of generator.throw() is deprecated, you're only supposed to use the 1-arg signature where you pass only an exception instance. I *think* this is the right thing to pass in this case.

## Scope and purpose

Fixes #12026 (use of a deprecated form of `generator.throw()` causes deprecation warnings on Python 3.12). Note we are not totally sure yet whether this is safe on Python 3.8: see [here](https://github.com/python/cpython/issues/96348#issuecomment-1783626480).

## Contributor Checklist: (done)