### PR TITLE
#12273 Fix twisted.conch tests with OpenSSH >= 9.8

### DIFF
--- a/src/twisted/conch/newsfragments/12273.bugfix
+++ b/src/twisted/conch/newsfragments/12273.bugfix
@@ -1,0 +1,1 @@
+twisted.conch tests no longer rely on OpenSSH supporting DSA keys, fixing compatibility with OpenSSH >= 9.8.

--- a/src/twisted/conch/test/test_cftp.py
+++ b/src/twisted/conch/test/test_cftp.py
@@ -1482,6 +1482,8 @@ class OurServerSftpClientTests(CFTPClientTestBase):
             "-F",
             "/dev/null",
             "-o",
+            "IdentitiesOnly=yes",
+            "-o",
             "IdentityFile=rsa_test",
             "-o",
             "UserKnownHostsFile=kh_test",

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -544,6 +544,7 @@ class OpenSSHClientMixin:
             (
                 "ssh -2 -l testuser -p %i "
                 "-F /dev/null "
+                "-oIdentitiesOnly=yes "
                 "-oUserKnownHostsFile=kh_test "
                 "-oPasswordAuthentication=no "
                 # Always use the RSA key, since that's the one in kh_test.

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -560,9 +560,7 @@ class OpenSSHClientMixin:
         cmds = (cmdline % port).split()
         encodedCmds = []
         for cmd in cmds:
-            if isinstance(cmd, str):
-                cmd = cmd.encode("utf-8")
-            encodedCmds.append(cmd)
+            encodedCmds.append(cmd.encode("utf-8"))
         reactor.spawnProcess(process, which("ssh")[0], encodedCmds)
         return process.deferred
 

--- a/src/twisted/conch/test/test_ssh.py
+++ b/src/twisted/conch/test/test_ssh.py
@@ -475,10 +475,10 @@ if cryptography is not None:
 
         def getPrivateKey(self):
             self.canSucceedPublicKey = 1
-            return defer.succeed(keys.Key.fromString(privateDSA_openssh))
+            return defer.succeed(keys.Key.fromString(privateRSA_openssh))
 
         def getPublicKey(self):
-            return keys.Key.fromString(publicDSA_openssh)
+            return keys.Key.fromString(publicRSA_openssh)
 
     class ConchTestClientConnection(connection.SSHConnection):
         """
@@ -538,7 +538,7 @@ if cryptography is not None:
         @return: L{twisted.conch.checkers.SSHPublicKeyChecker}
         """
         conchTestPublicKeyDB = checkers.InMemorySSHKeyDB(
-            {b"testuser": [keys.Key.fromString(publicDSA_openssh)]}
+            {b"testuser": [keys.Key.fromString(publicRSA_openssh)]}
         )
         return checkers.SSHPublicKeyChecker(conchTestPublicKeyDB)
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12273

OpenSSH 9.8 disables support for DSA keys by default at compile-time (https://www.openssh.com/releasenotes.html#9.8p1).  Since DSA keys are now largely a thing of the past, it seems unwise for Twisted Conch's tests to rely on them any more.  These tests aren't testing anything specifically about DSA, and an RSA key will do just as well.

Unit tests for Twisted Conch's DSA features still exist; those tests don't rely on support in OpenSSH.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.