### PR TITLE
Update pydoctor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
 # release scripts and process.
 dev-release = [
     "towncrier ~= 23.6",
-    "pydoctor >= 24.11.0",
+    "pydoctor ~= 24.11.1",
     "sphinx-rtd-theme ~= 1.3",
     "sphinx >= 6, <7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
 # release scripts and process.
 dev-release = [
     "towncrier ~= 23.6",
-    "pydoctor ~= 23.9.0",
+    "pydoctor >= 24.11.0",
     "sphinx-rtd-theme ~= 1.3",
     "sphinx >= 6, <7",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ quiet=1
 warnings-as-errors=true
 project-name=Twisted
 project-url=https://twisted.org/
+html-base-url=https://docs.twisted.org/en/stable/api/
 docformat=epytext
 theme=readthedocs
 privacy=
@@ -106,8 +107,7 @@ intersphinx=
 ; These options are used as default for the tox and direct command line usage.
 ; They are designed to help with documentation development.
 ; For documentation publishing, they need to be overriden in sphinx's conf.py
-; No custom `--template-dir` is use here.
-; We do have a custom template for final documentation publishing.
 project-base-dir=src/twisted
 html-output=docs/_build/api
 html-viewsource-base=https://github.com/twisted/twisted/tree/trunk/src
+template-dir=src/twisted/python/_pydoctortemplates

--- a/src/twisted/newsfragments/12384.misc
+++ b/src/twisted/newsfragments/12384.misc
@@ -1,0 +1,4 @@
+Update pydoctor API documentation generator to 24.11.1.
+Fix "Go to the latest version of this document." links.
+The API documentation pages now includes a <link rel="canonical"> element that points to the stable version.
+Remove google analytics from the API docs.

--- a/src/twisted/python/_pydoctortemplates/stable-link.js
+++ b/src/twisted/python/_pydoctortemplates/stable-link.js
@@ -1,14 +1,18 @@
 // If the documentation isn't stable or latest, insert a stable link
+const HTML_BASE_URL = "https://docs.twisted.org/en/stable/api/";
+
 if ((window.location.pathname.indexOf('/stable/') == -1) && (window.location.pathname.indexOf('/latest/') == -1)) {
     // Give the user a link to this page, but in the stable version of the docs.
     var link = document.getElementById('current-docs-link');
-    var href = window.location.pathname.replace(/\/\d+\.\d+\.\d+\/api\//, '/stable/api/');
+    var url = window.location.pathname;
+    var filename = url.substring(url.lastIndexOf('/')+1);
     // And make it visible
-    if (href.toString() != window.location.pathname.toString()){
-        var container = document.getElementById('current-docs-container');
-        container.style.display = "";
-        link.href = href;
-        delete link;
-        delete container;
-    }
+    var container = document.getElementById('current-docs-container');
+    container.style.display = "block";
+    link.href = HTML_BASE_URL + filename;
+    delete link;
+    delete container;
+    delete url;
+    delete filename;
+    
 }

--- a/src/twisted/python/_pydoctortemplates/stable-link.js
+++ b/src/twisted/python/_pydoctortemplates/stable-link.js
@@ -1,0 +1,14 @@
+// If the documentation isn't stable or latest, insert a stable link
+if ((window.location.pathname.indexOf('/stable/') == -1) && (window.location.pathname.indexOf('/latest/') == -1)) {
+    // Give the user a link to this page, but in the stable version of the docs.
+    var link = document.getElementById('current-docs-link');
+    var href = window.location.pathname.replace(/\/\d+\.\d+\.\d+\/api\//, '/stable/api/');
+    // And make it visible
+    if (href.toString() != window.location.pathname.toString()){
+        var container = document.getElementById('current-docs-container');
+        container.style.display = "";
+        link.href = href;
+        delete link;
+        delete container;
+    }
+}

--- a/src/twisted/python/_pydoctortemplates/subheader.html
+++ b/src/twisted/python/_pydoctortemplates/subheader.html
@@ -5,25 +5,5 @@
     </a>
   </div>
 
-  <!-- Google analytics, obviously. -->
-  <script src="//www.google-analytics.com/urchin.js" type="text/javascript"></script>
-  <script type="text/javascript">
-    _uacct = "UA-99018-6";
-    urchinTracker();
-  </script>
-
-  <!-- If the documentation isn't current, insert a current link. -->
-  <script type="text/javascript">
-    if (window.location.pathname.indexOf('/current/') == -1) {
-      <!-- Give the user a link to this page, but in the current version of the docs. -->
-      var link = document.getElementById('current-docs-link');
-      link.href = window.location.pathname.replace(/\/\d+\.\d+\.\d+\/api\//, '/current/api/');
-      <!-- And make it visible -->
-      var container = document.getElementById('current-docs-container');
-      container.style.display = "";
-      delete link;
-      delete container;
-    }
-  </script>
-  
+  <script src="stable-link.js" type="text/javascript"></script>
 </div>


### PR DESCRIPTION
## Scope and purpose

- Update pydoctor to at least 24.11.0. 
- Fixes the "Go to the latest version of this document." links. 
- Use the new pydoctor option --html-base-url. 
- Remove google analytics from the API docs.
