### PR TITLE
#12133 Speed up twisted.web's HTTP/1.1 server by about 10%

### DIFF
--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -47,7 +47,8 @@ To deprecate properties you can use::
             '''
 
 
-To mark module-level attributes as being deprecated you can use::
+While it's best to avoid this as it adds performance overhead to *any* usage of
+the module, to mark module-level attributes as being deprecated you can use::
 
     badAttribute = "someValue"
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2498,8 +2498,6 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
                 self._networkProducer.pauseProducing()
             return
 
-        self.resetTimeout()
-
         try:
             self._transferDecoder.dataReceived(data)
         except _MalformedChunkedDataError:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -412,7 +412,7 @@ def stringToDatetime(dateString):
         # Two digit year, yucko.
         day, month, year = parts[1].split("-")
         time = parts[2]
-        year = year
+        year = int(year)
         if year < 69:
             year = year + 2000
         elif year < 100:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1363,19 +1363,15 @@ class Request:
             cookie += b"; SameSite=" + sameSite
         self.cookies.append(cookie)
 
-    def setResponseCode(self, code, message=None):
+    def setResponseCode(self, code: int, message: Optional[bytes] = None) -> None:
         """
         Set the HTTP response code.
 
         @type code: L{int}
         @type message: L{bytes}
         """
-        if not isinstance(code, int):
-            raise TypeError("HTTP response code must be int or long")
         self.code = code
-        if message:
-            if not isinstance(message, bytes):
-                raise TypeError("HTTP response status message must be bytes")
+        if message is not None:
             self.code_message = message
         else:
             self.code_message = RESPONSES.get(code, b"Unknown Status")

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2425,12 +2425,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
         if not self._maybeChooseTransferDecoder(header, data):
             return False
 
-        reqHeaders = self.requests[-1].requestHeaders
-        values = reqHeaders.getRawHeaders(header)
-        if values is not None:
-            values.append(data)
-        else:
-            reqHeaders.setRawHeaders(header, [data])
+        self.requests[-1].requestHeaders.addRawHeader(header, data)
 
         self._receivedHeaderCount += 1
         if self._receivedHeaderCount > self.maxHeaders:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -379,7 +379,7 @@ def timegm(year, month, day, hour, minute, second):
     return seconds
 
 
-def stringToDatetime(dateString: bytes) -> int:
+def stringToDatetime(dateString):
     """
     Convert an HTTP date string (one of three formats) to seconds since epoch.
 
@@ -412,7 +412,7 @@ def stringToDatetime(dateString: bytes) -> int:
         # Two digit year, yucko.
         day, month, year = parts[1].split("-")
         time = parts[2]
-        year = int(year)
+        year = year
         if year < 69:
             year = year + 2000
         elif year < 100:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -379,13 +379,13 @@ def timegm(year, month, day, hour, minute, second):
     return seconds
 
 
-def stringToDatetime(dateString):
+def stringToDatetime(dateString: bytes) -> int:
     """
     Convert an HTTP date string (one of three formats) to seconds since epoch.
 
     @type dateString: C{bytes}
     """
-    parts = nativeString(dateString).split()
+    parts = dateString.decode("ascii").split()
 
     if not parts[0][0:3].lower() in weekdayname_lower:
         # Weekday is stupid. Might have been omitted.

--- a/src/twisted/web/newsfragments/12133.feature
+++ b/src/twisted/web/newsfragments/12133.feature
@@ -1,0 +1,1 @@
+twisted.web's HTTP/1.1 server now runs a little faster, with about 10% lower CPU overhead.

--- a/src/twisted/web/newsfragments/12133.removal
+++ b/src/twisted/web/newsfragments/12133.removal
@@ -1,0 +1,1 @@
+Request.setResponseCode no longer validates the types of inputs; we encourage you to use a type checker like mypy to catch these sort of errors.

--- a/src/twisted/web/newsfragments/12133.removal
+++ b/src/twisted/web/newsfragments/12133.removal
@@ -1,1 +1,1 @@
-Request.setResponseCode no longer validates the types of inputs; we encourage you to use a type checker like mypy to catch these sort of errors.
+``twisted.web.http.Request.setResponseCode()`` no longer validates the types of inputs; we encourage you to use a type checker like mypy to catch these sort of errors. The long-deprecated ``twisted.web.server.string_date_time()`` and ``twisted.web.server.date_time_string()`` APIs were removed altogether.

--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -28,7 +28,7 @@ from incremental import Version
 
 from twisted.python.compat import nativeString
 from twisted.python.components import proxyForInterface
-from twisted.python.deprecate import deprecatedModuleAttribute
+from twisted.python.deprecate import deprecated
 from twisted.python.reflect import prefixedMethodNames
 from twisted.web._responses import FORBIDDEN, NOT_FOUND
 from twisted.web.error import UnsupportedMethod
@@ -355,6 +355,10 @@ class _UnsafeErrorPage(Resource):
         return self
 
 
+@deprecated(
+    Version("Twisted", 22, 10, 0),
+    "Use twisted.web.pages.notFound instead, which properly escapes HTML.",
+)
 class _UnsafeNoResource(_UnsafeErrorPage):
     """
     L{_UnsafeNoResource}, publicly available via the deprecated alias
@@ -369,6 +373,10 @@ class _UnsafeNoResource(_UnsafeErrorPage):
         _UnsafeErrorPage.__init__(self, NOT_FOUND, "No Such Resource", message)
 
 
+@deprecated(
+    Version("Twisted", 22, 10, 0),
+    "Use twisted.web.pages.forbidden instead, which properly escapes HTML.",
+)
 class _UnsafeForbiddenResource(_UnsafeErrorPage):
     """
     L{_UnsafeForbiddenResource}, publicly available via the deprecated alias
@@ -384,30 +392,12 @@ class _UnsafeForbiddenResource(_UnsafeErrorPage):
 
 
 # Deliberately undocumented public aliases. See GHSA-vg46-2rrj-3647.
-ErrorPage = _UnsafeErrorPage
-NoResource = _UnsafeNoResource
-ForbiddenResource = _UnsafeForbiddenResource
-
-deprecatedModuleAttribute(
+ErrorPage = deprecated(
     Version("Twisted", 22, 10, 0),
     "Use twisted.web.pages.errorPage instead, which properly escapes HTML.",
-    __name__,
-    "ErrorPage",
-)
-
-deprecatedModuleAttribute(
-    Version("Twisted", 22, 10, 0),
-    "Use twisted.web.pages.notFound instead, which properly escapes HTML.",
-    __name__,
-    "NoResource",
-)
-
-deprecatedModuleAttribute(
-    Version("Twisted", 22, 10, 0),
-    "Use twisted.web.pages.forbidden instead, which properly escapes HTML.",
-    __name__,
-    "ForbiddenResource",
-)
+)(_UnsafeErrorPage)
+NoResource = _UnsafeNoResource
+ForbiddenResource = _UnsafeForbiddenResource
 
 
 class _IEncodingResource(Interface):

--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -294,15 +294,9 @@ def _computeAllowedMethods(resource):
     return allowedMethods
 
 
-class _UnsafeErrorPage(Resource):
+class _UnsafeErrorPageBase(Resource):
     """
-    L{_UnsafeErrorPage}, publicly available via the deprecated alias
-    C{ErrorPage}, is a resource which responds with a particular
-    (parameterized) status and a body consisting of HTML containing some
-    descriptive text.  This is useful for rendering simple error pages.
-
-    Deprecated in Twisted 22.10.0 because it permits HTML injection; use
-    L{twisted.web.pages.errorPage} instead.
+    Base class for deprecated error page resources.
 
     @ivar template: A native string which will have a dictionary interpolated
         into it to generate the response body.  The dictionary has the following
@@ -355,11 +349,26 @@ class _UnsafeErrorPage(Resource):
         return self
 
 
-@deprecated(
-    Version("Twisted", 22, 10, 0),
-    "Use twisted.web.pages.notFound instead, which properly escapes HTML.",
-)
-class _UnsafeNoResource(_UnsafeErrorPage):
+class _UnsafeErrorPage(_UnsafeErrorPageBase):
+    """
+    L{_UnsafeErrorPage}, publicly available via the deprecated alias
+    C{ErrorPage}, is a resource which responds with a particular
+    (parameterized) status and a body consisting of HTML containing some
+    descriptive text.  This is useful for rendering simple error pages.
+
+    Deprecated in Twisted 22.10.0 because it permits HTML injection; use
+    L{twisted.web.pages.errorPage} instead.
+    """
+
+    @deprecated(
+        Version("Twisted", 22, 10, 0),
+        "Use twisted.web.pages.errorPage instead, which properly escapes HTML.",
+    )
+    def __init__(self, status, brief, detail):
+        _UnsafeErrorPageBase.__init__(self, status, brief, detail)
+
+
+class _UnsafeNoResource(_UnsafeErrorPageBase):
     """
     L{_UnsafeNoResource}, publicly available via the deprecated alias
     C{NoResource}, is a specialization of L{_UnsafeErrorPage} which
@@ -369,15 +378,15 @@ class _UnsafeNoResource(_UnsafeErrorPage):
     L{twisted.web.pages.notFound} instead.
     """
 
+    @deprecated(
+        Version("Twisted", 22, 10, 0),
+        "Use twisted.web.pages.notFound instead, which properly escapes HTML.",
+    )
     def __init__(self, message="Sorry. No luck finding that resource."):
-        _UnsafeErrorPage.__init__(self, NOT_FOUND, "No Such Resource", message)
+        _UnsafeErrorPageBase.__init__(self, NOT_FOUND, "No Such Resource", message)
 
 
-@deprecated(
-    Version("Twisted", 22, 10, 0),
-    "Use twisted.web.pages.forbidden instead, which properly escapes HTML.",
-)
-class _UnsafeForbiddenResource(_UnsafeErrorPage):
+class _UnsafeForbiddenResource(_UnsafeErrorPageBase):
     """
     L{_UnsafeForbiddenResource}, publicly available via the deprecated alias
     C{ForbiddenResource} is a specialization of L{_UnsafeErrorPage} which
@@ -387,15 +396,16 @@ class _UnsafeForbiddenResource(_UnsafeErrorPage):
     L{twisted.web.pages.forbidden} instead.
     """
 
+    @deprecated(
+        Version("Twisted", 22, 10, 0),
+        "Use twisted.web.pages.forbidden instead, which properly escapes HTML.",
+    )
     def __init__(self, message="Sorry, resource is forbidden."):
-        _UnsafeErrorPage.__init__(self, FORBIDDEN, "Forbidden Resource", message)
+        _UnsafeErrorPageBase.__init__(self, FORBIDDEN, "Forbidden Resource", message)
 
 
 # Deliberately undocumented public aliases. See GHSA-vg46-2rrj-3647.
-ErrorPage = deprecated(
-    Version("Twisted", 22, 10, 0),
-    "Use twisted.web.pages.errorPage instead, which properly escapes HTML.",
-)(_UnsafeErrorPage)
+ErrorPage = _UnsafeErrorPage
 NoResource = _UnsafeNoResource
 ForbiddenResource = _UnsafeForbiddenResource
 

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -25,15 +25,12 @@ from urllib.parse import quote as _quote
 
 from zope.interface import implementer
 
-from incremental import Version
-
 from twisted import copyright
 from twisted.internet import address, interfaces
 from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from twisted.logger import Logger
 from twisted.python import components, failure, reflect
 from twisted.python.compat import nativeString, networkString
-from twisted.python.deprecate import deprecated
 from twisted.spread.pb import Copyable, ViewPoint
 from twisted.web import http, iweb, resource, util
 from twisted.web.error import UnsupportedMethod
@@ -50,24 +47,6 @@ __all__ = [
     "NOT_DONE_YET",
     "GzipEncoderFactory",
 ]
-
-
-# backwards compatibility
-@deprecated(
-    Version("Twisted", 12, 1, 0),
-    "twisted.web.http.datetimeToString",
-)
-def date_time_string(dt):
-    return http.datetimeToString(dt)
-
-
-@deprecated(
-    Version("Twisted", 12, 1, 0),
-    "twisted.web.http.stringToDatetime",
-)
-def string_date_time(dts):
-    return http.stringToDatetime(dts)
-
 
 # Support for other methods may be implemented on a per-resource basis.
 supportedMethods = (b"GET", b"HEAD", b"POST")

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -33,7 +33,7 @@ from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from twisted.logger import Logger
 from twisted.python import components, failure, reflect
 from twisted.python.compat import nativeString, networkString
-from twisted.python.deprecate import deprecatedModuleAttribute
+from twisted.python.deprecate import deprecated
 from twisted.spread.pb import Copyable, ViewPoint
 from twisted.web import http, iweb, resource, util
 from twisted.web.error import UnsupportedMethod
@@ -50,6 +50,24 @@ __all__ = [
     "NOT_DONE_YET",
     "GzipEncoderFactory",
 ]
+
+
+# backwards compatibility
+@deprecated(
+    Version("Twisted", 12, 1, 0),
+    "twisted.web.http.datetimeToString",
+)
+def date_time_string(dt: int) -> bytes:
+    return http.datetimeToString(dt)
+
+
+@deprecated(
+    Version("Twisted", 12, 1, 0),
+    "twisted.web.http.stringToDatetime",
+)
+def string_date_time(dts: bytes) -> int:
+    return http.stringToDatetime(dts)
+
 
 # Support for other methods may be implemented on a per-resource basis.
 supportedMethods = (b"GET", b"HEAD", b"POST")

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -51,23 +51,6 @@ __all__ = [
     "GzipEncoderFactory",
 ]
 
-
-# backwards compatibility
-deprecatedModuleAttribute(
-    Version("Twisted", 12, 1, 0),
-    "Please use twisted.web.http.datetimeToString instead",
-    "twisted.web.server",
-    "date_time_string",
-)
-deprecatedModuleAttribute(
-    Version("Twisted", 12, 1, 0),
-    "Please use twisted.web.http.stringToDatetime instead",
-    "twisted.web.server",
-    "string_date_time",
-)
-date_time_string = http.datetimeToString
-string_date_time = http.stringToDatetime
-
 # Support for other methods may be implemented on a per-resource basis.
 supportedMethods = (b"GET", b"HEAD", b"POST")
 

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -57,7 +57,7 @@ __all__ = [
     Version("Twisted", 12, 1, 0),
     "twisted.web.http.datetimeToString",
 )
-def date_time_string(dt: int) -> bytes:
+def date_time_string(dt):
     return http.datetimeToString(dt)
 
 
@@ -65,7 +65,7 @@ def date_time_string(dt: int) -> bytes:
     Version("Twisted", 12, 1, 0),
     "twisted.web.http.stringToDatetime",
 )
-def string_date_time(dts: bytes) -> int:
+def string_date_time(dts):
     return http.stringToDatetime(dts)
 
 

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2864,28 +2864,10 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
             b"(no clientproto yet) 202 happily accepted",
         )
 
-    def test_setResponseCodeAndMessageNotBytes(self):
-        """
-        L{http.Request.setResponseCode} accepts C{bytes} for the message
-        parameter and raises L{TypeError} if passed anything else.
-        """
-        channel = DummyChannel()
-        req = http.Request(channel, False)
-        self.assertRaises(TypeError, req.setResponseCode, 202, "not happily accepted")
-
     def test_setResponseCodeAcceptsIntegers(self):
         """
         L{http.Request.setResponseCode} accepts C{int} for the code parameter
         and raises L{TypeError} if passed anything else.
-        """
-        req = http.Request(DummyChannel(), False)
-        req.setResponseCode(1)
-        self.assertRaises(TypeError, req.setResponseCode, "1")
-
-    def test_setResponseCodeAcceptsLongIntegers(self):
-        """
-        L{http.Request.setResponseCode} accepts L{int} for the code
-        parameter.
         """
         req = http.Request(DummyChannel(), False)
         req.setResponseCode(1)

--- a/src/twisted/web/test/test_resource.py
+++ b/src/twisted/web/test/test_resource.py
@@ -26,21 +26,13 @@ class ErrorPageTests(TestCase):
     Tests for L{_UnafeErrorPage}, L{_UnsafeNoResource}, and
     L{_UnsafeForbiddenResource}.
     """
-
-    errorPage = ErrorPage
-    noResource = NoResource
-    forbiddenResource = ForbiddenResource
-
     def test_deprecatedErrorPage(self) -> None:
         """
         The public C{twisted.web.resource.ErrorPage} alias for the
         corresponding C{_Unsafe} class produces a deprecation warning when
-        imported.
+        called.
         """
-        from twisted.web.resource import ErrorPage
-
-        self.assertIs(ErrorPage, self.errorPage)
-
+        _ = ErrorPage(123, "ono", "ono!")
         [warning] = self.flushWarnings()
         self.assertEqual(warning["category"], DeprecationWarning)
         self.assertIn("twisted.web.pages.errorPage", warning["message"])
@@ -49,12 +41,9 @@ class ErrorPageTests(TestCase):
         """
         The public C{twisted.web.resource.NoResource} alias for the
         corresponding C{_Unsafe} class produces a deprecation warning when
-        imported.
+        called.
         """
-        from twisted.web.resource import NoResource
-
-        self.assertIs(NoResource, self.noResource)
-
+        _ = NoResource()
         [warning] = self.flushWarnings()
         self.assertEqual(warning["category"], DeprecationWarning)
         self.assertIn("twisted.web.pages.notFound", warning["message"])
@@ -63,12 +52,9 @@ class ErrorPageTests(TestCase):
         """
         The public C{twisted.web.resource.ForbiddenResource} alias for the
         corresponding C{_Unsafe} class produce a deprecation warning when
-        imported.
+        called.
         """
-        from twisted.web.resource import ForbiddenResource
-
-        self.assertIs(ForbiddenResource, self.forbiddenResource)
-
+        _ = ForbiddenResource()
         [warning] = self.flushWarnings()
         self.assertEqual(warning["category"], DeprecationWarning)
         self.assertIn("twisted.web.pages.forbidden", warning["message"])
@@ -78,7 +64,7 @@ class ErrorPageTests(TestCase):
         The C{getChild} method of L{ErrorPage} returns the L{ErrorPage} it is
         called on.
         """
-        page = self.errorPage(321, "foo", "bar")
+        page = ErrorPage(321, "foo", "bar")
         self.assertIdentical(page.getChild(b"name", object()), page)
 
     def _pageRenderingTest(
@@ -113,7 +99,7 @@ class ErrorPageTests(TestCase):
         code = 321
         brief = "brief description text"
         detail = "much longer text might go here"
-        page = self.errorPage(code, brief, detail)
+        page = ErrorPage(code, brief, detail)
         self._pageRenderingTest(page, code, brief, detail)
 
     def test_noResourceRendering(self) -> None:
@@ -121,7 +107,7 @@ class ErrorPageTests(TestCase):
         L{NoResource} sets the HTTP I{NOT FOUND} code.
         """
         detail = "long message"
-        page = self.noResource(detail)
+        page = NoResource(detail)
         self._pageRenderingTest(page, NOT_FOUND, "No Such Resource", detail)
 
     def test_forbiddenResourceRendering(self) -> None:
@@ -129,7 +115,7 @@ class ErrorPageTests(TestCase):
         L{ForbiddenResource} sets the HTTP I{FORBIDDEN} code.
         """
         detail = "longer message"
-        page = self.forbiddenResource(detail)
+        page = ForbiddenResource(detail)
         self._pageRenderingTest(page, FORBIDDEN, "Forbidden Resource", detail)
 
 

--- a/src/twisted/web/test/test_resource.py
+++ b/src/twisted/web/test/test_resource.py
@@ -26,6 +26,7 @@ class ErrorPageTests(TestCase):
     Tests for L{_UnafeErrorPage}, L{_UnsafeNoResource}, and
     L{_UnsafeForbiddenResource}.
     """
+
     def test_deprecatedErrorPage(self) -> None:
         """
         The public C{twisted.web.resource.ErrorPage} alias for the

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1794,7 +1794,7 @@ class ServerAttributesTests(unittest.TestCase):
         twisted.web.server.date_time_string should not be used; instead use
         twisted.web.http.datetimeToString directly
         """
-        server.date_time_string
+        server.date_time_string(10)
         warnings = self.flushWarnings(
             offendingFunctions=[self.test_deprecatedAttributeDateTimeString]
         )
@@ -1805,7 +1805,7 @@ class ServerAttributesTests(unittest.TestCase):
             warnings[0]["message"],
             (
                 "twisted.web.server.date_time_string was deprecated in Twisted "
-                "12.1.0: Please use twisted.web.http.datetimeToString instead"
+                "12.1.0; please use twisted.web.http.datetimeToString instead"
             ),
         )
 
@@ -1814,7 +1814,7 @@ class ServerAttributesTests(unittest.TestCase):
         twisted.web.server.string_date_time should not be used; instead use
         twisted.web.http.stringToDatetime directly
         """
-        server.string_date_time
+        server.string_date_time(b"Thursday, 29-Sep-16 17:15:29 GMT")
         warnings = self.flushWarnings(
             offendingFunctions=[self.test_deprecatedAttributeStringDateTime]
         )
@@ -1825,7 +1825,7 @@ class ServerAttributesTests(unittest.TestCase):
             warnings[0]["message"],
             (
                 "twisted.web.server.string_date_time was deprecated in Twisted "
-                "12.1.0: Please use twisted.web.http.stringToDatetime instead"
+                "12.1.0; please use twisted.web.http.stringToDatetime instead"
             ),
         )
 

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -1783,53 +1783,6 @@ class LogEscapingTests(unittest.TestCase):
         )
 
 
-class ServerAttributesTests(unittest.TestCase):
-    """
-    Tests that deprecated twisted.web.server attributes raise the appropriate
-    deprecation warnings when used.
-    """
-
-    def test_deprecatedAttributeDateTimeString(self):
-        """
-        twisted.web.server.date_time_string should not be used; instead use
-        twisted.web.http.datetimeToString directly
-        """
-        server.date_time_string(10)
-        warnings = self.flushWarnings(
-            offendingFunctions=[self.test_deprecatedAttributeDateTimeString]
-        )
-
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["category"], DeprecationWarning)
-        self.assertEqual(
-            warnings[0]["message"],
-            (
-                "twisted.web.server.date_time_string was deprecated in Twisted "
-                "12.1.0; please use twisted.web.http.datetimeToString instead"
-            ),
-        )
-
-    def test_deprecatedAttributeStringDateTime(self):
-        """
-        twisted.web.server.string_date_time should not be used; instead use
-        twisted.web.http.stringToDatetime directly
-        """
-        server.string_date_time(b"Thursday, 29-Sep-16 17:15:29 GMT")
-        warnings = self.flushWarnings(
-            offendingFunctions=[self.test_deprecatedAttributeStringDateTime]
-        )
-
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["category"], DeprecationWarning)
-        self.assertEqual(
-            warnings[0]["message"],
-            (
-                "twisted.web.server.string_date_time was deprecated in Twisted "
-                "12.1.0; please use twisted.web.http.stringToDatetime instead"
-            ),
-        )
-
-
 class ExplicitHTTPFactoryReactor(unittest.TestCase):
     """
     L{http.HTTPFactory} accepts explicit reactor selection.


### PR DESCRIPTION
## Scope and purpose

Fixes #12133

Doing deprecations on module-level is expensive, turns out, because it adds lots of attribute-lookup overhead for _everything_, including non-deprecated code. And other speedups as well.

Before:

```
$ hyperfine --warmup 1 "python http_server_benchmark.py"
Benchmark 1: python http_server_benchmark.py
  Time (mean ± σ):      1.220 s ±  0.010 s    [User: 1.190 s, System: 0.030 s]
  Range (min … max):    1.207 s …  1.238 s    10 runs
```

After:

```
$ hyperfine --warmup 1 "python http_server_benchmark.py"
Benchmark 1: python http_server_benchmark.py
  Time (mean ± σ):      1.105 s ±  0.012 s    [User: 1.081 s, System: 0.024 s]
  Range (min … max):    1.096 s …  1.137 s    10 runs
```

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
