### PR TITLE
#12308 Remove deprecated encryption CAST5 and Blowfish from ssh

### DIFF
--- a/docs/conch/man/conch.1
+++ b/docs/conch/man/conch.1
@@ -108,7 +108,7 @@ Enable compression.
 .It Fl c Ar cipher_spec
 Selects encryption algorithms to be used for this connection, as a comma-separated list of ciphers in order of preference.  The list that
 .Nm
-supports is (in order of default preference): aes256-ctr, aes256-cbc, aes192-ctr, aes192-cbc, aes128-ctr, aes128-cbc, cast128-ctr, cast128-cbc, blowfish-ctr, blowfish, idea-ctr, idea-cbc, 3des-ctr, 3des-cbc.
+supports is (in order of default preference): aes256-ctr, aes256-cbc, aes192-ctr, aes192-cbc, aes128-ctr, aes128-cbc, idea-ctr, idea-cbc, 3des-ctr, 3des-cbc.
 .It Fl e Ar ch | ^ch | none
 Sets the escape character for sessions with a PTY (default:
 .Ql ~ ) .

--- a/src/twisted/conch/newsfragments/12308.bugfix
+++ b/src/twisted/conch/newsfragments/12308.bugfix
@@ -1,1 +1,2 @@
-Blowfish and CAST5 encryoption were deprecated and are now removed from Twisted to remove runtime warning CryptographyDeprecationWarning
+twisted.conch.ssh.SSHCiphers no longer supports the cast128-ctr, cast128-cbc, blowfish-ctr, and blowfish-cbc ciphers.
+The Blowfish and CAST5 ciphers were removed as they were deprecated by the Python cryptography library.```

--- a/src/twisted/conch/newsfragments/12308.bugfix
+++ b/src/twisted/conch/newsfragments/12308.bugfix
@@ -1,0 +1,1 @@
+Blowfish and CAST5 encryoption were deprecated and are now removed from Twisted to remove runtime warning CryptographyDeprecationWarning

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -103,17 +103,13 @@ class SSHCiphers:
 
     cipherMap = {
         b"3des-cbc": (algorithms.TripleDES, 24, modes.CBC),
-        b"blowfish-cbc": (algorithms.Blowfish, 16, modes.CBC),
         b"aes256-cbc": (algorithms.AES, 32, modes.CBC),
         b"aes192-cbc": (algorithms.AES, 24, modes.CBC),
         b"aes128-cbc": (algorithms.AES, 16, modes.CBC),
-        b"cast128-cbc": (algorithms.CAST5, 16, modes.CBC),
         b"aes128-ctr": (algorithms.AES, 16, modes.CTR),
         b"aes192-ctr": (algorithms.AES, 24, modes.CTR),
         b"aes256-ctr": (algorithms.AES, 32, modes.CTR),
         b"3des-ctr": (algorithms.TripleDES, 24, modes.CTR),
-        b"blowfish-ctr": (algorithms.Blowfish, 16, modes.CTR),
-        b"cast128-ctr": (algorithms.CAST5, 16, modes.CTR),
         b"none": (None, 0, modes.CBC),
     }
     macMap = {
@@ -295,10 +291,6 @@ def _getSupportedCiphers():
         b"aes192-cbc",
         b"aes128-ctr",
         b"aes128-cbc",
-        b"cast128-ctr",
-        b"cast128-cbc",
-        b"blowfish-ctr",
-        b"blowfish-cbc",
         b"3des-ctr",
         b"3des-cbc",
     ]


### PR DESCRIPTION
## Scope and purpose

Fixes #12308 
Fixes #11793
Fixes #11794


Removes runtime warning. Change is deletion of lines, in list. 
Only tradeoff is inablity to simulate / test deprecated ciphers..

## Contributor Checklist:
I goofed on a prior PR without the newsfragment setup properly. should be in same PR now...