### PR TITLE
[#12113] type annotation updates

### DIFF
--- a/src/twisted/mail/test/test_bounce.py
+++ b/src/twisted/mail/test/test_bounce.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import email.message
 import email.parser
+from email.message import Message
 from io import BytesIO, StringIO
 from typing import IO, AnyStr, Callable
 
@@ -89,8 +90,11 @@ Subject: test
         self.assertEqual(mess["From"], "postmaster@example.org")
         self.assertEqual(mess["subject"], "Returned Mail: see transcript for details")
         self.assertTrue(mess.is_multipart())
-        parts = mess.get_payload()
-        self.assertEqual(parts[0].get_payload(), "Custom transcript\n")
+        parts: list[Message] = mess.get_payload()  # type:ignore[assignment]
+        self.assertEqual(
+            parts[0].get_payload(),
+            "Custom transcript\n",
+        )
 
     def _bounceBigMessage(
         self, header: AnyStr, message: AnyStr, ioType: Callable[[AnyStr], IO[AnyStr]]
@@ -107,13 +111,14 @@ Subject: test
         self.assertEqual(mess["From"], "postmaster@example.org")
         self.assertEqual(mess["subject"], "Returned Mail: see transcript for details")
         self.assertTrue(mess.is_multipart())
-        parts = mess.get_payload()
-        innerMessage = parts[1].get_payload()
+        parts: list[Message] = mess.get_payload()  # type:ignore[assignment]
+        innerMessage: list[Message] = parts[1].get_payload()  # type:ignore[assignment]
         if isinstance(message, bytes):
             messageText = message.decode("utf-8")
         else:
             messageText = message
-        self.assertEqual(innerMessage[0].get_payload() + "\n", messageText)
+        pl: str = innerMessage[0].get_payload()  # type:ignore[assignment]
+        self.assertEqual(pl + "\n", messageText)
 
     def test_bounceBigMessage(self) -> None:
         """

--- a/src/twisted/trial/test/test_script.py
+++ b/src/twisted/trial/test/test_script.py
@@ -528,7 +528,7 @@ class CoverageTests(unittest.SynchronousTestCase):
         self.assertEqual(
             sys.gettrace(),
             # the globaltrace attribute of trace.Trace is undocumented
-            options.tracer.globaltrace,  # type: ignore[attr-defined]
+            options.tracer.globaltrace,
         )
 
     def test_coverdirDefault(self) -> None:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -109,7 +109,7 @@ import tempfile
 import time
 import warnings
 from email import message_from_bytes
-from email.message import EmailMessage
+from email.message import EmailMessage, Message
 from io import BytesIO
 from typing import AnyStr, Callable, Dict, List, Optional, Tuple
 from urllib.parse import (
@@ -253,11 +253,16 @@ def _getMultiPartArgs(content: bytes, ctype: bytes) -> dict[bytes, list[bytes]]:
     if not msg.is_multipart():
         raise _MultiPartParseException("Not a multipart.")
 
-    for part in msg.get_payload():
-        name = part.get_param("name", header="content-disposition")
+    part: Message
+    # "per Python docs, a list of Message objects when is_multipart() is True,
+    # or a string when is_multipart() is False"
+    for part in msg.get_payload():  # type:ignore[assignment]
+        name: str | None = part.get_param(
+            "name", header="content-disposition"
+        )  # type:ignore[assignment]
         if not name:
             continue
-        payload = part.get_payload(decode=True)
+        payload: bytes = part.get_payload(decode=True)  # type:ignore[assignment]
         result[name.encode("utf8")] = [payload]
     return result
 


### PR DESCRIPTION
- email.message.Message is more accurate now about get_payload's union
- globaltrace attribute is now exposed

## Scope and purpose

Fixes #12113 

Add a few words about why this PR is needed and what is its scope.
If the associate ticket(s) fully explain the need you can just refer to it/them.

Add any comments about trade-offs (if any) made in this PR and the reasoning behind them.

Add mentions of things that are not covered here and are planed to be done in separate PRs.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
