### PR TITLE
#5824 `trial -j auto`

### DIFF
--- a/docs/core/howto/testing.rst
+++ b/docs/core/howto/testing.rst
@@ -240,7 +240,8 @@ Some caveats apply in parallel mode:
 
 * Anything written to standard out or standard error,
   such as by the ``print()`` function,
-  is suppressed.
+  is captured in separate text files.
+  The console output is suppressed.
 * Trial's ``--debug`` flag doesn't work,
   nor does the ``breakpoint()`` built-in.
-* Parallel mode doesn't work on Windows.
+* Parallel mode doesn't work on Windows. See `GitHub Issue 10152 <https://github.com/twisted/twisted/issues/10152>`_ if you want to help with support for Windows.

--- a/docs/core/howto/testing.rst
+++ b/docs/core/howto/testing.rst
@@ -215,34 +215,32 @@ errors.  However, if called outside of a test method (for example, at module
 scope in a test module or a module imported by a test module) then it
 *will* raise an exception.
 
+Test parallelization
+~~~~~~~~~~~~~~~~~~~~
 
-
-
-
-Parallel test
-~~~~~~~~~~~~~
-
-
-
-In many situations, your unit tests may run faster if they are allowed to
-run in parallel, such that blocking I/O calls allow other tests to continue.
-Trial, like unittest, supports the -j parameter.  Run ``trial -j 3``
-to run 3 test runners at the same time.
-
-
-
+In many situations, your unit tests may run faster if they run in parallel,
+such that blocking I/O calls allow other tests to continue.
+Trial, unlike unittest, supports the ``-j`` parameter.
+Run ``trial -j 3`` to run 3 test runners at the same time,
+or ``trial -j auto`` to run a number of test runners based on the number of available CPUs.
 
 This requires care in your test creation.  Obviously, you need to ensure that
 your code is otherwise content to work in a parallel fashion while working within
 Twisted... and if you are using weird global variables in places, parallel tests
 might reveal this.
 
-
-
-
 However, if you have a test that fires up a schema on an external database
 in the ``setUp`` function, does some operations on it in the test, and
-then deletes that schema in the tearDown function, your tests will behave in an
+then deletes that schema in the ``tearDown`` function, your tests will behave in an
 unpredictable fashion as they tromp upon each other if they have their own
 schema.  And this won't actually indicate a real error in your code, merely a
 testing-specific race-condition.
+
+Some caveats apply in parallel mode:
+
+* Anything written to standard out or standard error,
+  such as by the ``print()`` function,
+  is suppressed.
+* Trial's ``--debug`` flag doesn't work,
+  nor does the ``breakpoint()`` built-in.
+* Parallel mode doesn't work on Windows.

--- a/src/twisted/trial/newsfragments/5824.feature
+++ b/src/twisted/trial/newsfragments/5824.feature
@@ -1,0 +1,1 @@
+Trial's ``-j`` flag now accepts an ``auto`` keyword to spawn a number of workers based on the available CPUs.

--- a/src/twisted/trial/test/test_script.py
+++ b/src/twisted/trial/test/test_script.py
@@ -722,6 +722,10 @@ class MakeRunnerTests(unittest.TestCase):
         self.assertEqual("Expecting integer argument to jobs, got 'nan'", str(exc))
 
     def test_jobsNonPositive(self) -> None:
+        """
+        C{parseOptions} raises a C{UsageError} when C{--jobs} is passed a non-positive
+        integer.
+        """
         exc = self.assertRaises(UsageError, self.options.parseOptions, ["--jobs", "0"])
         self.assertEqual(
             "Argument to jobs must be a strictly positive integer or 'auto'", str(exc)

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ commands =
     posix: python -c "print('Running on POSIX (no special dependencies)')"
 
     ; Run tests without wrapping them using coverage.
-    nocov: python -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reporter={env:TRIAL_REPORTER:verbose} {env:TRIAL_ARGS:-j8} {posargs:twisted}
+    nocov: python -m twisted.trial --temp-directory={envtmpdir}/_trial_temp --reporter={env:TRIAL_REPORTER:verbose} {env:TRIAL_ARGS:-jauto} {posargs:twisted}
 
     ; Run the tests wrapped using coverage.
     withcov: python {toxinidir}/admin/_copy.py {toxinidir}/admin/zz_coverage.pth {envsitepackagesdir}/zz_coverage.pth


### PR DESCRIPTION
## Scope and purpose

Add support for a ``trial -j auto`` flag that detects the number of available CPUs. As a side effect of the `os` APIs in use, on Python 3.13+ it also obeys the [`PYTHON_CPU_COUNT`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHON_CPU_COUNT) environment variable.

This was originally based on the patch attached to #5824 but I ended up basically rewriting it because now the `os` module provides a bunch of relevant functionality.

Fixes #5824.
