### PR TITLE
#12301 Add '&' to the set of allowed characters in HTTP tokens

### DIFF
--- a/src/twisted/web/_abnf.py
+++ b/src/twisted/web/_abnf.py
@@ -15,7 +15,7 @@ def _istoken(b: bytes) -> bool:
         if c not in (
             b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"  # ALPHA
             b"0123456789"  # DIGIT
-            b"!#$%^'*+-.^_`|~"
+            b"!#$%&'*+-.^_`|~"
         ):
             return False
     return b != b""

--- a/src/twisted/web/newsfragments/12301.bugfix
+++ b/src/twisted/web/newsfragments/12301.bugfix
@@ -1,0 +1,1 @@
+twisted.web's HTTP/1.1 server now accepts '&' within tokens (methods, header field names, etc.), in compliance with RFC 9110.

--- a/src/twisted/web/test/test_abnf.py
+++ b/src/twisted/web/test/test_abnf.py
@@ -18,6 +18,7 @@ class IsTokenTests(unittest.SynchronousTestCase):
         for b in (
             b"GET",
             b"Cache-Control",
+            b"&",
         ):
             self.assertTrue(_istoken(b))
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12301