### PR TITLE
12286 Implement benchmark for callLater() and reactor.runUntilCurrent() and speed them up

### DIFF
--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -9,6 +9,7 @@ class Reactor(ReactorBase):
     """
     Implement minimal methods a subclass needs.
     """
+
     _currentTime = 0.0
 
     def seconds(self) -> float:

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -7,6 +7,13 @@ class Reactor(ReactorBase):
     """
     Implement minimal methods a subclass needs.
     """
+    _currentTime = 0.0
+
+    def seconds(self) -> float:
+        return self._currentTime
+
+    def advance(self, seconds: float):
+        self._currentTime += seconds
 
     def installWaker(self):
         pass
@@ -19,6 +26,11 @@ def test_spaced_out_events(benchmark):
 
     def go():
         reactor = Reactor()
+        for i in range(10):
+            reactor.callLater(i, lambda: None)
+        for _ in range(10):
+            reactor.runUntilCurrent()
+            reactor.advance(1)
         return reactor
 
     reactor = benchmark(go)

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -26,9 +26,9 @@ def test_spaced_out_events(benchmark):
 
     def go():
         reactor = Reactor()
-        for i in range(10):
+        for i in range(100):
             reactor.callLater(i, lambda: None)
-        for _ in range(10):
+        for _ in range(100):
             reactor.runUntilCurrent()
             reactor.advance(1)
         return reactor

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -35,8 +35,8 @@ def test_spaced_out_events(benchmark, reversed_times):
         for time in timestamps:
             reactor.callLater(time, lambda: None)
         for _ in range(len(timestamps)):
+            reactor.advance(reactor.timeout() or 0)
             reactor.runUntilCurrent()
-            reactor.advance(1)
         return reactor
 
     reactor = benchmark(go)

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -1,0 +1,26 @@
+"""Tests for scheduled events."""
+
+from twisted.internet.base import ReactorBase
+
+
+class Reactor(ReactorBase):
+    """
+    Implement minimal methods a subclass needs.
+    """
+
+    def installWaker(self):
+        pass
+
+
+def test_spaced_out_events(benchmark):
+    """
+    Add spaced out events, then run them all.
+    """
+
+    def go():
+        reactor = Reactor()
+        return reactor
+
+    reactor = benchmark(go)
+    assert not reactor._pendingTimedCalls
+    assert not reactor._newTimedCalls

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -5,20 +5,29 @@ import pytest
 from twisted.internet.base import ReactorBase
 
 
-class Reactor(ReactorBase):
+class ReactorWithRiggedTime(ReactorBase):
     """
-    Implement minimal methods a subclass needs.
+    Allows controlling the passed time while benchmarking C{ReactorBase}.
     """
 
     _currentTime = 0.0
 
     def seconds(self) -> float:
+        """
+        Override the regular time function in C{ReactorBase}.
+        """
         return self._currentTime
 
-    def advance(self, seconds: float):
+    def advance(self, seconds: float) -> None:
+        """
+        Advance time by the given numbe of seconds.
+        """
         self._currentTime += seconds
 
-    def installWaker(self):
+    def installWaker(self) -> None:
+        """
+        Subclasses of C{ReactorBase} are required to implement this.
+        """
         pass
 
 
@@ -32,7 +41,7 @@ def test_spaced_out_events(benchmark, reversed_times):
         timestamps.reverse()
 
     def go():
-        reactor = Reactor()
+        reactor = ReactorWithRiggedTime()
         for time in timestamps:
             reactor.callLater(time, lambda: None)
         for _ in range(len(timestamps)):

--- a/benchmarks/test_calllater.py
+++ b/benchmarks/test_calllater.py
@@ -1,5 +1,7 @@
 """Tests for scheduled events."""
 
+import pytest
+
 from twisted.internet.base import ReactorBase
 
 
@@ -19,16 +21,20 @@ class Reactor(ReactorBase):
         pass
 
 
-def test_spaced_out_events(benchmark):
+@pytest.mark.parametrize("reversed_times", [False, True])
+def test_spaced_out_events(benchmark, reversed_times):
     """
     Add spaced out events, then run them all.
     """
+    timestamps = list(range(100))
+    if reversed_times:
+        timestamps.reverse()
 
     def go():
         reactor = Reactor()
-        for i in range(100):
-            reactor.callLater(i, lambda: None)
-        for _ in range(100):
+        for time in timestamps:
+            reactor.callLater(time, lambda: None)
+        for _ in range(len(timestamps)):
             reactor.runUntilCurrent()
             reactor.advance(1)
         return reactor

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -1007,6 +1007,12 @@ class ReactorBase(PluggableResolverMixin):
         ]
 
     def _insertNewDelayedCalls(self) -> None:
+        # This function is called twice per reactor iteration, once in
+        # timeout() and once in runUntilCurrent(), and in most cases there
+        # won't be any new timeouts. So have a fast path for the empty case.
+        if not self._newTimedCalls:
+            return
+
         for call in self._newTimedCalls:
             if call.cancelled:
                 self._cancellations -= 1

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -213,29 +213,23 @@ class DelayedCall:
         """
         return not (self.cancelled or self.called)
 
-    def __le__(self, other: object) -> bool:
+    def __le__(self, other: "DelayedCall") -> bool:
         """
         Implement C{<=} operator between two L{DelayedCall} instances.
 
         Comparison is based on the C{time} attribute (unadjusted by the
         delayed time).
         """
-        if isinstance(other, DelayedCall):
-            return self.time <= other.time
-        else:
-            return NotImplemented
+        return self.time <= other.time
 
-    def __lt__(self, other: object) -> bool:
+    def __lt__(self, other: "DelayedCall") -> bool:
         """
         Implement C{<} operator between two L{DelayedCall} instances.
 
         Comparison is based on the C{time} attribute (unadjusted by the
         delayed time).
         """
-        if isinstance(other, DelayedCall):
-            return self.time < other.time
-        else:
-            return NotImplemented
+        return self.time < other.time
 
     def __repr__(self) -> str:
         """
@@ -964,7 +958,6 @@ class ReactorBase(PluggableResolverMixin):
         """
         See twisted.internet.interfaces.IReactorTime.callLater.
         """
-        assert builtins.callable(callable), f"{callable} is not callable"
         assert delay >= 0, f"{delay} is not greater than or equal to 0 seconds"
         delayedCall = DelayedCall(
             self.seconds() + delay,

--- a/src/twisted/newsfragments/12286.feature
+++ b/src/twisted/newsfragments/12286.feature
@@ -1,1 +1,1 @@
-The reactor now will use a little CPU when events have been scheduled with callLater().
+The reactor now will use a little less CPU when events have been scheduled with callLater().

--- a/src/twisted/newsfragments/12286.feature
+++ b/src/twisted/newsfragments/12286.feature
@@ -1,0 +1,1 @@
+The reactor now will use a little CPU when events have been scheduled with callLater().


### PR DESCRIPTION
## Scope and purpose

Fixes #12286 

The benchmark is about 20% faster on my computer after optimizations. Only a small part of a program's execution, of course, but every little bit adds up.