### PR TITLE
#12221 Run the coverage reports for the benchmarks tests.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ source=
    src/twisted
    */site-packages/twisted
    *\site-packages\twisted
+   benchmarks
 
 [report]
 precision = 2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -316,7 +316,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install . pytest pytest-codspeed
+        python -m pip install . pytest pytest-codspeed pytest-cov pytest-benchmark
 
     - name: Run benchmarks
       uses: CodSpeedHQ/action@v2
@@ -325,6 +325,27 @@ jobs:
         # codspeed runs this command under a CPU emulator, so it's super-slow,
         # so we try to just do the benchmarks and nothing else.
         run: python -m pytest --codspeed benchmarks/
+
+    - name: Collect benchmarks coverage
+      run: |
+        # We try to run the benchmark tests only once.
+        # It should be enough to collect the coverage.
+        # The previous Codspeed run takes care of the actual benchmark
+        # measurements.
+        pytest \
+          --benchmark-min-rounds 1 --benchmark-max-time 0.00001 \
+          --cov benchmarks --cov twisted --cov-config=.coveragerc \
+          --cov-report=xml --cov-report=term:skip-covered \
+          benchmarks
+
+    - name: Publish benchmarks coverage
+      uses: codecov/codecov-action@v3
+      if: ${{ !cancelled() && !matrix['skip-coverage'] }}
+      with:
+        files: coverage.xml
+        name: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-benchmarks
+        fail_ci_if_error: true
+
 
   static-checks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -293,6 +293,7 @@ jobs:
         name: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-${{matrix.job-name || 'default-tests' }}
         fail_ci_if_error: true
 
+
   benchmarks:
     runs-on: ubuntu-22.04
 
@@ -334,8 +335,9 @@ jobs:
         # measurements.
         pytest \
           --benchmark-min-rounds 1 --benchmark-max-time 0.00001 \
+          --benchmark-columns=rounds \
           --cov benchmarks --cov twisted --cov-config=.coveragerc \
-          --cov-report=xml --cov-report=term:skip-covered \
+          --cov-report=xml \
           benchmarks
 
     - name: Publish benchmarks coverage
@@ -345,6 +347,13 @@ jobs:
         files: coverage.xml
         name: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-benchmarks
         fail_ci_if_error: true
+
+    - name: Fail on missing benchmarks coverage
+      run: |
+        # This makes sure that the benchmark tests always have 100% coverage.
+        # Make sure the include expression is escaped to prevent shell
+        # expansion.
+        coverage report --fail-under=100 --include 'benchmarks/*'
 
 
   static-checks:

--- a/benchmarks/test_web_server.py
+++ b/benchmarks/test_web_server.py
@@ -14,10 +14,8 @@ class Data(resource.Resource):
     This is a static, in-memory resource.
     """
 
+    # Being a leaf, we will not have getChild called on this resource.
     isLeaf = True
-
-    def getChild(self, name):
-        return self
 
     def __init__(self, data, type):
         resource.Resource.__init__(self)


### PR DESCRIPTION
## Scope and purpose

Fixes #12221

Enable coverage reporting for the benchmarks test run.

If we later add helper code for benchmarks, this can help keep that code clean... plus the benchmarks code itself.

This also fixes the coverage for the benchmarks to be 100%

previously there was one uncovered line

![image](https://github.com/twisted/twisted/assets/204609/8b71c6a3-fb44-4836-b0bc-2f8e204511de)
