### PR TITLE
#12249 Purge `bytes == str` and `bytes != str` type checks

### DIFF
--- a/src/twisted/conch/manhole.py
+++ b/src/twisted/conch/manhole.py
@@ -306,10 +306,6 @@ class VT102Writer:
         s = b"".join(self.written)
         return s.strip(b"\n").splitlines()[-1]
 
-    if bytes == str:
-        # Compat with Python 2.7
-        __str__ = __bytes__
-
 
 def lastColorizedLine(source):
     """

--- a/src/twisted/protocols/ftp.py
+++ b/src/twisted/protocols/ftp.py
@@ -835,8 +835,7 @@ class FTP(basic.LineReceiver, policies.TimeoutMixin):
     def lineReceived(self, line):
         self.resetTimeout()
         self.pauseProducing()
-        if bytes != str:
-            line = line.decode(self._encoding)
+        line = line.decode(self._encoding)
 
         def processFailed(err):
             if err.check(FTPCmdError):
@@ -2804,8 +2803,7 @@ class FTPClientBasic(basic.LineReceiver):
         (Private) Parses the response messages from the FTP server.
         """
         # Add this line to the current response
-        if bytes != str:
-            line = line.decode(self._encoding)
+        line = line.decode(self._encoding)
 
         if self.debug:
             log.msg("--> %s" % line)
@@ -3370,8 +3368,7 @@ class FTPFileListProtocol(basic.LineReceiver):
         self.files = []
 
     def lineReceived(self, line):
-        if bytes != str:
-            line = line.decode(self._encoding)
+        line = line.decode(self._encoding)
         d = self.parseDirectoryLine(line)
         if d is None:
             self.unknownLine(line)

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -2650,8 +2650,7 @@ class IRCClient(basic.LineReceiver):
         basic.LineReceiver.dataReceived(self, data)
 
     def lineReceived(self, line):
-        if bytes != str and isinstance(line, bytes):
-            # decode bytes from transport to unicode
+        if isinstance(line, bytes):
             line = line.decode("utf-8")
 
         line = lowDequote(line)

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -979,9 +979,7 @@ class PBGroup(pb.Referenceable):
 class PBGroupReference(pb.RemoteReference):
     def unjellyFor(self, unjellier, unjellyList):
         clsName, name, ref = unjellyList
-        self.name = name
-        if isinstance(self.name, bytes):
-            self.name = self.name.decode("utf-8")
+        self.name = name.decode("utf-8")
         return pb.RemoteReference.unjellyFor(self, unjellier, [clsName, ref])
 
     def leave(self, reason=None):

--- a/src/twisted/words/service.py
+++ b/src/twisted/words/service.py
@@ -980,7 +980,7 @@ class PBGroupReference(pb.RemoteReference):
     def unjellyFor(self, unjellier, unjellyList):
         clsName, name, ref = unjellyList
         self.name = name
-        if bytes != str and isinstance(self.name, bytes):
+        if isinstance(self.name, bytes):
             self.name = self.name.decode("utf-8")
         return pb.RemoteReference.unjellyFor(self, unjellier, [clsName, ref])
 

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -2158,8 +2158,7 @@ class ClientTests(IRCTestCase):
         Return the last IRC message in the transport buffer.
         """
         line = transport.value()
-        if isinstance(line, bytes):
-            line = line.decode("utf-8")
+        line = line.decode("utf-8")
         return line.split("\r\n")[-2]
 
     def test_away(self):

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -2158,7 +2158,7 @@ class ClientTests(IRCTestCase):
         Return the last IRC message in the transport buffer.
         """
         line = transport.value()
-        if bytes != str and isinstance(line, bytes):
+        if isinstance(line, bytes):
             line = line.decode("utf-8")
         return line.split("\r\n")[-2]
 

--- a/src/twisted/words/test/test_irc_service.py
+++ b/src/twisted/words/test/test_irc_service.py
@@ -71,7 +71,7 @@ class IRCUserTests(IRCTestCase):
         """
         response = self.ircUser.transport.value()
         self.ircUser.transport.clear()
-        if bytes != str and isinstance(response, bytes):
+        if isinstance(response, bytes):
             response = response.decode("utf-8")
         response = response.splitlines()
         return [irc.parsemsg(r) for r in response]

--- a/src/twisted/words/test/test_irc_service.py
+++ b/src/twisted/words/test/test_irc_service.py
@@ -71,8 +71,7 @@ class IRCUserTests(IRCTestCase):
         """
         response = self.ircUser.transport.value()
         self.ircUser.transport.clear()
-        if isinstance(response, bytes):
-            response = response.decode("utf-8")
+        response = response.decode("utf-8")
         response = response.splitlines()
         return [irc.parsemsg(r) for r in response]
 

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -212,7 +212,7 @@ class IRCProtocolTests(unittest.TestCase):
         If messageType is defined, only messages of that type will be returned.
         """
         response = user.transport.value()
-        if bytes != str and isinstance(response, bytes):
+        if isinstance(response, bytes):
             response = response.decode("utf-8")
         response = response.splitlines()
         user.transport.clear()

--- a/src/twisted/words/test/test_service.py
+++ b/src/twisted/words/test/test_service.py
@@ -212,8 +212,7 @@ class IRCProtocolTests(unittest.TestCase):
         If messageType is defined, only messages of that type will be returned.
         """
         response = user.transport.value()
-        if isinstance(response, bytes):
-            response = response.decode("utf-8")
+        response = response.decode("utf-8")
         response = response.splitlines()
         user.transport.clear()
         result = []


### PR DESCRIPTION
## Scope and purpose

Fixes #12249 

Purge type checks like `bytes != str` and `bytes == str` which are remnants from supporting Python 2 and Python 3 at the same time. Today only Python 3 is supported so these checks are no longer useful at runtime.

There is no change in functionality from these changes. Just smaller code.
