### PR TITLE
12084 PyPy stack depth check change for 7.3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.10'
+          - python-version: 'pypy3.10-v7.3.14'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10'
+          - python-version: 'pypy3.10-v7.3.14'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -168,14 +168,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.10-v7.3.13'
+          - python-version: 'pypy3.10'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10-v7.3.13'
+          - python-version: 'pypy3.10'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -175,7 +175,7 @@ jobs:
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.10-v7.3.14'
+          - python-version: 'pypy3.10-v7.3.13'
             trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -58,6 +58,9 @@ log = Logger()
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
+# See use in _inlineCallbacks for explanation and removal timeline.
+_oldPypyStack = _PYPY and implementation.version < (7, 3, 14)
+
 
 class AlreadyCalledError(Exception):
     """
@@ -2022,14 +2025,10 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            _oldPypyStackCompatibility = _PYPY and implementation.version < (
-                7,
-                3,
-                14,
-            )
-            if _oldPypyStackCompatibility:
-                # PyPy before 7.3.14 adds an extra frame.
-                # This code can be removed once we no longer need to support PyPy 7.3.13 or older.
+            if _oldPypyStack:
+                # PyPy versions through 7.3.13 add an extra frame; 7.3.14 fixed
+                # this discrepancy with CPython.  This code can be removed once
+                # we no longer need to support PyPy 7.3.13 or older.
                 appCodeTrace = appCodeTrace.tb_next
                 assert appCodeTrace is not None
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -17,7 +17,7 @@ from asyncio import AbstractEventLoop, Future, iscoroutine
 from contextvars import Context as _Context, copy_context as _copy_context
 from enum import Enum
 from functools import wraps
-from sys import exc_info
+from sys import exc_info, implementation
 from types import CoroutineType, GeneratorType, MappingProxyType, TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -53,6 +53,8 @@ from twisted.python.deprecate import deprecated, warnAboutFunction
 from twisted.python.failure import Failure, _extraneous
 
 log = Logger()
+
+_STACK_LEVEL_INCOMPATIBLE = _PYPY and implementation.version < (7, 3, 14)
 
 
 _T = TypeVar("_T")
@@ -2022,8 +2024,8 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            if _PYPY:
-                # PyPy as of 3.7 adds an extra frame.
+            if _STACK_LEVEL_INCOMPATIBLE:
+                # PyPy as of 3.7 and before 7.3.14 adds an extra frame.
                 appCodeTrace = appCodeTrace.tb_next
                 assert appCodeTrace is not None
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -54,7 +54,6 @@ from twisted.python.failure import Failure, _extraneous
 
 log = Logger()
 
-_STACK_LEVEL_INCOMPATIBLE = _PYPY and implementation.version < (7, 3, 14)
 
 
 _T = TypeVar("_T")
@@ -2024,8 +2023,10 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            if _STACK_LEVEL_INCOMPATIBLE:
-                # PyPy as of 3.7 and before 7.3.14 adds an extra frame.
+            _old_pypy_stack_compatibility = _PYPY and implementation.version < (7, 3, 14)
+            if _old_pypy_stack_compatibility:
+                # PyPy before 7.3.14 adds an extra frame.
+                # This code can be removed once we no longer need to support PyPy 7.3.13 or older.
                 appCodeTrace = appCodeTrace.tb_next
                 assert appCodeTrace is not None
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -2022,12 +2022,12 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            _old_pypy_stack_compatibility = _PYPY and implementation.version < (
+            _oldPypyStackCompatibility = _PYPY and implementation.version < (
                 7,
                 3,
                 14,
             )
-            if _old_pypy_stack_compatibility:
+            if _oldPypyStackCompatibility:
                 # PyPy before 7.3.14 adds an extra frame.
                 # This code can be removed once we no longer need to support PyPy 7.3.13 or older.
                 appCodeTrace = appCodeTrace.tb_next

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -55,7 +55,6 @@ from twisted.python.failure import Failure, _extraneous
 log = Logger()
 
 
-
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
@@ -2023,7 +2022,11 @@ def _inlineCallbacks(
             appCodeTrace = traceback.tb_next
             assert appCodeTrace is not None
 
-            _old_pypy_stack_compatibility = _PYPY and implementation.version < (7, 3, 14)
+            _old_pypy_stack_compatibility = _PYPY and implementation.version < (
+                7,
+                3,
+                14,
+            )
             if _old_pypy_stack_compatibility:
                 # PyPy before 7.3.14 adds an extra frame.
                 # This code can be removed once we no longer need to support PyPy 7.3.13 or older.

--- a/src/twisted/newsfragments/12083.bugfix
+++ b/src/twisted/newsfragments/12083.bugfix
@@ -1,0 +1,1 @@
+The stack depth check in twisted.internet.defer was adjusted for PyPy > 7.3.14

--- a/src/twisted/newsfragments/12083.bugfix
+++ b/src/twisted/newsfragments/12083.bugfix
@@ -1,1 +1,1 @@
-The stack depth check in twisted.internet.defer was adjusted for PyPy > 7.3.14
+twisted.internet.defer inline deferred stack introspection was adjusted for latest PyPy 7.3.14 release.

--- a/src/twisted/newsfragments/12083.bugfix
+++ b/src/twisted/newsfragments/12083.bugfix
@@ -1,1 +1,0 @@
-twisted.internet.defer inline deferred stack introspection was adjusted for latest PyPy 7.3.14 release.

--- a/src/twisted/newsfragments/12084.bugfix
+++ b/src/twisted/newsfragments/12084.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.defer.inlineCallbacks.returnValue's stack introspection was adjusted for the latest PyPy 7.3.14 release, allowing legacy @inlineCallbacks to run on new PyPY versions.


### PR DESCRIPTION
## Scope and purpose

Fixes #12084

PyPy 7.3.14 made stack crawling more compatible with CPython, this broke tests in twisted. Since this is a testing-only fix, does it need a release note?

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
