### PR TITLE
12288 Significantly simplify how Failures work, plus steps towards 3.13 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,10 +144,8 @@ jobs:
             # FIXME:https://github.com/twisted/twisted/issues/12060
             # Also add twisted.python
             # FIXME:https://github.com/twisted/twisted/issues/12061
-            # Add full twisted.internet
-            # FIXME:https://github.com/twisted/twisted/issues/12062
             # Add full twisted.test
-            trial-target: 'twisted.conch twisted.cred twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.web twisted.words'
+            trial-target: 'twisted.conch twisted.cred twisted.internet.test.test_inlinecb twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.runner twisted.spread twisted.test.test_defer twisted.trial twisted.web twisted.words'
             # Disable concurrency for now, since we get occasional segfaults and
             # this helps debug them:
             trial-args: '--reactor=default'

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1141,7 +1141,6 @@ class Deferred(Awaitable[_SelfResultT]):
                 if isinstance(current.result, Failure):
                     # Stash the Failure in the _debugInfo for unhandled error
                     # reporting.
-                    current.result.cleanFailure()
                     if current._debugInfo is None:
                         current._debugInfo = DebugInfo()
                     current._debugInfo.failResult = current.result
@@ -1189,8 +1188,7 @@ class Deferred(Awaitable[_SelfResultT]):
                 # exception"
                 assert self._debugInfo is not None
                 self._debugInfo.failResult = None
-                result.value.__failure__ = result
-                raise result.value
+                result.raiseException()
             else:
                 return result  # type: ignore[return-value]
 

--- a/src/twisted/internet/test/test_inlinecb.py
+++ b/src/twisted/internet/test/test_inlinecb.py
@@ -1214,7 +1214,6 @@ class ForwardTraceBackTests(SynchronousTestCase):
         self.assertIn("in calling", tb)
         self.assertIn("in calling2", tb)
         self.assertIn("in calling3", tb)
-        self.assertNotIn("throwExceptionIntoGenerator", tb)
         self.assertIn("Error Marker", tb)
         self.assertIn("in erroring", f.getTraceback())
 
@@ -1249,7 +1248,6 @@ class ForwardTraceBackTests(SynchronousTestCase):
         self.assertIn("in calling", tb)
         self.assertIn("in calling2", tb)
         self.assertIn("in calling3", tb)
-        self.assertNotIn("throwExceptionIntoGenerator", tb)
         self.assertIn("Error Marker", tb)
         self.assertIn("in erroring", f.getTraceback())
 

--- a/src/twisted/newsfragments/12234.feature
+++ b/src/twisted/newsfragments/12234.feature
@@ -1,0 +1,1 @@
+twisted.internet.defer.Deferred will no longer remove the traceback object from Failures. This may result in more objects staying in memory if you don't clean up failed Dferreds, but it will speed up error handling and enable improvements to traceback reporting.

--- a/src/twisted/newsfragments/12234.feature
+++ b/src/twisted/newsfragments/12234.feature
@@ -1,1 +1,1 @@
-twisted.internet.defer.Deferred will no longer remove the traceback object from Failures. This may result in more objects staying in memory if you don't clean up failed Dferreds, but it will speed up error handling and enable improvements to traceback reporting.
+twisted.internet.defer.Deferred no longer removes the traceback object from Failures. This may result in more objects staying in memory if you don't clean up failed Deferreds, but it speeds up error handling and enables improvements to traceback reporting.

--- a/src/twisted/newsfragments/12288.feature
+++ b/src/twisted/newsfragments/12288.feature
@@ -1,1 +1,1 @@
-Create of twisted.python.failure.Failure is now faster.
+Creation of twisted.python.failure.Failure is now faster.

--- a/src/twisted/newsfragments/12288.feature
+++ b/src/twisted/newsfragments/12288.feature
@@ -1,0 +1,1 @@
+Create of twisted.python.failure.Failure is now faster.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -24,7 +24,6 @@ from inspect import getmro
 from io import StringIO
 from typing import Callable, NoReturn, TypeVar
 
-import opcode
 from incremental import Version
 
 from twisted.python import reflect

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -291,13 +291,10 @@ class Failure(BaseException):
         self.type = self.value = tb = None
         self.captureVars = captureVars
 
-        stackOffset = 0
-
         if exc_value is None:
             self.type, self.value, tb = sys.exc_info()
             if self.type is None:
                 raise NoCurrentExceptionError()
-            stackOffset = 1
         elif exc_type is None:
             if isinstance(exc_value, Exception):
                 self.type = exc_value.__class__
@@ -328,21 +325,6 @@ class Failure(BaseException):
 
         frames = []
         tb = self.tb
-        stackOffset = 0
-
-        if tb:
-            f = tb.tb_frame
-        elif not isinstance(self.value, Failure):
-            # We don't do frame introspection since it's expensive,
-            # and if we were passed a plain exception with no
-            # traceback, it's not useful anyway
-            f = stackOffset = None
-
-        while stackOffset and f:
-            # This excludes this Failure.__init__ frame from the
-            # stack, leaving it to start with our caller instead.
-            f = f.f_back
-            stackOffset -= 1
 
         while tb is not None:
             f = tb.tb_frame

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -371,7 +371,9 @@ class Failure(BaseException):
             tb = tb.tb_next
         return frames
 
-    # TODO backwards compat @frames.setter
+    @frames.setter
+    def frames(self, frames):
+        self._frames = frames
 
     @deprecatedProperty(Version("Twisted", "NEXT", 0, 0))
     def stack(self):
@@ -560,7 +562,7 @@ class Failure(BaseException):
                 for v in self.frames
             ]
         else:
-           c["frames"] = self.frames
+            c["frames"] = self.frames
 
         # Added 2003-06-23. See comment above in __init__
         c["tb"] = None
@@ -637,12 +639,11 @@ class Failure(BaseException):
             in the traceback.  Must be one of C{'brief'}, C{'default'}, or
             C{'verbose'}.
         """
-        # TODO use Python's traceback printer when possible so we get column
-        # indicators, not just lines of code
         if file is None:
             from twisted.python import log
 
             file = log.logerr
+
         w = file.write
 
         if detail == "verbose" and not self.captureVars:

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -382,7 +382,7 @@ class Failure(BaseException):
             one.
         @type otherFailure: L{Failure}
         """
-        # Copy all infos from that failure (including self.frames).
+        # Copy all infos from that failure (including self._frames).
         self.__dict__ = copy.copy(otherFailure.__dict__)
 
     @staticmethod

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -253,14 +253,6 @@ class Failure(BaseException):
     pickled = 0
     _parents = None
 
-    # The opcode of "yield" in Python bytecode. We need this in
-    # _findFailure in order to identify whether an exception was
-    # thrown by a throwExceptionIntoGenerator.
-    # on PY3, b'a'[0] == 97 while in py2 b'a'[0] == b'a' opcodes
-    # are stored in bytes so we need to properly account for this
-    # difference.
-    _yieldOpcode = opcode.opmap["YIELD_VALUE"]
-
     def __init__(self, exc_value=None, exc_type=None, exc_tb=None, captureVars=False):
         """
         Initialize me with an explanation of the error.
@@ -473,8 +465,6 @@ class Failure(BaseException):
         @raise StopIteration: If there are no more values in the generator.
         @raise anything else: Anything that the generator raises.
         """
-        # Note that the actual magic to find the traceback information
-        # is done in _findFailure.
         return g.throw(self.value.with_traceback(self.tb))
 
     def __repr__(self) -> str:

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -323,7 +323,7 @@ class Failure(BaseException):
         if hasattr(self, "_frames"):
             return self._frames
 
-        frames = []
+        frames = self._frames = []
         tb = self.tb
 
         while tb is not None:

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -392,24 +392,6 @@ class Failure(BaseException):
         """
         # Copy all infos from that failure (including self.frames).
         self.__dict__ = copy.copy(otherFailure.__dict__)
-        return
-
-        # If we are re-throwing a Failure, we merge the stack-trace stored in
-        # the failure with the current exception's stack.  This integrated with
-        # throwExceptionIntoGenerator and allows to provide full stack trace,
-        # even if we go through several layers of inlineCallbacks.
-        _, _, tb = sys.exc_info()
-        frames = []
-        while tb is not None:
-            f = tb.tb_frame
-            if f.f_code not in _inlineCallbacksExtraneous:
-                frames.append(
-                    (f.f_code.co_name, f.f_code.co_filename, tb.tb_lineno, (), ())
-                )
-            tb = tb.tb_next
-        # Merging current stack with stack stored in the Failure.
-        frames.extend(self.frames)
-        self.frames = frames
 
     @staticmethod
     def _withoutTraceback(value: BaseException) -> Failure:

--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -520,7 +520,7 @@ setUnjellyableForClass(CopyableFailure, CopiedFailure)
 
 
 def failure2Copyable(fail, unsafeTracebacks=0):
-    f = _newInstance(CopyableFailure, fail.__dict__)
+    f = _newInstance(CopyableFailure, fail.__getstate__())
     f.unsafeTracebacks = unsafeTracebacks
     return f
 

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -549,7 +549,12 @@ class FailureTests(SynchronousTestCase):
         failure2 = failure.Failure._withoutTraceback(exc)
         self.assertPicklingRoundtrips(failure2)
 
-        # TODO a Failure with frames
+        # Here we test a Failure with a traceback:
+        try:
+            raise ComparableException("boo")
+        except:
+            failure3 = failure.Failure()
+        self.assertPicklingRoundtrips(failure3)
 
     def assertPicklingRoundtrips(self, original_failure: failure.Failure) -> None:
         """
@@ -559,6 +564,7 @@ class FailureTests(SynchronousTestCase):
         failure2 = pickle.loads(pickle.dumps(original_failure))
         expected = original_failure.__dict__.copy()
         expected["pickled"] = 1
+        expected["tb"] = None
         result = failure2.__dict__.copy()
         result.pop("_frames")
         self.assertEqual(expected, result)

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -566,7 +566,6 @@ class FailureTests(SynchronousTestCase):
         expected["pickled"] = 1
         expected["tb"] = None
         result = failure2.__dict__.copy()
-        result.pop("_frames")
         self.assertEqual(expected, result)
         self.assertEqual(failure2.frames, original_failure.frames)
 

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -552,7 +552,7 @@ class FailureTests(SynchronousTestCase):
         # Here we test a Failure with a traceback:
         try:
             raise ComparableException("boo")
-        except:
+        except BaseException:
             failure3 = failure.Failure()
         self.assertPicklingRoundtrips(failure3)
 

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -577,6 +577,16 @@ class FailureTests(SynchronousTestCase):
         f = failure.Failure(ComparableException("hello"))
         self.assertEqual(f.__getstate__()["parents"], f.parents)
 
+    def test_settableFrames(self) -> None:
+        """
+        C{Failure.frames} can be set, both before and after pickling.
+        """
+        original_failure = failure.Failure(getDivisionFailure())
+        original_failure.frames = original_failure.frames[:]
+        failure2 = pickle.loads(pickle.dumps(original_failure))
+        failure2.frames = failure2.frames[:-1]
+        self.assertEqual(failure2.frames, original_failure.frames[:-1])
+
     def test_settableParents(self) -> None:
         """
         C{Failure.parents} can be set, both before and after pickling.

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -699,7 +699,7 @@ class GetTracebackTests(SynchronousTestCase):
 
 class FindFailureTests(SynchronousTestCase):
     """
-    Tests for functionality related to L{Failure._findFailure}.
+    Tests for functionality related to identifying the C{Failure}.
     """
 
     @skipIf(raiser is None, "raiser extension not available")
@@ -994,9 +994,9 @@ class ExtendedGeneratorTests(SynchronousTestCase):
 
     def test_ambiguousFailureInGenerator(self) -> None:
         """
-        When a generator reraises a different exception,
-        L{Failure._findFailure} inside the generator should find the reraised
-        exception rather than original one.
+        When a generator reraises a different exception, creating a L{Failure}
+        inside the generator should find the reraised exception rather than
+        original one.
         """
 
         def generator() -> Generator[None, None, None]:
@@ -1015,9 +1015,9 @@ class ExtendedGeneratorTests(SynchronousTestCase):
 
     def test_ambiguousFailureFromGenerator(self) -> None:
         """
-        When a generator reraises a different exception,
-        L{Failure._findFailure} above the generator should find the reraised
-        exception rather than original one.
+        When a generator reraises a different exception, creating a L{Failure}
+        above the generator should find the reraised exception rather than
+        original one.
         """
 
         def generator() -> Generator[None, None, None]:


### PR DESCRIPTION
## Scope and purpose

Fixes #12288 
Fixes #12061 
Fixes #12234 

## An explanation

### The starting point

1. `Failure._findFailure` did some very _intrusive_ things to find the current `Failure` in the context of `inlineCallbacks`.
2. In Python 3.13 this didn't work. I have an alternative branch that just fixes that, by doing pattern matching of "these 3 bytecodes in a row mean it's a yield" which is not a good approach, it's way too tied to implementation details.
3. CPython is moving towards a JIT. This sort of bytecode munging may well get even harder.

### What I ended up with

1. Ripping out all the traceback and frame munging logic.
2. Just keeping the traceback object on the `Failure` pretty much at all times; I expect this will make things rather faster. The downside is that there are more references to more objects for longer, which can increase memory if people keep `Deferred`s around for too long. See #12234 for a broader discussion.
3. Everything is simpler now!
4. Tracebacks have a bit more Twisted boilerplate methods in them.

### Next steps

If this is merged, we can start generating traceback strings using Python's built-in logic, which is nicer these days, in particular including column markers so you can see which part of the line was responsible for the traceback. See #12289.