### PR TITLE
#12327  Fix the URLs in README and pyproject.toml for PyPI project page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,13 +34,13 @@ To install the latest version of Twisted using pip::
 
   $ pip install twisted
 
-Additional instructions for installing this software are in `the installation instructions <https://docs.twisted.org/en/latest/installations.rst>`_.
+Additional instructions for installing this software are in `the installation instructions <https://docs.twisted.org/en/latest/installation.html>`_.
 
 
 Documentation and Support
 -------------------------
 
-Twisted's documentation is available from the `Twisted Matrix website <https://twistedmatrix.com/documents/current/>`_.
+Twisted's documentation is available from the `Twisted Matrix Read The Docs website <https://docs.twisted.org/>`_.
 This documentation contains how-tos, code examples, and an API reference.
 
 Help is also available on the `Twisted mailing list <https://mail.python.org/mailman3/lists/twisted.python.org/>`_.
@@ -75,7 +75,7 @@ Some of these tests may fail if you:
 Static Code Checkers
 --------------------
 
-You can ensure that code complies to Twisted `coding standards <https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html>`_::
+You can ensure that code complies to Twisted `coding standards <https://docs.twisted.org/en/latest/development/coding-standard.html>`_::
 
   $ tox -e lint   # run pre-commit to check coding stanards
   $ tox -e mypy   # run MyPy static type checker to check for type errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,12 +147,16 @@ twist = "twisted.application.twist._twist:Twist.main"
 twistd = "twisted.scripts.twistd:run"
 
 [project.urls]
+# For available URL types see
+# https://docs.pypi.org/project_metadata/
 Changelog = "https://github.com/twisted/twisted/blob/HEAD/NEWS.rst"
 Documentation = "https://docs.twisted.org/"
 Homepage = "https://twisted.org/"
 Issues = "https://github.com/twisted/twisted/issues"
 Source = "https://github.com/twisted/twisted"
 Twitter = "https://twitter.com/twistedmatrix"
+Funding-PSF = "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=44"
+Funding-GitHub = "https://github.com/sponsors/twisted"
 
 [tool.hatch.metadata]
 # This is here to enable backward compatible extra dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
 requires-python = ">=3.8.0"
 authors = [
-    { name = "Twisted Matrix Laboratories", email = "twisted-python@twistedmatrix.com" },
+    { name = "Twisted Matrix Community", email = "twisted@python.org" },
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -148,9 +148,9 @@ twistd = "twisted.scripts.twistd:run"
 
 [project.urls]
 Changelog = "https://github.com/twisted/twisted/blob/HEAD/NEWS.rst"
-Documentation = "https://docs.twistedmatrix.com/"
-Homepage = "https://twistedmatrix.com/"
-Issues = "https://twistedmatrix.com/trac/report"
+Documentation = "https://docs.twisted.org/"
+Homepage = "https://twisted.org/"
+Issues = "https://github.com/twisted/twisted/issues"
 Source = "https://github.com/twisted/twisted"
 Twitter = "https://twitter.com/twistedmatrix"
 

--- a/src/twisted/newsfragments/12327.bugfix
+++ b/src/twisted/newsfragments/12327.bugfix
@@ -1,0 +1,1 @@
+The URLs from README and pyproject.toml were updated.


### PR DESCRIPTION
## Scope and purpose

Fixes #12327 

This updates the links in pyproject.toml so that the sidebar links and in page links on https://pypi.org/project/Twisted/ will work


The available PyPI links are documented here https://docs.pypi.org/project_metadata/

