### PR TITLE
# 12269 - bump codecov & codspeed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -301,7 +301,7 @@ jobs:
         path: .coverage-job-*
 
     - name: Publish to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: ${{ !cancelled() && !matrix['skip-coverage'] }}
       with:
         files: coverage.xml
@@ -394,7 +394,7 @@ jobs:
         python -m pip install . pytest pytest-codspeed pytest-cov pytest-benchmark
 
     - name: Run benchmarks
-      uses: CodSpeedHQ/action@v2
+      uses: CodSpeedHQ/action@v3
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
         # codspeed runs this command under a CPU emulator, so it's super-slow,
@@ -415,7 +415,7 @@ jobs:
           benchmarks
 
     - name: Publish benchmarks coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: ${{ !cancelled() && !matrix['skip-coverage'] }}
       with:
         files: coverage.xml

--- a/src/twisted/newsfragments/12669.misc
+++ b/src/twisted/newsfragments/12669.misc
@@ -1,0 +1,1 @@
+Bump versions of CodSpeed and CodeCov GH actions using deprecated Node.js.


### PR DESCRIPTION
Fixes #12269

Bump GH actions version for CodSpeed & CodeCov.

Apologies for missing this in #12259, but I only checked the versions I changed.