### PR TITLE
#12228 Forbid NUL in HTTP header values

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2503,6 +2503,9 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
 
         header = header.lower()
         data = data.strip(b" \t")
+        if b"\x00" in data:
+            self._respondToBadRequestAndDisconnect()
+            return False
 
         if not self._maybeChooseTransferDecoder(header, data):
             return False

--- a/src/twisted/web/newsfragments/12228.bugfix
+++ b/src/twisted/web/newsfragments/12228.bugfix
@@ -1,0 +1,1 @@
+twisted.web's HTTP/1.1 server now rejects header values containing a NUL byte with a 400 error, in compliance with RFC 9110.

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2179,9 +2179,9 @@ class ParsingTests(unittest.TestCase):
             ]
         )
 
-    def test_invalidHeaderChars(self):
+    def test_invalidHeaderNameChars(self):
         """
-        A request with a header that contains invalid characters
+        A request with a header name that contains invalid characters
         is rejected with a 400 status code.
         """
         for header in [
@@ -2189,6 +2189,21 @@ class ParsingTests(unittest.TestCase):
             b"foo\x1bbar: baz",  # ESC byte
             b"Foo\vBar: baz",  # exotic whitespace
             b"foo\xe2\x80\xbdbar: baz",  # non-ASCII bytes
+        ]:
+            self.assertRequestRejected(
+                [b"GET / HTTP/1.1", b"Host: foo.example", header, b"", b""]
+            )
+
+    def test_invalidHeaderValueNUL(self):
+        """
+        A request with a header value that contains a NUL byte
+        is rejected with a 400 status code.
+        """
+        for header in [
+            b"x-foo: \x00",  # NUL byte
+            b"x-foo: a\x00",  # trailing NUL
+            b"x-foo: \x00baz",  # leading NUL
+            b"x-foo:  \x00\x00\x00x0\0 ",  # lots of NULs
         ]:
             self.assertRequestRejected(
                 [b"GET / HTTP/1.1", b"Host: foo.example", header, b"", b""]


### PR DESCRIPTION
## Scope and purpose

Fixes #12228.

I chose to forbid NUL values rather than coerce them to whitespace. Note that this only applies to the HTTP server — `http_headers.Headers` still permits all sorts of malformed header names and values.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
