### PR TITLE
#12108 Speed up the twisted.web HTTP client

### DIFF
--- a/src/twisted/logger/_json.py
+++ b/src/twisted/logger/_json.py
@@ -55,7 +55,7 @@ def failureFromJSON(failureDict: JSONDict) -> Failure:
     f = Failure.__new__(Failure)
     typeInfo = failureDict["type"]
     failureDict["type"] = type(typeInfo["__name__"], (), typeInfo)
-    f.__dict__ = failureDict
+    f.__setstate__(failureDict)
     return f
 
 

--- a/src/twisted/newsfragments/12112.bugfix
+++ b/src/twisted/newsfragments/12112.bugfix
@@ -1,1 +1,1 @@
-Fix bug where ``twisted.python.failure.Failure``'s custom pickling code wasn't being used.
+twisted.python.failure.Failure once again utilizes the custom pickling logic it used to in the past.

--- a/src/twisted/newsfragments/12112.bugfix
+++ b/src/twisted/newsfragments/12112.bugfix
@@ -1,0 +1,1 @@
+Fix bug where ``twisted.python.failure.Failure``'s custom pickling code wasn't being used.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 # System Imports
 import builtins
 import copy
-from functools import partial
 import inspect
 import linecache
 import sys
+from functools import partial
 from inspect import getmro
 from io import StringIO
 from typing import Callable, NoReturn, TypeVar

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -459,7 +459,7 @@ class Failure(BaseException):
         self.frames = frames
 
     @staticmethod
-    def without_traceback(value: BaseException) -> Failure:
+    def _without_traceback(value: BaseException) -> Failure:
         """
         Create a L{Failure} for an exception without a traceback.
 

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -472,7 +472,7 @@ class Failure(BaseException):
         result.captureVars = False
         result.count = count
         result.frames = []
-        result.stack = []
+        result.stack = []  # type: ignore
         result.value = value
         result.type = value.__class__
         result.tb = None

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -249,6 +249,7 @@ class Failure(BaseException):
 
     pickled = 0
     stack = None
+    __parents = None
 
     # The opcode of "yield" in Python bytecode. We need this in
     # _findFailure in order to identify whether an exception was
@@ -417,11 +418,18 @@ class Failure(BaseException):
                 )
             )
             tb = tb.tb_next
+
+    @property
+    def parents(self):
+        if self.__parents is not None:
+            return self.__parents
+
         if inspect.isclass(self.type) and issubclass(self.type, Exception):
             parentCs = getmro(self.type)
-            self.parents = list(map(reflect.qual, parentCs))
+            self.__parents = list(map(reflect.qual, parentCs))
         else:
-            self.parents = [self.type]
+            self.__parents = [self.type]
+        return self.__parents
 
     def _extrapolate(self, otherFailure):
         """

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -289,9 +289,6 @@ class Failure(BaseException):
         self.type = self.value = tb = None
         self.captureVars = captureVars
 
-        if isinstance(exc_value, str) and exc_type is None:
-            raise TypeError("Strings are not supported by Failure")
-
         stackOffset = 0
 
         if exc_value is None:

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -11,6 +11,7 @@ Asynchronous-friendly error mechanism.
 See L{Failure}.
 """
 
+from __future__ import annotations
 
 # System Imports
 import builtins
@@ -456,6 +457,26 @@ class Failure(BaseException):
         # Merging current stack with stack stored in the Failure.
         frames.extend(self.frames)
         self.frames = frames
+
+    @staticmethod
+    def without_traceback(value: Exception) -> Failure:
+        """
+        Create a L{Failure} for an exception without a traceback.
+
+        By restricting the inputs significantly, this constructor runs much
+        faster.
+        """
+        result = Failure.__new__(Failure)
+        global count
+        count += 1
+        result.captureVars = False
+        result.count = count
+        result.frames = []
+        result.stack = []
+        result.value = value
+        result.type = value.__class__
+        result.tb = None
+        return result
 
     def trap(self, *errorTypes):
         """

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -667,6 +667,7 @@ class Failure(BaseException):
     def __reduce__(self):
         # BaseException implements a __reduce__ (in C, technically), so TODO
         from functools import partial
+
         return (partial(Failure.__new__, Failure), (), self.__getstate__())
 
     def cleanFailure(self):

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 # System Imports
 import builtins
 import copy
+from functools import partial
 import inspect
 import linecache
 import sys
@@ -665,9 +666,8 @@ class Failure(BaseException):
         return c
 
     def __reduce__(self):
-        # BaseException implements a __reduce__ (in C, technically), so TODO
-        from functools import partial
-
+        # BaseException implements a __reduce__ (in C, technically), so we need
+        # to override this to get pickling working.
         return (partial(Failure.__new__, Failure), (), self.__getstate__())
 
     def cleanFailure(self):

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -754,6 +754,35 @@ class Failure(BaseException):
         """
         self.printTraceback(file, elideFrameworkCode, detail="verbose")
 
+    def _freeze(self) -> "_FrozenFailure":
+        """
+        Create a frozen instance, consuming this one.
+        """
+        result = _FrozenFailure.__new__(_FrozenFailure)
+        result.__dict__ = self.__dict__
+        # Destroy this failure, just to be sure:
+        self.__dict__ = {}
+        return result
+
+
+class _FrozenFailure(Failure):
+    """
+    A L{Failure} that shouldn't be mutated.
+    """
+
+    def __setattr__(self, key, value):
+        if key == "__dict__":
+            object.__setattr__(self, key, value)
+            return
+        raise RuntimeError(
+            f"Tried to set {key} to {value}, but this object should not be mutated"
+        )
+
+    def __delattr__(self, key):
+        raise RuntimeError(
+            f"Tried to delete attribute {key}, but this object should not be mutated"
+        )
+
 
 def _safeReprVars(varsDictItems):
     """

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -459,7 +459,7 @@ class Failure(BaseException):
         self.frames = frames
 
     @staticmethod
-    def without_traceback(value: Exception) -> Failure:
+    def without_traceback(value: BaseException) -> Failure:
         """
         Create a L{Failure} for an exception without a traceback.
 

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -460,7 +460,7 @@ class Failure(BaseException):
         self.frames = frames
 
     @staticmethod
-    def _without_traceback(value: BaseException) -> Failure:
+    def _withoutTraceback(value: BaseException) -> Failure:
         """
         Create a L{Failure} for an exception without a traceback.
 

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -754,35 +754,6 @@ class Failure(BaseException):
         """
         self.printTraceback(file, elideFrameworkCode, detail="verbose")
 
-    def _freeze(self) -> "_FrozenFailure":
-        """
-        Create a frozen instance, consuming this one.
-        """
-        result = _FrozenFailure.__new__(_FrozenFailure)
-        result.__dict__ = self.__dict__
-        # Destroy this failure, just to be sure:
-        self.__dict__ = {}
-        return result
-
-
-class _FrozenFailure(Failure):
-    """
-    A L{Failure} that shouldn't be mutated.
-    """
-
-    def __setattr__(self, key, value):
-        if key == "__dict__":
-            object.__setattr__(self, key, value)
-            return
-        raise RuntimeError(
-            f"Tried to set {key} to {value}, but this object should not be mutated"
-        )
-
-    def __delattr__(self, key):
-        raise RuntimeError(
-            f"Tried to delete attribute {key}, but this object should not be mutated"
-        )
-
 
 def _safeReprVars(varsDictItems):
     """

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -449,7 +449,11 @@ class CopyableFailure(failure.Failure, Copyable):
         Collect state related to the exception which occurred, discarding
         state which cannot reasonably be serialized.
         """
+        # Make sure self._parents is populated:
+        _ = self.parents
+
         state = self.__dict__.copy()
+        state["parents"] = state.pop("_parents")
         state["tb"] = None
         state["frames"] = []
         state["stack"] = []
@@ -480,6 +484,10 @@ class CopiedFailure(RemoteCopy, failure.Failure):
     @ivar traceback: The remote traceback.
     @type traceback: C{str}
     """
+
+    def setCopyableState(self, state):
+        state["_parents"] = state.pop("parents")
+        return super().setCopyableState(state)
 
     def printTraceback(self, file=None, elideFrameworkCode=0, detail="default"):
         if file is None:

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -522,14 +522,14 @@ class FailureTests(SynchronousTestCase):
             "<twisted.python.failure.Failure " "%s: division by zero>" % (typeName,),
         )
 
-    def test_failure_without_traceback(self) -> None:
+    def test_failureWithoutTraceback(self) -> None:
         """
-        C{Failure._without_traceback(exc)} gives the same result as
+        C{Failure._withoutTraceback(exc)} gives the same result as
         C{Failure(exc)}.
         """
         exc = ZeroDivisionError("hello")
         dict1 = failure.Failure(exc).__dict__.copy()
-        failure2 = failure.Failure._without_traceback(exc)
+        failure2 = failure.Failure._withoutTraceback(exc)
         self.assertIsInstance(failure2, failure.Failure)
         dict2 = failure2.__dict__.copy()
 
@@ -539,9 +539,9 @@ class FailureTests(SynchronousTestCase):
         # The rest of the attributes should be identical:
         self.assertEqual(dict1, dict2)
 
-    def test_failure_pickling(self) -> None:
+    def test_failurePickling(self) -> None:
         """
-        C{Failure(exc)} and C{Failure._without_traceback(exc)} can be pickled
+        C{Failure(exc)} and C{Failure._withoutTraceback(exc)} can be pickled
         and unpickled.
         """
         exc = ComparableException("hello")
@@ -551,7 +551,7 @@ class FailureTests(SynchronousTestCase):
         # You would think this test is unnecessary, since it's just a
         # C{Failure}, but actually the behavior of pickling can sometimes be
         # different because of the way the constructor works!
-        failure2 = failure.Failure._without_traceback(exc)
+        failure2 = failure.Failure._withoutTraceback(exc)
         self.assertPicklingRoundtrips(failure2)
 
     def assertPicklingRoundtrips(self, original_failure: failure.Failure) -> None:
@@ -564,7 +564,7 @@ class FailureTests(SynchronousTestCase):
         expected["pickled"] = 1
         self.assertEqual(expected, failure2.__dict__)
 
-    def test_failure_pickling_includes_parents(self) -> None:
+    def test_failurePicklingIncludesParents(self) -> None:
         """
         C{Failure.parents} is included in the pickle.
         """

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import linecache
 import pdb
+import pickle
 import re
 import sys
 import traceback
@@ -22,6 +23,16 @@ from cython_test_exception_raiser import raiser
 
 from twisted.python import failure, reflect
 from twisted.trial.unittest import SynchronousTestCase
+
+
+class ComparableException(Exception):
+    """An exception that can be compared by value."""
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__) and (self.args == other.args)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 def getDivisionFailure(*, captureVars: bool = False) -> failure.Failure:
@@ -508,6 +519,55 @@ class FailureTests(SynchronousTestCase):
             repr(f),
             "<twisted.python.failure.Failure " "%s: division by zero>" % (typeName,),
         )
+
+    def test_failure_without_traceback(self) -> None:
+        """
+        C{Failure._without_traceback(exc)} gives the same result as
+        C{Failure(exc)}.
+        """
+        exc = ZeroDivisionError("hello")
+        dict1 = failure.Failure(exc).__dict__.copy()
+        failure2 = failure.Failure._without_traceback(exc)
+        self.assertIsInstance(failure2, failure.Failure)
+        dict2 = failure2.__dict__.copy()
+
+        # count increments with each new Failure constructed:
+        self.assertEqual(dict1.pop("count") + 1, dict2.pop("count"))
+
+        # The rest of the attributes should be identical:
+        self.assertEqual(dict1, dict2)
+
+    def test_failure_pickling(self) -> None:
+        """
+        C{Failure(exc)} and C{Failure._without_traceback(exc)} can be pickled
+        and unpickled.
+        """
+        exc = ComparableException("hello")
+        failure1 = failure.Failure(exc)
+        self.assertPicklingRoundtrips(failure1)
+
+        # You would think this test is unnecessary, since it's just a
+        # C{Failure}, but actually the behavior of pickling can sometimes be
+        # different because of the way the constructor works!
+        failure2 = failure.Failure._without_traceback(exc)
+        self.assertPicklingRoundtrips(failure2)
+
+    def assertPicklingRoundtrips(self, original_failure: failure.Failure) -> None:
+        """
+        The failure can be pickled and unpickled, and the C{parents} attribute
+        is included in the pickle.
+        """
+        failure2 = pickle.loads(pickle.dumps(original_failure))
+        expected = original_failure.__dict__.copy()
+        expected["pickled"] = 1
+        self.assertEqual(expected, failure2.__dict__)
+
+    def test_failure_pickling_includes_parents(self):
+        """
+        C{Failure.parents} is included in the pickle.
+        """
+        f = failure.Failure(ComparableException("hello"))
+        self.assertEqual(f.__getstate__()["parents"], f.parents)
 
 
 class BrokenStr(Exception):
@@ -1032,20 +1092,3 @@ class ExtendedGeneratorTests(SynchronousTestCase):
             self._throwIntoGenerator(f, g)
         except BaseException:
             self.assertIsInstance(failure.Failure().value, IndexError)
-
-    def test_failure_without_traceback(self) -> None:
-        """
-        C{Failure.without_traceback(exc)} gives the same result as
-        C{Failure(exc)}.
-        """
-        exc = ZeroDivisionError("hello")
-        dict1 = failure.Failure(exc).__dict__.copy()
-        failure2 = failure.Failure._without_traceback(exc)
-        self.assertIsInstance(failure2, failure.Failure)
-        dict2 = failure2.__dict__.copy()
-
-        # count increments with each new Failure constructed:
-        self.assertEqual(dict1.pop("count") + 1, dict2.pop("count"))
-
-        # The rest of the attributes should be identical:
-        self.assertEqual(dict1, dict2)

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -16,7 +16,7 @@ from dis import distb
 from io import StringIO
 from traceback import FrameSummary
 from types import TracebackType
-from typing import Any, Generator
+from typing import Any, Generator, cast
 from unittest import skipIf
 
 from cython_test_exception_raiser import raiser
@@ -28,10 +28,12 @@ from twisted.trial.unittest import SynchronousTestCase
 class ComparableException(Exception):
     """An exception that can be compared by value."""
 
-    def __eq__(self, other):
-        return (self.__class__ == other.__class__) and (self.args == other.args)
+    def __eq__(self, other: object) -> bool:
+        return (self.__class__ == other.__class__) and (
+            self.args == cast(ComparableException, other).args
+        )
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
 
@@ -562,7 +564,7 @@ class FailureTests(SynchronousTestCase):
         expected["pickled"] = 1
         self.assertEqual(expected, failure2.__dict__)
 
-    def test_failure_pickling_includes_parents(self):
+    def test_failure_pickling_includes_parents(self) -> None:
         """
         C{Failure.parents} is included in the pickle.
         """

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -1033,7 +1033,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
         except BaseException:
             self.assertIsInstance(failure.Failure().value, IndexError)
 
-    def test_failure_without_traceback(self):
+    def test_failure_without_traceback(self) -> None:
         """
         C{Failure.without_traceback(exc)} gives the same result as
         C{Failure(exc)}.

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -398,14 +398,6 @@ class FailureTests(SynchronousTestCase):
         innerline = self._getInnermostFrameLine(f)
         self.assertEqual(innerline, "1 / 0")
 
-    def test_stringExceptionConstruction(self) -> None:
-        """
-        Constructing a C{Failure} with a string as its exception value raises
-        a C{TypeError}, as this is no longer supported as of Python 2.6.
-        """
-        exc = self.assertRaises(TypeError, failure.Failure, "ono!")
-        self.assertIn("Strings are not supported by Failure", str(exc))
-
     def test_ConstructionFails(self) -> None:
         """
         Creating a Failure with no arguments causes it to try to discover the

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -1032,3 +1032,20 @@ class ExtendedGeneratorTests(SynchronousTestCase):
             self._throwIntoGenerator(f, g)
         except BaseException:
             self.assertIsInstance(failure.Failure().value, IndexError)
+
+    def test_failure_without_traceback(self):
+        """
+        C{Failure.without_traceback(exc)} gives the same result as
+        C{Failure(exc)}.
+        """
+        exc = ZeroDivisionError("hello")
+        dict1 = failure.Failure(exc).__dict__.copy()
+        failure2 = failure.Failure.without_traceback(exc)
+        self.assertIsInstance(failure2, failure.Failure)
+        dict2 = failure2.__dict__.copy()
+
+        # count increments with each new Failure constructed:
+        self.assertEqual(dict1.pop("count") + 1, dict2.pop("count"))
+
+        # The rest of the attributes should be identical:
+        self.assertEqual(dict1, dict2)

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -1040,7 +1040,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
         """
         exc = ZeroDivisionError("hello")
         dict1 = failure.Failure(exc).__dict__.copy()
-        failure2 = failure.Failure.without_traceback(exc)
+        failure2 = failure.Failure._without_traceback(exc)
         self.assertIsInstance(failure2, failure.Failure)
         dict2 = failure2.__dict__.copy()
 

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -1040,28 +1040,3 @@ class ExtendedGeneratorTests(SynchronousTestCase):
             self._throwIntoGenerator(f, g)
         except BaseException:
             self.assertIsInstance(failure.Failure().value, IndexError)
-
-
-class FrozenFailureTests(SynchronousTestCase):
-    """
-    Tests for C{_FrozenFailure}.
-    """
-
-    def test_immutable(self) -> None:
-        """
-        L{failure.Failure._freeze} returns a C{_FrozenFailure} that can't be trivially
-        mutated.
-        """
-        frozen = getDivisionFailure()._freeze()
-        self.assertIsInstance(frozen, failure.Failure)
-        self.assertIsInstance(frozen.value, ZeroDivisionError)
-
-        # Can't set:
-        with self.assertRaises(RuntimeError):
-            frozen.value = 3
-        self.assertIsInstance(frozen.value, ZeroDivisionError)
-
-        # Can't delete:
-        with self.assertRaises(RuntimeError):
-            del frozen.value
-        self.assertIsInstance(frozen.value, ZeroDivisionError)

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -33,9 +33,6 @@ class ComparableException(Exception):
             self.args == cast(ComparableException, other).args
         )
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
-
 
 def getDivisionFailure(*, captureVars: bool = False) -> failure.Failure:
     """

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -1040,3 +1040,28 @@ class ExtendedGeneratorTests(SynchronousTestCase):
             self._throwIntoGenerator(f, g)
         except BaseException:
             self.assertIsInstance(failure.Failure().value, IndexError)
+
+
+class FrozenFailureTests(SynchronousTestCase):
+    """
+    Tests for C{_FrozenFailure}.
+    """
+
+    def test_immutable(self) -> None:
+        """
+        L{failure.Failure._freeze} returns a C{_FrozenFailure} that can't be trivially
+        mutated.
+        """
+        frozen = getDivisionFailure()._freeze()
+        self.assertIsInstance(frozen, failure.Failure)
+        self.assertIsInstance(frozen.value, ZeroDivisionError)
+
+        # Can't set:
+        with self.assertRaises(RuntimeError):
+            frozen.value = 3
+        self.assertIsInstance(frozen.value, ZeroDivisionError)
+
+        # Can't delete:
+        with self.assertRaises(RuntimeError):
+            del frozen.value
+        self.assertIsInstance(frozen.value, ZeroDivisionError)

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1270,7 +1270,7 @@ class Response:
         """
         self._state = "DEFERRED_CLOSE"
         if reason is None:
-            reason = Failure._without_traceback(
+            reason = Failure._withoutTraceback(
                 ResponseDone("Response body fully received")
             )
         self._reason = reason
@@ -1280,7 +1280,7 @@ class Response:
         Disconnect the protocol and move to the C{'FINISHED'} state.
         """
         if reason is None:
-            reason = Failure._without_traceback(
+            reason = Failure._withoutTraceback(
                 ResponseDone("Response body fully received")
             )
         self._bodyProtocol.connectionLost(reason)
@@ -1597,7 +1597,7 @@ class HTTP11ClientProtocol(Protocol):
             or self._state != "QUIESCENT"
             or not self._currentRequest.persistent
         ):
-            self._giveUp(Failure._without_traceback(reason))
+            self._giveUp(Failure._withoutTraceback(reason))
         else:
             # Just in case we had paused the transport, resume it before
             # considering it quiescent again.

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1052,7 +1052,7 @@ def makeStatefulDispatcher(name, template):
 _ClientRequestProxy = proxyForInterface(IClientRequest)
 
 # Pre-create this since it gets created for every response.
-_RESPONSE_DONE_FAILURE = Failure(ResponseDone("Response body fully received"))
+_RESPONSE_DONE_FAILURE = Failure(ResponseDone("Response body fully received"))._freeze()
 
 
 @implementer(IResponse)
@@ -1410,7 +1410,7 @@ class TransportProxyProducer:
 
 # Pre-created error and failure, since they are used for every request:
 _DONE = ConnectionDone("synthetic!")
-_DONE_FAILURE = Failure(_DONE)
+_DONE_FAILURE = Failure(_DONE)._freeze()
 
 
 class HTTP11ClientProtocol(Protocol):

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1051,6 +1051,9 @@ def makeStatefulDispatcher(name, template):
 # IClientRequest.
 _ClientRequestProxy = proxyForInterface(IClientRequest)
 
+# Pre-create this since it gets created for every response.
+_RESPONSE_DONE_FAILURE = Failure(ResponseDone("Response body fully received"))
+
 
 @implementer(IResponse)
 class Response:
@@ -1270,7 +1273,7 @@ class Response:
         """
         self._state = "DEFERRED_CLOSE"
         if reason is None:
-            reason = Failure(ResponseDone("Response body fully received"))
+            reason = _RESPONSE_DONE_FAILURE
         self._reason = reason
 
     def _bodyDataFinished_CONNECTED(self, reason=None):
@@ -1278,7 +1281,7 @@ class Response:
         Disconnect the protocol and move to the C{'FINISHED'} state.
         """
         if reason is None:
-            reason = Failure(ResponseDone("Response body fully received"))
+            reason = _RESPONSE_DONE_FAILURE
         self._bodyProtocol.connectionLost(reason)
         self._bodyProtocol = None
         self._state = "FINISHED"

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -388,6 +388,11 @@ class HTTPClientParser(HTTPParser):
         b'HTTP/1.1'.  Returns (protocol, major, minor).  Will raise ValueError
         on bad syntax.
         """
+        # Vast majority of the time this will be the response, so just
+        # immediately return the result:
+        if strversion == b"HTTP/1.1":
+            return (b"HTTP", 1, 1)
+
         try:
             proto, strnumber = strversion.split(b"/")
             major, minor = strnumber.split(b".")

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1270,7 +1270,9 @@ class Response:
         """
         self._state = "DEFERRED_CLOSE"
         if reason is None:
-            reason = Failure.without_traceback(ResponseDone("Response body fully received"))
+            reason = Failure.without_traceback(
+                ResponseDone("Response body fully received")
+            )
         self._reason = reason
 
     def _bodyDataFinished_CONNECTED(self, reason=None):
@@ -1278,7 +1280,9 @@ class Response:
         Disconnect the protocol and move to the C{'FINISHED'} state.
         """
         if reason is None:
-            reason = Failure.without_traceback(ResponseDone("Response body fully received"))
+            reason = Failure.without_traceback(
+                ResponseDone("Response body fully received")
+            )
         self._bodyProtocol.connectionLost(reason)
         self._bodyProtocol = None
         self._state = "FINISHED"

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -30,12 +30,7 @@ import re
 
 from zope.interface import implementer
 
-from twisted.internet.defer import (
-    CancelledError,
-    Deferred,
-    fail,
-    succeed,
-)
+from twisted.internet.defer import CancelledError, Deferred, fail, succeed
 from twisted.internet.error import ConnectionDone
 from twisted.internet.interfaces import IConsumer, IPushProducer
 from twisted.internet.protocol import Protocol

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1270,7 +1270,7 @@ class Response:
         """
         self._state = "DEFERRED_CLOSE"
         if reason is None:
-            reason = Failure(ResponseDone("Response body fully received"))
+            reason = Failure.without_traceback(ResponseDone("Response body fully received"))
         self._reason = reason
 
     def _bodyDataFinished_CONNECTED(self, reason=None):
@@ -1278,7 +1278,7 @@ class Response:
         Disconnect the protocol and move to the C{'FINISHED'} state.
         """
         if reason is None:
-            reason = Failure(ResponseDone("Response body fully received"))
+            reason = Failure.without_traceback(ResponseDone("Response body fully received"))
         self._bodyProtocol.connectionLost(reason)
         self._bodyProtocol = None
         self._state = "FINISHED"
@@ -1593,7 +1593,7 @@ class HTTP11ClientProtocol(Protocol):
             or self._state != "QUIESCENT"
             or not self._currentRequest.persistent
         ):
-            self._giveUp(Failure(reason))
+            self._giveUp(Failure.without_traceback(reason))
         else:
             # Just in case we had paused the transport, resume it before
             # considering it quiescent again.

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1270,7 +1270,7 @@ class Response:
         """
         self._state = "DEFERRED_CLOSE"
         if reason is None:
-            reason = Failure.without_traceback(
+            reason = Failure._without_traceback(
                 ResponseDone("Response body fully received")
             )
         self._reason = reason
@@ -1280,7 +1280,7 @@ class Response:
         Disconnect the protocol and move to the C{'FINISHED'} state.
         """
         if reason is None:
-            reason = Failure.without_traceback(
+            reason = Failure._without_traceback(
                 ResponseDone("Response body fully received")
             )
         self._bodyProtocol.connectionLost(reason)
@@ -1597,7 +1597,7 @@ class HTTP11ClientProtocol(Protocol):
             or self._state != "QUIESCENT"
             or not self._currentRequest.persistent
         ):
-            self._giveUp(Failure.without_traceback(reason))
+            self._giveUp(Failure._without_traceback(reason))
         else:
             # Just in case we had paused the transport, resume it before
             # considering it quiescent again.

--- a/src/twisted/web/newsfragments/12108.feature
+++ b/src/twisted/web/newsfragments/12108.feature
@@ -1,0 +1,1 @@
+The HTTP client now runs faster by using a little less CPU.

--- a/src/twisted/web/newsfragments/12108.feature
+++ b/src/twisted/web/newsfragments/12108.feature
@@ -1,1 +1,1 @@
-The HTTP client now runs faster by using a little less CPU.
+twisted.web.client.HTTPConnectionPool used by HTTP clients now runs faster by using a little less CPU.


### PR DESCRIPTION
## Scope and purpose

Fixes #12108 
Fixes #12112 

Why this is faster:

* Minor reductions in general effort.
* Only calculate `Failure.parents` on demand, since it's expensive and often not used.
* `Failure.__init__` does a huge amount of unnecessary work for simple cases, so avoided it with alternative constructor. The constructor results in different pickling behavior, because of subclassing `BaseException` it seems!!!! See https://gist.github.com/itamarst/4e984bddef23a96619b37bfb929e5b24

I run my benchmark script with `hyperfine` to reduce noise from dictionary ordering randomness and the like.

Before:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      3.992 s ±  0.056 s    [User: 3.979 s, System: 0.012 s]
  Range (min … max):    3.917 s …  4.118 s    10 runs
```

After:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      3.266 s ±  0.032 s    [User: 3.253 s, System: 0.012 s]
  Range (min … max):    3.222 s …  3.336 s    10 runs
```

## ORIGINAL APPROACH, NOW OBSOLETE

**Important:** This relies on `Failure` objects being effectively immutable, which I _think_ is the case but should be something to consider when reviewing.

I run my benchmark script with `hyperfine` to reduce noise from dictionary ordering randomness and the like.

Before:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      3.992 s ±  0.056 s    [User: 3.979 s, System: 0.012 s]
  Range (min … max):    3.917 s …  4.118 s    10 runs
```

After:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      3.022 s ±  0.025 s    [User: 3.005 s, System: 0.016 s]
  Range (min … max):    2.982 s …  3.051 s    10 runs
```

Test script:

```python
from twisted.web._newclient import HTTP11ClientProtocol, Request
from twisted.internet.testing import StringTransport
from twisted.web.http_headers import Headers
import time

RESPONSE = """HTTP/1.1 200 OK
Host: blah
Foo: bar
Gaz: baz
Content-length: 3

abc""".replace("\n", "\r\n").encode("utf-8")

start = time.time()
for i in range(100_000):
    protocol = HTTP11ClientProtocol()
    protocol.makeConnection(StringTransport())
    request = Request(b"GET", b"/foo/bar", Headers({b"Host": [b"example.com"]}), None)
    d = protocol.request(request)
    protocol.dataReceived(RESPONSE)
    l = []
    d.addCallback(l.append)
    assert l
print("requests/sec:", 100_000 / (time.time() - start))
``` 

Follow-up PRs will:

- Optimize http_headers.py, which does a lot of repetitive and unnecessary work.
- Possibly split up the identity transfer encoding into two variants, one with a fixed length and one without.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
