### PR TITLE
#12273 Skip tests requiring DSA if SSH does not support DSS

### DIFF
--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -20,6 +20,7 @@ from zope.interface import implementer
 
 from twisted.conch import ls
 from twisted.conch.interfaces import ISFTPFile
+from twisted.conch.test.test_conch import hasDsa
 from twisted.conch.test.test_filetransfer import FileTransferTestAvatar, SFTPTestBase
 from twisted.cred import portal
 from twisted.internet import defer, error, interfaces, protocol, reactor
@@ -1436,6 +1437,7 @@ exit
 @skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 @skipIf(not which("ssh"), "no ssh command-line client available")
 @skipIf(not which("sftp"), "no sftp command-line client available")
+@skipIf(not hasDsa, "needs ssh supporting dsa")
 class OurServerSftpClientTests(CFTPClientTestBase):
     """
     Test the sftp server against sftp command line client.

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -20,7 +20,7 @@ from zope.interface import implementer
 
 from twisted.conch import ls
 from twisted.conch.interfaces import ISFTPFile
-from twisted.conch.test.test_conch import hasDsa
+from twisted.conch.test.test_conch import HAS_DSA
 from twisted.conch.test.test_filetransfer import FileTransferTestAvatar, SFTPTestBase
 from twisted.cred import portal
 from twisted.internet import defer, error, interfaces, protocol, reactor
@@ -1437,7 +1437,7 @@ exit
 @skipIf(skipTests, "don't run w/o spawnProcess or cryptography")
 @skipIf(not which("ssh"), "no ssh command-line client available")
 @skipIf(not which("sftp"), "no sftp command-line client available")
-@skipIf(not hasDsa, "needs ssh supporting dsa")
+@skipIf(not HAS_DSA, "needs ssh supporting dsa")
 class OurServerSftpClientTests(CFTPClientTestBase):
     """
     Test the sftp server against sftp command line client.

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -59,6 +59,19 @@ except ImportError as e:
 else:
     StdioInteractingSession = _StdioInteractingSession
 
+hasDsa = False
+try:
+    output = subprocess.check_output(
+        [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT
+    )
+    if not isinstance(output, str):
+        output = output.decode("utf-8")
+    keys = output.split()
+    if "ssh-dss" in keys:
+        hasDsa = True
+except BaseException:
+    pass
+
 
 class FakeStdio:
     """
@@ -293,6 +306,9 @@ run()"""
 class ConchServerSetupMixin:
     if not cryptography:
         skip = "can't run without cryptography"
+
+    if not hasDsa:
+        skip = "needs ssh supporting dsa"
 
     @staticmethod
     def realmFactory():

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -59,16 +59,20 @@ except ImportError as e:
 else:
     StdioInteractingSession = _StdioInteractingSession
 
-hasDsa = False
-try:
-    output = subprocess.check_output(
-        [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT, text=True
-    )
-    keys = output.split()
-    if "ssh-dss" in keys:
-        hasDsa = True
-except BaseException:
-    pass
+def _has_dsa():
+    has_dsa = False
+    try:
+        output = subprocess.check_output(
+            [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT, text=True
+        )
+        keys = output.split()
+        if "ssh-dss" in keys:
+            has_dsa = True
+    except BaseException:
+        pass
+    return has_dsa
+
+hasDsa = _has_dsa()
 
 
 class FakeStdio:

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -59,6 +59,7 @@ except ImportError as e:
 else:
     StdioInteractingSession = _StdioInteractingSession
 
+
 def _has_dsa():
     has_dsa = False
     try:
@@ -71,6 +72,7 @@ def _has_dsa():
     except BaseException:
         pass
     return has_dsa
+
 
 HAS_DSA = _has_dsa()
 

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -64,8 +64,6 @@ try:
     output = subprocess.check_output(
         [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT, text=True
     )
-    if not isinstance(output, str):
-        output = output.decode("utf-8")
     keys = output.split()
     if "ssh-dss" in keys:
         hasDsa = True

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -307,9 +307,6 @@ class ConchServerSetupMixin:
     if not cryptography:
         skip = "can't run without cryptography"
 
-    if not hasDsa:
-        skip = "needs ssh supporting dsa"
-
     @staticmethod
     def realmFactory():
         return ConchTestRealm(b"testuser")
@@ -546,6 +543,9 @@ class RekeyTestsMixin(ConchServerSetupMixin):
 class OpenSSHClientMixin:
     if not which("ssh"):
         skip = "no ssh command-line client available"
+
+    if not hasDsa:
+        skip = "needs ssh supporting dsa"
 
     def execute(self, remoteCommand, process, sshArgs=""):
         """

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -62,7 +62,7 @@ else:
 hasDsa = False
 try:
     output = subprocess.check_output(
-        [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT
+        [which("ssh")[0], "-Q", "key"], stderr=subprocess.STDOUT, text=True
     )
     if not isinstance(output, str):
         output = output.decode("utf-8")

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -72,7 +72,7 @@ def _has_dsa():
         pass
     return has_dsa
 
-hasDsa = _has_dsa()
+HAS_DSA = _has_dsa()
 
 
 class FakeStdio:
@@ -546,7 +546,7 @@ class OpenSSHClientMixin:
     if not which("ssh"):
         skip = "no ssh command-line client available"
 
-    if not hasDsa:
+    if not HAS_DSA:
         skip = "needs ssh supporting dsa"
 
     def execute(self, remoteCommand, process, sshArgs=""):

--- a/src/twisted/newsfragments/12274.bugfix
+++ b/src/twisted/newsfragments/12274.bugfix
@@ -1,4 +1,4 @@
 Tests in twisted.conch.test.test_cftp and twisted.conch.test.test_conch that
-require DSA are now skipped if the installed SSH does not support DSS. The
+require DSA are now skipped if the installed SSH does not support DSA. The
 availability of DSA is checked by querying `ssh -Q key`, which includes
-`ssh-dss` if DSS is available.
+`ssh-dss` if DSA is available.

--- a/src/twisted/newsfragments/12274.bugfix
+++ b/src/twisted/newsfragments/12274.bugfix
@@ -1,0 +1,4 @@
+Tests in twisted.conch.test.test_cftp and twisted.conch.test.test_conch that
+require DSA are now skipped if the installed SSH does not support DSS. The
+availability of DSA is checked by querying `ssh -Q key`, which includes
+`ssh-dss` if DSS is available.


### PR DESCRIPTION
## Scope and purpose

Modern OpenSSH no longer supports DSA/DSS. We need to skip tests that use DSA if it is not supported by the installed SSH. The availability of DSA can be checked by querying `ssh -Q key`, which includes `ssh-dss` in the output if DSS is available, as suggested in [1].

[1] https://github.com/twisted/twisted/issues/12273#issuecomment-2260799255

Fixes #12273

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
