### PR TITLE
12195 some examples

### DIFF
--- a/docs/core/howto/logger.rst
+++ b/docs/core/howto/logger.rst
@@ -138,6 +138,7 @@ Therefore, most of the time, you should be accepting the behavior of ``handlingF
 However, if you require more customization of behavior beyond catching everything and continuing on, you can use :py:meth:`failure <twisted.logger.Logger.failure>` directly, like so:
 
 .. code-block:: python
+
     try:
         1 / 0
     except ZeroDivisionError:

--- a/docs/core/howto/logger.rst
+++ b/docs/core/howto/logger.rst
@@ -101,26 +101,24 @@ For example:
 This example will show the string "object with value 7 doing a task" because the ``log_source`` key is automatically set to the ``MyObject`` instance that the ``Logger`` is retrieved from.
 
 
-Capturing Failures
-~~~~~~~~~~~~~~~~~~
+Handling Failures
+~~~~~~~~~~~~~~~~~
 
-:py:class:`Logger <twisted.logger.Logger>` provides a :py:meth:`failure <twisted.logger.Logger.failure>` method, which allows one to capture a :py:class:`Failure <twisted.python.failure.Failure>` object conveniently:
+:py:class:`Logger <twisted.logger.Logger>` provides a :py:meth:`failure <twisted.logger.Logger.handlingFailures>` method, which allows one to run some application code, then capture a :py:class:`Failure <twisted.python.failure.Failure>` in the log stream if that code raises an exception:
 
 .. code-block:: python
 
     from twisted.logger import Logger
     log = Logger()
 
-    try:
+    with log.handlingFailures("While doing some math:"):
         1 / 0
-    except BaseException:
-        log.failure("Math is hard!")
 
 The emitted event will have the ``"log_failure"`` key set, which is a :py:class:`Failure <twisted.python.failure.Failure>` that captures the exception.
 This can be used by my observers to obtain a traceback.
-For example, :py:class:`FileLogObserver <twisted.logger.FileLogObserver>` will append the traceback to it's output::
+For example, :py:class:`FileLogObserver <twisted.logger.FileLogObserver>` will append the traceback to its output::
 
-    Math is hard!
+    While doing some math:
 
     Traceback (most recent call last):
     --- <exception caught here> ---
@@ -128,10 +126,24 @@ For example, :py:class:`FileLogObserver <twisted.logger.FileLogObserver>` will a
         1/0
     exceptions.ZeroDivisionError: integer division or modulo by zero
 
-Note that this API is meant to capture unexpected and unhandled errors (that is: bugs, which is why tracebacks are preserved).
+Note that this API is meant to capture **unexpected and otherwise unhandled** errors (in other words: bugs, which is why tracebacks are preserved).
 As such, it defaults to logging at the :py:attr:`critical <twisted.logger.LogLevel.critical>` level.
-It is generally more appropriate to instead use `log.error()` when logging an expected error condition that was appropriately handled by the software.
+It is generally more appropriate to instead use ``log.error()`` when logging an expected type of error condition that was fully handled by your code.
+To put it differently, use ``.handlingFailures(...)`` for handling bugs in your code, and ``.error()`` for handling errors in input data, user configuration, and the like.
 
+``.handlingFailures(...)`` is intended for frameworks (such as Twisted itself) which call out to “application code”, where misbehavior on the part of the application should not corrupt the state of the framework itself.
+For example, a buggy protocol implementation will not cause the entire Twisted reactor to crash and exit, it will log a traceback, disconnect the protocol which caused the exception, and keep running.
+
+Therefore, most of the time, you should be accepting the behavior of ``handlingFailures``, of catching everything via ``BaseException``.
+However, if you require more customization of behavior beyond catching everything and continuing on, you can use :py:meth:`failure <twisted.logger.Logger.failure>` directly, like so:
+
+.. code-block:: python
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        log.failure("While dividing by zero, specifically:")
+
+The ``.failure`` method requires a log message, but can discover an exception on the stack automatically, so if it is called from within an ``except:`` block it will do the right thing.
 
 Namespaces
 ~~~~~~~~~~

--- a/src/twisted/internet/_baseprocess.py
+++ b/src/twisted/internet/_baseprocess.py
@@ -9,10 +9,12 @@ L{IReactorProcess} implementations.
 
 from typing import Optional
 
+from twisted.logger import Logger
 from twisted.python.deprecate import getWarningMethod
 from twisted.python.failure import Failure
-from twisted.python.log import err
 from twisted.python.reflect import qual
+
+_log = Logger()
 
 _missingProcessExited = (
     "Since Twisted 8.2, IProcessProtocol.processExited "
@@ -39,10 +41,8 @@ class BaseProcess:
                 stacklevel=0,
             )
         else:
-            try:
+            with _log.handlingFailures("while calling processExited:"):
                 processExited(Failure(reason))
-            except BaseException:
-                err(None, "unexpected error in processExited")
 
     def processEnded(self, status):
         """
@@ -62,7 +62,5 @@ class BaseProcess:
             reason = self._getReason(self.status)
             proto = self.proto
             self.proto = None
-            try:
+            with _log.handlingFailures("while calling processEnded:"):
                 proto.processEnded(Failure(reason))
-            except BaseException:
-                err(None, "unexpected error in processEnded")

--- a/src/twisted/internet/_posixstdio.py
+++ b/src/twisted/internet/_posixstdio.py
@@ -10,6 +10,7 @@ Future Plans::
 
 Maintainer: James Y Knight
 """
+from __future__ import annotations
 
 from zope.interface import implementer
 

--- a/src/twisted/internet/_posixstdio.py
+++ b/src/twisted/internet/_posixstdio.py
@@ -13,7 +13,8 @@ Maintainer: James Y Knight
 
 from zope.interface import implementer
 
-from twisted.internet import error, interfaces, process
+from twisted.internet import interfaces, process
+from twisted.internet.interfaces import IProtocol, IReactorFDSet
 from twisted.logger import Logger
 from twisted.python.failure import Failure
 
@@ -37,10 +38,16 @@ class StandardIO:
     disconnected = False
     disconnecting = False
 
-    def __init__(self, proto, stdin=0, stdout=1, reactor=None):
+    def __init__(
+        self,
+        proto: IProtocol,
+        stdin: int = 0,
+        stdout: int = 1,
+        reactor: IReactorFDSet | None = None,
+    ):
         if reactor is None:
-            from twisted.internet import reactor
-        self.protocol = proto
+            from twisted.internet import reactor  # type:ignore[assignment]
+        self.protocol: IProtocol = proto
 
         self._writer = process.ProcessWriter(reactor, self, "write", stdout)
         self._reader = process.ProcessReader(reactor, self, "read", stdin)
@@ -78,21 +85,16 @@ class StandardIO:
         return PipeAddress()
 
     # Callbacks from process.ProcessReader/ProcessWriter
-    def childDataReceived(self, fd, data):
+    def childDataReceived(self, fd: str, data: bytes) -> None:
         self.protocol.dataReceived(data)
 
-    def childConnectionLost(self, fd, reason):
+    def childConnectionLost(self, fd: str, reason: Failure) -> None:
         if self.disconnected:
             return
-
-        if reason.value.__class__ == error.ConnectionDone:
-            # Normal close
-            if fd == "read":
-                self._readConnectionLost(reason)
-            else:
-                self._writeConnectionLost(reason)
+        if fd == "read":
+            self._readConnectionLost(reason)
         else:
-            self.connectionLost(reason)
+            self._writeConnectionLost(reason)
 
     def connectionLost(self, reason):
         self.disconnected = True
@@ -102,7 +104,7 @@ class StandardIO:
         _writer = self._writer
         protocol = self.protocol
         self._reader = self._writer = None
-        self.protocol = None
+        self.protocol = None  # type:ignore[assignment]
 
         if _writer is not None and not _writer.disconnected:
             _writer.connectionLost(reason)

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: twisted.test.test_producer_helpers -*-
+# -*- test-case-name: twisted.protocols.test.test_tls,twisted.web.test.test_http2 -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -12,8 +12,9 @@ from zope.interface import implementer
 
 from twisted.internet.interfaces import IPushProducer
 from twisted.internet.task import cooperate
-from twisted.python import log
-from twisted.python.reflect import safe_str
+from twisted.logger import Logger
+
+_log = Logger()
 
 # This module exports nothing public, it's for internal Twisted use only.
 __all__: List[str] = []
@@ -60,26 +61,19 @@ class _PullToPush:
         unregistered, which should result in streaming stopping.
         """
         while True:
-            try:
+            with _log.handlingFailures(
+                "while calling resumeProducing on {producer}", producer=self._producer
+            ) as op:
                 self._producer.resumeProducing()
-            except BaseException:
-                log.err(
-                    None,
-                    "%s failed, producing will be stopped:"
-                    % (safe_str(self._producer),),
-                )
-                try:
+            if op.failed:
+                with _log.handlingFailures(
+                    "while calling unregisterProducer on {consumer}",
+                    consumer=self._consumer,
+                ) as handlingop:
                     self._consumer.unregisterProducer()
+                if handlingop.failed:
                     # The consumer should now call stopStreaming() on us,
                     # thus stopping the streaming.
-                except BaseException:
-                    # Since the consumer blew up, we may not have had
-                    # stopStreaming() called, so we just stop on our own:
-                    log.err(
-                        None,
-                        "%s failed to unregister producer:"
-                        % (safe_str(self._consumer),),
-                    )
                     self._finished = True
                     return
             yield None

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -28,12 +28,15 @@ from twisted.internet.interfaces import (
     IOpenSSLClientConnectionCreator,
     IOpenSSLContextFactory,
 )
-from twisted.python import log, util
+from twisted.logger import Logger
 from twisted.python.compat import nativeString
 from twisted.python.deprecate import _mutuallyExclusiveArguments, deprecated
 from twisted.python.failure import Failure
 from twisted.python.randbytes import secureRandom
+from twisted.python.util import nameToLabel
 from ._idna import _idnaBytes
+
+_log = Logger()
 
 
 class TLSVersion(Names):
@@ -344,7 +347,7 @@ class DistinguishedName(Dict[str, bytes]):
             return set(mapping.values())
 
         for k in sorted(uniqueValues(_x509names)):
-            label = util.nameToLabel(k)
+            label = nameToLabel(k)
             lablen = max(len(label), lablen)
             v = getattr(self, k, None)
             if v is not None:
@@ -1058,11 +1061,9 @@ def _tolerateErrors(wrapped):
     """
 
     def infoCallback(connection, where, ret):
-        try:
+        with _log.handlingFailures("Error during info_callback") as op:
             return wrapped(connection, where, ret)
-        except BaseException:
-            f = Failure()
-            log.err(f, "Error during info_callback")
+        if (f := op.failure) is not None:
             connection.get_app_data().failVerification(f)
 
     return infoCallback

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1062,7 +1062,9 @@ def _tolerateErrors(wrapped):
 
     def infoCallback(connection, where, ret):
         with _log.handlingFailures("Error during info_callback") as op:
-            return wrapped(connection, where, ret)
+            result = wrapped(connection, where, ret)
+            return result
+
         if (f := op.failure) is not None:
             connection.get_app_data().failVerification(f)
 

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1060,13 +1060,13 @@ def _tolerateErrors(wrapped):
     @rtype: L{callable}
     """
 
-    def infoCallback(connection, where, ret):
+    def infoCallback(connection: SSL.Connection, where: int, ret: int) -> object:
+        result = None
         with _log.handlingFailures("Error during info_callback") as op:
             result = wrapped(connection, where, ret)
-            return result
-
         if (f := op.failure) is not None:
             connection.get_app_data().failVerification(f)
+        return result
 
     return infoCallback
 

--- a/src/twisted/internet/_threadedselect.py
+++ b/src/twisted/internet/_threadedselect.py
@@ -308,7 +308,7 @@ class ThreadedSelectReactor(posixbase.PosixReactorBase):
         self._cleanUpThread()
 
     def iterate(self, timeout: float = 0.0) -> None:
-        if self._iterationQueue is None and self.mainWaker is None:
+        if self._iterationQueue is None and self.mainWaker is None:  # pragma: no branch
             self._testMainLoopSetup()
         self.wakeUp()
         super().iterate(timeout)

--- a/src/twisted/internet/_threadedselect.py
+++ b/src/twisted/internet/_threadedselect.py
@@ -104,13 +104,19 @@ def _threadsafeSelect(
         except OSError as se:
             # The select() system call encountered an error.
             if se.args[0] == EINTR:
-                return
+                # EINTR is hard to replicate in tests using an actual select(),
+                # and I don't want to dedicate effort to testing this function
+                # when it needs to be refactored with selectreactor.
+
+                return  # pragma: no cover
             elif se.args[0] == EBADF:
                 preen = True
                 break
             else:
-                # OK, I really don't know what's going on.  Blow up.
-                raise
+                # OK, I really don't know what's going on.  Blow up.  Never
+                # mind with the coverage here, since we are just trying to make
+                # sure we don't swallow an exception.
+                raise  # pragma: no cover
         else:
             r, w, ignored = result
             break

--- a/src/twisted/internet/_threadedselect.py
+++ b/src/twisted/internet/_threadedselect.py
@@ -323,6 +323,10 @@ class ThreadedSelectReactor(posixbase.PosixReactorBase):
         posixbase.PosixReactorBase.stop(self)
         self.wakeUp()
 
+    def crash(self):
+        posixbase.PosixReactorBase.crash(self)
+        self.wakeUp()
+
     def run(self, installSignalHandlers=True):
         q = Queue()
         self.interleave(q.put, installSignalHandlers=installSignalHandlers)

--- a/src/twisted/internet/_win32stdio.py
+++ b/src/twisted/internet/_win32stdio.py
@@ -20,8 +20,8 @@ from twisted.internet.interfaces import (
     IPushProducer,
     ITransport,
 )
-from twisted.python.failure import Failure
 from twisted.logger import Logger
+from twisted.python.failure import Failure
 
 _log = Logger()
 

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -56,8 +56,10 @@ from twisted.internet.interfaces import (
     _ISupportsExitSignalCapturing,
 )
 from twisted.internet.protocol import ClientFactory
-from twisted.python import log, reflect
+from twisted.logger import Logger
+from twisted.python import reflect
 from twisted.python.failure import Failure
+from twisted.python.log import callWithLogger as _callWithLogger
 from twisted.python.runtime import platform, seconds as runtimeSeconds
 from ._signals import SignalHandling, _WithoutSignalHandling, _WithSignalHandling
 
@@ -72,6 +74,11 @@ if platform.supportsThreads():
     from twisted.python.threadpool import ThreadPool
 else:
     ThreadPool = None  # type: ignore[misc, assignment]
+
+_log = Logger()
+_topHandler = _log.failureHandler("Unexpected error in main loop")
+_threadCallHandler = _log.failureHandler("while calling from thread")
+_systemEventHandler = _log.failureHandler("While calling system event trigger handler")
 
 
 @implementer(IDelayedCall)
@@ -494,13 +501,11 @@ class _ThreePhaseEvent:
         while self.before:
             callable, args, kwargs = self.before.pop(0)
             self.finishedBefore.append((callable, args, kwargs))
-            try:
+            result = None
+            with _systemEventHandler:
                 result = callable(*args, **kwargs)
-            except BaseException:
-                log.err()
-            else:
-                if isinstance(result, Deferred):
-                    beforeResults.append(result)
+            if isinstance(result, Deferred):
+                beforeResults.append(result)
         DeferredList(beforeResults).addCallback(self._continueFiring)
 
     def _continueFiring(self, ignored: object) -> None:
@@ -512,10 +517,8 @@ class _ThreePhaseEvent:
         for phase in self.during, self.after:
             while phase:
                 callable, args, kwargs = phase.pop(0)
-                try:
+                with _systemEventHandler:
                     callable(*args, **kwargs)
-                except BaseException:
-                    log.err()
 
 
 @implementer(IReactorPluggableNameResolver, IReactorPluggableResolver)
@@ -698,19 +701,13 @@ class ReactorBase(PluggableResolverMixin):
 
     def mainLoop(self) -> None:
         while self._started:
-            try:
-                while self._started:
-                    # Advance simulation time in delayed event
-                    # processors.
-                    self.runUntilCurrent()
-                    t2 = self.timeout()
-                    t = self.running and t2
-                    self.doIteration(t)
-            except BaseException:
-                log.msg("Unexpected error in main loop.")
-                log.err()
-            else:
-                log.msg("Main loop terminated.")  # type:ignore[unreachable]
+            with _topHandler:
+                # Advance simulation time in delayed event processors.
+                self.runUntilCurrent()
+                t2 = self.timeout()
+                t = self.running and t2
+                self.doIteration(t)
+        _log.info("Main loop terminated.")
 
     # override in subclasses
 
@@ -815,7 +812,7 @@ class ReactorBase(PluggableResolverMixin):
         @param number: See handler specification in L{signal.signal}
         @param frame: See handler specification in L{signal.signal}
         """
-        log.msg("Received SIGINT, shutting down.")
+        _log.info("Received SIGINT, shutting down.")
         self.callFromThread(self.stop)
         self._exitSignal = number
 
@@ -826,7 +823,7 @@ class ReactorBase(PluggableResolverMixin):
         @param number: See handler specification in L{signal.signal}
         @param frame: See handler specification in L{signal.signal}
         """
-        log.msg("Received SIGBREAK, shutting down.")
+        _log.info("Received SIGBREAK, shutting down.")
         self.callFromThread(self.stop)
         self._exitSignal = number
 
@@ -837,7 +834,7 @@ class ReactorBase(PluggableResolverMixin):
         @param number: See handler specification in L{signal.signal}
         @param frame: See handler specification in L{signal.signal}
         """
-        log.msg("Received SIGTERM, shutting down.")
+        _log.info("Received SIGTERM, shutting down.")
         self.callFromThread(self.stop)
         self._exitSignal = number
 
@@ -845,7 +842,7 @@ class ReactorBase(PluggableResolverMixin):
         """Disconnect every reader, and writer in the system."""
         selectables = self.removeAll()
         for reader in selectables:
-            log.callWithLogger(
+            _callWithLogger(
                 reader, reader.connectionLost, Failure(main.CONNECTION_LOST)
             )
 
@@ -1059,10 +1056,8 @@ class ReactorBase(PluggableResolverMixin):
             count = 0
             total = len(self.threadCallQueue)
             for f, a, kw in self.threadCallQueue:
-                try:
+                with _threadCallHandler:
                     f(*a, **kw)
-                except BaseException:
-                    log.err()
                 count += 1
                 if count == total:
                     break
@@ -1085,21 +1080,20 @@ class ReactorBase(PluggableResolverMixin):
                 heappush(self._pendingTimedCalls, call)
                 continue
 
-            try:
+            with _log.handlingFailures(
+                "while handling timed call {previous()}",
+                previous=lambda creator=call.creator: (
+                    ""
+                    if creator is None
+                    else "\n"
+                    + (" C: from a DelayedCall created here:\n")
+                    + " C:"
+                    + "".join(creator).rstrip().replace("\n", "\n C:")
+                    + "\n"
+                ),
+            ):
                 call.called = 1
                 call.func(*call.args, **call.kw)
-            except BaseException:
-                log.err()
-                if call.creator is not None:
-                    e = "\n"
-                    e += (
-                        " C: previous exception occurred in "
-                        + "a DelayedCall created here:\n"
-                    )
-                    e += " C:"
-                    e += "".join(call.creator).rstrip().replace("\n", "\n C:")
-                    e += "\n"
-                    log.msg(e)
 
         if (
             self._cancellations > 50

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -39,7 +39,6 @@ from ._signals import (
 )
 
 # Exceptions that doSelect might return frequently
-_NO_FILENO = error.ConnectionFdescWentAway("Handler has no fileno method")
 _NO_FILEDESC = error.ConnectionFdescWentAway("File descriptor lost")
 
 

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -11,12 +11,12 @@ import select
 import sys
 from errno import EBADF, EINTR
 from time import sleep
-from typing import Type
+from typing import Callable, Type, TypeVar
 
 from zope.interface import implementer
 
 from twisted.internet import posixbase
-from twisted.internet.interfaces import IReactorFDSet
+from twisted.internet.interfaces import IReactorFDSet, IReadDescriptor, IWriteDescriptor
 from twisted.python import log
 from twisted.python.runtime import platformType
 
@@ -52,6 +52,36 @@ except ImportError:
 else:
     _extraBase = _ThreadedWin32EventsMixin
 
+_T = TypeVar("_T")
+
+
+def _onePreen(
+    toPreen: list[_T],
+    preenInto: set[_T],
+    disconnect: Callable[[_T, Exception, bool], None],
+) -> None:
+    preenInto.clear()
+    for selectable in toPreen:
+        try:
+            select.select([selectable], [selectable], [selectable], 0)
+        except Exception as e:
+            log.msg("bad descriptor %s" % selectable)
+            disconnect(selectable, e, False)
+        else:
+            preenInto.add(selectable)
+
+
+def _preenDescriptors(
+    reads: set[IReadDescriptor],
+    writes: set[IWriteDescriptor],
+    disconnect: Callable[[IReadDescriptor | IWriteDescriptor, Exception, bool], None],
+) -> None:
+    log.msg("Malformed file descriptor found.  Preening lists.")
+    readers: list[IReadDescriptor] = list(reads)
+    writers: list[IWriteDescriptor] = list(writes)
+    _onePreen(readers, reads, disconnect)
+    _onePreen(writers, writes, disconnect)
+
 
 @implementer(IReactorFDSet)
 class SelectReactor(posixbase.PosixReactorBase, _extraBase):  # type: ignore[misc,valid-type]
@@ -65,29 +95,16 @@ class SelectReactor(posixbase.PosixReactorBase, _extraBase):  # type: ignore[mis
         checked for writability.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize file descriptor tracking dictionaries and the base class.
         """
-        self._reads = set()
-        self._writes = set()
+        self._reads: set[IReadDescriptor] = set()
+        self._writes: set[IWriteDescriptor] = set()
         posixbase.PosixReactorBase.__init__(self)
 
-    def _preenDescriptors(self):
-        log.msg("Malformed file descriptor found.  Preening lists.")
-        readers = list(self._reads)
-        writers = list(self._writes)
-        self._reads.clear()
-        self._writes.clear()
-        for selSet, selList in ((self._reads, readers), (self._writes, writers)):
-            for selectable in selList:
-                try:
-                    select.select([selectable], [selectable], [selectable], 0)
-                except Exception as e:
-                    log.msg("bad descriptor %s" % selectable)
-                    self._disconnectSelectable(selectable, e, False)
-                else:
-                    selSet.add(selectable)
+    def _preenDescriptors(self) -> None:
+        _preenDescriptors(self._reads, self._writes, self._disconnectSelectable)
 
     def doSelect(self, timeout):
         """
@@ -136,7 +153,7 @@ class SelectReactor(posixbase.PosixReactorBase, _extraBase):  # type: ignore[mis
             for selectable in selectables:
                 # if this was disconnected in another thread, kill it.
                 # ^^^^ --- what the !@#*?  serious!  -exarkun
-                if selectable not in fdset:
+                if selectable not in fdset:  # type:ignore[operator]
                     continue
                 # This for pausing input when we're not ready for more.
                 _logrun(selectable, _drdw, selectable, method)

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -5,7 +5,7 @@
 """
 Select reactor
 """
-
+from __future__ import annotations
 
 import select
 import sys

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -154,6 +154,7 @@ class ReactorBuilder:
         )
 
         _reactors.append("twisted.internet.test.reactormixins.AsyncioSelectorReactor")
+        _reactors.append("twisted.internet._threadedselect.ThreadedSelectReactor")
 
         if platform.isMacOSX():
             _reactors.append("twisted.internet.cfreactor.CFReactor")

--- a/src/twisted/internet/test/test_fdset.py
+++ b/src/twisted/internet/test/test_fdset.py
@@ -8,19 +8,22 @@ Tests for implementations of L{IReactorFDSet}.
 import os
 import socket
 import traceback
+from typing import TYPE_CHECKING
 from unittest import skipIf
 
 from zope.interface import implementer
 
 from twisted.internet.abstract import FileDescriptor
 from twisted.internet.interfaces import IReactorFDSet, IReadDescriptor
-
-# twisted.internet.tcp nicely defines some names with proper values on
-# several different platforms.
 from twisted.internet.tcp import EINPROGRESS, EWOULDBLOCK
 from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.python.runtime import platform
-from twisted.trial.unittest import SkipTest
+from twisted.trial.unittest import SkipTest, SynchronousTestCase
+
+if TYPE_CHECKING:
+    PretendTestCase = SynchronousTestCase
+else:
+    PretendTestCase = object
 
 
 def socketpair():
@@ -46,7 +49,7 @@ def socketpair():
     return client, server
 
 
-class ReactorFDSetTestsBuilder(ReactorBuilder):
+class ReactorFDSetTestsBuilder(ReactorBuilder, PretendTestCase):
     """
     Builder defining tests relating to L{IReactorFDSet}.
     """

--- a/src/twisted/logger/__init__.py
+++ b/src/twisted/logger/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "LogEvent",
     # From ._logger
     "Logger",
+    "Operation",
     "_loggerFor",
     # From ._observer
     "LogPublisher",
@@ -102,7 +103,7 @@ from ._format import (
 
 from ._interfaces import ILogObserver, LogEvent
 
-from ._logger import Logger, _loggerFor
+from ._logger import Logger, _loggerFor, Operation
 
 from ._observer import LogPublisher
 

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -312,6 +312,8 @@ class Logger:
             in non-deterministic behavior from observers that schedule work for
             later execution.
 
+        @see: L{Logger.failure}
+
         @return: An L{Operation} which will have either its C{succeeded} or
             C{failed} attribute set to C{True} upon completion of the code
             within the code within the C{with} block.

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -8,7 +8,6 @@ Logger class.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from time import time
 from types import TracebackType
 from typing import Any, Callable, ContextManager, Optional, Protocol, cast
@@ -33,11 +32,12 @@ class Operation(Protocol):
         ...
 
 
-@dataclass
 class _FailCtxMgr:
-    _fail: Callable[[Failure], None]
     succeeded: bool = False
     failure: Failure | None = None
+
+    def __init__(self, fail: Callable[[Failure], None]) -> None:
+        self._fail = fail
 
     @property
     def failed(self) -> bool:

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -6,6 +6,8 @@
 Logger class.
 """
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from dataclasses import dataclass
 from time import time

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -6,10 +6,10 @@
 Logger class.
 """
 
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from dataclasses import dataclass
 from time import time
-from typing import Any, Iterator, Optional, cast
+from typing import Any, ContextManager, Iterator, Optional, cast
 
 from twisted.python.compat import currentframe
 from twisted.python.failure import Failure
@@ -279,7 +279,7 @@ class Logger:
 
     def handlingFailures(
         self, format: str, level: LogLevel = LogLevel.critical, **kwargs: object
-    ) -> AbstractContextManager[Operation]:
+    ) -> ContextManager[Operation]:
         """
         Run some application code, logging a failure and emitting a traceback
         in the event that any of it fails, but continuing on.  For example::
@@ -335,6 +335,8 @@ class Logger:
         else:
             op.succeeded = True
 
+    # Remove pointless additional call-stack frame, since the extra method is
+    # just defined to make the AST look correct for pydoctor.
     handlingFailures = _handlingFailures  # noqa
 
 

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -8,7 +8,7 @@ Logger class.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from time import time
 from types import TracebackType
 from typing import Any, ContextManager, Optional, Protocol, cast
@@ -39,7 +39,6 @@ class _FailCtxMgr:
     _format: str
     _level: LogLevel
     _kwargs: dict[str, object]
-    _op: Operation = field(default_factory=Operation)
 
     succeeded: bool = False
     failure: Failure | None = None

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -25,7 +25,11 @@ class Operation:
     """
 
     succeeded: bool = False
-    failed: bool = False
+    failure: Failure | None = None
+
+    @property
+    def failed(self) -> bool:
+        return self.failure is not None
 
 
 class Logger:
@@ -330,8 +334,9 @@ class Logger:
         try:
             yield op
         except BaseException:
-            op.failed = True
-            self.failure(format, None, level, **kwargs)
+            failure = Failure()
+            op.failure = failure
+            self.failure(format, failure, level, **kwargs)
         else:
             op.succeeded = True
 

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -278,7 +278,7 @@ class LoggerTests(unittest.TestCase):
 
     def test_handlingFailures(self) -> None:
         """
-        The handlingFailures context manager catches any BaseException and convert it into a logged Failure.
+        The handlingFailures context manager catches any BaseException and converts it into a logged Failure.
         """
         events = []
 

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -11,6 +11,7 @@ from zope.interface import implementer
 
 from constantly import NamedConstant
 
+from twisted.python.failure import Failure
 from twisted.trial import unittest
 from .._format import formatEvent
 from .._global import globalLogPublisher
@@ -274,3 +275,49 @@ class LoggerTests(unittest.TestCase):
 
         log = TestLogger(observer=publisher)
         log.info("Hello.", log_trace=[])
+
+    def test_handlingFailures(self) -> None:
+        """
+        The handlingFailures context manager can handle failures.
+        """
+        events = []
+
+        @implementer(ILogObserver)
+        def logged(event: LogEvent) -> None:
+            events.append(event)
+
+        log = TestLogger(observer=logged)
+
+        reprd = 0
+
+        class Reprable:
+            def __repr__(self) -> str:
+                nonlocal reprd
+                reprd += 1
+                return f"<repr {reprd}>"
+
+        with log.handlingFailures(
+            "while testing failure handling for {value}", value=Reprable()
+        ) as operation:
+            1 / 0
+        self.assertEqual(operation.succeeded, False)
+        self.assertEqual(operation.failed, True)
+        self.assertEqual(len(events), 1)
+        [logged] = events
+        events[:] = []
+        f: Failure = logged["log_failure"]
+
+        self.assertEqual(reprd, 0)
+        self.assertEqual(
+            formatEvent(logged), "while testing failure handling for <repr 1>"
+        )
+        self.assertEqual(reprd, 1)
+        self.assertEqual(f.type, ZeroDivisionError)
+
+        with log.handlingFailures("succeeding for {value}", value=Reprable()) as op2:
+            self.assertEqual(op2.succeeded, False)
+            self.assertEqual(op2.failed, False)
+
+        self.assertEqual(reprd, 1)
+        self.assertEqual(op2.succeeded, True)
+        self.assertEqual(op2.failed, False)

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -278,7 +278,7 @@ class LoggerTests(unittest.TestCase):
 
     def test_handlingFailures(self) -> None:
         """
-        The handlingFailures context manager can handle failures.
+        The handlingFailures context manager catches any BaseException and convert it into a logged Failure.
         """
         events = []
 

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -287,7 +287,6 @@ class LoggerTests(unittest.TestCase):
             events.append(event)
 
         log = TestLogger(observer=logged)
-
         reprd = 0
 
         class Reprable:
@@ -306,18 +305,15 @@ class LoggerTests(unittest.TestCase):
         [logged] = events
         events[:] = []
         f: Failure = logged["log_failure"]
-
         self.assertEqual(reprd, 0)
         self.assertEqual(
             formatEvent(logged), "while testing failure handling for <repr 1>"
         )
         self.assertEqual(reprd, 1)
         self.assertEqual(f.type, ZeroDivisionError)
-
         with log.handlingFailures("succeeding for {value}", value=Reprable()) as op2:
             self.assertEqual(op2.succeeded, False)
             self.assertEqual(op2.failed, False)
-
         self.assertEqual(reprd, 1)
         self.assertEqual(op2.succeeded, True)
         self.assertEqual(op2.failed, False)

--- a/src/twisted/newsfragments/12188.feature
+++ b/src/twisted/newsfragments/12188.feature
@@ -1,0 +1,1 @@
+Added a new method, twisted.logger.Logger.handlingFailures, which allows for more concise and convenient handling of exceptions when dispatching out to application code.

--- a/src/twisted/newsfragments/12188.feature
+++ b/src/twisted/newsfragments/12188.feature
@@ -1,1 +1,1 @@
-Added a new method, twisted.logger.Logger.handlingFailures, which allows for more concise and convenient handling of exceptions when dispatching out to application code.
+Added two new methods, twisted.logger.Logger.handlingFailures and twisted.logger.Logger.failureHandler, which allow for more concise and convenient handling of exceptions when dispatching out to application code.  The former can arbitrarily customize failure handling at the call site, and the latter can be used for performance-sensitive cases where no additional information needs to be logged.

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -1752,7 +1752,7 @@ class NonStreamingProducerTests(TestCase):
         """
         consumer = StringTransport()
         done = self.resumeProducingRaises(
-            consumer, [(ZeroDivisionError, "failed, producing will be stopped")]
+            consumer, [(ZeroDivisionError, "while calling resumeProducing on")]
         )
 
         def cleanShutdown(ignore):
@@ -1778,8 +1778,8 @@ class NonStreamingProducerTests(TestCase):
         return self.resumeProducingRaises(
             consumer,
             [
-                (ZeroDivisionError, "failed, producing will be stopped"),
-                (RuntimeError, "failed to unregister producer"),
+                (ZeroDivisionError, "while calling resumeProducing"),
+                (RuntimeError, "while calling unregisterProducer"),
             ],
         )
 

--- a/src/twisted/test/stdio_test_halfclose.py
+++ b/src/twisted/test/stdio_test_halfclose.py
@@ -4,9 +4,8 @@
 
 """
 Main program for the child process run by
-L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost}
-to test that IHalfCloseableProtocol.readConnectionLost works for process
-transports.
+L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost} to
+test that IHalfCloseableProtocol.readConnectionLost works for stdio transports.
 """
 
 

--- a/src/twisted/test/stdio_test_halfclose_buggy.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy.py
@@ -1,0 +1,68 @@
+# -*- test-case-name: twisted.test.test_stdio.StandardInputOutputTests.test_buggyReadConnectionLost -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Main program for the child process run by
+L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost}
+to test that IHalfCloseableProtocol.readConnectionLost works for process
+transports.
+"""
+
+
+import sys
+
+from zope.interface import implementer
+
+from twisted.internet import protocol, stdio
+from twisted.internet.interfaces import IHalfCloseableProtocol, IReactorCore, ITransport
+from twisted.python import log, reflect
+
+
+@implementer(IHalfCloseableProtocol)
+class HalfCloseProtocol(protocol.Protocol):
+    """
+    A protocol to hook up to stdio and observe its transport being
+    half-closed.  If all goes as expected, C{exitCode} will be set to C{0};
+    otherwise it will be set to C{1} to indicate failure.
+    """
+
+    exitCode = None
+    transport: ITransport
+
+    def connectionMade(self) -> None:
+        """
+        Signal the parent process that we're ready.
+        """
+        self.transport.write(b"x")
+
+    def readConnectionLost(self) -> None:
+        """
+        This is the desired event.  Once it has happened, stop the reactor so
+        the process will exit.
+        """
+        raise ValueError("something went wrong")
+
+    def connectionLost(self, reason: object = None) -> None:
+        """
+        This may only be invoked after C{readConnectionLost}.  If it happens
+        otherwise, mark it as an error and shut down.
+        """
+        self.exitCode = 0
+        reactor.stop()
+
+    def writeConnectionLost(self) -> None:
+        # IHalfCloseableProtocol.writeConnectionLost
+        pass
+
+
+if __name__ == "__main__":
+    reflect.namedAny(sys.argv[1]).install()
+    log.startLogging(open(sys.argv[2], "wb"))
+    reactor: IReactorCore
+    from twisted.internet import reactor  # type:ignore[assignment]
+
+    halfCloseProtocol = HalfCloseProtocol()
+    stdio.StandardIO(halfCloseProtocol)
+    reactor.run()
+    sys.exit(halfCloseProtocol.exitCode)

--- a/src/twisted/test/stdio_test_halfclose_buggy.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy.py
@@ -4,9 +4,8 @@
 
 """
 Main program for the child process run by
-L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost}
-to test that IHalfCloseableProtocol.readConnectionLost works for process
-transports.
+L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost} to
+test that IHalfCloseableProtocol.readConnectionLost works for stdio transports.
 """
 
 

--- a/src/twisted/test/stdio_test_halfclose_buggy.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy.py
@@ -55,7 +55,7 @@ class HalfCloseProtocol(protocol.Protocol):
         pass
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no branch
     reflect.namedAny(sys.argv[1]).install()
     log.startLogging(open(sys.argv[2], "w"))
     reactor: IReactorCore

--- a/src/twisted/test/stdio_test_halfclose_buggy_write.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy_write.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: twisted.test.test_stdio.StandardInputOutputTests.test_buggyReadConnectionLost -*-
+# -*- test-case-name: twisted.test.test_stdio.StandardInputOutputTests.test_buggyWriteConnectionLost -*-
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
@@ -27,7 +27,8 @@ class HalfCloseProtocol(protocol.Protocol):
     otherwise it will be set to C{1} to indicate failure.
     """
 
-    exitCode = None
+    exitCode = 9
+    wasWriteConnectionLost = False
     transport: ITransport
 
     def connectionMade(self) -> None:
@@ -41,19 +42,19 @@ class HalfCloseProtocol(protocol.Protocol):
         This is the desired event.  Once it has happened, stop the reactor so
         the process will exit.
         """
-        raise ValueError("something went wrong")
 
     def connectionLost(self, reason: object = None) -> None:
         """
         This may only be invoked after C{readConnectionLost}.  If it happens
         otherwise, mark it as an error and shut down.
         """
-        self.exitCode = 0
+        if self.wasWriteConnectionLost:
+            self.exitCode = 0
         reactor.stop()
 
     def writeConnectionLost(self) -> None:
-        # IHalfCloseableProtocol.writeConnectionLost
-        pass
+        self.wasWriteConnectionLost = True
+        raise ValueError("something went wrong")
 
 
 if __name__ == "__main__":

--- a/src/twisted/test/stdio_test_halfclose_buggy_write.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy_write.py
@@ -4,8 +4,8 @@
 
 """
 Main program for the child process run by
-L{twisted.test.test_stdio.StandardInputOutputTests.test_readConnectionLost}
-to test that IHalfCloseableProtocol.readConnectionLost works for process
+L{twisted.test.test_stdio.StandardInputOutputTests.test_buggyWriteConnectionLost}
+to test that IHalfCloseableProtocol.writeConnectionLost works for stdio
 transports.
 """
 

--- a/src/twisted/test/stdio_test_halfclose_buggy_write.py
+++ b/src/twisted/test/stdio_test_halfclose_buggy_write.py
@@ -48,7 +48,7 @@ class HalfCloseProtocol(protocol.Protocol):
         This may only be invoked after C{readConnectionLost}.  If it happens
         otherwise, mark it as an error and shut down.
         """
-        if self.wasWriteConnectionLost:
+        if self.wasWriteConnectionLost:  # pragma: no branch
             self.exitCode = 0
         reactor.stop()
 
@@ -57,7 +57,7 @@ class HalfCloseProtocol(protocol.Protocol):
         raise ValueError("something went wrong")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no branch
     reflect.namedAny(sys.argv[1]).install()
     log.startLogging(open(sys.argv[2], "w"))
     reactor: IReactorCore

--- a/src/twisted/test/test_stdio.py
+++ b/src/twisted/test/test_stdio.py
@@ -87,7 +87,7 @@ class StandardInputOutputTests(TestCase):
         )
 
     def _spawnProcess(
-        self, proto: ProcessProtocol, sibling: str, *args: str, **kw: Any
+        self, proto: ProcessProtocol, sibling: str | bytes, *args: str, **kw: Any
     ) -> IProcessTransport:
         """
         Launch a child Python process and communicate with it using the given
@@ -106,6 +106,8 @@ class StandardInputOutputTests(TestCase):
 
         @return: The L{IProcessTransport} provider for the spawned process.
         """
+        if isinstance(sibling, bytes):
+            sibling = sibling.decode()
         procargs = [
             sys.executable,
             "-m",

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -325,6 +325,11 @@ class HTTPParser(LineReceiver):
         self.switchToBodyMode(None)
 
 
+_fastFailureHandler = _moduleLog.handlingFailures(
+    "while interacting with body decoder:"
+)
+
+
 class HTTPClientParser(HTTPParser):
     """
     An HTTP parser which only handles HTTP responses.
@@ -525,7 +530,7 @@ class HTTPClientParser(HTTPParser):
             # application code.  The response is part of the HTTP server and
             # really shouldn't raise exceptions, but maybe there's some buggy
             # application code somewhere making things difficult.
-            with _moduleLog.handlingFailures("while interacting with body decoder:"):
+            with _fastFailureHandler:
                 try:
                     self.bodyDecoder.noMoreData()
                 except PotentialDataLoss:

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -26,6 +26,8 @@ Various other classes in this module support this usage:
     response.
 """
 
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Optional
 

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -1095,9 +1095,10 @@ def makeStatefulDispatcher(name, template):
 
     @return: The dispatcher function.
     """
+    pfx = f"_{name}_"
 
     def dispatcher(self, *args, **kwargs):
-        func = getattr(self, "_" + name + "_" + self._state, None)
+        func = getattr(self, f"{pfx}{self._state}", None)
         if func is None:
             raise RuntimeError(f"{self!r} has no {name} method in state {self._state}")
         return func(*args, **kwargs)

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -185,12 +185,10 @@ def _callAppFunction(function):
 
     @return: L{None}
     """
-    try:
+    with _moduleLog.handlingFailures(
+        "Unexpected exception from {name}", name=fullyQualifiedName(function)
+    ):
         function()
-    except BaseException:
-        _moduleLog.failure(
-            "Unexpected exception from {name}", name=fullyQualifiedName(function)
-        )
 
 
 class HTTPParser(LineReceiver):


### PR DESCRIPTION
## Scope and purpose

Fixes #12188

Fixes #12195 

This includes all the changes from #12189 , but attempts to demonstrate their utility. In so doing, I discovered a performance regression due to the additional allocation from creating a new context manager, so this also adds `Logger.failureHandler`, which allows for pre-allocating a context manager with a *fixed* error message, suitable for use within hot loops.

It also includes a ton of examples of the usages of both decorators, as well as a *huge* amount of refactoring, because:

- many of the places that I wanted to use this are *very* old Twisted code
  - `ThreadedSelectReactor` was, in particular, a buggy mess with no test coverage that basically didn't work
- using this new API requires migrating from old-logger to new-logger, so I had to go do that too
- as I migrated I wanted type checking, and touching type checking in some places caused knock-on changes to be needed
- in addressing the coverage gaps, I fixed a few bugs, in particular in half-close support, which previously just … did not work at all, with `StandardIO` just never calling `writeConnectionLost` at all.

There are no particularly interesting bugs fixed here, or major new subsystems with full type coverage, so not much for the release notes, but i think it's worth dealing with a slightly larger and more diffuse PR for getting all these minor improvements.