### PR TITLE
#12325 fix TLS client endpoint parser handling of bindAddress=

### DIFF
--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -840,7 +840,7 @@ class HostnameEndpoint:
             if isinstance(bindAddress, (bytes, str)):
                 bindAddress = (bindAddress, 0)
             if isinstance(bindAddress[0], bytes):
-                bindAddress = (nativeString(bindAddress[0]), bindAddress[1])
+                bindAddress = (bindAddress[0].decode(), bindAddress[1])
         self._bindAddress = bindAddress
         if attemptDelay is None:
             attemptDelay = self._DEFAULT_ATTEMPT_DELAY

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -589,7 +589,6 @@ class TCP4ClientEndpoint:
         self._host = host
         self._port = port
         self._timeout = timeout
-        assert isinstance(bindAddress, (tuple, type(None)))
         self._bindAddress = bindAddress
 
     def connect(self, protocolFactory):
@@ -642,7 +641,6 @@ class TCP6ClientEndpoint:
         self._host = host
         self._port = port
         self._timeout = timeout
-        assert isinstance(bindAddress, (tuple, type(None)))
         self._bindAddress = bindAddress
 
     def connect(self, protocolFactory):
@@ -810,11 +808,18 @@ class HostnameEndpoint:
             seconds to wait before assuming the connection has failed.
         @type timeout: L{float} or L{int}
 
-        @param bindAddress: The local address of the network interface to make
-            the connections from, or a (host, port) tuple of local address to
-            bind to, or None.
-
-        @type bindAddress: L{bytes}, L{tuple}, or None
+        @param bindAddress: The client socket normally uses whatever
+            local interface (eth0, en0, lo, etc) is best suited for the
+            target address, and a randomly-assigned port. This argument
+            allows that local address/port to be overridden. Providing
+            just an address (as a str) will bind the client socket to
+            whichever interface is assigned that address. Providing a
+            tuple of (str, int) will bind it to both an interface and a
+            specific local port. To bind the port, but leave the
+            interface unbound, use a tuple of ("", port), or ("0.0.0.0",
+            port) for IPv4, or ("::0", port) for IPv6. To leave both
+            interface and port unbound, just use None.
+        @type bindAddress: L{str}, L{tuple}, or None
 
         @param attemptDelay: The number of seconds to delay between connection
             attempts.
@@ -831,10 +836,11 @@ class HostnameEndpoint:
         self._hostStr = self._hostBytes if bytes is str else self._hostText
         self._port = port
         self._timeout = timeout
-        assert isinstance(bindAddress, (bytes, str, tuple, type(None)))
-        if isinstance(bindAddress, (bytes, str)):
-            bindAddress = (bindAddress, 0)
-        assert isinstance(bindAddress, (tuple, type(None)))
+        if bindAddress is not None:
+            if isinstance(bindAddress, (bytes, str)):
+                bindAddress = (bindAddress, 0)
+            if isinstance(bindAddress[0], bytes):
+                bindAddress = (nativeString(bindAddress[0]), bindAddress[1])
         self._bindAddress = bindAddress
         if attemptDelay is None:
             attemptDelay = self._DEFAULT_ATTEMPT_DELAY

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -589,6 +589,7 @@ class TCP4ClientEndpoint:
         self._host = host
         self._port = port
         self._timeout = timeout
+        assert isinstance(bindAddress, (tuple, type(None)))
         self._bindAddress = bindAddress
 
     def connect(self, protocolFactory):
@@ -641,6 +642,7 @@ class TCP6ClientEndpoint:
         self._host = host
         self._port = port
         self._timeout = timeout
+        assert isinstance(bindAddress, (tuple, type(None)))
         self._bindAddress = bindAddress
 
     def connect(self, protocolFactory):
@@ -808,9 +810,11 @@ class HostnameEndpoint:
             seconds to wait before assuming the connection has failed.
         @type timeout: L{float} or L{int}
 
-        @param bindAddress: the local address of the network interface to make
-            the connections from.
-        @type bindAddress: L{bytes}
+        @param bindAddress: The local address of the network interface to make
+            the connections from, or a (host, port) tuple of local address to
+            bind to, or None.
+
+        @type bindAddress: L{bytes}, L{tuple}, or None
 
         @param attemptDelay: The number of seconds to delay between connection
             attempts.
@@ -827,6 +831,10 @@ class HostnameEndpoint:
         self._hostStr = self._hostBytes if bytes is str else self._hostText
         self._port = port
         self._timeout = timeout
+        assert isinstance(bindAddress, (bytes, str, tuple, type(None)))
+        if isinstance(bindAddress, (bytes, str)):
+            bindAddress = (bindAddress, 0)
+        assert isinstance(bindAddress, (tuple, type(None)))
         self._bindAddress = bindAddress
         if attemptDelay is None:
             attemptDelay = self._DEFAULT_ATTEMPT_DELAY
@@ -2299,7 +2307,9 @@ def _parseClientTLS(
         ),
         clientFromString(reactor, endpoint)
         if endpoint is not None
-        else HostnameEndpoint(reactor, _idnaBytes(host), port, timeout, bindAddress),
+        else HostnameEndpoint(
+            reactor, _idnaBytes(host), port, timeout, (bindAddress, 0)
+        ),
     )
 
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -727,6 +727,7 @@ class _BaseTCPClient:
             whenDone = None
         if whenDone and bindAddress is not None:
             try:
+                assert type(bindAddress) == tuple
                 if abstract.isIPv6Address(bindAddress[0]):
                     bindinfo = _resolveIPv6(*bindAddress)
                 else:

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -58,7 +58,6 @@ from twisted.logger import ILogObserver, globalLogPublisher
 from twisted.plugin import getPlugins
 from twisted.protocols import basic, policies
 from twisted.python import log
-from twisted.python.compat import nativeString
 from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
@@ -2711,17 +2710,27 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
     def test_bytes(self):
         ba = b"1.2.3.4"
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
-        self.assertEqual(ep._bindAddress, (b"1.2.3.4", 0))
+        self.assertEqual(ep._bindAddress, ("1.2.3.4", 0))
 
     def test_str(self):
         ba = "1.2.3.4"
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
         self.assertEqual(ep._bindAddress, ("1.2.3.4", 0))
 
-    def test_tuple(self):
+    def test_tuple_bytes(self):
+        ba = (b"1.2.3.4", 1234)
+        ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
+        self.assertEqual(ep._bindAddress, ("1.2.3.4", 1234))
+
+    def test_tuple_str(self):
         ba = ("1.2.3.4", 1234)
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
         self.assertEqual(ep._bindAddress, ("1.2.3.4", 1234))
+
+    def test_none(self):
+        ba = None
+        ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
+        self.assertEqual(ep._bindAddress, None)
 
 
 @skipIf(skipSSL, skipSSLReason)
@@ -4214,14 +4223,14 @@ class WrapClientTLSParserTests(unittest.TestCase):
         reactor = object()
         endpoint = endpoints.clientFromString(
             reactor,
-            nativeString("tls:example.com:443:timeout=10:bindAddress=127.0.0.1"),
+            "tls:example.com:443:timeout=10:bindAddress=127.0.0.1",
         )
         hostnameEndpoint = endpoint._wrappedEndpoint
         self.assertIs(hostnameEndpoint._reactor, reactor)
         self.assertEqual(hostnameEndpoint._hostBytes, b"example.com")
         self.assertEqual(hostnameEndpoint._port, 443)
         self.assertEqual(hostnameEndpoint._timeout, 10)
-        self.assertEqual(hostnameEndpoint._bindAddress, (nativeString("127.0.0.1"), 0))
+        self.assertEqual(hostnameEndpoint._bindAddress, ("127.0.0.1", 0))
 
     def test_utf8Encoding(self):
         """

--- a/src/twisted/newsfragments/12325.bugfix
+++ b/src/twisted/newsfragments/12325.bugfix
@@ -1,0 +1,1 @@
+TLS endpoint strings with "bindAddress=" should no longer crash during connect. The HostnameEndpoint() "bindAddress" argument now accepts either hostnames or (host,port) tuples.

--- a/src/twisted/newsfragments/12325.bugfix
+++ b/src/twisted/newsfragments/12325.bugfix
@@ -1,1 +1,1 @@
-TLS endpoint strings with "bindAddress=" should no longer crash during connect. The HostnameEndpoint() "bindAddress" argument now accepts either hostnames or (host,port) tuples.
+twisted.internet.endpoints.clientFromString for TLS endpoints with "bindAddress="  no longer crashes during connect. twisted.internet.endpoints.HostnameEndpoint() no longer crashes when given a bindAddress= argument that is just a string, and that argument now accepts either address strings or (address, port) tuples.

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -1256,7 +1256,7 @@ class AgentTests(
         agent = client.Agent(self.reactor, bindAddress="192.168.0.1")
         agent.request(b"GET", b"http://foo/")
         address = self.reactor.tcpClients.pop()[4]
-        self.assertEqual("192.168.0.1", address)
+        self.assertEqual(("192.168.0.1", 0), address)
 
     @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_bindAddressSSL(self):
@@ -1267,7 +1267,7 @@ class AgentTests(
         agent = client.Agent(self.reactor, bindAddress="192.168.0.1")
         agent.request(b"GET", b"https://foo/")
         address = self.reactor.tcpClients.pop()[4]
-        self.assertEqual("192.168.0.1", address)
+        self.assertEqual(("192.168.0.1", 0), address)
 
     def test_responseIncludesRequest(self):
         """


### PR DESCRIPTION
## Scope and purpose

Fixes `_parseClientTLS` to supply `HostnameEndpoint()` with `bindAddress=` as a tuple, not a string, to avoid a subsequent crash during `endpoint.connect()`. Updates the docstring on `HostnameEndpoint()` to point out that it requires a tuple. Adds (perhaps too many) assertions of tuple-ness to catch similar problems earlier next time. Updates unit tests.

Fixes #12325
