### PR TITLE
#12377 Remove 403-ing Twitter URL.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ Documentation = "https://docs.twisted.org/"
 Homepage = "https://twisted.org/"
 Issues = "https://github.com/twisted/twisted/issues"
 Source = "https://github.com/twisted/twisted"
-Twitter = "https://twitter.com/twistedmatrix"
 Funding-PSF = "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=44"
 Funding-GitHub = "https://github.com/sponsors/twisted"
 

--- a/src/twisted/newsfragments/12377.misc
+++ b/src/twisted/newsfragments/12377.misc
@@ -1,0 +1,1 @@
+Remove twitter URL from package metadata.


### PR DESCRIPTION
## Scope and purpose

Fixes #12377 

The twitter URL is 403-ing, I've removed it from the metadata

We could add a mastodon account?

Looks like it needs removing from https://twisted.org/ also


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
