### PR TITLE
9930: deprecate defer returnvalue

### DIFF
--- a/docs/core/howto/defer-intro.rst
+++ b/docs/core/howto/defer-intro.rst
@@ -411,15 +411,7 @@ a couple of things are happening here:
 #. instead of calling ``addCallback`` on the ``Deferred`` returned by ``makeRequest``, we *yield* it.
    This causes Twisted to return the ``Deferred``\ 's result to us.
 
-#. we use ``returnValue`` to propagate the final result of our function.
-   Because this function is a generator, we cannot use the return statement; that would be a syntax error.
-
-.. note::
-
-    .. versionadded:: 15.0
-
-    On Python 3, instead of writing ``returnValue(json.loads(responseBody))`` you can instead write ``return json.loads(responseBody)``.
-    This can be a significant readability advantage, but unfortunately if you need compatibility with Python 2, this isn't an option.
+#. the final result of the function is propagated using ``return`` as usual.
 
 Both versions of ``getUsers`` present exactly the same API to their callers: both return a ``Deferred`` that fires with the parsed JSON body of the request.
 Though the ``inlineCallbacks`` version looks like synchronous code, which blocks while waiting for the request to finish, each ``yield`` statement allows other code to run while waiting for the ``Deferred`` being yielded to fire.

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -2223,17 +2223,15 @@ def inlineCallbacks(
 
     Your inlineCallbacks-enabled generator will return a L{Deferred} object, which
     will result in the return value of the generator (or will fail with a
-    failure object if your generator raises an unhandled exception). Note that
-    you can't use C{return result} to return a value; use C{returnValue(result)}
-    instead. Falling off the end of the generator, or simply using C{return}
-    will cause the L{Deferred} to have a result of L{None}.
+    failure object if your generator raises an unhandled exception). Inside
+    the generator simply use C{return result} to return a value.
 
-    Be aware that L{returnValue} will not accept a L{Deferred} as a parameter.
+    Be aware that generator must not return a L{Deferred}.
     If you believe the thing you'd like to return could be a L{Deferred}, do
     this::
 
         result = yield result
-        returnValue(result)
+        return result
 
     The L{Deferred} returned from your deferred generator may errback if your
     generator raised an exception::
@@ -2243,17 +2241,10 @@ def inlineCallbacks(
             thing = yield makeSomeRequestResultingInDeferred()
             if thing == 'I love Twisted':
                 # will become the result of the Deferred
-                returnValue('TWISTED IS GREAT!')
+                return 'TWISTED IS GREAT!'
             else:
                 # will trigger an errback
                 raise Exception('DESTROY ALL LIFE')
-
-    It is possible to use the C{return} statement instead of L{returnValue}::
-
-        @inlineCallbacks
-        def loadData(url):
-            response = yield makeRequest(url)
-            return json.loads(response)
 
     You can cancel the L{Deferred} returned from your L{inlineCallbacks}
     generator before it is fired by your generator completing (either by

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1898,6 +1898,7 @@ class _DefGen_Return(BaseException):
         self.value = value
 
 
+@deprecated(Version("Twisted", "NEXT", 0, 0), replacement="standard return statement")
 def returnValue(val: object) -> NoReturn:
     """
     Return val from a L{inlineCallbacks} generator.
@@ -2051,17 +2052,28 @@ def _inlineCallbacks(
             # directly.  returnValue itself consumes a stack frame, so the
             # application code will have a tb_next, but it will *not* have a
             # second tb_next.
+            #
+            # Note that there's one additional level due to returnValue being
+            # deprecated
             assert appCodeTrace.tb_next is not None
-            if appCodeTrace.tb_next.tb_next:
+            assert appCodeTrace.tb_next.tb_next is not None
+            if appCodeTrace.tb_next.tb_next.tb_next:
                 # If returnValue was invoked non-local to the frame which it is
                 # exiting, identify the frame that ultimately invoked
                 # returnValue so that we can warn the user, as this behavior is
                 # confusing.
+                #
+                # Note that there's one additional level due to returnValue being
+                # deprecated
                 ultimateTrace = appCodeTrace
 
                 assert ultimateTrace is not None
                 assert ultimateTrace.tb_next is not None
-                while ultimateTrace.tb_next.tb_next:
+
+                # Note that there's one additional level due to returnValue being
+                # deprecated
+                assert ultimateTrace.tb_next.tb_next is not None
+                while ultimateTrace.tb_next.tb_next.tb_next:
                     ultimateTrace = ultimateTrace.tb_next
                     assert ultimateTrace is not None
 

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -2665,7 +2665,7 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
                     ("\\SEEN", "\\DELETED"),
                     "Tue, 17 Jun 2003 11:22:16 -0600 (MDT)",
                 )
-                defer.returnValue(result)
+                return result
 
         d1 = self.connected.addCallback(strip(login))
         d1.addCallbacks(strip(append), self._ebGeneral)
@@ -2713,7 +2713,7 @@ class IMAP4ServerTests(IMAP4HelperMixin, TestCase):
                         message,
                     )
                 )
-                defer.returnValue(result)
+                return result
 
         d1 = self.connected.addCallback(strip(login))
         d1.addCallbacks(strip(append), self._ebGeneral)

--- a/src/twisted/newsfragments/9930.removal
+++ b/src/twisted/newsfragments/9930.removal
@@ -1,0 +1,1 @@
+twisted.internet.defer.returnValue has been deprecated. You can replace it with the standard `return` statement.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -29,6 +29,7 @@ from typing import (
     Dict,
     Generator,
     List,
+    Literal,
     Mapping,
     NoReturn,
     Optional,
@@ -3759,7 +3760,7 @@ class CoroutineContextVarsTests(unittest.TestCase):
 
         # context is 1 when the function is defined
         @defer.inlineCallbacks
-        def testFunction() -> Generator[Deferred[Any], Any, None]:
+        def testFunction() -> Generator[Deferred[Any], Any, Literal[True]]:
             # Expected to be 2
             self.assertEqual(var.get(), 2)
 
@@ -3793,9 +3794,9 @@ class CoroutineContextVarsTests(unittest.TestCase):
             yield yieldingDeferred()
             self.assertEqual(var.get(), 2)
 
-            defer.returnValue(True)
+            return True
 
-        assert_type(testFunction, Callable[[], Deferred[None]])
+        assert_type(testFunction, Callable[[], Deferred[Literal[True]]])
         # The inlineCallbacks context is 2 when it's called
         var.set(2)
         d = testFunction()


### PR DESCRIPTION
## Scope and purpose

Fixes #9930.

This PR deprecates `defer.returnValue()`. returnValue is no longer needed since Twisted dropped Python 2.7 support several years ago.
