### PR TITLE
#11848 Remove the usage of cgi.parse_multipart and replace with email module.

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -294,6 +294,9 @@ def parse_qs(qs, keep_blank_values=0, strict_parsing=0):
     """
     Like C{cgi.parse_qs}, but with support for parsing byte strings on Python 3.
 
+    This was created to help with Python 2 to Python 3 migration.
+    Consider using L{urllib.parse.parse_qs}.
+
     @type qs: C{bytes}
     """
     d = {}

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -226,7 +226,7 @@ weekdayname_lower = [name.lower() for name in weekdayname]
 monthname_lower = [name and name.lower() for name in monthname]
 
 
-def _parseContentType(line: bytes) -> tuple[bytes, dict[str, bytes]]:
+def _parseContentType(line: bytes) -> bytes:
     """
     Parse the Content-Type header.
     """
@@ -243,7 +243,7 @@ class _MultiPartParseException(Exception):
     """
 
 
-def _getMultiPartArgs(content, ctype):
+def _getMultiPartArgs(content: bytes, ctype: bytes) -> dict[bytes, list[bytes]]:
     """
     Parse the content of a multipart/form-data request.
     """

--- a/src/twisted/web/newsfragments/11848.removal
+++ b/src/twisted/web/newsfragments/11848.removal
@@ -1,0 +1,2 @@
+twisted.web.http.Request now parses the `multipart/form-data` using `email.message_from_bytes`.
+The usage of `cgi.parse_multipart` was removed as the `cgi` module will be removed in Python 3.13.


### PR DESCRIPTION
## Scope and purpose

Fixes #11848

This should be the last usage of `cgi` module in Twisted.

It uses the stdlib `email` module.

I with with stdlib to reduce the need for an extra dependency or reinvent the wheel.

I think that if there are any issued with stdlib, they should be fixed upstream.

See https://github.com/twisted/treq/issues/355 for other options.