### PR TITLE
12191 Speed up HTTP header processing even more

### DIFF
--- a/benchmarks/test_web_server.py
+++ b/benchmarks/test_web_server.py
@@ -70,13 +70,13 @@ Content-Length: 0
     benchmark(go)
 
 
-def test_http1_server_empty_request(benchmark):
+def test_http11_server_empty_request(benchmark):
     """Benchmark just returning some data."""
     data = Data(b"This is a result hello hello" * 4, b"text/plain")
     http11_server_empty_request(data, benchmark)
 
 
-def test_bit_more_complex_response(benchmark):
+def test_http11_server_bit_more_complex_response(benchmark):
     """Benchmark that also involves calling more request methods."""
     data = ComplexData(b"This is a result hello hello" * 4, b"text/plain")
     http11_server_empty_request(data, benchmark)

--- a/benchmarks/test_web_server.py
+++ b/benchmarks/test_web_server.py
@@ -31,7 +31,20 @@ class Data(resource.Resource):
         return self.data
 
 
-def test_http11_server_empty_request(benchmark):
+class ComplexData(Data):
+    """
+    Interact more with the request.
+    """
+
+    def render_GET(self, request):
+        request.setLastModified(123)
+        request.setETag(b"xykjlk")
+        _ = request.getRequestHostname()
+        request.setHost(b"example.com")
+        return Data.render_GET(self, request)
+
+
+def http11_server_empty_request(resource, benchmark):
     """Benchmark of handling an bodyless HTTP/1.1 request."""
     data = Data(b"This is a result hello hello" * 4, b"text/plain")
     factory = server.Site(data)
@@ -55,3 +68,15 @@ Content-Length: 0
         assert b"200 OK" in transport.io.getvalue()
 
     benchmark(go)
+
+
+def test_http1_server_empty_request(benchmark):
+    """Benchmark just returning some data."""
+    data = Data(b"This is a result hello hello" * 4, b"text/plain")
+    http11_server_empty_request(data, benchmark)
+
+
+def test_bit_more_complex_response(benchmark):
+    """Benchmark that also involves calling more request methods."""
+    data = ComplexData(b"This is a result hello hello" * 4, b"text/plain")
+    http11_server_empty_request(data, benchmark)

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -42,15 +42,15 @@ from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from twisted.python.reflect import fullyQualifiedName
 from twisted.web.http import (
+    _ENCODED_CONNECTION_HEADER,
+    _ENCODED_CONTENT_LENGTH_HEADER,
+    _ENCODED_HOST_HEADER,
+    _ENCODED_TRANSFER_ENCODING_HEADER,
     NO_CONTENT,
     NOT_MODIFIED,
     PotentialDataLoss,
     _ChunkedTransferDecoder,
     _DataLoss,
-    _ENCODED_CONNECTION_HEADER,
-    _ENCODED_CONTENT_LENGTH_HEADER,
-    _ENCODED_HOST_HEADER,
-    _ENCODED_TRANSFER_ENCODING_HEADER,
     _IdentityTransferDecoder,
 )
 from twisted.web.http_headers import Headers

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -37,7 +37,7 @@ from twisted.python.deprecate import (
 from twisted.python.failure import Failure
 from twisted.web import error, http
 from twisted.web._newclient import _ensureValidMethod, _ensureValidURI
-from twisted.web.http_headers import Headers
+from twisted.web.http_headers import Headers, _encodeName as _canonicalHeaderName
 from twisted.web.iweb import (
     UNKNOWN_LENGTH,
     IAgent,
@@ -1530,7 +1530,6 @@ class ContentDecoderAgent:
         return response
 
 
-_canonicalHeaderName = Headers()._encodeName
 _defaultSensitiveHeaders = frozenset(
     [
         b"Authorization",

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -15,7 +15,7 @@ import zlib
 from dataclasses import dataclass
 from functools import wraps
 from http.cookiejar import CookieJar
-from typing import cast, TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 from urllib.parse import urldefrag, urljoin, urlunparse as _urlunparse
 
 from zope.interface import implementer

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -15,7 +15,7 @@ import zlib
 from dataclasses import dataclass
 from functools import wraps
 from http.cookiejar import CookieJar
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import cast, TYPE_CHECKING, Iterable, Optional
 from urllib.parse import urldefrag, urljoin, urlunparse as _urlunparse
 
 from zope.interface import implementer
@@ -1531,7 +1531,8 @@ class ContentDecoderAgent:
 
 
 _defaultSensitiveHeaders = frozenset(
-    [
+    _canonicalHeaderName(h)
+    for h in [
         b"Authorization",
         b"Cookie",
         b"Cookie2",

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -180,7 +180,7 @@ from twisted.web._responses import (
     UNSUPPORTED_MEDIA_TYPE,
     USE_PROXY,
 )
-from twisted.web.http_headers import Headers, _sanitizeLinearWhitespace, _encodeName
+from twisted.web.http_headers import Headers, _encodeName, _sanitizeLinearWhitespace
 from twisted.web.iweb import IAccessLogFormatter, INonQueuedRequestFactory, IRequest
 
 try:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -236,6 +236,7 @@ _ENCODED_TRANSFER_ENCODING_HEADER = _encodeName(b"transfer-encoding")
 _ENCODED_LAST_MODIFED_HEADER = _encodeName(b"last-modified")
 _ENCODED_ETAG_HEADER = _encodeName(b"etag")
 _ENCODED_SET_COOKIE_HEADER = _encodeName(b"set-cookie")
+_ENCODED_IF_MODIFIED_SINCE = _encodeName(b"if-modified-since")
 
 
 def _parseContentType(line: bytes) -> bytes:
@@ -1452,7 +1453,7 @@ class Request:
         if (not self.lastModified) or (self.lastModified < when):
             self.lastModified = when
 
-        modifiedSince = self.getHeader(b"if-modified-since")
+        modifiedSince = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_IF_MODIFIED_SINCE)
         if modifiedSince:
             firstPart = modifiedSince.split(b";", 1)[0]
             try:
@@ -1521,7 +1522,6 @@ class Request:
         @rtype: C{bytes}
         """
         host = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_HOST_HEADER)
-        host = self.getHeader(b"host")
         if host is not None:
             match = _hostHeaderExpression.match(host)
             if match is not None:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -237,7 +237,7 @@ _ENCODED_LAST_MODIFED_HEADER = _encodeName(b"last-modified")
 _ENCODED_ETAG_HEADER = _encodeName(b"etag")
 _ENCODED_SET_COOKIE_HEADER = _encodeName(b"set-cookie")
 _ENCODED_IF_MODIFIED_SINCE_HEADER = _encodeName(b"if-modified-since")
-_ENCODED_IF_NOT_MATCH_HEADER = _encodeName(b"if-not-match")
+_ENCODED_IF_NONE_MATCH_HEADER = _encodeName(b"if-none-match")
 
 
 def _parseContentType(line: bytes) -> bytes:
@@ -1455,7 +1455,7 @@ class Request:
             self.lastModified = when
 
         modifiedSince = self.requestHeaders._getRawHeaderLastFaster(
-            _ENCODED_IF_MODIFIED_SINCE
+            _ENCODED_IF_MODIFIED_SINCE_HEADER
         )
         if modifiedSince:
             firstPart = modifiedSince.split(b";", 1)[0]
@@ -1490,7 +1490,9 @@ class Request:
         if etag:
             self.etag = etag
 
-        tags = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_IF_NOT_MATCH_HEADER)
+        tags = self.requestHeaders._getRawHeaderLastFaster(
+            _ENCODED_IF_NONE_MATCH_HEADER
+        )
         if tags:
             tags = tags.split()
             if (etag in tags) or (b"*" in tags):

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -236,7 +236,8 @@ _ENCODED_TRANSFER_ENCODING_HEADER = _encodeName(b"transfer-encoding")
 _ENCODED_LAST_MODIFED_HEADER = _encodeName(b"last-modified")
 _ENCODED_ETAG_HEADER = _encodeName(b"etag")
 _ENCODED_SET_COOKIE_HEADER = _encodeName(b"set-cookie")
-_ENCODED_IF_MODIFIED_SINCE = _encodeName(b"if-modified-since")
+_ENCODED_IF_MODIFIED_SINCE_HEADER = _encodeName(b"if-modified-since")
+_ENCODED_IF_NOT_MATCH_HEADER = _encodeName(b"if-not-match")
 
 
 def _parseContentType(line: bytes) -> bytes:
@@ -1453,7 +1454,9 @@ class Request:
         if (not self.lastModified) or (self.lastModified < when):
             self.lastModified = when
 
-        modifiedSince = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_IF_MODIFIED_SINCE)
+        modifiedSince = self.requestHeaders._getRawHeaderLastFaster(
+            _ENCODED_IF_MODIFIED_SINCE
+        )
         if modifiedSince:
             firstPart = modifiedSince.split(b";", 1)[0]
             try:
@@ -1487,7 +1490,7 @@ class Request:
         if etag:
             self.etag = etag
 
-        tags = self.getHeader(b"if-none-match")
+        tags = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_IF_NOT_MATCH_HEADER)
         if tags:
             tags = tags.split()
             if (etag in tags) or (b"*" in tags):

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -1520,7 +1520,7 @@ class Request:
 
         @rtype: C{bytes}
         """
-        host = self.requestHeaders._getRawHeaderFaster(_ENCODED_HOST_HEADER)
+        host = self.requestHeaders._getRawHeaderLastFaster(_ENCODED_HOST_HEADER)
         host = self.getHeader(b"host")
         if host is not None:
             match = _hostHeaderExpression.match(host)

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -7,7 +7,6 @@ An API for storing HTTP header names and values.
 """
 
 from typing import (
-    cast,
     AnyStr,
     ClassVar,
     Dict,
@@ -20,6 +19,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -194,11 +194,15 @@ class Headers:
         @param values: A list of bytes, each one being a header value of the
             given name. These will be still be sanitized since otherwise it's
             too easy for security bugs to allow unescaped whitespace through.
-
         """
         self._rawHeaders[name] = [_sanitizeLinearWhitespace(v) for v in values]
 
-    def _getRawHeaderFaster(self, name: _EncodedHeader) -> Optional[bytes]:
+    def _getRawHeaderLastFaster(self, name: _EncodedHeader) -> Optional[bytes]:
+        """
+        Get the last header value, if any.
+
+        @param name: The name of the HTTP header to get the value for.
+        """
         result = self._rawHeaders.get(name, None)
         if result is not None:
             return result[-1]
@@ -206,6 +210,11 @@ class Headers:
             return None
 
     def _getRawHeadersFaster(self, name: _EncodedHeader) -> Optional[list[bytes]]:
+        """
+        Get the header values, if any.
+
+        @param name: The name of the HTTP header to get the values for.
+        """
         return self._rawHeaders.get(name, None)
 
     def setRawHeaders(

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -7,6 +7,7 @@ An API for storing HTTP header names and values.
 """
 
 from typing import (
+    cast,
     AnyStr,
     ClassVar,
     Dict,
@@ -19,7 +20,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast,
     overload,
 )
 
@@ -68,8 +68,11 @@ def _encodeName(name: Union[str, bytes]) -> _EncodedHeader:
         # Some headers have special capitalization:
         result = mappings[bytes_name.lower()]
     else:
-        result = _sanitizeLinearWhitespace(
-            b"-".join([word.capitalize() for word in bytes_name.split(b"-")])
+        result = cast(
+            _EncodedHeader,
+            _sanitizeLinearWhitespace(
+                b"-".join([word.capitalize() for word in bytes_name.split(b"-")])
+            ),
         )
 
     # In general, we should only see a very small number of header
@@ -202,7 +205,7 @@ class Headers:
         else:
             return None
 
-    def _getRawHeadersFaster(self, name: _EncodedHeader) -> Optional[bytes]:
+    def _getRawHeadersFaster(self, name: _EncodedHeader) -> Optional[list[bytes]]:
         return self._rawHeaders.get(name, None)
 
     def setRawHeaders(

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -5,6 +5,7 @@
 """
 An API for storing HTTP header names and values.
 """
+from __future__ import annotations
 
 from typing import (
     AnyStr,
@@ -209,7 +210,7 @@ class Headers:
         else:
             return None
 
-    def _getRawHeadersFaster(self, name: _EncodedHeader) -> Optional[list[bytes]]:
+    def _getRawHeadersFaster(self, name: _EncodedHeader) -> Optional[List[bytes]]:
         """
         Get the header values, if any.
 

--- a/src/twisted/web/newsfragments/12191.feature
+++ b/src/twisted/web/newsfragments/12191.feature
@@ -1,0 +1,1 @@
+twisted.web.server and twisted.web.client are 2-3% faster, thanks to faster handling for commonly-used headers.

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -35,9 +35,9 @@ from twisted.spread.pb import Copyable, ViewPoint
 from twisted.web import http, iweb, resource, util
 from twisted.web.error import UnsupportedMethod
 from twisted.web.http import (
-    unquote,
     _ENCODED_CONTENT_LENGTH_HEADER,
     _ENCODED_CONTENT_TYPE_HEADER,
+    unquote,
 )
 from twisted.web.http_headers import _encodeName
 

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Sequence
 
 from twisted.trial.unittest import TestCase
-from twisted.web.http_headers import Headers
+from twisted.web.http_headers import Headers, _encodeName
 from twisted.web.test.requesthelper import (
     bytesLinearWhitespaceComponents,
     sanitizedBytes,
@@ -181,18 +181,17 @@ class BytesHeadersTests(TestCase):
         L{Headers._encodeName} returns the canonical capitalization for
         the given header.
         """
-        h = Headers()
-        self.assertEqual(h._encodeName(b"test"), b"Test")
-        self.assertEqual(h._encodeName(b"test-stuff"), b"Test-Stuff")
-        self.assertEqual(h._encodeName(b"content-md5"), b"Content-MD5")
-        self.assertEqual(h._encodeName(b"dnt"), b"DNT")
-        self.assertEqual(h._encodeName(b"etag"), b"ETag")
-        self.assertEqual(h._encodeName(b"p3p"), b"P3P")
-        self.assertEqual(h._encodeName(b"te"), b"TE")
-        self.assertEqual(h._encodeName(b"www-authenticate"), b"WWW-Authenticate")
-        self.assertEqual(h._encodeName(b"WWW-authenticate"), b"WWW-Authenticate")
-        self.assertEqual(h._encodeName(b"Www-Authenticate"), b"WWW-Authenticate")
-        self.assertEqual(h._encodeName(b"x-xss-protection"), b"X-XSS-Protection")
+        self.assertEqual(_encodeName(b"test"), b"Test")
+        self.assertEqual(_encodeName(b"test-stuff"), b"Test-Stuff")
+        self.assertEqual(_encodeName(b"content-md5"), b"Content-MD5")
+        self.assertEqual(_encodeName(b"dnt"), b"DNT")
+        self.assertEqual(_encodeName(b"etag"), b"ETag")
+        self.assertEqual(_encodeName(b"p3p"), b"P3P")
+        self.assertEqual(_encodeName(b"te"), b"TE")
+        self.assertEqual(_encodeName(b"www-authenticate"), b"WWW-Authenticate")
+        self.assertEqual(_encodeName(b"WWW-authenticate"), b"WWW-Authenticate")
+        self.assertEqual(_encodeName(b"Www-Authenticate"), b"WWW-Authenticate")
+        self.assertEqual(_encodeName(b"x-xss-protection"), b"X-XSS-Protection")
 
     def test_getAllRawHeaders(self) -> None:
         """

--- a/src/twisted/web/test/test_wsgi.py
+++ b/src/twisted/web/test/test_wsgi.py
@@ -1275,7 +1275,7 @@ class StartResponseTests(WSGITestsMixin, TestCase):
         included in the response.
         """
         # Make the Date header value deterministic
-        self.patch(http, "datetimeToString", lambda: "Tuesday")
+        self.patch(http, "datetimeToString", lambda: b"Tuesday")
 
         channel = DummyChannel()
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12191

There are many commonly used HTTP headers. Instead of re-encoding them every time, we can just encode them once.

