### PR TITLE
12223 speed up Deferred.addCallback by removing use of isinstance()

### DIFF
--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -95,6 +95,9 @@ def test_deferred_chained_already_fired(benchmark):
         d.addCallback(lambda _: d2)
         d.addCallback(lambda _: d3)
         d.callback(123)
+        l = []
+        d.addCallback(l.append)
+        assert l[0] == 456
 
     benchmark(go)
 
@@ -118,5 +121,8 @@ def test_deferred_chained_not_fired(benchmark):
         d2.callback(123)
         d4.callback(57)
         d.callback(7)
+        l = []
+        d.addCallback(l.append)
+        assert l[0] == 57
 
     benchmark(go)

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -117,5 +117,6 @@ def test_deferred_chained_not_fired(benchmark):
         d.addCallback(lambda _: d3)
         d2.callback(123)
         d4.callback(57)
+        d.callback(7)
 
     benchmark(go)

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -92,7 +92,9 @@ def test_deferred_chained_already_fired(benchmark):
         d3 = Deferred()
         d2.callback(123)
         d3.callback(456)
-        d.callback(lambda _: d2)
+        d.addCallback(lambda _: d2)
+        d.addCallback(lambda _: d3)
+        d.callback(123)
 
     benchmark(go)
 

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -78,3 +78,38 @@ def test_deferred_errback_chain(benchmark):
         d.addBoth(swallowErr)
 
     benchmark(go)
+
+
+def test_deferred_chained_already_fired(benchmark):
+    """
+    Measure speed of chained Deferred, where the chained Deferred fires before
+    the callback returning it is added.
+    """
+
+    def go():
+        d = Deferred()
+        d2 = Deferred()
+        d3 = Deferred()
+        d2.callback(123)
+        d3.callback(456)
+        d.callback(lambda _: d2)
+
+    benchmark(go)
+
+
+def test_deferred_chained_not_fired(benchmark):
+    """
+    Measure speed of chained Deferred, where the chained Deferred fires after
+    the callback returning it is added.
+    """
+
+    def go():
+        d = Deferred()
+        d2 = Deferred()
+        d3 = Deferred()
+        d.addCallback(lambda _: d2)
+        d.addCallback(lambda _: d3)
+        d2.callback(123)
+        d3.callback(456)
+
+    benchmark(go)

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -128,4 +128,3 @@ def test_deferred_chained_not_fired(benchmark):
     l = []
     d.addCallback(l.append)
     assert l[0] == 57
-

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -106,10 +106,14 @@ def test_deferred_chained_not_fired(benchmark):
     def go():
         d = Deferred()
         d2 = Deferred()
+        # d3 has its own chained result:
         d3 = Deferred()
+        d4 = Deferred()
+        d3.addCallback(lambda _: d4)
+        d3.callback(123)
         d.addCallback(lambda _: d2)
         d.addCallback(lambda _: d3)
         d2.callback(123)
-        d3.callback(456)
+        d4.callback(57)
 
     benchmark(go)

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -95,11 +95,12 @@ def test_deferred_chained_already_fired(benchmark):
         d.addCallback(lambda _: d2)
         d.addCallback(lambda _: d3)
         d.callback(123)
-        l = []
-        d.addCallback(l.append)
-        assert l[0] == 456
+        return d
 
-    benchmark(go)
+    d = benchmark(go)
+    l = []
+    d.addCallback(l.append)
+    assert l[0] == 456
 
 
 def test_deferred_chained_not_fired(benchmark):
@@ -121,8 +122,10 @@ def test_deferred_chained_not_fired(benchmark):
         d2.callback(123)
         d4.callback(57)
         d.callback(7)
-        l = []
-        d.addCallback(l.append)
-        assert l[0] == 57
+        return d
 
-    benchmark(go)
+    d = benchmark(go)
+    l = []
+    d.addCallback(l.append)
+    assert l[0] == 57
+

--- a/benchmarks/test_deferred.py
+++ b/benchmarks/test_deferred.py
@@ -98,9 +98,9 @@ def test_deferred_chained_already_fired(benchmark):
         return d
 
     d = benchmark(go)
-    l = []
-    d.addCallback(l.append)
-    assert l[0] == 456
+    result = []
+    d.addCallback(result.append)
+    assert result == [456]
 
 
 def test_deferred_chained_not_fired(benchmark):
@@ -125,7 +125,6 @@ def test_deferred_chained_not_fired(benchmark):
         return d
 
     d = benchmark(go)
-    l = []
-    d.addCallback(l.append)
-    assert l[0] == 57
-
+    result = []
+    d.addCallback(result.append)
+    assert result == [57]

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1091,7 +1091,7 @@ class Deferred(Awaitable[_SelfResultT]):
                     current.result = Failure(captureVars=self.debug)
                 else:
                     # isinstance() with Awaitable subclass is expensive:
-                    if current.result.__class__ in _DEFERRED_SUBCLASSES:
+                    if type(current.result) in _DEFERRED_SUBCLASSES:
                         # The result is another Deferred.  If it has a result,
                         # we can take it and keep going.
                         resultResult = getattr(current.result, "result", _NO_RESULT)

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1097,7 +1097,7 @@ class Deferred(Awaitable[_SelfResultT]):
                         resultResult = getattr(current.result, "result", _NO_RESULT)
                         if (
                             resultResult is _NO_RESULT
-                            or isinstance(resultResult, Deferred)
+                            or type(resultResult) in _DEFERRED_SUBCLASSES
                             or current.result.paused
                         ):
                             # Nope, it didn't.  Pause and chain.

--- a/src/twisted/newsfragments/12223.feature
+++ b/src/twisted/newsfragments/12223.feature
@@ -1,0 +1,1 @@
+twisted.internet.defer.Deferred.addCallback now runs about 10% faster.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1815,13 +1815,18 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         """
         C{_DEFERRED_SUBCLASSES} includes all subclasses of L{Deferred}.
         """
-        self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList])
+        self.assertEqual(defer._DEFERRED_SUBCLASSES[:2], [Deferred, DeferredList])
 
         class D2(Deferred[int]):
             pass
 
-        self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList, D2])
+        self.assertEqual(defer._DEFERRED_SUBCLASSES[-1], D2)
         defer._DEFERRED_SUBCLASSES.pop(-1)
+
+        # There are other potential subclasses, e.g. twisted.persisted.crefutil
+        # has a Deferred subclass:
+        for klass in defer._DEFERRED_SUBCLASSES:
+            self.assertTrue(issubclass(klass, Deferred))
 
 
 class DummyCanceller:

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1811,20 +1811,17 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # been freed.
         self.assertIsNone(weakCanceller())
 
-    def test_isInstance(self):
+    def test_DEFERRED_SUBCLASSES(self):
         """
-        C{isinstance()} correctly identifies instances of classes that subclass
-        L{Deferred}.
+        C{_DEFERRED_SUBCLASSES} includes all subclasses of L{Deferred}.
         """
-        self.assertIsInstance(Deferred(), Deferred)
-        self.assertIsInstance(DeferredList([]), Deferred)
+        self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList])
 
         class D2(Deferred):
             pass
 
-        self.assertIsInstance(D2(), Deferred)
-
-        self.assertNotIsInstance(3, Deferred)
+        self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList, D2])
+        defer._DEFERRED_SUBCLASSES.pop(-1)
 
 
 class DummyCanceller:

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1811,6 +1811,21 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # been freed.
         self.assertIsNone(weakCanceller())
 
+    def test_isInstance(self):
+        """
+        C{isinstance()} correctly identifies instances of classes that subclass
+        L{Deferred}.
+        """
+        self.assertIsInstance(Deferred(), Deferred)
+        self.assertIsInstance(DeferredList([]), Deferred)
+
+        class D2(Deferred):
+            pass
+
+        self.assertIsInstance(D2(), Deferred)
+
+        self.assertNotIsInstance(3, Deferred)
+
 
 class DummyCanceller:
     """

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1811,13 +1811,13 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # been freed.
         self.assertIsNone(weakCanceller())
 
-    def test_DEFERRED_SUBCLASSES(self):
+    def test_DEFERRED_SUBCLASSES(self) -> None:
         """
         C{_DEFERRED_SUBCLASSES} includes all subclasses of L{Deferred}.
         """
         self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList])
 
-        class D2(Deferred):
+        class D2(Deferred[int]):
             pass
 
         self.assertEqual(defer._DEFERRED_SUBCLASSES, [Deferred, DeferredList, D2])


### PR DESCRIPTION
## Scope and purpose

Fixes #12223

Also threw up in a couple benchmarks, one of which was used to measure one of the improvements locally.

The performance problem being fixed is that `isinstance(x, Deferred)` has to use the custom implementation of instance checking from `Awaitable`, which is slower.