### PR TITLE
#12184 Add support in conch.ssh to ETM HMACs.

### DIFF
--- a/src/twisted/conch/newsfragments/12184.feature
+++ b/src/twisted/conch/newsfragments/12184.feature
@@ -1,0 +1,3 @@
+twisted.conch.ssh.transport.SSHTransportBase now supports the
+`hmac-sha2-256-etm@openssh.com` and `hmac-sha2-512-etm@openssh.com` HMAC
+algorithms.

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -32,7 +32,7 @@ from twisted.conch.ssh.common import MP, NS, ffs, getMP, getNS
 from twisted.internet import defer, protocol
 from twisted.logger import Logger
 from twisted.python import randbytes
-from twisted.python.compat import iterbytes, networkString
+from twisted.python.compat import iterbytes
 
 # This import is needed if SHA256 hashing is used.
 # from twisted.python.compat import nativeString
@@ -117,6 +117,8 @@ class SSHCiphers:
         b"none": (None, 0, modes.CBC),
     }
     macMap = {
+        b"hmac-sha2-256-etm@openssh.com": sha256,
+        b"hmac-sha2-512-etm@openssh.com": sha512,
         b"hmac-sha2-512": sha512,
         b"hmac-sha2-384": sha384,
         b"hmac-sha2-256": sha256,
@@ -214,7 +216,7 @@ class SSHCiphers:
         result.key = key
         return result
 
-    def encrypt(self, blocks):
+    def _encrypt(self, blocks):
         """
         Encrypt some data.
 
@@ -238,7 +240,7 @@ class SSHCiphers:
         """
         return self.decryptor.update(blocks)
 
-    def makeMAC(self, seqid, data):
+    def _makeMAC(self, seqid, data):
         """
         Create a message authentication code (MAC) for the given packet using
         the outgoing MAC values.
@@ -256,6 +258,49 @@ class SSHCiphers:
             return b""
         data = struct.pack(">L", seqid) + data
         return hmac.HMAC(self.outMAC.key, data, self.outMAC[0]).digest()
+
+    def createPacket(self, payload: bytes, outgoingPacketSequence: int) -> bytes:
+        """
+        Return the SSH packet at it should be sent to the peer over the wire.
+
+        `payload` is the actual data.
+        """
+        # Start by computing the required padding.
+        #
+        # Extra 1 byte for the padding length
+        payloadSize = len(payload) + 1
+
+        if not self.outMACType.endswith(b"-etm@openssh.com"):
+            # For not ETM, the packet length is also included.
+            payloadSize += 4
+
+        bs = self.encBlockSize
+        lenPad = bs - (payloadSize % bs)
+        if lenPad < 4:
+            lenPad = lenPad + bs
+
+        # Create the unencrypted packet.
+        payloadPacket = (
+            struct.pack("!B", lenPad) + payload + randbytes.secureRandom(lenPad)
+        )
+
+        if self.outMACType.endswith(b"-etm@openssh.com"):
+            # For Encrypt-then-MAC the total size is not encrypted.
+            encryptedPayload = self._encrypt(payloadPacket)
+            totalSizePacket = struct.pack("!L", len(encryptedPayload))
+            encryptedPacket = totalSizePacket + encryptedPayload
+            macTarget = encryptedPacket
+        else:
+            # For non ETM, we substract the 4 bytes added to compute the
+            # padding size.
+            # But we also encrypt the package lenth.
+            totalSizePacket = struct.pack("!L", payloadSize + lenPad - 4)
+            encryptedPacket = self._encrypt(totalSizePacket + payloadPacket)
+            macTarget = totalSizePacket + payloadPacket
+
+        macPacket = self._makeMAC(outgoingPacketSequence, macTarget)
+
+        return encryptedPacket + macPacket
 
     def verify(self, seqid, data, mac):
         """
@@ -278,6 +323,12 @@ class SSHCiphers:
         data = struct.pack(">L", seqid) + data
         outer = hmac.HMAC(self.inMAC.key, data, self.inMAC[0]).digest()
         return hmac.compare_digest(mac, outer)
+
+
+class _InvalidPacket(Exception):
+    """
+    Used internally when an invalid packet was received.
+    """
 
 
 def _getSupportedCiphers():
@@ -454,9 +505,11 @@ class SSHTransportBase(protocol.Protocol):
     # List ordered by preference.
     supportedCiphers = _getSupportedCiphers()
     supportedMACs = [
-        b"hmac-sha2-512",
-        b"hmac-sha2-384",
+        b"hmac-sha2-256-etm@openssh.com",
+        b"hmac-sha2-512-etm@openssh.com",
         b"hmac-sha2-256",
+        b"hmac-sha2-384",
+        b"hmac-sha2-512",
         b"hmac-sha1",
         b"hmac-md5",
         # `none`,
@@ -637,36 +690,56 @@ class SSHTransportBase(protocol.Protocol):
             payload = self.outgoingCompression.compress(
                 payload
             ) + self.outgoingCompression.flush(2)
-        bs = self.currentEncryptions.encBlockSize
-        # 4 for the packet length and 1 for the padding length
-        totalSize = 5 + len(payload)
-        lenPad = bs - (totalSize % bs)
-        if lenPad < 4:
-            lenPad = lenPad + bs
-        packet = (
-            struct.pack("!LB", totalSize + lenPad - 4, lenPad)
-            + payload
-            + randbytes.secureRandom(lenPad)
+
+        wirePacket = self.currentEncryptions.createPacket(
+            payload,
+            self.outgoingPacketSequence,
         )
-        encPacket = self.currentEncryptions.encrypt(
-            packet
-        ) + self.currentEncryptions.makeMAC(self.outgoingPacketSequence, packet)
-        self.transport.write(encPacket)
+
+        self.transport.write(wirePacket)
         self.outgoingPacketSequence += 1
 
-    def getPacket(self):
+    def getPacket(self) -> bytes | None:
         """
         Try to return a decrypted, authenticated, and decompressed packet
         out of the buffer.  If there is not enough data, return None.
 
-        @rtype: L{str} or L{None}
-        @return: The decoded packet, if any.
+        @return: The decoded packet, if any. C{None} is returned if no packet was received yet.
+        """
+        if len(self.buf) < self.currentEncryptions.decBlockSize:
+            # Not enough data for a block
+            return
+
+        try:
+            if self.currentEncryptions.inMACType.endswith(b"-etm@openssh.com"):
+                payload = self._getPacketETM()
+            else:
+                payload = self._getPacketMTE()
+
+        except _InvalidPacket as error:
+            self.sendDisconnect(
+                DISCONNECT_PROTOCOL_ERROR,
+                error.args[0].encode("ascii"),
+            )
+            return
+
+        if payload is None:
+            # No packet received yet.
+            return
+
+        packet = self._decompressPacket(payload)
+        self.incomingPacketSequence += 1
+        return packet
+
+    def _getPacketMTE(self) -> bytes | None:
+        """
+        Handle decoding a packet when mac then encrypt.
+
+        @return: None if no packet was yet received.
         """
         bs = self.currentEncryptions.decBlockSize
         ms = self.currentEncryptions.verifyDigestSize
-        if len(self.buf) < bs:
-            # Not enough data for a block
-            return
+
         if not hasattr(self, "first"):
             first = self.currentEncryptions.decrypt(self.buf[:bs])
         else:
@@ -674,47 +747,94 @@ class SSHTransportBase(protocol.Protocol):
             del self.first
         packetLen, paddingLen = struct.unpack("!LB", first[:5])
         if packetLen > 1048576:  # 1024 ** 2
-            self.sendDisconnect(
-                DISCONNECT_PROTOCOL_ERROR,
-                networkString(f"bad packet length {packetLen}"),
-            )
-            return
+            raise _InvalidPacket(f"bad packet length {packetLen}")
+
         if len(self.buf) < packetLen + 4 + ms:
             # Not enough data for a packet
             self.first = first
             return
         if (packetLen + 4) % bs != 0:
-            self.sendDisconnect(
-                DISCONNECT_PROTOCOL_ERROR,
-                networkString(
-                    "bad packet mod (%i%%%i == %i)"
-                    % (packetLen + 4, bs, (packetLen + 4) % bs)
-                ),
+            raise _InvalidPacket(
+                "bad packet mod ({}%{} == {})".format(
+                    packetLen + 4, bs, (packetLen + 4) % bs
+                )
             )
-            return
+
         encData, self.buf = self.buf[: 4 + packetLen], self.buf[4 + packetLen :]
         packet = first + self.currentEncryptions.decrypt(encData[bs:])
         if len(packet) != 4 + packetLen:
-            self.sendDisconnect(DISCONNECT_PROTOCOL_ERROR, b"bad decryption")
-            return
+            raise _InvalidPacket("bad decryption")
+
         if ms:
             macData, self.buf = self.buf[:ms], self.buf[ms:]
             if not self.currentEncryptions.verify(
                 self.incomingPacketSequence, packet, macData
             ):
-                self.sendDisconnect(DISCONNECT_MAC_ERROR, b"bad MAC")
-                return
+                raise _InvalidPacket("bad MAC for MTE")
+
         payload = packet[5:-paddingLen]
-        if self.incomingCompression:
-            try:
-                payload = self.incomingCompression.decompress(payload)
-            except Exception:
-                # Tolerate any errors in decompression
-                self._log.failure("Error decompressing payload")
-                self.sendDisconnect(DISCONNECT_COMPRESSION_ERROR, b"compression error")
-                return
-        self.incomingPacketSequence += 1
         return payload
+
+    def _getPacketETM(self) -> bytes | None:
+        """
+        Handle decoding a packet when encrypt then MAC is used.
+
+        @return: None if no packet was yet received.
+        """
+        bs = self.currentEncryptions.decBlockSize
+        ms = self.currentEncryptions.verifyDigestSize
+
+        packetLen = struct.unpack("!L", self.buf[:4])[0]
+
+        if packetLen > 1048576:  # 1024 ** 2
+            raise _InvalidPacket(f"bad packet length {packetLen}")
+
+        if packetLen % bs != 0:
+            raise _InvalidPacket(
+                "bad packet mod ({}%{} == {})".format(packetLen, bs, packetLen % bs)
+            )
+
+        if len(self.buf) < packetLen + ms:
+            # Not enough data for a packet
+            return
+
+        # Consume the encrypted data from the buffer.
+        #
+        # The first 4 bytes are the package lenght field.
+        encData, self.buf = self.buf[: 4 + packetLen], self.buf[4 + packetLen :]
+        packet = self.currentEncryptions.decrypt(encData[4:])
+        if len(packet) != packetLen:
+            raise _InvalidPacket("bad decryption")
+
+        # Consume the MAC data from the buffer.
+        macData, self.buf = self.buf[:ms], self.buf[ms:]
+        if not self.currentEncryptions.verify(
+            self.incomingPacketSequence, encData, macData
+        ):
+            raise _InvalidPacket("bad MAC for ETM")
+
+        paddingLen = struct.unpack("!B", packet[:1])[0]
+        payload = packet[1:-paddingLen]
+        return payload
+
+    def _decompressPacket(self, payload: bytes) -> bytes:
+        """
+        Decompress the packet if needed.
+
+        @param payload: The packet that might be compressed.
+
+        @return: The decompressed packet.
+        """
+        if not self.incomingCompression:
+            return payload
+
+        try:
+            return self.incomingCompression.decompress(payload)
+        except Exception:
+            # Tolerate any errors in decompression
+            self._log.failure("Error decompressing payload")
+            self.sendDisconnect(DISCONNECT_COMPRESSION_ERROR, b"compression error")
+            return
 
     def _unsupportedVersionReceived(self, remoteVersion):
         """

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -166,17 +166,17 @@ class MockCipher:
     inMAC = (None, b"", b"", 1)
     keys = ()
 
-    def _encrypt(self, x):
+    def encrypt(self, x):
         """
         Called to encrypt the packet.  Simply record that encryption was used
         and return the data unchanged.
         """
         self.usedEncrypt = True
-        # if (len(x) % self.encBlockSize) != 0:
-        #     raise RuntimeError(
-        #         "length %i modulo blocksize %i is not 0: %i"
-        #         % (len(x), self.encBlockSize, len(x) % self.encBlockSize)
-        #     )
+        if (len(x) % self.encBlockSize) != 0:
+            raise RuntimeError(
+                "length %i modulo blocksize %i is not 0: %i"
+                % (len(x), self.encBlockSize, len(x) % self.encBlockSize)
+            )
         return x
 
     def decrypt(self, x):
@@ -192,8 +192,12 @@ class MockCipher:
             )
         return x
 
-    def createPacket(self, payload, outgoingPacketSequence):
-        return self._encrypt(payload)
+    def makeMAC(self, outgoingPacketSequence, payload):
+        """
+        Make a Message Authentication Code by sending the character value of
+        the outgoing packet.
+        """
+        return bytes((outgoingPacketSequence,))
 
     def verify(self, incomingPacketSequence, packet, macData):
         """
@@ -2947,8 +2951,8 @@ class SSHCiphersTests(TestCase):
             encryptor = cip.encryptor()
             enc = encryptor.update(key[:bs])
             enc2 = encryptor.update(key[:bs])
-            self.assertEqual(encCipher._encrypt(key[:bs]), enc)
-            self.assertEqual(encCipher._encrypt(key[:bs]), enc2)
+            self.assertEqual(encCipher.encrypt(key[:bs]), enc)
+            self.assertEqual(encCipher.encrypt(key[:bs]), enc2)
             self.assertEqual(decCipher.decrypt(enc), key[:bs])
             self.assertEqual(decCipher.decrypt(enc2), key[:bs])
 
@@ -2976,7 +2980,7 @@ class SSHCiphersTests(TestCase):
                 mac = mod(o + mod(i + packet).digest()).digest()
             else:
                 mac = b""
-            self.assertEqual(outMac._makeMAC(seqid, data), mac)
+            self.assertEqual(outMac.makeMAC(seqid, data), mac)
             self.assertTrue(inMac.verify(seqid, data, mac))
 
     def test_makeMAC(self):
@@ -3002,7 +3006,7 @@ class SSHCiphersTests(TestCase):
             shortened = data[4:]
             self.assertEqual(
                 mac,
-                binascii.hexlify(outMAC._makeMAC(seqid, shortened)),
+                binascii.hexlify(outMAC.makeMAC(seqid, shortened)),
                 f"Failed HMAC test vector; key={key!r} data={data!r}",
             )
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12184

It adds for now `hmac-sha2-256-etm@openssh.com` and `hmac-sha2-512-etm@openssh.com`

I don't think that we need `hmac-sha1-etm@openssh.com` or `hmac-md5-etm@openssh.com`.
They can be added later.

## How to test

### ssh server

You can use OpenSSH ssh client to connect using only ETM HMAC

```
ssh -oMACs=hmac-sha2-256-etm@openssh.com -oPort=5022 user@localhost
```