### PR TITLE
# 12259 - bump versions of GH actions 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,7 +209,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -436,7 +436,7 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Need full history for various diff checks to work.
         fetch-depth: 0
@@ -464,7 +464,7 @@ jobs:
     name: API docs build
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -481,7 +481,7 @@ jobs:
     name: Narrative docs build
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -504,7 +504,7 @@ jobs:
     name: Check release and publish on twisted-* tag
     runs-on: 'ubuntu-22.04'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -223,7 +223,7 @@ jobs:
         echo "cache-dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.cache-dir }}
         key:
@@ -375,7 +375,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         # When you will need to change this to run the benchmarks
         # on a different Python version,
@@ -442,7 +442,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
 
@@ -466,7 +466,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
@@ -483,7 +483,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
@@ -507,7 +507,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
 

--- a/src/twisted/newsfragments/12259.misc
+++ b/src/twisted/newsfragments/12259.misc
@@ -1,0 +1,1 @@
+Bump versions of Node.js GitHub actions triggering deprecation warnings.


### PR DESCRIPTION
## Scope and purpose

Fixes #12259
Bump versions of Node.js GH actions triggering deprecation warnings



