### PR TITLE
#11902 - Fix type for twisted.web.server.Request.defaultContentType

### DIFF
--- a/src/twisted/newsfragments/11902.misc
+++ b/src/twisted/newsfragments/11902.misc
@@ -1,0 +1,1 @@
+Change typing for twisted.web.server.Request.defaultContentType to allow None.

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -101,8 +101,7 @@ class Request(Copyable, http.Request, components.Componentized):
         will be transmitted only over HTTPS.
     """
 
-    defaultContentType = b"text/html"
-
+    defaultContentType: Optional[bytes] = b"text/html"
     site = None
     appRootURL = None
     prepath: Optional[List[bytes]] = None


### PR DESCRIPTION
## Scope and purpose

Fixes #11902

Set type for twisted.web.server.Request.defaultContentType to allow bytes or None.




