### PR TITLE
#11869 Configure PyPi trusted publishing.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -484,7 +484,8 @@ jobs:
       run: |
         tox -e narrativedocs
 
-  # Used for various release automation, but not publishing
+  # Used for various release automation, but not for publishing, as publishing needs extra permissions for the API token.
+  # So we isolate the actual publish step in a separate job.
   # This is also executed for each PR to exercise the release as much
   # as possible and reduce the possibility of finding bugs in the release
   # process late in the release cycle,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -548,7 +548,7 @@ jobs:
     if: always()
     steps:
       - name: fail if release-publish failed
-        if: ${{ contains(fromJSON('["success", "skipped"]'), needs.release-publish.result) }}
+        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.release-publish.result) }}
         run: exit 1
 
   # We have this job so that the PR can be blocked on a single job.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -493,7 +493,6 @@ jobs:
     name: Build and check release, then upload artifact
     runs-on: 'ubuntu-22.04'
     steps:
-
     - uses: actions/checkout@v4
 
     - name: Set up Python
@@ -535,7 +534,6 @@ jobs:
     name: publish on twisted-* tag
     runs-on: ubuntu-latest
     steps:
-
     - uses: actions/download-artifact@v4
       with:
         name: dist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -550,7 +550,7 @@ jobs:
     if: always()
     steps:
       - name: fail if release-publish failed
-        if: ${{ contains(['success', 'skipped'], needs.release-publish.result) }}
+        if: ${{ contains(fromJSON('["success", "skipped"]'), needs.release-publish.result) }}
         run: exit 1
 
   # We have this job so that the PR can be blocked on a single job.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -490,7 +490,7 @@ jobs:
   # process late in the release cycle,
   # The files are published only when a tag is created using the next job, release-publish
   release-build:
-      name: Build and check release, then upload artifact
+    name: Build and check release, then upload artifact
     runs-on: 'ubuntu-22.04'
     steps:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -550,7 +550,7 @@ jobs:
     if: always()
     steps:
       - name: fail if release-publish failed
-        if: ${{ needs.release-publish.result != 'success' }}
+        if: ${{ contains(['success', 'skipped'], needs.release-publish.result) }}
         run: exit 1
 
   # We have this job so that the PR can be blocked on a single job.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -484,16 +484,10 @@ jobs:
       run: |
         tox -e narrativedocs
 
-
-  # Used for various release automation.
-  # This is also executed for each PR to exercise the release as much
-  # as possible and reduce the possibility of finding bugs in the release
-  # process late in the release cycle,
-  # The files are published only when a tag is created.
-  release-publish:
-    name: Check release and publish on twisted-* tag
+  release-build:
     runs-on: 'ubuntu-22.04'
     steps:
+
     - uses: actions/checkout@v4
 
     - name: Set up Python
@@ -513,16 +507,45 @@ jobs:
       run: |
         ls -R dist/
 
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist
+
     - name: Check matched tag version and branch version - on tag
       if: startsWith(github.ref, 'refs/tags/twisted-')
       run: python admin/check_tag_version_match.py "${{ github.ref }}"
 
-    - name: Publish to PyPI - on tag
-      if: startsWith(github.ref, 'refs/tags/twisted-')
-      uses: pypa/gh-action-pypi-publish@v1.5.1
-      with:
-        password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+  # Used for various release automation.
+  # This is also executed for each PR to exercise the release as much
+  # as possible and reduce the possibility of finding bugs in the release
+  # process late in the release cycle,
+  # The files are published only when a tag is created.
+  release-publish:
+    needs:
+      release-build
+    if: startsWith(github.ref, 'refs/tags/twisted-')
+    environment:
+      release
+    name: publish on twisted-* tag
+    runs-on: ubuntu-latest
+    steps:
 
+    - uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+
+    - name: Publish to PyPI - on tag
+      uses: pypa/gh-action-pypi-publish@v1.12.2
+
+  release-publish-success:
+    needs: release-publish
+    if: always()
+    steps:
+      - name: fail if release-publish failed
+        if: ${{ needs.release-publish.result != 'success' }}
+        run: exit 1
 
   # We have this job so that the PR can be blocked on a single job.
   # In this way, each time a job is modified,
@@ -541,16 +564,12 @@ jobs:
       - narrativedocs
       - apidocs
       - static-checks
-      - release-publish
+      - release-build
+      - release-publish-success
       - coverage-report
     steps:
-      - name: Require all successes
-        shell: python
-        env:
-          RESULTS: ${{ toJSON(needs.*.result) }}
-        run: |
-          import json
-          import os
-          import sys
-          results = json.loads(os.environ["RESULTS"])
-          sys.exit(0 if all(result == "success" for result in results) else 1)
+      - v1.2.2
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -484,7 +484,13 @@ jobs:
       run: |
         tox -e narrativedocs
 
+  # Used for various release automation, but not publishing
+  # This is also executed for each PR to exercise the release as much
+  # as possible and reduce the possibility of finding bugs in the release
+  # process late in the release cycle,
+  # The files are published only when a tag is created using the next job, release-publish
   release-build:
+      name: Build and check release, then upload artifact
     runs-on: 'ubuntu-22.04'
     steps:
 
@@ -516,11 +522,10 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/twisted-')
       run: python admin/check_tag_version_match.py "${{ github.ref }}"
 
-  # Used for various release automation.
-  # This is also executed for each PR to exercise the release as much
+  # Used exclusively for various release publishing.
+  # This is only executed on tags, but just does the publish to exercise the release as much
   # as possible and reduce the possibility of finding bugs in the release
   # process late in the release cycle,
-  # The files are published only when a tag is created.
   release-publish:
     needs:
       release-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -546,6 +546,7 @@ jobs:
 
   release-publish-success:
     needs: release-publish
+    runs-on: ubuntu-latest
     if: always()
     steps:
       - name: fail if release-publish failed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -545,7 +545,7 @@ jobs:
     - name: Publish to PyPI - on tag
       uses: pypa/gh-action-pypi-publish@v1.12.2
 
-  release-publish-success:
+  release-publish-success-or-skipped:
     needs: release-publish
     runs-on: ubuntu-latest
     if: always()
@@ -572,7 +572,7 @@ jobs:
       - apidocs
       - static-checks
       - release-build
-      - release-publish-success
+      - release-publish-success-or-skipped
       - coverage-report
     steps:
       - name: Require all successes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -531,6 +531,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/twisted-')
     environment:
       release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     name: publish on twisted-* tag
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -573,8 +573,13 @@ jobs:
       - release-publish-success
       - coverage-report
     steps:
-      - v1.2.2
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.2.2
-        with:
-          jobs: ${{ toJSON(needs) }}
+      - name: Require all successes
+        shell: python
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -522,10 +522,11 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/twisted-')
       run: python admin/check_tag_version_match.py "${{ github.ref }}"
 
-  # Used exclusively for various release publishing.
-  # This is only executed on tags, but just does the publish to exercise the release as much
-  # as possible and reduce the possibility of finding bugs in the release
-  # process late in the release cycle,
+  # Used exclusively for PyPi release publishing.
+  # This is only executed on tags and only does the publishing.
+  # The actual build is done by `release-build` job,
+  # which is executed for each PR to help detect release
+  # defects during the normal development cycle.
   release-publish:
     needs:
       release-build
@@ -546,14 +547,6 @@ jobs:
     - name: Publish to PyPI - on tag
       uses: pypa/gh-action-pypi-publish@v1.12.2
 
-  release-publish-success-or-skipped:
-    needs: release-publish
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: fail if release-publish failed
-        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.release-publish.result) }}
-        run: exit 1
 
   # We have this job so that the PR can be blocked on a single job.
   # In this way, each time a job is modified,
@@ -573,7 +566,6 @@ jobs:
       - apidocs
       - static-checks
       - release-build
-      - release-publish-success-or-skipped
       - coverage-report
     steps:
       - name: Require all successes

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -137,7 +137,7 @@ Prepare the branch
 #. Use ``Twisted VERSION`` as the name of the release, for example ``Twisted 24.2.0rc1``.
 #. Add the release NEWS to GitHub Release page.
 #. Make sure 'This is a pre-release` is checked.
-#. Github Actions will upload the dist to PyPI when a new tag is pushed to the repo.
+#. Github Actions will upload the dist to PyPI when a new tag is pushed to the repo, using the 'release' environment.
 #. You can check the status of the automatic upload via `GitHub Action <https://github.com/twisted/twisted/actions/workflows/test.yaml?query=event%3Apush>`_
 #. Read the Docs hooks not have version for the release candidate.
    Use the Read the Docs published for the pull request.
@@ -314,3 +314,15 @@ We don't do maintenance / patch releases, including for security issues, due to 
 We just do a normal release using the calendar base versioning scheme.
 
 We welcome additional volunteers to help drive the release effort.
+
+
+Notes
+-----
+
+The release process uses a GitHub Actions environment, configured here: 
+https://github.com/twisted/twisted/settings/environments/4731362866/edit
+currently only tags of the form 'twisted-*' can use that environment
+and only CI runs in that environment can release to PyPI.
+
+In the future it could be possible to add collaborators who can, for example,
+approve PRs but not create releases; or ensure releases are always reviewed.

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -137,7 +137,8 @@ Prepare the branch
 #. Use ``Twisted VERSION`` as the name of the release, for example ``Twisted 24.2.0rc1``.
 #. Add the release NEWS to GitHub Release page.
 #. Make sure 'This is a pre-release` is checked.
-#. Github Actions will upload the dist to PyPI when a new tag is pushed to the repo, using the 'release' environment.
+#. Github Actions will upload the dist to PyPI when a new tag is pushed to the repo, using the GitHub 'release' environment.
+#. In PyPI the GitHub Actions `test.yaml` workflow is configure to allow publishing new PyPI releases.
 #. You can check the status of the automatic upload via `GitHub Action <https://github.com/twisted/twisted/actions/workflows/test.yaml?query=event%3Apush>`_
 #. Read the Docs hooks not have version for the release candidate.
    Use the Read the Docs published for the pull request.
@@ -316,8 +317,8 @@ We just do a normal release using the calendar base versioning scheme.
 We welcome additional volunteers to help drive the release effort.
 
 
-Notes
------
+Secirity notes
+--------------
 
 The release process uses a GitHub Actions environment, configured here:
 https://github.com/twisted/twisted/settings/environments/4731362866/edit

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -319,7 +319,7 @@ We welcome additional volunteers to help drive the release effort.
 Notes
 -----
 
-The release process uses a GitHub Actions environment, configured here: 
+The release process uses a GitHub Actions environment, configured here:
 https://github.com/twisted/twisted/settings/environments/4731362866/edit
 currently only tags of the form 'twisted-*' can use that environment
 and only CI runs in that environment can release to PyPI.

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -320,10 +320,10 @@ We welcome additional volunteers to help drive the release effort.
 Secirity notes
 --------------
 
-The release process uses a GitHub Actions environment, configured here:
-https://github.com/twisted/twisted/settings/environments/4731362866/edit
-currently only tags of the form 'twisted-*' can use that environment
-and only CI runs in that environment can release to PyPI.
+The release process uses a GitHub Actions environment, configured `here
+<https://github.com/twisted/twisted/settings/environments/4731362866/edit>`_.
+Currently only branches and tags of the form `twisted-*` can use the `release` environment.
+Only jobs from `.github/workflows/test.yaml` that are executed in the `release` environment can release to PyPI.
 
 In the future it could be possible to add collaborators who can, for example,
 approve PRs but not create releases; or ensure releases are always reviewed.

--- a/src/twisted/newsfragments/11869.misc
+++ b/src/twisted/newsfragments/11869.misc
@@ -1,0 +1,1 @@
+Configure trusted publishing.


### PR DESCRIPTION
## Scope and purpose

Fixes #11869

This splits the package build and publish steps, moves the publish steps into a GHA environment that only allows running on tags

We should add tag protection rules

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
