### PR TITLE
#12056 Update dis.findlinestarts for Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,7 +139,15 @@ jobs:
           # No coverage also.
           - python-version: '3.13.0-alpha.2'
             tox-env: 'mindeps-nocov-posix'
-            job-name: 'mindeps-nocov-deps-3.13'
+            job-name: 'mindeps-nocov-3.13'
+            skip-coverage: yes
+            # FIXME:https://github.com/twisted/twisted/issues/12060
+            # Also add twisted.python
+            # FIXME:https://github.com/twisted/twisted/issues/12061
+            # Add full twisted.internet
+            # FIXME:https://github.com/twisted/twisted/issues/12062
+            # Add full twisted.test
+            trial-args: '-j 4 twisted.conch twisted.cred twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.words'
 
           # Newest macOS and oldest Python (major) supported versions.
           - python-version: '3.8'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,7 +135,10 @@ jobs:
           - python-version: '3.11'
 
           # Just Python 3.13 alpha with default settings.
+          # For now, minimum dependencies as cffi doesn't work on 3.13
           - python-version: '3.13.0-alpha.2'
+            tox-env: 'mindeps-withcov-posix'
+            job-name: 'minimum-deps-3.13'
 
           # Newest macOS and oldest Python (major) supported versions.
           - python-version: '3.8'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,9 +135,10 @@ jobs:
           - python-version: '3.11'
 
           # Just Python 3.13 alpha with default settings.
-          # For now, minimum dependencies as cffi doesn't work on 3.13
+          # For now, minimum dependencies as cffi doesn't work on 3.13.
+          # No coverage also.
           - python-version: '3.13.0-alpha.2'
-            tox-env: 'mindeps-withcov-posix'
+            tox-env: 'mindeps-nocov-posix'
             job-name: 'minimum-deps-3.13'
 
           # Newest macOS and oldest Python (major) supported versions.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,6 +134,9 @@ jobs:
           # Just Python 3.11 with default settings.
           - python-version: '3.11'
 
+          # Just Python 3.13 alpha with default settings.
+          - python-version: '3.13.0-alpha.2'
+
           # Newest macOS and oldest Python (major) supported versions.
           - python-version: '3.8'
             runs-on: 'macos-12'
@@ -194,7 +197,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,7 +139,7 @@ jobs:
           # No coverage also.
           - python-version: '3.13.0-alpha.2'
             tox-env: 'mindeps-nocov-posix'
-            job-name: 'minimum-deps-3.13'
+            job-name: 'mindeps-nocov-deps-3.13'
 
           # Newest macOS and oldest Python (major) supported versions.
           - python-version: '3.8'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,11 +135,11 @@ jobs:
           - python-version: '3.11'
 
           # Just Python 3.13 alpha with default settings.
-          # For now, minimum dependencies as cffi doesn't work on 3.13.
+          # For now, no dependencies as cffi doesn't work on 3.13.
           # No coverage also.
-          - python-version: '3.13.0-alpha.2'
-            tox-env: 'mindeps-nocov-posix'
-            job-name: 'mindeps-nocov-3.13'
+          - python-version: '3.13.0-alpha.3'
+            tox-env: 'nodeps-nocov-posix'
+            job-name: 'nodeps-nocov-3.13'
             skip-coverage: yes
             # FIXME:https://github.com/twisted/twisted/issues/12060
             # Also add twisted.python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -147,7 +147,7 @@ jobs:
             # Add full twisted.internet
             # FIXME:https://github.com/twisted/twisted/issues/12062
             # Add full twisted.test
-            trial-args: '-j 4 twisted.conch twisted.cred twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.words'
+            trial-target: 'twisted.conch twisted.cred twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.words'
 
           # Newest macOS and oldest Python (major) supported versions.
           - python-version: '3.8'

--- a/src/twisted/newsfragments/12056.feature
+++ b/src/twisted/newsfragments/12056.feature
@@ -1,1 +1,0 @@
-Update `int` and `None` comparisons as required by Python 3.13.

--- a/src/twisted/newsfragments/12056.feature
+++ b/src/twisted/newsfragments/12056.feature
@@ -1,0 +1,1 @@
+Update `int` and `None` comparisons as required by Python 3.13.

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -601,12 +601,19 @@ def warnAboutFunction(offender, warningString):
     """
     # inspect.getmodule() is attractive, but somewhat
     # broken in Python < 2.6.  See Python bug 4845.
+    # In Python 3.13 line numbers returned by findlinestarts
+    # can be None for bytecode that does not map to source
+    # lines.
     offenderModule = sys.modules[offender.__module__]
     warn_explicit(
         warningString,
         category=DeprecationWarning,
         filename=inspect.getabsfile(offenderModule),
-        lineno=max(lineNumber for _, lineNumber in findlinestarts(offender.__code__)),
+        lineno=max(
+            lineNumber
+            for _, lineNumber in findlinestarts(offender.__code__)
+            if lineNumber is not None
+        ),
         module=offenderModule.__name__,
         registry=offender.__globals__.setdefault("__warningregistry__", {}),
         module_globals=None,

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -1189,9 +1189,14 @@ class SynchronousTestCase(_Assertions):
 
                     if filename != os.path.normcase(aWarning.filename):
                         continue
+
+                    # In Python 3.13 line numbers returned by findlinestarts
+                    # can be None for bytecode that does not map to source
+                    # lines.
                     lineNumbers = [
                         lineNumber
                         for _, lineNumber in _findlinestarts(aFunction.__code__)
+                        if lineNumber is not None
                     ]
                     if not (min(lineNumbers) <= aWarning.lineno <= max(lineNumbers)):
                         continue


### PR DESCRIPTION
## Scope and purpose

Fixes #12056 

This updates the usage of dis.findlinestarts.

The Python 3.13 tests are cherry picked to be executed.
Later we can enable more.

As a drive-by, update GitHub Actions Python helper to the latest version.