### PR TITLE
#12233, #12235 Better validate HTTP request line and headers

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2489,7 +2489,8 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
             self._respondToBadRequestAndDisconnect()
             return False
 
-        if not header or header[-1:].isspace():
+        # Header names must be tokens, per RFC 9110 section 5.1.
+        if not _istoken(header):
             self._respondToBadRequestAndDisconnect()
             return False
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -513,9 +513,9 @@ def _istoken(b: bytes) -> bool:
     """
     for c in b:
         if c not in (
-            b"!#$%^'*+-.^_`|~"
-            b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"  # ALPHA
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"  # ALPHA
             b"0123456789"  # DIGIT
+            b"!#$%^'*+-.^_`|~"
         ):
             return False
     return b != b""

--- a/src/twisted/web/newsfragments/12233.bugfix
+++ b/src/twisted/web/newsfragments/12233.bugfix
@@ -1,0 +1,1 @@
+The HTTP 1.0/1.1 server provided by twisted.web.http is now more picky about the first line of a request, improving compliance with RFC 9112.

--- a/src/twisted/web/newsfragments/12233.bugfix
+++ b/src/twisted/web/newsfragments/12233.bugfix
@@ -1,1 +1,1 @@
-The HTTP 1.0/1.1 server provided by twisted.web.http is now more picky about the first line of a request, improving compliance with RFC 9112.
+The HTTP 1.0/1.1 server provided by twisted.web is now more picky about the first line of a request, improving compliance with RFC 9112.

--- a/src/twisted/web/newsfragments/12235.bugfix
+++ b/src/twisted/web/newsfragments/12235.bugfix
@@ -1,0 +1,1 @@
+The HTTP 1.0/1.1 server provided by twisted.web now constains the characters set of HTTP header names, improving compliance with RFC 9110.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -1745,6 +1745,24 @@ class ParsingTests(unittest.TestCase):
         self.assertTrue(channel.transport.disconnecting)
         self.assertEqual(processed, [])
 
+    def test_invalidRequestLineExtraSpaces(self):
+        """
+        The three components of the request line must not be
+        separated by anything other than a single SP character,
+        or a 400 status results.
+        """
+        for requestLine in [
+            b"GET  / HTTP/1.0",
+            b"GET /  HTTP/1.0",
+            b"GET\t/ HTTP/1.0",
+            b"GET /\vHTTP/1.1",
+            b"GET / HTTP/1.1 ",
+            b" GET / HTTP/1.1",
+        ]:
+            self.assertRequestRejected(
+                [requestLine, b"Content-Length: 0", b"Host: foo.example", b"", b""]
+            )
+
     def test_invalidMethodEmpty(self):
         """
         A request with an empty method field is rejected with a


### PR DESCRIPTION
## Scope and purpose

Fixes #12233 and fixes #12235.

I opted to be reject all HTTP versions other than `HTTP/1.0` and `HTTP/1.1`, since I doubt HTTP 1.2 will ever be a thing.

I also added validation that the HTTP method has the correct character set and that the URI contains only printable characters. The elements of the line must be delimited by a single space, as [RFC 9112 requires](https://datatracker.ietf.org/doc/html/rfc9112#name-request-line).

Since it was a tiny change that depends on the `_istoken` function added here, I also included a fix for #12235.

- [RFC 9112 on request-line](https://datatracker.ietf.org/doc/html/rfc9112#name-request-line)
- [RFC 9110 on field names](https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
