### PR TITLE
Convert some async TestCase code to coroutines 

### DIFF
--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -162,7 +162,10 @@ class TestCase(SynchronousTestCase):
                         self._testMethodName,
                         result
                     )
-                    self._cbDeferTestMethod(None, result)
+                    if self.getTodo() is not None:
+                        result.addUnexpectedSuccess(self, self.getTodo())
+                    else:
+                        self._passed = True
                 except BaseException as e:
                     self._ebDeferTestMethod(failure.Failure(e), result)
                     raise
@@ -170,13 +173,6 @@ class TestCase(SynchronousTestCase):
                 await self._deferRunCleanups(None, result)
         finally:
             await self._deferTearDown(None, result)
-
-    def _cbDeferTestMethod(self, ignored, result):
-        if self.getTodo() is not None:
-            result.addUnexpectedSuccess(self, self.getTodo())
-        else:
-            self._passed = True
-        return ignored
 
     def _ebDeferTestMethod(self, f, result):
         todo = self.getTodo()

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -138,18 +138,18 @@ class TestCase(SynchronousTestCase):
         try:
             await self._run(self.setUp, "setUp", result)
         except BaseException as e:  # May be KeyboardInterrupt
-            await self._ebDeferSetUp(failure.Failure(e), result)
+            await self._ebDeferSetUp(e, result)
             return
         await self._deferTestMethod(None, result)
 
-    def _ebDeferSetUp(self, failure, result):
-        if failure.check(SkipTest):
-            result.addSkip(self, self._getSkipReason(self.setUp, failure.value))
+    async def _ebDeferSetUp(self, e, result):
+        if isinstance(e, SkipTest):
+            result.addSkip(self, self._getSkipReason(self.setUp, e))
         else:
-            result.addError(self, failure)
-            if failure.check(KeyboardInterrupt):
+            result.addError(self, failure.Failure(e))
+            if isinstance(e, KeyboardInterrupt):
                 result.stop()
-        return self._deferRunCleanups(None, result)
+        await self._deferRunCleanups(None, result)
 
     def _deferTestMethod(self, ignored, result):
         d = self._run(getattr(self, self._testMethodName), self._testMethodName, result)

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -172,7 +172,7 @@ class TestCase(SynchronousTestCase):
             finally:
                 await self._deferRunCleanups(None, result)
         finally:
-            await self._deferTearDown(None, result)
+            await self._deferTearDown(result)
 
     def _ebDeferTestMethod(self, f, result):
         todo = self.getTodo()
@@ -190,10 +190,11 @@ class TestCase(SynchronousTestCase):
         else:
             result.addError(self, f)
 
-    def _deferTearDown(self, ignored, result):
-        d = self._run(self.tearDown, "tearDown", result)
-        d.addErrback(self._ebDeferTearDown, result)
-        return d
+    async def _deferTearDown(self, result):
+        try:
+            await self._run(self.tearDown, "tearDown", result)
+        except BaseException as e:
+            self._ebDeferTearDown(failure.Failure(e), result)
 
     def _ebDeferTearDown(self, failure, result):
         result.addError(self, failure)

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -143,7 +143,7 @@ class TestCase(SynchronousTestCase):
             try:
                 await self._deferSetUpAndRun(result)
             finally:
-                await self._deferRunCleanups(None, result)
+                await self._deferRunCleanups(result)
         finally:
             if self._twistedPrivateNeedsTearDown:
                 await self._deferTearDown(result)
@@ -207,7 +207,7 @@ class TestCase(SynchronousTestCase):
             self._passed = False
 
     @defer.inlineCallbacks
-    def _deferRunCleanups(self, ignored, result):
+    def _deferRunCleanups(self, result):
         """
         Run any scheduled cleanups and report errors (if any) to the result.
         object.

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -193,14 +193,13 @@ class TestCase(SynchronousTestCase):
     async def _deferTearDown(self, result):
         try:
             await self._run(self.tearDown, "tearDown", result)
-        except BaseException as e:
-            self._ebDeferTearDown(failure.Failure(e), result)
-
-    def _ebDeferTearDown(self, failure, result):
-        result.addError(self, failure)
-        if failure.check(KeyboardInterrupt):
+        except KeyboardInterrupt as e:
+            result.addError(self, failure.Failure(e))
             result.stop()
-        self._passed = False
+            self._passed = False
+        except BaseException as e:
+            result.addError(self, failure.Failure(e))
+            self._passed = False
 
     @defer.inlineCallbacks
     def _deferRunCleanups(self, ignored, result):

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -151,9 +151,6 @@ class TestCase(SynchronousTestCase):
             await self._deferRunCleanups(None, result)
             return
 
-        await self._deferTestMethod(result)
-
-    async def _deferTestMethod(self, result):
         try:
             try:
                 try:

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -535,29 +535,37 @@ class Reporter(TestResult):
 
         When a C{SynchronousTestCase} method fails synchronously, the stack
         looks like this:
-         - [0]: C{SynchronousTestCase._run}
+         - [0]: C{TestCase._run}
          - [1]: C{util.runWithWarningsSuppressed}
          - [2:-2]: code in the test method which failed
          - [-1]: C{_synctest.fail}
 
         When a C{TestCase} method fails synchronously, the stack looks like
         this:
-         - [0]: C{defer.maybeDeferred}
-         - [1]: C{utils.runWithWarningsSuppressed}
-         - [2]: C{utils.runWithWarningsSuppressed}
-         - [3:-2]: code in the test method which failed
+         - [0]: C{TestCase._deferTestMethod}
+         - [1]: C{defer.__iter__}
+         - [2]: C{defer.raiseException}
+         - [3]: C{defer.maybeDeferred}
+         - [4]: C{utils.runWithWarningsSuppressed}
+         - [5]: C{utils.runWithWarningsSuppressed}
+         - [6:-2]: code in the test method which failed
          - [-1]: C{_synctest.fail}
 
         When a method fails inside a C{Deferred} (i.e., when the test method
         returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
         captured inside the resulting C{Failure} looks like this:
-         - [0]: C{defer.Deferred._runCallbacks}
-         - [1:-2]: code in the testmethod which failed
+
+         - [0]: C{TestCase._deferTestMethod}
+         - [1]: C{defer.__iter__}
+         - [2]: C{defer.Deferred._runCallbacks}
+         - [3:-2]: code in the testmethod which failed
          - [-1]: C{_synctest.fail}
 
-        As a result, we want to trim either [maybeDeferred, runWWS, runWWS] or
-        [Deferred._runCallbacks] or [SynchronousTestCase._run, runWWS] from the
-        front, and trim the [unittest.fail] from the end.
+        As a result, we want to trim either
+        [deferTestMethod, __iter__, raiseException, maybeDeferred, runWWS, runWWS] or
+        [defer.deferTestMethod, __iter__, Deferred._runCallbacks] or
+        [SynchronousTestCase._run, runWWS] from the front, and trim the [unittest.fail]
+        from the end.
 
         There is also another case, when the test method is badly defined and
         contains extra arguments.
@@ -571,19 +579,25 @@ class Reporter(TestResult):
         """
         newFrames = list(frames)
 
-        if len(frames) < 2:
+        if len(frames) < 3:
             return newFrames
 
-        firstMethod = newFrames[0][0]
-        firstFile = os.path.splitext(os.path.basename(newFrames[0][1]))[0]
+        frames = [
+            (frame[0], os.path.splitext(os.path.basename(frame[1]))[0])
+            for frame in newFrames[:3]
+        ]
 
-        secondMethod = newFrames[1][0]
-        secondFile = os.path.splitext(os.path.basename(newFrames[1][1]))[0]
-
-        syncCase = (("_run", "_synctest"), ("runWithWarningsSuppressed", "util"))
-        asyncCase = (("maybeDeferred", "defer"), ("runWithWarningsSuppressed", "utils"))
-
-        twoFrames = ((firstMethod, firstFile), (secondMethod, secondFile))
+        syncCase = [("_run", "_synctest"), ("runWithWarningsSuppressed", "util")]
+        asyncCase = [
+            ("_deferTestMethod", "_asynctest"),
+            ("__iter__", "defer"),
+            ("raiseException", "failure"),
+        ]
+        deferCase = [
+            ("_deferTestMethod", "_asynctest"),
+            ("__iter__", "defer"),
+            ("_runCallbacks", "defer"),
+        ]
 
         # On PY3, we have an extra frame which is reraising the exception
         for frame in newFrames:
@@ -592,12 +606,12 @@ class Reporter(TestResult):
                 # If it's in the compat module and is reraise, BLAM IT
                 newFrames.pop(newFrames.index(frame))
 
-        if twoFrames == syncCase:
+        if frames[:2] == syncCase:
             newFrames = newFrames[2:]
-        elif twoFrames == asyncCase:
+        elif frames[:3] == asyncCase:
+            newFrames = newFrames[6:]
+        elif frames[:3] == deferCase:
             newFrames = newFrames[3:]
-        elif (firstMethod, firstFile) == ("_runCallbacks", "defer"):
-            newFrames = newFrames[1:]
 
         if not newFrames:
             # The method fails before getting called, probably an argument

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -542,7 +542,7 @@ class Reporter(TestResult):
 
         When a C{TestCase} method fails synchronously, the stack looks like
         this:
-         - [0]: C{TestCase._deferTestMethod}
+         - [0]: C{TestCase._deferSetUp}
          - [1]: C{defer.__iter__}
          - [2]: C{defer.raiseException}
          - [3]: C{defer.maybeDeferred}
@@ -555,7 +555,7 @@ class Reporter(TestResult):
         returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
         captured inside the resulting C{Failure} looks like this:
 
-         - [0]: C{TestCase._deferTestMethod}
+         - [0]: C{TestCase._deferSetUp}
          - [1]: C{defer.__iter__}
          - [2]: C{defer.Deferred._runCallbacks}
          - [3:-2]: code in the testmethod which failed
@@ -589,12 +589,12 @@ class Reporter(TestResult):
 
         syncCase = [("_run", "_synctest"), ("runWithWarningsSuppressed", "util")]
         asyncCase = [
-            ("_deferTestMethod", "_asynctest"),
+            ("_deferSetUp", "_asynctest"),
             ("__iter__", "defer"),
             ("raiseException", "failure"),
         ]
         deferCase = [
-            ("_deferTestMethod", "_asynctest"),
+            ("_deferSetUp", "_asynctest"),
             ("__iter__", "defer"),
             ("_runCallbacks", "defer"),
         ]

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -542,7 +542,7 @@ class Reporter(TestResult):
 
         When a C{TestCase} method fails synchronously, the stack looks like
         this:
-         - [0]: C{TestCase._deferSetUp}
+         - [0]: C{TestCase._deferSetUpAndRun}
          - [1]: C{defer.__iter__}
          - [2]: C{defer.raiseException}
          - [3]: C{defer.maybeDeferred}
@@ -555,7 +555,7 @@ class Reporter(TestResult):
         returns a C{Deferred}, and that C{Deferred}'s errback fires), the stack
         captured inside the resulting C{Failure} looks like this:
 
-         - [0]: C{TestCase._deferSetUp}
+         - [0]: C{defer._deferSetUpAndRun}
          - [1]: C{defer.__iter__}
          - [2]: C{defer.Deferred._runCallbacks}
          - [3:-2]: code in the testmethod which failed
@@ -589,12 +589,12 @@ class Reporter(TestResult):
 
         syncCase = [("_run", "_synctest"), ("runWithWarningsSuppressed", "util")]
         asyncCase = [
-            ("_deferSetUp", "_asynctest"),
+            ("_deferSetUpAndRun", "_asynctest"),
             ("__iter__", "defer"),
             ("raiseException", "failure"),
         ]
         deferCase = [
-            ("_deferSetUp", "_asynctest"),
+            ("_deferSetUpAndRun", "_asynctest"),
             ("__iter__", "defer"),
             ("_runCallbacks", "defer"),
         ]


### PR DESCRIPTION
This PR cleans up some asynchronous TestCase code. Previous code was relatively hard to follow due to it relying on callbacks based implementation, which forced the logic to be split across many small functions. The new code puts everything into regular code flow across several functions and uses standard `try...except` and `try...finally` for error handling.

The code would be even simplier if `IReporter.addError` supported regular exceptions, but this is for a future.

The PR has been split across many small commits so that it is possible to bisect the changes in the future if there are any bugs that may be caused by this PR. Also, review should be easier, as the changes in isolation are almost trivial.