### PR TITLE
#12026 Suppress a deprecation warning on Python 3.12

### DIFF
--- a/src/twisted/newsfragments/12026.bugfix
+++ b/src/twisted/newsfragments/12026.bugfix
@@ -1,0 +1,1 @@
+Suppress a deprecation warning on Python 3.12

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -18,6 +18,7 @@ import copy
 import inspect
 import linecache
 import sys
+import warnings
 from inspect import getmro
 from io import StringIO
 from typing import Callable, NoReturn, TypeVar
@@ -516,7 +517,12 @@ class Failure(BaseException):
         """
         # Note that the actual magic to find the traceback information
         # is done in _findFailure.
-        return g.throw(self.type, self.value, self.tb)
+        with warnings.catch_warnings():
+            # three-arg form is deprecated in Python 3.12, but one-arg
+            # form was only introduced in 3.9, so filter the warning
+            # until 3.9 is EOL
+            warnings.simplefilter("ignore")
+            return g.throw(self.type, self.value, self.tb)
 
     @classmethod
     def _findFailure(cls):


### PR DESCRIPTION
The three-arg form of generator.throw() was deprecated in Python 3.12. However, we're not sure if the modern one-arg form works on Python 3.8, which is still supported, so instead of changing it right now, this just suppresses the warning.

## Scope and purpose

Fixes #12026 (use of a deprecated form of `generator.throw()` causes deprecation warnings on Python 3.12). An alternative to #12027 - this one just suppresses the warning, rather than changing the call. @glyph asked me to submit both options.

## Contributor Checklist: (done)