### PR TITLE
12193 Move some of the Twisted infrastructure benchmarks into a codspeed benchmark

### DIFF
--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -1,4 +1,4 @@
-from twisted.internet.defer import succeed, ensureDeferred, Deferred
+from twisted.internet.defer import Deferred, ensureDeferred, succeed
 
 
 def test_deferred_await(benchmark):

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -1,0 +1,80 @@
+from twisted.internet.defer import succeed, ensureDeferred, Deferred
+
+
+def test_deferred_await(benchmark):
+    """Measure the speed of awaiting and of defer.succeed()."""
+
+    async def _run():
+        for x in range(1000):
+            await succeed(x)
+
+    def go():
+        ensureDeferred(_run())
+
+    benchmark(go)
+
+
+def f(x: int, a: int) -> int:
+    return x + a
+
+
+def test_deferred_callback_chain_fires_at_start(benchmark):
+    """
+    Measure speed of successful callbacks, where the Deferred fires before the
+    callbacks are added.
+    """
+
+    def go():
+        d = Deferred()
+        d.callback(2)
+        d.addCallback(f, 1)
+        d.addCallback(f, 2)
+        d.addCallback(f, 3)
+        d.addCallback(f, 4)
+
+    benchmark(go)
+
+
+def test_deferred_callback_chain_fires_at_end(benchmark):
+    """
+    Measure speed of successful callbacks, where the Deferred fires after the
+    callbacks are added.
+    """
+
+    def go():
+        d = Deferred()
+        d.addCallback(f, 1)
+        d.addCallback(f, 2)
+        d.addCallback(f, 3)
+        d.addCallback(f, 4)
+        d.callback(2)
+
+    benchmark(go)
+
+
+def test_deferred_errback_chain(benchmark):
+    """
+    Measure speed of error handling in callbacks.
+    callbacks are added.
+    """
+
+    def go():
+        d = succeed("result")
+
+        def cbRaiseErr(_):
+            raise Exception("boom!")
+
+        d.addCallback(cbRaiseErr)
+
+        def ebHandleErr(failure):
+            failure.trap(Exception)
+            raise Exception("lesser boom!")
+
+        d.addErrback(ebHandleErr)
+
+        def swallowErr(_):
+            return None
+
+        d.addBoth(swallowErr)
+
+    benchmark(go)

--- a/benchmarks/test_linereceiver.py
+++ b/benchmarks/test_linereceiver.py
@@ -4,8 +4,8 @@ Benchmarks for line parsing protocols.
 
 import pytest
 
-from twisted.protocols.basic import LineReceiver, LineOnlyReceiver
 from twisted.internet.protocol import Protocol
+from twisted.protocols.basic import LineOnlyReceiver, LineReceiver
 from twisted.test.proto_helpers import StringTransport
 
 
@@ -21,6 +21,7 @@ def test_lineReceiver(benchmark, chunkSize):
     """
     Parses lines, but can in theory also parse raw data.
     """
+
     class MyLineReceiver(LineReceiver):
         def lineReceived(self, _):
             pass
@@ -37,6 +38,7 @@ def test_lineOnlyReceiver(benchmark, chunkSize):
     """
     Parses only lines.
     """
+
     class MyLineReceiver(LineOnlyReceiver):
         def lineReceived(self, line):
             pass

--- a/benchmarks/test_linereceiver.py
+++ b/benchmarks/test_linereceiver.py
@@ -1,0 +1,48 @@
+"""
+Benchmarks for line parsing protocols.
+"""
+
+import pytest
+
+from twisted.protocols.basic import LineReceiver, LineOnlyReceiver
+from twisted.internet.protocol import Protocol
+from twisted.test.proto_helpers import StringTransport
+
+
+def deliverData(protocol: Protocol, data: bytes, chunkSize: int) -> None:
+    i = 0
+    while i < len(data):
+        protocol.dataReceived(data[i : i + chunkSize])
+        i += chunkSize
+
+
+@pytest.mark.parametrize("chunkSize", [16, 64, 256, 1024])
+def test_lineReceiver(benchmark, chunkSize):
+    """
+    Parses lines, but can in theory also parse raw data.
+    """
+    class MyLineReceiver(LineReceiver):
+        def lineReceived(self, _):
+            pass
+
+    protocol = MyLineReceiver()
+    protocol.makeConnection(StringTransport())
+    data = ((b"abcde" * 10) + b"\r\n") * 1000
+
+    benchmark(lambda: deliverData(protocol, data, chunkSize))
+
+
+@pytest.mark.parametrize("chunkSize", [16, 64, 256, 1024])
+def test_lineOnlyReceiver(benchmark, chunkSize):
+    """
+    Parses only lines.
+    """
+    class MyLineReceiver(LineOnlyReceiver):
+        def lineReceived(self, line):
+            pass
+
+    protocol = MyLineReceiver()
+    protocol.makeConnection(StringTransport())
+    data = ((b"abcde" * 10) + b"\r\n") * 1000
+
+    benchmark(lambda: deliverData(protocol, data, chunkSize))


### PR DESCRIPTION
## Scope and purpose

Fixes #12193

Most of the benchmarks were _not_ yet ported, partially because they are out of the scope of my remit, but mostly because they require a reactor and I haven't figured out how to benchmark reactor-y things yet. I will move them into a new ticket when this one is closed.