### PR TITLE
#12197 - Run benchmarks on Python 3.12 so we can get flamegraphs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -299,8 +299,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        # Changing this will change the benchmark outcomes, this is expected and
-        # unavoidable.
+        # When you will need to change this to run the benchmarks
+        # on a different Python version,
+        # it will also change the benchmark results.
+        # This is expected and unavoidable.
+        # This is why it's best not to configure the default
+        # Python version here,
+        # but rather have an explicit Python version.
+        # The PRs that are changing the Python version can
+        # be merged by ignoring the benchmark results.
         python-version: '3.12'
 
     - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -299,7 +299,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
+        # Changing this will change the benchmark outcomes, this is expected and
+        # unavoidable.
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Scope and purpose

Fixes #12197 

The performance change in benchmarks is due to switching to Python 3.12, it's not meaningful.

You can see the flamegraphs by clicking through to the performance report, and then clicking on a specific benchmark.
