### PR TITLE
#12095 Increase RSA keys generated in tests

### DIFF
--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -1675,8 +1675,8 @@ class PersistentRSAKeyTests(unittest.TestCase):
         tempDir = FilePath(self.mktemp())
         keyFile = tempDir.child("mykey.pem")
 
-        key = keys._getPersistentRSAKey(keyFile, keySize=512)
-        self.assertEqual(key.size(), 512)
+        key = keys._getPersistentRSAKey(keyFile, keySize=1024)
+        self.assertEqual(key.size(), 1024)
         self.assertTrue(keyFile.exists())
 
     def test_noRegeneration(self):
@@ -1687,15 +1687,15 @@ class PersistentRSAKeyTests(unittest.TestCase):
         tempDir = FilePath(self.mktemp())
         keyFile = tempDir.child("mykey.pem")
 
-        key = keys._getPersistentRSAKey(keyFile, keySize=512)
-        self.assertEqual(key.size(), 512)
+        key = keys._getPersistentRSAKey(keyFile, keySize=1024)
+        self.assertEqual(key.size(), 1024)
         self.assertTrue(keyFile.exists())
         keyContent = keyFile.getContent()
 
-        # Set the key size to 1024 bits. Since it exists already, it will find
-        # the 512 bit key, and not generate a 1024 bit key.
-        key = keys._getPersistentRSAKey(keyFile, keySize=1024)
-        self.assertEqual(key.size(), 512)
+        # Set the key size to 2048 bits. Since it exists already, it will find
+        # the 1024 bit key, and not generate a 2048 bit key.
+        key = keys._getPersistentRSAKey(keyFile, keySize=2048)
+        self.assertEqual(key.size(), 1024)
         self.assertEqual(keyFile.getContent(), keyContent)
 
     def test_keySizeZero(self):
@@ -1706,6 +1706,6 @@ class PersistentRSAKeyTests(unittest.TestCase):
         tempDir = FilePath(self.mktemp())
         keyFile = tempDir.child("mykey.pem")
 
-        key = keys._getPersistentRSAKey(keyFile, keySize=512)
+        key = keys._getPersistentRSAKey(keyFile, keySize=1024)
         key._keyObject = None
         self.assertEqual(key.size(), 0)

--- a/src/twisted/conch/test/test_manhole_tap.py
+++ b/src/twisted/conch/test/test_manhole_tap.py
@@ -80,7 +80,7 @@ class MakeServiceTests(TestCase):
                 "--sshKeyDir",
                 self.mktemp(),
                 "--sshKeySize",
-                "512",
+                "1024",
                 "--sshPort",
                 "tcp:223",
             ]


### PR DESCRIPTION
This will allow pyca/cryptography to increase the minimum key size. 512-bit keys are wildly insecure, so we want to disallow them.