### PR TITLE
#12279 Fix regression in CopiedFailure

### DIFF
--- a/src/twisted/newsfragments/12279.bugfix
+++ b/src/twisted/newsfragments/12279.bugfix
@@ -1,0 +1,1 @@
+Fixed unreleased regression caused by PR 12109.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -429,6 +429,10 @@ class Failure(BaseException):
             self._parents = [self.type]
         return self._parents
 
+    @parents.setter
+    def parents(self, parents):
+        self._parents = parents
+
     def _extrapolate(self, otherFailure):
         """
         Extrapolate from one failure into another, copying its stack frames.

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -568,6 +568,17 @@ class FailureTests(SynchronousTestCase):
         f = failure.Failure(ComparableException("hello"))
         self.assertEqual(f.__getstate__()["parents"], f.parents)
 
+    def test_settableParents(self) -> None:
+        """
+        C{Failure.parents} can be set, both before and after pickling.
+
+        This is used by Perspective Broker.
+        """
+        original_failure = failure.Failure(ComparableException("hello"))
+        original_failure.parents = original_failure.parents[:]
+        failure2 = pickle.loads(pickle.dumps(original_failure))
+        failure2.parents = failure2.parents[:]
+
 
 class BrokenStr(Exception):
     """

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -572,7 +572,7 @@ class FailureTests(SynchronousTestCase):
         """
         C{Failure.parents} can be set, both before and after pickling.
 
-        This is used by Perspective Broker.
+        This is used by Foolscap.
         """
         original_failure = failure.Failure(ComparableException("hello"))
         original_failure.parents = original_failure.parents[:]


### PR DESCRIPTION
## Scope and purpose

Fixes #12279

`twisted.spread` breaks serialization of `CopiedFailure` in trunk due to #12109.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
