### PR TITLE
12290 Fix twisted.internet.test.test_process on Python 313

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -147,7 +147,7 @@ jobs:
             # Add full twisted.internet
             # FIXME:https://github.com/twisted/twisted/issues/12062
             # Add full twisted.test
-            trial-target: 'twisted.conch twisted.cred twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.web twisted.words'
+            trial-target: 'twisted.conch twisted.cred twisted.internet.test.test_process twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.web twisted.words'
             # Disable concurrency for now, since we get occasional segfaults and
             # this helps debug them:
             trial-args: '--reactor=default'

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -10,6 +10,7 @@ Tests for implementations of L{IReactorProcess}.
 
 
 import io
+import json
 import os
 import signal
 import subprocess
@@ -1024,12 +1025,12 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
                 pyExe,
                 b"-c",
                 networkString(
-                    "import os, sys; "
+                    "import os, sys, json; "
                     "env = dict(os.environ); "
                     # LC_CTYPE is set by python, see https://peps.python.org/pep-0538/
                     'env.pop("LC_CTYPE", None); '
                     'env.pop("__CF_USER_TEXT_ENCODING", None); '
-                    "sys.stderr.write(str(sorted(env.items())))"
+                    "sys.stderr.write(json.dumps(env))"
                 ),
             ],
             usePTY=self.usePTY,
@@ -1045,10 +1046,14 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
 
         expectedEnv.pop("LC_CTYPE", None)
         expectedEnv.pop("__CF_USER_TEXT_ENCODING", None)
-        self.assertEqual(
-            bytes(str(sorted(expectedEnv.items())), "utf-8"),
-            p.outF.getvalue() if self.usePTY else p.errF.getvalue(),
-        )
+        # subprocess might get COLUMNS and LINES added for some reason in 3.13 or later...
+        expectedExcess = {"COLUMNS", "LINES"}
+        resultEnv = json.loads(
+            p.outF.getvalue() if self.usePTY else p.errF.getvalue()
+        ).items()
+        self.assertGreaterEqual(resultEnv, expectedEnv.items())
+        resultExcess = {pair[0] for pair in resultEnv - expectedEnv.items()}
+        self.assertGreaterEqual(expectedExcess, resultExcess)
 
     def checkSpawnProcessEnvironmentWithPosixSpawnp(self, spawnKwargs, expectedEnv):
         return self.checkSpawnProcessEnvironment(


### PR DESCRIPTION
## Scope and purpose

Fixes #12290 

Bit of a hack, but :shrug: welcome better ideas. Doesn't seem like an important problem. Possibly it's an actual bug in 3.13? Dunno.