### PR TITLE
#12277 Fix usage of hash argument to attr.s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "incremental >= 24.7.0",
     "Automat >= 0.8.0",
     "hyperlink >= 17.1.1",
-    "attrs >= 21.3.0",
+    "attrs >= 22.2.0",
     "typing_extensions >= 4.2.0",
 ]
 

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -21,7 +21,7 @@ from twisted.python.runtime import platform
 
 
 @implementer(IAddress)
-@attr.s(hash=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True)
 class IPv4Address:
     """
     An L{IPv4Address} represents the address of an IPv4 socket endpoint.
@@ -45,7 +45,7 @@ class IPv4Address:
 
 
 @implementer(IAddress)
-@attr.s(hash=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True)
 class IPv6Address:
     """
     An L{IPv6Address} represents the address of an IPv6 socket endpoint.
@@ -85,7 +85,7 @@ class _ProcessAddress:
     """
 
 
-@attr.s(hash=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True)
 @implementer(IAddress)
 class HostnameAddress:
     """
@@ -102,7 +102,7 @@ class HostnameAddress:
     port: int
 
 
-@attr.s(hash=False, repr=False, eq=False, auto_attribs=True)
+@attr.s(repr=False, eq=False, auto_attribs=True)
 @implementer(IAddress)
 class UNIXAddress:
     """

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -21,7 +21,7 @@ from twisted.python.runtime import platform
 
 
 @implementer(IAddress)
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(unsafe_hash=True, auto_attribs=True)
 class IPv4Address:
     """
     An L{IPv4Address} represents the address of an IPv4 socket endpoint.
@@ -45,7 +45,7 @@ class IPv4Address:
 
 
 @implementer(IAddress)
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(unsafe_hash=True, auto_attribs=True)
 class IPv6Address:
     """
     An L{IPv6Address} represents the address of an IPv6 socket endpoint.
@@ -85,7 +85,7 @@ class _ProcessAddress:
     """
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(unsafe_hash=True, auto_attribs=True)
 @implementer(IAddress)
 class HostnameAddress:
     """
@@ -102,7 +102,7 @@ class HostnameAddress:
     port: int
 
 
-@attr.s(repr=False, eq=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, repr=False, eq=False, auto_attribs=True)
 @implementer(IAddress)
 class UNIXAddress:
     """

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from twisted.web.template import Flattenable
 
 
-@attr.s(eq=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, eq=False, auto_attribs=True)
 class slot:
     """
     Marker for markup insertion in a template.
@@ -82,7 +82,7 @@ class slot:
     """
 
 
-@attr.s(eq=False, repr=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, eq=False, repr=False, auto_attribs=True)
 class Tag:
     """
     A L{Tag} represents an XML tags with a tag name, attributes, and children.
@@ -314,7 +314,7 @@ voidElements = (
 )
 
 
-@attr.s(eq=False, repr=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, eq=False, repr=False, auto_attribs=True)
 class CDATA:
     """
     A C{<![CDATA[]]>} block from a template.  Given a separate representation in
@@ -329,7 +329,7 @@ class CDATA:
         return f"CDATA({self.data!r})"
 
 
-@attr.s(eq=False, repr=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, eq=False, repr=False, auto_attribs=True)
 class Comment:
     """
     A C{<!-- -->} comment from a template.  Given a separate representation in
@@ -344,7 +344,7 @@ class Comment:
         return f"Comment({self.data!r})"
 
 
-@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
+@attr.s(unsafe_hash=False, eq=False, repr=False, auto_attribs=True)
 class CharRef:
     """
     A numeric character reference.  Given a separate representation in the DOM

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from twisted.web.template import Flattenable
 
 
-@attr.s(hash=False, eq=False, auto_attribs=True)
+@attr.s(eq=False, auto_attribs=True)
 class slot:
     """
     Marker for markup insertion in a template.
@@ -82,7 +82,7 @@ class slot:
     """
 
 
-@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
+@attr.s(eq=False, repr=False, auto_attribs=True)
 class Tag:
     """
     A L{Tag} represents an XML tags with a tag name, attributes, and children.
@@ -314,7 +314,7 @@ voidElements = (
 )
 
 
-@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
+@attr.s(eq=False, repr=False, auto_attribs=True)
 class CDATA:
     """
     A C{<![CDATA[]]>} block from a template.  Given a separate representation in
@@ -329,7 +329,7 @@ class CDATA:
         return f"CDATA({self.data!r})"
 
 
-@attr.s(hash=False, eq=False, repr=False, auto_attribs=True)
+@attr.s(eq=False, repr=False, auto_attribs=True)
 class Comment:
     """
     A C{<!-- -->} comment from a template.  Given a separate representation in

--- a/src/twisted/web/newsfragments/12277.bugfix
+++ b/src/twisted/web/newsfragments/12277.bugfix
@@ -1,1 +1,1 @@
-twisted.internet.address no longer raises DeprecationWarning when used with attrs>=24.1.0. As a side effect, `IPV4Address`/`IPV6Address`/`HostnameAddress` instances are now `frozen` (i.e. immutable).
+twisted.internet.address no longer raises DeprecationWarning when used with attrs>=24.1.0.

--- a/src/twisted/web/newsfragments/12277.bugfix
+++ b/src/twisted/web/newsfragments/12277.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.address no longer raises DeprecationWarning when used with attrs>=24.1.0. As a side effect, `IPV4Address`/`IPV6Address`/`HostnameAddress` instances are now `frozen` (i.e. immutable).


### PR DESCRIPTION
## Scope and purpose

Fixes #12277 

According to [attr.s documentation](https://www.attrs.org/en/stable/hashing.html), `hash` shouldn't be used directly. Either `frozen` or `eq` should be manipulated, so used `frozen` wherever the code called for `hash=True` and `eq=False` (which was
present already) wherever it called for `hash=False`.