### PR TITLE
Expose passivePortRange via cmd args for the FTP command

### DIFF
--- a/src/twisted/newsfragments/12166.feature
+++ b/src/twisted/newsfragments/12166.feature
@@ -1,0 +1,1 @@
+twisted.tap.ftp now accepts a new argument --passive-port-range.

--- a/src/twisted/tap/ftp.py
+++ b/src/twisted/tap/ftp.py
@@ -47,6 +47,17 @@ class Options(usage.Options, strcred.AuthOptionMixin):
         warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
         self.addChecker(checkers.FilePasswordDB(filename, cache=True))
 
+    def opt_passive_port_range(self, port_range_str):
+        """
+        Two numbers, colon separated, denoting the range of passive ports (both
+        ends inclusive). E.g. "--passive-port-range=30000:31000".
+        """
+        # Let it fail upon invalid user inputs.
+        port_0, port_1 = [int(x) for x in port_range_str.split(":")]
+        assert port_0 <= port_1
+        # See also twisted.protocols.ftp.FTPFactory.passivePortRange
+        self["passivePortRange"] = range(port_0, port_1 + 1)
+
 
 def makeService(config):
     f = ftp.FTPFactory()
@@ -58,6 +69,8 @@ def makeService(config):
     f.userAnonymous = config["userAnonymous"]
     f.portal = p
     f.protocol = ftp.FTP
+    if config.get("passivePortRange"):
+        f.passivePortRange = config["passivePortRange"]
 
     try:
         portno = int(config["port"])

--- a/src/twisted/test/test_ftp_options.py
+++ b/src/twisted/test/test_ftp_options.py
@@ -74,3 +74,10 @@ class FTPOptionsTests(TestCase):
         return checker.requestAvatarId(correct).addCallback(
             lambda username: self.assertEqual(username, correct.username)
         )
+
+    def test_passivePortRange(self) -> None:
+        """
+        The C{--passive-port-range} option is parsed as expected when provided.
+        """
+        self.options.parseOptions(["--passive-port-range=30000:31000"])
+        self.assertEqual(self.options["passivePortRange"], range(30000, 31001))


### PR DESCRIPTION
## Scope and purpose

Introducing a new parameter `--passive-port-range` for the `ftp` command.

Sorry there is no existing issue number included because there doesn't seem to be a relevant one.


## Contributor Checklist:

- [x] The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
- [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
- [x] The automated tests were updated.
- [ ] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
