### PR TITLE
#12296 Report to codecov after combining coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -318,14 +318,6 @@ jobs:
         name: coverage-${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-${{ matrix.job-name || 'default-tests' }}
         path: .coverage-job-*
 
-    - name: Publish to codecov.io
-      uses: codecov/codecov-action@v4
-      if: ${{ !cancelled() && !matrix['skip-coverage'] }}
-      with:
-        files: coverage.xml
-        name: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-${{ matrix.job-name || 'default-tests' }}
-        fail_ci_if_error: true
-
 
   coverage-report:
     name: Coverage report
@@ -384,6 +376,14 @@ jobs:
       with:
         name: html-report
         path: htmlcov
+
+    - name: Publish to codecov.io
+      uses: codecov/codecov-action@v4
+      if: ${{ !cancelled() }}
+      with:
+        files: coverage.xml
+        name: coverage-combined
+        fail_ci_if_error: true
 
 
   benchmarks:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -382,7 +382,7 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         files: coverage.xml
-        name: coverage-combined
+        name: tests-combined
         fail_ci_if_error: true
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -434,10 +434,10 @@ jobs:
 
     - name: Publish benchmarks coverage
       uses: codecov/codecov-action@v4
-      if: ${{ !cancelled() && !matrix['skip-coverage'] }}
+      if: ${{ !cancelled() }}
       with:
         files: coverage.xml
-        name: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}-benchmarks
+        name: benchmarks
         fail_ci_if_error: true
 
     - name: Fail on missing benchmarks coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,10 +9,8 @@ codecov:
   token: fb52015a-b78e-4d89-a6e0-a4829aea2efa
   require_ci_to_pass: yes
   notify:
-    # We have at least 5 builds in GitHub Actions,
-    # so try not to send the reports too soon with partial results.
-    after_n_builds: 5
     wait_for_ci: yes
+  disable_default_path_fixes: true
 
 coverage:
   precision: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,7 @@ codecov:
   token: fb52015a-b78e-4d89-a6e0-a4829aea2efa
   require_ci_to_pass: yes
   notify:
-    wait_for_ci: yes
-  disable_default_path_fixes: true
+    wait_for_ci: false
 
 coverage:
   precision: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ codecov:
   token: fb52015a-b78e-4d89-a6e0-a4829aea2efa
   require_ci_to_pass: yes
   notify:
+    after_n_builds: 2  # tests (combined) + benchmarks
     wait_for_ci: false
 
 coverage:


### PR DESCRIPTION
This should stop Codecov from reporting before all of the builds have run.

Fixes #12296.