### PR TITLE
Fix chat.py example

### DIFF
--- a/docs/core/howto/listings/servers/chat.py
+++ b/docs/core/howto/listings/servers/chat.py
@@ -26,13 +26,15 @@ class Chat(LineReceiver):
         if name in self.users:
             self.sendLine(b"Name taken, please choose another.")
             return
-        self.sendLine(f"Welcome, {name.decode('utf-8')}!".encode('utf-8'))
+        self.sendLine(f"Welcome, {name.decode('utf-8')}!".encode("utf-8"))
         self.name = name
         self.users[name] = self
         self.state = "CHAT"
 
     def handle_CHAT(self, message):
-        message = f"<{self.name.decode('utf-8')}> {message.decode('utf-8')}".encode('utf-8')
+        message = f"<{self.name.decode('utf-8')}> {message.decode('utf-8')}".encode(
+            "utf-8"
+        )
         for name, protocol in self.users.items():
             if protocol != self:
                 protocol.sendLine(message)

--- a/docs/core/howto/listings/servers/chat.py
+++ b/docs/core/howto/listings/servers/chat.py
@@ -10,7 +10,7 @@ class Chat(LineReceiver):
         self.state = "GETNAME"
 
     def connectionMade(self):
-        self.sendLine("What's your name?")
+        self.sendLine(b"What's your name?")
 
     def connectionLost(self, reason):
         if self.name in self.users:
@@ -24,16 +24,16 @@ class Chat(LineReceiver):
 
     def handle_GETNAME(self, name):
         if name in self.users:
-            self.sendLine("Name taken, please choose another.")
+            self.sendLine(b"Name taken, please choose another.")
             return
-        self.sendLine(f"Welcome, {name}!")
+        self.sendLine(f"Welcome, {name.decode('utf-8')}!".encode('utf-8'))
         self.name = name
         self.users[name] = self
         self.state = "CHAT"
 
     def handle_CHAT(self, message):
-        message = f"<{self.name}> {message}"
-        for name, protocol in self.users.iteritems():
+        message = f"<{self.name.decode('utf-8')}> {message.decode('utf-8')}".encode('utf-8')
+        for name, protocol in self.users.items():
             if protocol != self:
                 protocol.sendLine(message)
 

--- a/src/twisted/words/newsfragments/12070.doc
+++ b/src/twisted/words/newsfragments/12070.doc
@@ -1,0 +1,1 @@
+The documented IRC example was updated for Python3 usage.


### PR DESCRIPTION
Apparently, twisted changed the behavior in that
the library now expects byte arrays rather than
strings.
Also, Python3 replaced the dict method iteritems() with items()
