### PR TITLE
#12243 wsgi: drop Python 2 variants of  `_wsgiString` and `_wsgiStringToBytes`

### DIFF
--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -8,7 +8,7 @@ U{Python Web Server Gateway Interface v1.0.1<http://www.python.org/dev/peps/pep-
 
 from collections.abc import Sequence
 from sys import exc_info
-from typing import Union
+from typing import List, Union
 from warnings import warn
 
 from zope.interface import implementer
@@ -79,7 +79,7 @@ class _ErrorStream:
 
     _log = Logger()
 
-    def write(self, data):
+    def write(self, data: str) -> None:
         """
         Generate an event for the logging system with the given bytes as the
         message.
@@ -88,27 +88,19 @@ class _ErrorStream:
 
         @type data: str
 
-        @raise TypeError: On Python 3, if C{data} is not a native string. On
-            Python 2 a warning will be issued.
+        @raise TypeError: if C{data} is not a native string.
         """
         if not isinstance(data, str):
-            if str is bytes:
-                warn(
-                    "write() argument should be str, not %r (%s)"
-                    % (data, type(data).__name__),
-                    category=UnicodeWarning,
-                )
-            else:
-                raise TypeError(
-                    "write() argument must be str, not %r (%s)"
-                    % (data, type(data).__name__)
-                )
+            raise TypeError(
+                "write() argument must be str, not %r (%s)"
+                % (data, type(data).__name__)
+            )
 
         # Note that in old style, message was a tuple.  logger._legacy
         # will overwrite this value if it is not properly formatted here.
         self._log.error(data, system="wsgi", isError=True, message=(data,))
 
-    def writelines(self, iovec):
+    def writelines(self, iovec: List[str]) -> None:
         """
         Join the given lines and pass them to C{write} to be handled in the
         usual way.
@@ -118,8 +110,7 @@ class _ErrorStream:
         @param iovec: A C{list} of C{'\\n'}-terminated C{str} which will be
             logged.
 
-        @raise TypeError: On Python 3, if C{iovec} contains any non-native
-            strings. On Python 2 a warning will be issued.
+        @raise TypeError: if C{iovec} contains any non-native strings.
         """
         self.write("".join(iovec))
 

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -321,8 +321,7 @@ class _WSGIResponse:
             raise excInfo[1].with_traceback(excInfo[2])
 
         # PEP-3333 mandates that status should be a native string. In practice
-        # this is mandated by Twisted's HTTP implementation too, so we enforce
-        # on both Python 2 and Python 3.
+        # this is mandated by Twisted's HTTP implementation too.
         if not isinstance(status, str):
             raise TypeError(
                 "status must be str, not {!r} ({})".format(


### PR DESCRIPTION
## Scope and purpose

Fixes #12243 

`str is bytes` is always `False` today because Python 2 is no longer supported. This pull request cleans up a few instances where this type check is performed in `twisted.web.wsgi`.
* Remove variants of `_wsgiString()` and `_wsgiStringToBytes()` methods which were only used for Python 2. Python 3 variants of these functions are not changed.
* Remove the `str is bytes` check in `_ErrorStream`'s `write()` method as it is redundant in Python 3.
* Added type annotation to `_wsgiString()`, `_wsgiStringToBytes()`, `_ErrorStream.write()` and `_ErrorStream.writelines()`

The purpose is to simply help with cleanup :)