### PR TITLE
#12071: Document when spawnProcess uses os.posix_spawnp

### DIFF
--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1090,6 +1090,16 @@ class IReactorProcess(Interface):
         arguments will be decoded up to L{unicode} using the encoding given by
         L{sys.getfilesystemencoding} (C{utf8}) and given to Windows's native "wide" APIs.
 
+        On POSIX, C{spawnProcess} may use deprecated C{os.fork} under the following
+        conditions:
+
+         - C{path} being not C{None} or a path that resolves to something different
+            than the current directory.
+         - C{uid} being not C{None}.
+         - C{gid} being not C{None}.
+
+        If none of the above conditions hold, deprecated C{os.fork} will not be used.
+
         @param processProtocol: An object which will be notified of all events
             related to the created process.
 

--- a/src/twisted/newsfragments/12071.doc
+++ b/src/twisted/newsfragments/12071.doc
@@ -1,0 +1,1 @@
+twisted.internet.interfaces.IReactorProcess now documents certain details of the POSIX-based implementation included with Twisted.


### PR DESCRIPTION
posix_spawnp is not identical to fork+execve. New python versions throw a deprecation warning on os.fork usage. Downstream users may want to adjust usages of spawnProcess to not use fork+execve.

## Scope and purpose

Fixes #12071.

