### PR TITLE
Switch to 'multipart' library for form data parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "hyperlink >= 17.1.1",
     "attrs >= 22.2.0",
     "typing_extensions >= 4.2.0",
+    "multipart >= 1.1.0, < 2.0",
 ]
 
 # Switch to this when the legacy optional dependency names are removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "hyperlink >= 17.1.1",
     "attrs >= 22.2.0",
     "typing_extensions >= 4.2.0",
+    "multipart >= 1.1.0, < 2.0",
 ]
 
 # Switch to this when the legacy optional dependency names are removed

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -108,9 +108,6 @@ import os
 import re
 import tempfile
 import warnings
-from collections import defaultdict
-from email import message_from_bytes
-from email.message import EmailMessage, Message
 from io import BufferedIOBase, BytesIO, TextIOWrapper
 from time import gmtime, time
 from typing import AnyStr, Callable, Protocol as TypingProtocol
@@ -122,6 +119,7 @@ from urllib.parse import (
 
 from zope.interface import Attribute, Interface, implementer, provider
 
+import multipart
 from incremental import Version
 
 from twisted.internet import address, interfaces, protocol
@@ -292,47 +290,6 @@ def _parseRequestLine(line: bytes) -> tuple[bytes, bytes, bytes]:
         raise ValueError("Invalid version")
 
     return method, request, version
-
-
-def _parseContentType(line: bytes) -> bytes:
-    """
-    Parse the Content-Type header.
-    """
-    msg = EmailMessage()
-    msg["content-type"] = line.decode("charmap")
-    key = msg.get_content_type()
-    encodedKey = key.encode("charmap")
-    return encodedKey
-
-
-class _MultiPartParseException(Exception):
-    """
-    Failed to parse the multipart/form-data payload.
-    """
-
-
-def _getMultiPartArgs(content: bytes, ctype: bytes) -> dict[bytes, list[bytes]]:
-    """
-    Parse the content of a multipart/form-data request.
-    """
-    result = defaultdict(list)
-    multiPartHeaders = b"MIME-Version: 1.0\r\n" + b"Content-Type: " + ctype + b"\r\n"
-    msg = message_from_bytes(multiPartHeaders + content)
-    if not msg.is_multipart():
-        raise _MultiPartParseException("Not a multipart.")
-
-    part: Message
-    # "per Python docs, a list of Message objects when is_multipart() is True,
-    # or a string when is_multipart() is False"
-    for part in msg.get_payload():  # type:ignore[assignment]
-        name: str | None = part.get_param(
-            "name", header="content-disposition"
-        )  # type:ignore[assignment]
-        if not name:
-            continue
-        payload: bytes = part.get_payload(decode=True)  # type:ignore[assignment]
-        result[name.encode("utf8")].append(payload)
-    return result
 
 
 def urlparse(url):
@@ -1065,8 +1022,9 @@ class Request:
             self.path, argstring = x
             self.args = parse_qs(argstring, 1)
 
-        # Argument processing
-        args = self.args
+        # Parse form requests into self.args
+        # TODO: Make parsing optional or only do that on-demand
+
         ctype = self.requestHeaders.getRawHeaders(b"Content-Type")
         if ctype is not None:
             ctype = ctype[0]
@@ -1077,21 +1035,39 @@ class Request:
             and clength
             and self._parsePOSTFormSubmission
         ):
-            mfd = b"multipart/form-data"
-            key = _parseContentType(ctype)
-            if key == b"application/x-www-form-urlencoded":
-                args.update(parse_qs(self.content.read(), 1))
-            elif key == mfd:
+            try:
+                key, opts = multipart.parse_options_header(str(ctype[0], "ASCII"))
+            except UnicodeDecodeError:
+                # Content-Type and all options must be ASCII
+                self.channel._respondToBadRequestAndDisconnect()
+                return
+
+            if key == "application/x-www-form-urlencoded":
+                self.args.update(parse_qs(self.content.read(), 1))
+                self.content.seek(0, 0)
+            elif key == "multipart/form-data" and "boundary" in opts:
                 try:
-                    self.content.seek(0)
-                    content = self.content.read()
-                    self.args.update(_getMultiPartArgs(content, ctype))
-                except _MultiPartParseException:
-                    # It was a bad request.
+                    parser = multipart.MultipartParser(
+                        stream=self.content,
+                        boundary=opts["boundary"],
+                        charset="charmap",
+                        # TODO: Make limits configurable. The default limits are
+                        # very generous to not break existing apps that rely on
+                        # large form fields.
+                        part_limit=1024,
+                        spool_limit=1024 * 1024,  # 1MB
+                        memory_limit=1024 * 1024 * 128,  # 128MB
+                    )
+                    for part in parser:
+                        # TODO: Put file uploads into a separate attribute
+                        # (e.g. self.files) and do not load them into memory.
+                        self.args.setdefault(part.name.encode("charmap"), []).append(
+                            part.raw
+                        )
+                    self.content.seek(0, 0)
+                except multipart.MultipartError:
                     self.channel._respondToBadRequestAndDisconnect()
                     return
-
-            self.content.seek(0, 0)
 
         self.process()
 

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2486,7 +2486,8 @@ abasdfg
 
     def test_multipartEmptyHeaderProcessingFailure(self):
         """
-        When the multipart does not contain a header is should be skipped
+        When a multipart segment is missing required headers, it should fail
+        the request.
         """
         processed = []
 
@@ -2508,8 +2509,7 @@ Content-Length: 14
 --AaBb1313--
 """
         channel = self.runRequest(req, MyRequest, success=False)
-        self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
-        self.assertEqual(processed[0].args, {})
+        self.assertEqual(channel.transport.value(), b"HTTP/1.1 400 Bad Request\r\n\r\n")
 
     def test_multipartFormData(self):
         """

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2487,7 +2487,8 @@ abasdfg
 
     def test_multipartEmptyHeaderProcessingFailure(self):
         """
-        When the multipart does not contain a header is should be skipped
+        When a multipart segment is missing required headers, it should fail
+        the request.
         """
         processed = []
 
@@ -2509,8 +2510,7 @@ Content-Length: 14
 --AaBb1313--
 """
         channel = self.runRequest(req, MyRequest, success=False)
-        self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
-        self.assertEqual(processed[0].args, {})
+        self.assertEqual(channel.transport.value(), b"HTTP/1.1 400 Bad Request\r\n\r\n")
 
     def test_multipartFormData(self):
         """


### PR DESCRIPTION
## Scope and purpose

I do not propose to merge this directly, but start a discussion on whether it would be a good idea to switch to a more specialized parser for `multipart/form-data`. This is just a proof of concept, a starting point.

### Why bother?
The `email` parser is not designed for form submissions by modern browsers. RFC 7578 is way more restrictive than the dozens of RFCs and workarounds a proper email parser has to support. As a result, `email` parsing is very slow compared to a specialized form parser. It also lacks certain safeguards (disk or memory limits) as it is designed to deal with emails that fit comfortably into memory. The `multipart.MultipartParser` parser is significantly faster, less complex, can deal with large file uploads and enforce disk or memory limits to prevent a bunch of issues.

### Drawbacks?
It adds another external dependency and enabling those safeguards by default may break existing applications. The more strict parser also behaves differently and may reject requests from broken clients that the legacy `cgi` or `email` parsers would happily accept. The most important difference is that `multipart` rejects inputs with invalid line breaks (`\n` or `\r` instead of `\r\n`). Those single-byte variants were never correct, not even for emails, but early email clients and servers were so broken that email parsers had to support it. We are not dealing with legacy email, though. Modern browsers and other HTTP clients should never emit broken multipart, and if they do, they should be served a 400 error.

### Wouldn't that break existing legacy stuff?
Yes, to some degree. Safeguards, strict parsing and reasonable default limits are a good idea, but they should be configurable and not break backwards compatibility too much. It may take some releases to implement *proper* form data handling by default and maybe fix some old API design mistakes in the progress. But we have to start somewhere, and switching just the parser while keeping the API contracts intact would be good start.

So, what do you think?