### PR TITLE
fix trunk failing build by pinning PyPy to 3.7.13, as 3.7.14 is failing currently, and add some type annotations to deal with new annotations in pyOpenSSL

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy-3.9'
+          - python-version: 'pypy-3.10'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy-3.9'
+          - python-version: 'pypy-3.10'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy-3.10'
+          - python-version: 'pypy3.10-v7.3.12'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy-3.10'
+          - python-version: 'pypy3.10-v7.3.12'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.10-v7.3.12'
+          - python-version: 'pypy3.10-v7.3.13'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10-v7.3.12'
+          - python-version: 'pypy3.10-v7.3.13'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.10-v7.3.13'
+          - python-version: 'pypy3.10-v7.3.14'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10-v7.3.13'
+          - python-version: 'pypy3.10-v7.3.14'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.10-v7.3.14'
+          - python-version: 'pypy3.10-v7.3.13'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10-v7.3.14'
+          - python-version: 'pypy3.10-v7.3.13'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -13,7 +13,7 @@ from typing import Dict
 from zope.interface import Interface, implementer
 
 from OpenSSL import SSL, crypto
-from OpenSSL._util import lib as pyOpenSSLlib  # type: ignore[import]
+from OpenSSL._util import lib as pyOpenSSLlib
 
 import attr
 from constantly import FlagConstant, Flags, NamedConstant, Names  # type: ignore[import]

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -8,12 +8,14 @@ TCP support for IOCP reactor
 import errno
 import socket
 import struct
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from zope.interface import classImplements, implementer
 
 from twisted.internet import address, defer, error, interfaces, main
 from twisted.internet.abstract import _LogOwner, isIPv6Address
+from twisted.internet.address import IPv4Address, IPv6Address
+from twisted.internet.interfaces import IProtocol
 from twisted.internet.iocpreactor import abstract, iocpsupport as _iocp
 from twisted.internet.iocpreactor.const import (
     ERROR_CONNECTION_REFUSED,
@@ -42,6 +44,9 @@ except ImportError:
 else:
     _startTLS = __startTLS
 
+if TYPE_CHECKING:
+    # Circular import only to describe a type.
+    from twisted.internet.iocpreactor.reactor import IOCPReactor
 
 # ConnectEx returns these. XXX: find out what it does for timeout
 connectExErrors = {
@@ -345,7 +350,15 @@ class Server(Connection):
 
     _tlsClientDefault = False
 
-    def __init__(self, sock, protocol, clientAddr, serverAddr, sessionno, reactor):
+    def __init__(
+        self,
+        sock: socket.socket,
+        protocol: IProtocol,
+        clientAddr: Union[IPv4Address, IPv6Address],
+        serverAddr: Union[IPv4Address, IPv6Address],
+        sessionno: int,
+        reactor: IOCPReactor,
+    ):
         """
         Server(sock, protocol, client, server, sessionno)
 

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -5,6 +5,8 @@
 TCP support for IOCP reactor
 """
 
+from __future__ import annotations
+
 import errno
 import socket
 import struct

--- a/src/twisted/internet/ssl.py
+++ b/src/twisted/internet/ssl.py
@@ -53,6 +53,7 @@ APIs listed above.
     throughout the documentation.
 """
 
+from __future__ import annotations
 
 from zope.interface import implementedBy, implementer, implementer_only
 
@@ -179,6 +180,8 @@ class Server(tcp.Server):
     """
     I am an SSL server.
     """
+
+    server: Port
 
     def __init__(self, *args, **kwargs):
         tcp.Server.__init__(self, *args, **kwargs)

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -8,13 +8,13 @@ Various asynchronous TCP/IP classes.
 End users shouldn't use this module directly - use the reactor APIs instead.
 """
 
-import os
+from __future__ import annotations
 
-# System Imports
+import os
 import socket
 import struct
 import sys
-from typing import Callable, ClassVar, List, Optional
+from typing import Callable, ClassVar, List, Optional, Union
 
 from zope.interface import Interface, implementer
 
@@ -24,6 +24,8 @@ import typing_extensions
 from twisted.internet.interfaces import (
     IHalfCloseableProtocol,
     IListeningPort,
+    IProtocol,
+    IReactorTCP,
     ISystemHandle,
     ITCPTransport,
 )
@@ -781,9 +783,19 @@ class Server(_TLSServerMixin, Connection):
 
     _base = Connection
 
-    _addressType = address.IPv4Address
+    _addressType: Union[
+        type[address.IPv4Address], type[address.IPv6Address]
+    ] = address.IPv4Address
 
-    def __init__(self, sock, protocol, client, server, sessionno, reactor):
+    def __init__(
+        self,
+        sock: socket.socket,
+        protocol: IProtocol,
+        client: tuple[object, ...],
+        server: Port,
+        sessionno: int,
+        reactor: IReactorTCP,
+    ) -> None:
         """
         Server(sock, protocol, client, server, sessionno)
 

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -202,7 +202,18 @@ from io import BytesIO
 from itertools import count
 from struct import pack
 from types import MethodType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from zope.interface import Interface, implementer
 
@@ -1686,18 +1697,23 @@ class Descriptor(Integer):
         return outString
 
 
+_Self = TypeVar("_Self")
+
+
 class _CommandMeta(type):
     """
     Metaclass hack to establish reverse-mappings for 'errors' and
     'fatalErrors' as class vars.
     """
 
-    def __new__(cls, name, bases, attrs):
+    def __new__(
+        cls: type[_Self], name: str, bases: tuple[type], attrs: dict[str, object]
+    ) -> Type[Command]:
         reverseErrors = attrs["reverseErrors"] = {}
         er = attrs["allErrors"] = {}
         if "commandName" not in attrs:
             attrs["commandName"] = name.encode("ascii")
-        newtype = type.__new__(cls, name, bases, attrs)
+        newtype: Type[Command] = type.__new__(cls, name, bases, attrs)  # type:ignore
 
         if not isinstance(newtype.commandName, bytes):
             raise TypeError(
@@ -1705,12 +1721,12 @@ class _CommandMeta(type):
                     newtype.commandName
                 )
             )
-        for name, _ in newtype.arguments:
-            if not isinstance(name, bytes):
-                raise TypeError(f"Argument names must be byte strings, got: {name!r}")
-        for name, _ in newtype.response:
-            if not isinstance(name, bytes):
-                raise TypeError(f"Response names must be byte strings, got: {name!r}")
+        for bname, _ in newtype.arguments:
+            if not isinstance(bname, bytes):
+                raise TypeError(f"Argument names must be byte strings, got: {bname!r}")
+        for bname, _ in newtype.response:
+            if not isinstance(bname, bytes):
+                raise TypeError(f"Response names must be byte strings, got: {bname!r}")
 
         errors: Dict[Type[Exception], bytes] = {}
         fatalErrors: Dict[Type[Exception], bytes] = {}
@@ -1718,9 +1734,9 @@ class _CommandMeta(type):
         accumulateClassDict(newtype, "fatalErrors", fatalErrors)
 
         if not isinstance(newtype.errors, dict):
-            newtype.errors = dict(newtype.errors)
+            newtype.errors = dict(newtype.errors)  # type:ignore[unreachable]
         if not isinstance(newtype.fatalErrors, dict):
-            newtype.fatalErrors = dict(newtype.fatalErrors)
+            newtype.fatalErrors = dict(newtype.fatalErrors)  # type:ignore[unreachable]
 
         for v, k in errors.items():
             reverseErrors[k] = v
@@ -1729,13 +1745,13 @@ class _CommandMeta(type):
             reverseErrors[k] = v
             er[v] = k
 
-        for _, name in newtype.errors.items():
-            if not isinstance(name, bytes):
-                raise TypeError(f"Error names must be byte strings, got: {name!r}")
-        for _, name in newtype.fatalErrors.items():
-            if not isinstance(name, bytes):
+        for _, bname in newtype.errors.items():
+            if not isinstance(bname, bytes):
+                raise TypeError(f"Error names must be byte strings, got: {bname!r}")
+        for _, bname in newtype.fatalErrors.items():
+            if not isinstance(bname, bytes):
                 raise TypeError(
-                    f"Fatal error names must be byte strings, got: {name!r}"
+                    f"Fatal error names must be byte strings, got: {bname!r}"
                 )
 
         return newtype
@@ -1784,14 +1800,15 @@ class Command(metaclass=_CommandMeta):
     want one.
     """
 
-    arguments: List[Tuple[bytes, Argument]] = []
-    response: List[Tuple[bytes, Argument]] = []
-    extra: List[Any] = []
-    errors: Dict[Type[Exception], bytes] = {}
-    fatalErrors: Dict[Type[Exception], bytes] = {}
+    commandName: ClassVar[bytes]
+    arguments: ClassVar[List[Tuple[bytes, Argument]]] = []
+    response: ClassVar[List[Tuple[bytes, Argument]]] = []
+    extra: ClassVar[List[Any]] = []
+    errors: ClassVar[Dict[Type[Exception], bytes]] = {}
+    fatalErrors: ClassVar[Dict[Type[Exception], bytes]] = {}
 
-    commandType: "Union[Type[Command], Type[Box]]" = Box
-    responseType: Type[AmpBox] = Box
+    commandType: "ClassVar[Union[Type[Command], Type[Box]]]" = Box
+    responseType: ClassVar[Type[AmpBox]] = Box
 
     requiresAnswer = True
 

--- a/src/twisted/python/modules.py
+++ b/src/twisted/python/modules.py
@@ -56,6 +56,7 @@ the modules outside the standard library's python-files directory::
 @type theSystemPath: L{PythonPath}
 """
 
+from __future__ import annotations
 
 import inspect
 import sys
@@ -251,7 +252,9 @@ class PythonAttribute:
     this class.
     """
 
-    def __init__(self, name, onObject, loaded, pythonValue):
+    def __init__(
+        self, name: str, onObject: PythonAttribute, loaded: bool, pythonValue: object
+    ) -> None:
         """
         Create a PythonAttribute.  This is a private constructor.  Do not construct
         me directly, use PythonModule.iterAttributes.
@@ -306,7 +309,9 @@ class PythonModule(_ModuleIteratorHelper):
     from.
     """
 
-    def __init__(self, name, filePath, pathEntry):
+    def __init__(
+        self, name: str, filePath: FilePath[str], pathEntry: PathEntry
+    ) -> None:
         """
         Create a PythonModule.  Do not construct this directly, instead inspect a
         PythonPath or other PythonModule instances.

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -9,7 +9,7 @@ Tests for L{twisted.protocols.amp}.
 
 import datetime
 import decimal
-from typing import Dict, Type, TypeVar
+from typing import ClassVar, Dict, Type, TypeVar
 from unittest import skipIf
 
 from zope.interface import implementer
@@ -136,9 +136,9 @@ class Hello(amp.Command):
 
     response = [(b"hello", amp.String()), (b"print", amp.Unicode(optional=True))]
 
-    errors: Dict[Type[Exception], bytes] = {UnfriendlyGreeting: b"UNFRIENDLY"}
+    errors: ClassVar[Dict[Type[Exception], bytes]] = {UnfriendlyGreeting: b"UNFRIENDLY"}
 
-    fatalErrors: Dict[Type[Exception], bytes] = {DeathThreat: b"DEAD"}
+    fatalErrors: ClassVar[Dict[Type[Exception], bytes]] = {DeathThreat: b"DEAD"}
 
 
 class NoAnswerHello(Hello):
@@ -2136,7 +2136,9 @@ class BaseCommand(amp.Command):
     This provides a command that will be subclassed.
     """
 
-    errors: Dict[Type[Exception], bytes] = {InheritedError: b"INHERITED_ERROR"}
+    errors: ClassVar[Dict[Type[Exception], bytes]] = {
+        InheritedError: b"INHERITED_ERROR"
+    }
 
 
 class InheritedCommand(BaseCommand):
@@ -2153,7 +2155,7 @@ class AddErrorsCommand(BaseCommand):
     """
 
     arguments = [(b"other", amp.Boolean())]
-    errors: Dict[Type[Exception], bytes] = {
+    errors: ClassVar[Dict[Type[Exception], bytes]] = {
         OtherInheritedError: b"OTHER_INHERITED_ERROR"
     }
 

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -693,7 +693,7 @@ class FunctionalTests(TestCase):
         a.callback("result")
         assert_that(self.successResultOf(d), none())
 
-    def test_sequence(self):
+    def test_sequence(self) -> None:
         """
         ``sequence`` accepts two awaitables and returns an awaitable that waits
         for the first one to complete and then completes with the result of
@@ -707,7 +707,7 @@ class FunctionalTests(TestCase):
         a.callback("hello")
         assert_that(self.successResultOf(c), equal_to(42))
 
-    def test_iterateWhile(self):
+    def test_iterateWhile(self) -> None:
         """
         ``iterateWhile`` executes the actions from its factory until the predicate
         does not match an action result.

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -136,7 +136,7 @@ class ReporterRealtimeTests(TestResultTests):
 class ErrorReportingTests(StringTest):
     doubleSeparator = re.compile(r"^=+$")
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.loader = runner.TestLoader()
         self.output = StringIO()
         self.result: reporter.Reporter = reporter.Reporter(self.output)
@@ -264,7 +264,7 @@ class UncleanWarningWrapperErrorReportingTests(ErrorReportingTests):
     IReporter failure and error reporting methods to a L{reporter.Reporter}.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.loader = runner.TestLoader()
         self.output = StringIO()
         self.reporter: reporter.Reporter = reporter.Reporter(self.output)

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -110,7 +110,7 @@ import warnings
 from email import message_from_bytes
 from email.message import EmailMessage
 from io import BytesIO
-from typing import AnyStr, Callable, List, Optional, Tuple
+from typing import AnyStr, Callable, Dict, List, Optional, Tuple
 from urllib.parse import (
     ParseResultBytes,
     unquote_to_bytes as unquote,
@@ -132,8 +132,6 @@ from twisted.python.compat import nativeString, networkString
 from twisted.python.components import proxyForInterface
 from twisted.python.deprecate import deprecated
 from twisted.python.failure import Failure
-
-# twisted imports
 from twisted.web._responses import (
     ACCEPTED,
     BAD_GATEWAY,
@@ -859,7 +857,7 @@ class Request:
     _disconnected = False
     _log = Logger()
 
-    def __init__(self, channel, queued=_QUEUED_SENTINEL):
+    def __init__(self, channel: HTTPChannel, queued: object = _QUEUED_SENTINEL) -> None:
         """
         @param channel: the channel we're connected to.
         @param queued: (deprecated) are we in the request queue, or can we
@@ -875,9 +873,9 @@ class Request:
         self.host = self.channel.getHost()
 
         self.requestHeaders: Headers = Headers()
-        self.received_cookies = {}
+        self.received_cookies: Dict[bytes, bytes] = {}
         self.responseHeaders: Headers = Headers()
-        self.cookies = []  # outgoing cookies
+        self.cookies: List[bytes] = []  # outgoing cookies
         self.transport = self.channel.transport
 
         if queued is _QUEUED_SENTINEL:


### PR DESCRIPTION
Fixes #12076