### PR TITLE
#12183 Fix t.protocols.policies.LimitConnectionsByPeer handling of IPv4Address

### DIFF
--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -365,7 +365,7 @@ class LimitConnectionsByPeer(WrappingFactory):
         self.peerConnections = {}
 
     def buildProtocol(self, addr):
-        peerHost = addr[0]
+        peerHost = addr.host
         connectionCount = self.peerConnections.get(peerHost, 0)
         if connectionCount >= self.maxConnectionsPerPeer:
             return None
@@ -373,7 +373,7 @@ class LimitConnectionsByPeer(WrappingFactory):
         return WrappingFactory.buildProtocol(self, addr)
 
     def unregisterProtocol(self, p):
-        peerHost = p.getPeer()[1]
+        peerHost = p.getPeer().host
         self.peerConnections[peerHost] -= 1
         if self.peerConnections[peerHost] == 0:
             del self.peerConnections[peerHost]


### PR DESCRIPTION
Fixes #12183 

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/twisted/application/app.py", line 304, in runReactorWithLogging
    reactor.run()
  File "/usr/lib/python3/dist-packages/twisted/internet/base.py", line 1315, in run
    self.mainLoop()
  File "/usr/lib/python3/dist-packages/twisted/internet/base.py", line 1328, in mainLoop
    reactorBaseSelf.doIteration(t)
  File "/usr/lib/python3/dist-packages/twisted/internet/epollreactor.py", line 244, in doPoll
    log.callWithLogger(selectable, _drdw, selectable, fd, event)
--- <exception caught here> ---
  File "/usr/lib/python3/dist-packages/twisted/python/log.py", line 96, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/lib/python3/dist-packages/twisted/python/log.py", line 80, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/lib/python3/dist-packages/twisted/python/context.py", line 117, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/lib/python3/dist-packages/twisted/python/context.py", line 82, in callWithContext
    return func(*args, **kw)
  File "/usr/lib/python3/dist-packages/twisted/internet/posixbase.py", line 696, in _doReadOrWrite
    self._disconnectSelectable(selectable, why, inRead)
  File "/usr/lib/python3/dist-packages/twisted/internet/posixbase.py", line 300, in _disconnectSelectable
    selectable.connectionLost(f)
  File "/usr/lib/python3/dist-packages/twisted/internet/tcp.py", line 326, in connectionLost
    protocol.connectionLost(reason)
  File "/usr/lib/python3/dist-packages/twisted/protocols/policies.py", line 113, in connectionLost
    self.factory.unregisterProtocol(self)
  File "/usr/lib/python3/dist-packages/twisted/protocols/policies.py", line 377, in unregisterProtocol
    peerHost = p.getPeer()[1]
builtins.TypeError: 'IPv4Address' object is not subscriptable
```