### PR TITLE
#9591 Remove twisted.web.util.ChildRedirector

### DIFF
--- a/src/twisted/web/_template_util.py
+++ b/src/twisted/web/_template_util.py
@@ -118,34 +118,6 @@ class Redirect(resource.Resource):
         return self
 
 
-# FIXME: This is totally broken, see https://twistedmatrix.com/trac/ticket/9838
-class ChildRedirector(Redirect):
-    isLeaf = False
-
-    def __init__(self, url):
-        # XXX is this enough?
-        if (
-            (url.find("://") == -1)
-            and (not url.startswith(".."))
-            and (not url.startswith("/"))
-        ):
-            raise ValueError(
-                (
-                    "It seems you've given me a redirect (%s) that is a child of"
-                    " myself! That's not good, it'll cause an infinite redirect."
-                )
-                % url
-            )
-        Redirect.__init__(self, url)
-
-    def getChild(self, name, request):
-        newUrl = self.url
-        if not newUrl.endswith("/"):
-            newUrl += "/"
-        newUrl += name
-        return ChildRedirector(newUrl)
-
-
 class ParentRedirect(resource.Resource):
     """
     Redirect to the nearest directory and strip any query string.

--- a/src/twisted/web/newsfragments/9591.removal
+++ b/src/twisted/web/newsfragments/9591.removal
@@ -1,0 +1,1 @@
+twisted.web.util.ChildRedirector, which has never worked on Python 3, has been removed.

--- a/src/twisted/web/util.py
+++ b/src/twisted/web/util.py
@@ -9,7 +9,6 @@ An assortment of web server-related utilities.
 __all__ = [
     "redirectTo",
     "Redirect",
-    "ChildRedirector",
     "ParentRedirect",
     "DeferredResource",
     "FailureElement",
@@ -24,7 +23,6 @@ __all__ = [
 
 from ._template_util import (
     _PRE,
-    ChildRedirector,
     DeferredResource,
     FailureElement,
     ParentRedirect,


### PR DESCRIPTION
## Scope and purpose

Fixes #9591.

This has been implicitly deprecated (by way of a botched port to Python 3) since Python 2.7 went EoL, and was first reported broken on 2019. No working code will be affected by its removal, so let's do that.
