### PR TITLE
#12122 Speed up Deferred by removing assertions

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -522,9 +522,6 @@ class Deferred(Awaitable[_SelfResultT]):
         if errbackKeywords is None:
             errbackKeywords = {}  # type: ignore[unreachable]
 
-        assert callable(callback)
-        assert callable(errback)
-
         self.callbacks.append(
             (
                 (callback, callbackArgs, callbackKeywords),
@@ -873,7 +870,6 @@ class Deferred(Awaitable[_SelfResultT]):
         @raise AlreadyCalledError: If L{callback} or L{errback} has already been
             called on this L{Deferred}.
         """
-        assert not isinstance(result, Deferred)
         self._startRunCallbacks(result)
 
     def errback(self, fail: Optional[Union[Failure, BaseException]] = None) -> None:
@@ -1552,7 +1548,6 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
             if succeeded == SUCCESS and self.fireOnOneCallback:
                 self.callback((result, index))  # type: ignore[arg-type]
             elif succeeded == FAILURE and self.fireOnOneErrback:
-                assert isinstance(result, Failure)
                 self.errback(Failure(FirstError(result, index)))
             elif self.finishedCount == len(self.resultList):
                 # At this point, None values in self.resultList have been

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1548,6 +1548,7 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
             if succeeded == SUCCESS and self.fireOnOneCallback:
                 self.callback((result, index))  # type: ignore[arg-type]
             elif succeeded == FAILURE and self.fireOnOneErrback:
+                assert isinstance(result, Failure)
                 self.errback(Failure(FirstError(result, index)))
             elif self.finishedCount == len(self.resultList):
                 # At this point, None values in self.resultList have been

--- a/src/twisted/newsfragments/12122.feature
+++ b/src/twisted/newsfragments/12122.feature
@@ -1,0 +1,1 @@
+``twisted.internet.defer.Deferred`` operations use less CPU.

--- a/src/twisted/newsfragments/12122.feature
+++ b/src/twisted/newsfragments/12122.feature
@@ -1,1 +1,1 @@
-``twisted.internet.defer.Deferred`` operations use less CPU.
+twisted.internet.defer.Deferred.callback() and twisted.internet.defer.Deferred.addCallbacks() no longer use `assert` to check the type of the arguments. You should now use type checking to validate your code. These changes were done to reduce the CPU usage.


### PR DESCRIPTION
## Scope and purpose

Fixes #12122


This meaningfully impacts the HTTP client benchmark I've been using. Before:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      2.942 s ±  0.026 s    [User: 2.931 s, System: 0.011 s]
  Range (min … max):    2.902 s …  2.989 s    10 runs
```

After:

```
$ hyperfine --warmup 1 "python http_client_benchmark.py"
Benchmark 1: python http_client_benchmark.py
  Time (mean ± σ):      2.847 s ±  0.023 s    [User: 2.834 s, System: 0.012 s]
  Range (min … max):    2.807 s …  2.893 s    10 runs
```

## Some reasons not to merge this!

1. ~Some of these issues are caught by type checking, but not all. In particular, the assertion that the result is not a Deferred isn't caught by type checking, I think.~
2. ~Users could just run with PYTHONOPTIMIZE=2. In practice, that slows down execution(!), not sure why. And I suspect no one runs this way.~
3. Users who don't use type checking will have harder time.