### PR TITLE
#12339 Add documentation about sponsors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,16 @@ Twisted
 For information on changes in this release, see the `NEWS <NEWS.rst>`_ file.
 
 
+Sponsors
+--------
+
+Twisted is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and these awesome sponsors.
+If you'd like to join them, please consider `sponsoring Twisted's <https://docs.twisted.org/en/latest/development/sponsorship.html>`_ development.
+
+|thinkst|_
+|sftpplus|_
+
+
 What is this?
 -------------
 
@@ -121,3 +131,9 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 
 .. |rtd| image:: https://readthedocs.org/projects/twisted/badge/?version=latest&style=flat
 .. _rtd: https://docs.twistedmatrix.com
+
+.. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
+.. _thinkst: https://thinkst.com/
+
+.. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
+.. _sftpplus: https://www.sftpplus.com/

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Twisted is an MIT-licensed open source project with its ongoing development made
 If you'd like to join them, please consider `sponsoring Twisted's <https://docs.twisted.org/en/latest/development/sponsorship.html>`_ development.
 
 |thinkst|_
+
 |sftpplus|_
 
 

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,9 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 .. _rtd: https://docs.twistedmatrix.com
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
-.. _thinkst: https://thinkst.com/
+    :alt: Thinkst Canary
+    :target: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
-.. _sftpplus: https://www.sftpplus.com/
+    :alt: SFTPPlus
+    :target: https://www.sftpplus.com/

--- a/README.rst
+++ b/README.rst
@@ -135,8 +135,8 @@ Again, see the included `LICENSE <LICENSE>`_ file for specific legal details.
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
     :alt: Thinkst Canary
-    :target: https://thinkst.com/
+.. _thinkst: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
     :alt: SFTPPlus
-    :target: https://www.sftpplus.com/
+.. _sftpplus: https://www.sftpplus.com/

--- a/docs/development/coding-standard.rst
+++ b/docs/development/coding-standard.rst
@@ -1,5 +1,5 @@
-Twisted Coding Standard
-=======================
+Coding Standard
+===============
 
 Naming
 ------

--- a/docs/development/compatibility-policy.rst
+++ b/docs/development/compatibility-policy.rst
@@ -1,5 +1,5 @@
-Twisted Compatibility Policy
-============================
+Compatibility Policy
+====================
 
 Motivation
 ----------

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -7,6 +7,7 @@ This documentation is for people who work on the Twisted codebase itself, rather
 .. toctree::
    :maxdepth: 1
 
+   sponsorship
    coding-standard
    dev-process
    review-process

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -1,5 +1,5 @@
-Twisted Release Process
-=======================
+Release Process
+===============
 
 This document describes the Twisted release process.
 Although it is still incomplete, every effort has been made to ensure that it is accurate and up-to-date.

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -128,7 +128,7 @@ Sponsors logos are displayed on the following sites:
 
 * `twisted.org <https://twisted.org/>`_ project presentation site
 * `docs.twisted.org <https://docs.twisted.org/en/stable/>`_ Read The Docs site
-* `twisted/twisted <github.com/twisted/twisted>`_ GitHub repository
+* `twisted/twisted <https://github.com/twisted/twisted>`_ GitHub repository
 
 Logos will only be there for the year that a sponsor has donated.
 

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -1,4 +1,4 @@
-Sponsor the project
+Sponsor the Project
 ===================
 
 
@@ -24,7 +24,7 @@ Sponsors
 How to donate
 -------------
 
-Since April 2023, the Twisted project got fiscal sponsorship from the `Python Software Foundation <https://www.python.org/psf-landing/>`_.
+Since April 2023, the Twisted project has been fiscally sponsored by the `Python Software Foundation <https://www.python.org/psf-landing/>`_.
 
 This enables Twisted to dedicate financial resources to maintenance and development.
 
@@ -43,7 +43,7 @@ The PSF is a recognized 501(c)(3) non-profit organization.
 GitHub Sponsors allows monthly donations or one time donations.
 
 For the contributions made using Tidelift we don't have any insights.
-At the moment, we receive about $300 per month via Tidelift.
+As of October 2024, we receive about $300 per month via Tidelift.
 
 If you would prefer to make other arrangements (e.g., your corporation requires the use of a purchase order,
 even when donating to a charity), contact PSF at `sponsors@python.org`.
@@ -109,7 +109,7 @@ $200 per month or equivalent
 With $200 per month or the equivalent $2400/year we can have your logo:
 
 * In the README file of the twisted/twisted project.
-* On the twisted.org website in the Donation section
+* On the twisted.org website in the "Sponsors" section
 
 Your contribution is also mentioned:
 
@@ -136,7 +136,7 @@ Your contribution is also mentioned:
 Logos
 -----
 
-Sponsors logos are displayed on the following sites:
+Sponsor logos are displayed on the following sites:
 
 * `twisted.org <https://twisted.org/>`_ project presentation site
 * `docs.twisted.org <https://docs.twisted.org/en/stable/>`_ Read The Docs site
@@ -162,7 +162,7 @@ Non-monetary donations and contributions
 The Twisted Project will consider the value of non-monetary donations to the project, for example, donations of hardware, software licenses, or hosting - on a case-by-case basis.
 
 If your company is directly contributing code development or code review,
-we encourage to use company email addresses.
+we encourage you to use a company email address.
 You can mention in the description of a pull request,
 that the work for that pull request is supported by your company,
 and provide a link to your company.
@@ -179,7 +179,9 @@ In general, we suggest cash donations, as that process is much simpler.
    Once the file is uploaded, you can get the link.
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
-.. _thinkst: https://thinkst.com/
+    :alt: Thinkst Canary
+    :target: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
-.. _sftpplus: https://www.sftpplus.com/
+    :alt: SFTPPlus
+    :target: https://www.sftpplus.com/

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -1,5 +1,5 @@
-Sponsor the project development
-===============================
+Sponsor the project
+===================
 
 
 Sponsors
@@ -127,7 +127,7 @@ Logos
 Sponsors logos are displayed on the following sites:
 
 * `twisted.org <https://twisted.org/>`_ project presentation site
-* `docs.twisted.org https://docs.twisted.org/en/stable/`_ Read The Docs site
+* `docs.twisted.org <https://docs.twisted.org/en/stable/>`_ Read The Docs site
 * `twisted/twisted <github.com/twisted/twisted>`_ GitHub repository
 
 Logos will only be there for the year that a sponsor has donated.
@@ -140,6 +140,8 @@ New logos for the same sponsorship level are added after the existing logos.
 Make sure your logo looks good on both dark and light backgrounds.
 
 The size of the logo should be about 300x100 pixels.
+
+Logos can link to any URL suggested by the sponsors.
 
 
 Non-monetary donations and contributions

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -1,0 +1,171 @@
+Sponsor the project development
+===============================
+
+
+Sponsors
+--------
+
+|thinkst|_
+|sftpplus|_
+
+
+How to donate
+-------------
+
+Since April 2023, the Twisted project got fiscal sponsorship from the `Python Software Foundation <https://www.python.org/psf-landing/>`_.
+
+This enables Twisted to dedicate financial resources to maintenance and development.
+
+All monetary donations are managed by the Python Software Foundation,
+regardless of their source.
+
+We currently receive donations from the following sources:
+
+* Direct contributions via `Python Software Foundation donations <https://psfmember.org/civicrm/contribute/transact/?reset=1&id=44>`_
+* `GitHub Sponsors <https://github.com/sponsors/twisted/>`_
+* `Tidelift <https://tidelift.com/lifter/search/pypi/Twisted>`_
+
+Donations made directly via the Python Software Foundation (PSF) are tax-deductible in USA.
+The PSF is a recognized 501(c)(3) non-profit organization.
+
+GitHub Sponsors allows monthly donations or one time donations.
+
+For the contributions made using Tidelift we don't have any insights.
+At the moment, we receive about $300 per month via Tidelift.
+
+If you would prefer to make other arrangements (e.g., your corporation requires the use of a purchase order,
+even when donating to a charity), contact PSF at `sponsors@python.org`.
+
+
+Stewardship
+-----------
+
+Speaking of "the project" making decisions,
+while it is our fiscal sponsor in the form of the PSF who has final say over spending decisions,
+their goal is to have an accurate reflection of "the project" as making decisions,
+and surely that includes some of you, in your role as contributors and interested community members.
+
+We don't really have a ton of money to spend,
+so while we don't need a ton of big ambitious ideas,
+we would love to have more folks get involved in the process of decision-making (and fundraising!).
+
+Our process is lighter weight and less formal right now,
+so we do not have an elected Steering Committee or anything like that.
+
+As more people are interested we can evolve our loose consensus into something more explicitly documented.
+
+
+Goals
+-----
+
+Our plan is to bring a maintainer on to do about 5 hours of work per week,
+mostly just keeping the review queue clear,
+so that contributions can be more efficiently accepted.
+
+We have a lot of code that is stalled but not technically "in review" right now,
+so it might also involve going through the PR backlog to integrate those,
+doing triage, etc.
+
+If we are successful in raising more money, we might expand this role further.  But, as it was many years ago,
+our conviction remains that the highest priority of funded work should be facilitating the work of volunteers, not writing more code.
+
+
+Sponsorship levels and benefits
+-------------------------------
+
+..
+   Note to maintainers.
+   Keep the information from here in sync with GitHub Sponsors page
+   https://github.com/sponsors/twisted/dashboard/tiers
+
+
+$100 per month or equivalent
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With $100 per month or the equivalent $1200/year we can have your logo:
+
+* In the README file of the twisted/twisted project.
+
+Your contribution is also mentioned:
+
+* in the release notes
+
+
+$200 per month or equivalent
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With $200 per month or the equivalent $2400/year we can have your logo:
+
+* In the README file of the twisted/twisted project.
+* On the twisted.org website in the Donation section
+
+Your contribution is also mentioned:
+
+* in the release notes
+* other communications
+
+
+$400 per month or more
+^^^^^^^^^^^^^^^^^^^^^^
+
+With $400 or above per month or the equivalent of $4800/year we can have your logo:
+
+* In the README file of the twisted/twisted project
+* At the top of twisted.org website
+* On the twisted.org website in the Donation section
+
+Your contribution is also mentioned:
+
+* in the release notes
+* other communications
+* merchandise
+
+
+Logos
+-----
+
+Sponsors logos are displayed on the following sites:
+
+* `twisted.org <https://twisted.org/>`_ project presentation site
+* `docs.twisted.org https://docs.twisted.org/en/stable/`_ Read The Docs site
+* `twisted/twisted <github.com/twisted/twisted>`_ GitHub repository
+
+Logos will only be there for the year that a sponsor has donated.
+
+Each year starts fresh again, with an opportunity to get your logo at the top by early sponsorship.
+
+Logos are ordered based on the sponsorship level.
+New logos for the same sponsorship level are added after the existing logos.
+
+Make sure your logo looks good on both dark and light backgrounds.
+
+The size of the logo should be about 300x100 pixels.
+
+
+Non-monetary donations and contributions
+----------------------------------------
+
+The Twisted Project will consider the value of non-monetary donations to the project, for example, donations of hardware, software licenses, or hosting - on a case-by-case basis.
+
+If your company is directly contributing code development or code review,
+we encourage to use company email addresses.
+You can mention in the description of a pull request,
+that the work for that pull request is supported by your company,
+and provide a link to your company.
+
+We note that non-monetary donations may not be tax-deductible; to confirm, you should seek the counsel of a qualified tax professional.
+In general, we suggest cash donations, as that process is much simpler.
+
+..
+   Note to maintainers.
+   Add the logo first to twisted.org website, via twisted/twisted.github.io repo.
+   You can then take a screenshot / capture of the logo in PNG format.
+   You can upload the PNG logos via GitHub Issues, for example as part of the
+   GitHub Issue that was created to add a new sponsor.
+   Once the file is uploaded, you can get the link.
+
+.. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
+.. _thinkst: https://thinkst.com/
+
+.. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
+.. _sftpplus: https://www.sftpplus.com/

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -5,7 +5,19 @@ Sponsor the project
 Sponsors
 --------
 
+..
+   Note to maintainers.
+   Sponsors of the same level, should be kept on separate lines, but without
+   an empty line between them.
+   This will render them inline.
+
 |thinkst|_
+
+..
+   Note to maintainers.
+   We have empty lines between sponsors of different levels,
+   to render them as separate rows.
+
 |sftpplus|_
 
 

--- a/docs/development/sponsorship.rst
+++ b/docs/development/sponsorship.rst
@@ -180,8 +180,8 @@ In general, we suggest cash donations, as that process is much simpler.
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
     :alt: Thinkst Canary
-    :target: https://thinkst.com/
+.. _thinkst: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
     :alt: SFTPPlus
-    :target: https://www.sftpplus.com/
+.. _sftpplus: https://www.sftpplus.com/

--- a/docs/development/writing-standard.rst
+++ b/docs/development/writing-standard.rst
@@ -1,10 +1,5 @@
-
-:LastChangedDate: $LastChangedDate$
-:LastChangedRevision: $LastChangedRevision$
-:LastChangedBy: $LastChangedBy$
-
-Twisted Writing Standard
-========================
+Writing Standard
+================
 
 The Twisted writing standard describes the documentation writing
 styles we prefer in our narrative documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Sponsors
 --------
 
 |thinkst|_
+
 |sftpplus|_
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,8 @@ Sponsors
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
     :alt: Thinkst Canary
-    :target: https://thinkst.com/
+.. _thinkst: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
     :alt: SFTPPlus
-    :target: https://www.sftpplus.com/
+.. _sftpplus: https://www.sftpplus.com/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,9 @@ Sponsors
 |sftpplus|_
 
 .. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
-.. _thinkst: https://thinkst.com/
+    :alt: Thinkst Canary
+    :target: https://thinkst.com/
 
 .. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
-.. _sftpplus: https://www.sftpplus.com/
+    :alt: SFTPPlus
+    :target: https://www.sftpplus.com/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,6 @@
 Welcome to the Twisted documentation!
 =====================================
 
-Contents:
-
 .. toctree::
     :maxdepth: 2
     :includehidden:
@@ -27,3 +25,16 @@ Contents:
    api/index
    GitHub <https://github.com/twisted/twisted>
    PyPI <https://pypi.org/project/twisted>
+
+
+Sponsors
+--------
+
+|thinkst|_
+|sftpplus|_
+
+.. |thinkst| image:: https://github.com/user-attachments/assets/a5b52432-2d18-4d91-a3c9-772fb2e02781
+.. _thinkst: https://thinkst.com/
+
+.. |sftpplus| image:: https://github.com/user-attachments/assets/5f585316-c7e8-4ef1-8fbb-923f0756ceed
+.. _sftpplus: https://www.sftpplus.com/


### PR DESCRIPTION
## Scope and purpose

Fixes #12339

This is based on the old Trac wiki page https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSoftwareFoundation.mediawiki

and Glyph email https://mail.python.org/archives/list/twisted@python.org/thread/55VR6KWJ46WE4H3B7QOAWE53UT4LRQBW/


## How to test

* Check README rendering and content here https://github.com/twisted/twisted/tree/12339-sponsors-documentation 
* Check documentation sponsors https://twisted--12340.org.readthedocs.build/en/12340/development/sponsorship.html
* Check documentation start page https://twisted--12340.org.readthedocs.build/en/12340/
* Check documentation dev index page https://twisted--12340.org.readthedocs.build/en/12340/development/index.html
