### PR TITLE
Revert "#8840 re-enable PTY tests on macOS"

### DIFF
--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -1143,6 +1143,8 @@ class PTYProcessTestsBuilder(ProcessTestsBuilderBase):
     if platform.isWindows():
         skip = "PTYs are not supported on Windows."
     elif platform.isMacOSX():
+        skip = "PTYs are flaky from a Darwin bug. See #8840."
+
         skippedReactors = {
             "twisted.internet.pollreactor.PollReactor": "macOS's poll() does not support PTYs"
         }


### PR DESCRIPTION
Reverts twisted/twisted#12165

Reopens #8840 

