### PR TITLE
#12116 Speed up http_headers operations

### DIFF
--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1530,7 +1530,7 @@ class ContentDecoderAgent:
         return response
 
 
-_canonicalHeaderName = Headers()._canonicalNameCaps
+_canonicalHeaderName = Headers()._encodeName
 _defaultSensitiveHeaders = frozenset(
     [
         b"Authorization",

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -64,7 +64,7 @@ class Headers:
         header values as L{bytes}.
     """
 
-    _caseMappings = {
+    _caseMappings: ClassVar[Dict[bytes, bytes]] = {
         b"content-md5": b"Content-MD5",
         b"dnt": b"DNT",
         b"etag": b"ETag",
@@ -74,7 +74,7 @@ class Headers:
         b"x-xss-protection": b"X-XSS-Protection",
     }
 
-    _canonicalHeaderCache: Dict[Union[bytes, str], bytes] = {}
+    _canonicalHeaderCache: ClassVar[Dict[Union[bytes, str], bytes]] = {}
 
     _MAX_CACHED_HEADERS: ClassVar[int] = 10_000
 

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -122,10 +122,7 @@ class Headers:
         if canonicalName := self._canonicalHeaderCache.get(name, None):
             return canonicalName
 
-        if isinstance(name, str):
-            bytes_name = name.encode("iso-8859-1")
-        else:
-            bytes_name = name
+        bytes_name = name.encode("iso-8859-1") if isinstance(name, str) else name
 
         if bytes_name.lower() in self._caseMappings:
             # Some headers have special capitalization:

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -71,6 +71,8 @@ class Headers:
         b"x-xss-protection": b"X-XSS-Protection",
     }
 
+    __slots__ = ["_rawHeaders"]
+
     def __init__(
         self,
         rawHeaders: Optional[Mapping[AnyStr, Sequence[AnyStr]]] = None,

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -8,6 +8,7 @@ An API for storing HTTP header names and values.
 
 from typing import (
     AnyStr,
+    ClassVar,
     Dict,
     Iterator,
     List,
@@ -75,6 +76,8 @@ class Headers:
 
     _canonicalHeaderCache: Dict[Union[bytes, str], bytes] = {}
 
+    _MAX_CACHED_HEADERS: ClassVar[int] = 10_000
+
     __slots__ = ["_rawHeaders"]
 
     def __init__(
@@ -137,7 +140,7 @@ class Headers:
         # attacker could generate infinite header variations to fill up RAM, so
         # we cap how many we cache. The performance degradation from lack of
         # caching won't be that bad, and legit traffic won't hit it.
-        if len(self._canonicalHeaderCache) < 10_000:
+        if len(self._canonicalHeaderCache) < self._MAX_CACHED_HEADERS:
             self._canonicalHeaderCache[name] = result
 
         return result

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -6,7 +6,6 @@
 An API for storing HTTP header names and values.
 """
 
-from collections.abc import Sequence as _Sequence
 from typing import (
     AnyStr,
     Dict,

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -179,28 +179,6 @@ class Headers:
 
         @return: L{None}
         """
-        if not isinstance(values, _Sequence):
-            raise TypeError(
-                "Header entry %r should be sequence but found "
-                "instance of %r instead" % (name, type(values))
-            )
-
-        if not isinstance(name, (bytes, str)):
-            raise TypeError(
-                f"Header name is an instance of {type(name)!r}, not bytes or str"
-            )
-
-        for count, value in enumerate(values):
-            if not isinstance(value, (bytes, str)):
-                raise TypeError(
-                    "Header value at position %s is an instance of %r, not "
-                    "bytes or str"
-                    % (
-                        count,
-                        type(value),
-                    )
-                )
-
         _name = _sanitizeLinearWhitespace(self._encodeName(name))
         encodedValues: List[bytes] = []
         for v in values:
@@ -220,17 +198,6 @@ class Headers:
 
         @param value: The value to set for the named header.
         """
-        if not isinstance(name, (bytes, str)):
-            raise TypeError(
-                f"Header name is an instance of {type(name)!r}, not bytes or str"
-            )
-
-        if not isinstance(value, (bytes, str)):
-            raise TypeError(
-                "Header value is an instance of %r, not "
-                "bytes or str" % (type(value),)
-            )
-
         self._rawHeaders.setdefault(
             _sanitizeLinearWhitespace(self._encodeName(name)), []
         ).append(

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -171,21 +171,9 @@ class Headers:
         """
         self._rawHeaders.pop(self._encodeName(name), None)
 
-    @overload
-    def setRawHeaders(self, name: Union[str, bytes], values: Sequence[bytes]) -> None:
-        ...
-
-    @overload
-    def setRawHeaders(self, name: Union[str, bytes], values: Sequence[str]) -> None:
-        ...
-
-    @overload
     def setRawHeaders(
         self, name: Union[str, bytes], values: Sequence[Union[str, bytes]]
     ) -> None:
-        ...
-
-    def setRawHeaders(self, name: Union[str, bytes], values: object) -> None:
         """
         Sets the raw representation of the given header.
 

--- a/src/twisted/web/newsfragments/12116.feature
+++ b/src/twisted/web/newsfragments/12116.feature
@@ -1,0 +1,1 @@
+twisted.web.http_headers now uses less CPU.

--- a/src/twisted/web/newsfragments/12116.feature
+++ b/src/twisted/web/newsfragments/12116.feature
@@ -1,1 +1,1 @@
-twisted.web.http_headers now uses less CPU.
+twisted.web.http_headers now uses less CPU, making a small HTTP client request 10% faster or so.

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -298,7 +298,7 @@ class BytesHeadersTests(TestCase):
         i.addRawHeader(b"test", b"baz")
         self.assertEqual(h.getRawHeaders(b"test"), [b"foo", b"bar"])
 
-    def test_max_cached_headers(self):
+    def test_max_cached_headers(self) -> None:
         """
         Only a limited number of HTTP header names get cached.
         """

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -86,38 +86,6 @@ class BytesHeadersTests(TestCase):
         self.assertTrue(h.hasHeader(b"Test"))
         self.assertEqual(h.getRawHeaders(b"test"), rawValue)
 
-    def test_rawHeadersTypeCheckingValuesIterable(self) -> None:
-        """
-        L{Headers.setRawHeaders} requires values to be of type list.
-        """
-        h = Headers()
-        self.assertRaises(TypeError, h.setRawHeaders, b"key", {b"Foo": b"bar"})
-
-    def test_rawHeadersTypeCheckingName(self) -> None:
-        """
-        L{Headers.setRawHeaders} requires C{name} to be a L{bytes} or
-        L{str} string.
-        """
-        h = Headers()
-        e = self.assertRaises(TypeError, h.setRawHeaders, None, [b"foo"])
-        self.assertEqual(
-            e.args[0],
-            "Header name is an instance of <class 'NoneType'>, " "not bytes or str",
-        )
-
-    def test_rawHeadersTypeCheckingValuesAreString(self) -> None:
-        """
-        L{Headers.setRawHeaders} requires values to a L{list} of L{bytes} or
-        L{str} strings.
-        """
-        h = Headers()
-        e = self.assertRaises(TypeError, h.setRawHeaders, b"key", [b"bar", None])
-        self.assertEqual(
-            e.args[0],
-            "Header value at position 1 is an instance of <class 'NoneType'>, "
-            "not bytes or str",
-        )
-
     def test_addRawHeader(self) -> None:
         """
         L{Headers.addRawHeader} adds a new value for a given header.
@@ -127,30 +95,6 @@ class BytesHeadersTests(TestCase):
         self.assertEqual(h.getRawHeaders(b"test"), [b"lemur"])
         h.addRawHeader(b"test", b"panda")
         self.assertEqual(h.getRawHeaders(b"test"), [b"lemur", b"panda"])
-
-    def test_addRawHeaderTypeCheckName(self) -> None:
-        """
-        L{Headers.addRawHeader} requires C{name} to be a L{bytes} or L{str}
-        string.
-        """
-        h = Headers()
-        e = self.assertRaises(TypeError, h.addRawHeader, None, b"foo")
-        self.assertEqual(
-            e.args[0],
-            "Header name is an instance of <class 'NoneType'>, " "not bytes or str",
-        )
-
-    def test_addRawHeaderTypeCheckValue(self) -> None:
-        """
-        L{Headers.addRawHeader} requires value to be a L{bytes} or L{str}
-        string.
-        """
-        h = Headers()
-        e = self.assertRaises(TypeError, h.addRawHeader, b"key", None)
-        self.assertEqual(
-            e.args[0],
-            "Header value is an instance of <class 'NoneType'>, " "not bytes or str",
-        )
 
     def test_getRawHeadersNoDefault(self) -> None:
         """
@@ -434,13 +378,6 @@ class UnicodeHeadersTests(TestCase):
         h.setRawHeaders("\u00E1", ["\u2603", b"foo"])
         self.assertTrue(h.hasHeader(b"\xe1"))
         self.assertEqual(h.getRawHeaders(b"\xe1"), [b"\xe2\x98\x83", b"foo"])
-
-    def test_rawHeadersTypeChecking(self) -> None:
-        """
-        L{Headers.setRawHeaders} requires values to be of type sequence
-        """
-        h = Headers()
-        self.assertRaises(TypeError, h.setRawHeaders, "key", {"Foo": "bar"})
 
     def test_addRawHeader(self) -> None:
         """

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -176,21 +176,23 @@ class BytesHeadersTests(TestCase):
         h.removeHeader(b"test")
         self.assertEqual(list(h.getAllRawHeaders()), [])
 
-    def test_canonicalNameCaps(self) -> None:
+    def test_encodeName(self) -> None:
         """
-        L{Headers._canonicalNameCaps} returns the canonical capitalization for
+        L{Headers._encodeName} returns the canonical capitalization for
         the given header.
         """
         h = Headers()
-        self.assertEqual(h._canonicalNameCaps(b"test"), b"Test")
-        self.assertEqual(h._canonicalNameCaps(b"test-stuff"), b"Test-Stuff")
-        self.assertEqual(h._canonicalNameCaps(b"content-md5"), b"Content-MD5")
-        self.assertEqual(h._canonicalNameCaps(b"dnt"), b"DNT")
-        self.assertEqual(h._canonicalNameCaps(b"etag"), b"ETag")
-        self.assertEqual(h._canonicalNameCaps(b"p3p"), b"P3P")
-        self.assertEqual(h._canonicalNameCaps(b"te"), b"TE")
-        self.assertEqual(h._canonicalNameCaps(b"www-authenticate"), b"WWW-Authenticate")
-        self.assertEqual(h._canonicalNameCaps(b"x-xss-protection"), b"X-XSS-Protection")
+        self.assertEqual(h._encodeName(b"test"), b"Test")
+        self.assertEqual(h._encodeName(b"test-stuff"), b"Test-Stuff")
+        self.assertEqual(h._encodeName(b"content-md5"), b"Content-MD5")
+        self.assertEqual(h._encodeName(b"dnt"), b"DNT")
+        self.assertEqual(h._encodeName(b"etag"), b"ETag")
+        self.assertEqual(h._encodeName(b"p3p"), b"P3P")
+        self.assertEqual(h._encodeName(b"te"), b"TE")
+        self.assertEqual(h._encodeName(b"www-authenticate"), b"WWW-Authenticate")
+        self.assertEqual(h._encodeName(b"WWW-authenticate"), b"WWW-Authenticate")
+        self.assertEqual(h._encodeName(b"Www-Authenticate"), b"WWW-Authenticate")
+        self.assertEqual(h._encodeName(b"x-xss-protection"), b"X-XSS-Protection")
 
     def test_getAllRawHeaders(self) -> None:
         """
@@ -244,7 +246,7 @@ class BytesHeadersTests(TestCase):
         baz = b"baz"
         self.assertEqual(
             repr(Headers({foo: [bar, baz]})),
-            f"Headers({{{foo!r}: [{bar!r}, {baz!r}]}})",
+            f"Headers({{{foo.capitalize()!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_reprWithRawBytes(self) -> None:
@@ -261,7 +263,7 @@ class BytesHeadersTests(TestCase):
         baz = b"baz\xe1"
         self.assertEqual(
             repr(Headers({foo: [bar, baz]})),
-            f"Headers({{{foo!r}: [{bar!r}, {baz!r}]}})",
+            f"Headers({{{foo.capitalize()!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_subclassRepr(self) -> None:
@@ -278,7 +280,7 @@ class BytesHeadersTests(TestCase):
 
         self.assertEqual(
             repr(FunnyHeaders({foo: [bar, baz]})),
-            f"FunnyHeaders({{{foo!r}: [{bar!r}, {baz!r}]}})",
+            f"FunnyHeaders({{{foo.capitalize()!r}: [{bar!r}, {baz!r}]}})",
         )
 
     def test_copy(self) -> None:
@@ -551,7 +553,7 @@ class UnicodeHeadersTests(TestCase):
         foo = "foo\u00E1"
         bar = "bar\u2603"
         baz = "baz"
-        fooEncoded = "'foo\\xe1'"
+        fooEncoded = "'Foo\\xe1'"
         barEncoded = "'bar\\xe2\\x98\\x83'"
         fooEncoded = "b" + fooEncoded
         barEncoded = "b" + barEncoded
@@ -570,7 +572,7 @@ class UnicodeHeadersTests(TestCase):
         foo = "foo\u00E1"
         bar = "bar\u2603"
         baz = "baz"
-        fooEncoded = "b'foo\\xe1'"
+        fooEncoded = "b'Foo\\xe1'"
         barEncoded = "b'bar\\xe2\\x98\\x83'"
 
         class FunnyHeaders(Headers):

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -298,6 +298,17 @@ class BytesHeadersTests(TestCase):
         i.addRawHeader(b"test", b"baz")
         self.assertEqual(h.getRawHeaders(b"test"), [b"foo", b"bar"])
 
+    def test_max_cached_headers(self):
+        """
+        Only a limited number of HTTP header names get cached.
+        """
+        headers = Headers()
+        for i in range(Headers._MAX_CACHED_HEADERS + 200):
+            headers.addRawHeader(f"hello-{i}", "value")
+        self.assertEqual(
+            len(Headers._canonicalHeaderCache), Headers._MAX_CACHED_HEADERS
+        )
+
 
 class UnicodeHeadersTests(TestCase):
     """


### PR DESCRIPTION
## Scope and purpose

Fixes #12116

The most significant changes are:

1. Change the internal representation of headers, so they're canonicalized once instead of lowercased incoming and canonicalized outgoing.
2. Cache canonicalization, with limits to prevent high memory usage by attackers.
3. Get rid of runtime type checks, given static type checking is now available in Python.

Same benchmark as #12108, measuring sending and parsing a HTTP client request. This will likely speed up the HTTP server as well.

Before:

```
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      3.262 s ±  0.027 s    [User: 3.250 s, System: 0.012 s]
  Range (min … max):    3.223 s …  3.307 s    10 runs
```

After:

```
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      2.929 s ±  0.036 s    [User: 2.918 s, System: 0.011 s]
  Range (min … max):    2.877 s …  3.016 s    10 runs
```
