### PR TITLE
#12385 Expose t.i.endpoints._parse as parseDescription

### DIFF
--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -1693,7 +1693,7 @@ def _tokenize(description):
     yield _STRING, current
 
 
-def _parse(description):
+def parseDescription(description):
     """
     Convert a description string into a list of positional and keyword
     parameters, using logic vaguely like what Python does.
@@ -1704,7 +1704,7 @@ def _parse(description):
     @return: a 2-tuple of C{(args, kwargs)}, where 'args' is a list of all
         ':'-separated C{str}s not containing an '=' and 'kwargs' is a map of
         all C{str}s which do contain an '='.  For example, the result of
-        C{_parse('a:b:d=1:c')} would be C{(['a', 'b', 'c'], {'d': '1'})}.
+        C{parseDescription('a:b:d=1:c')} would be C{(['a', 'b', 'c'], {'d': '1'})}.
     """
     args, kw = [], {}
     colon = _matchingString(":", description)
@@ -1755,7 +1755,7 @@ def _parseServer(description, factory):
 
     @return: a 3-tuple of (plugin or name, arguments, keyword arguments)
     """
-    args, kw = _parse(description)
+    args, kw = parseDescription(description)
     endpointType = args[0]
     parser = _serverParsers.get(endpointType)
     if parser is None:
@@ -2168,7 +2168,7 @@ def clientFromString(reactor, description):
 
     @since: 10.2
     """
-    args, kwargs = _parse(description)
+    args, kwargs = parseDescription(description)
     aname = args.pop(0)
     name = aname.upper()
     if name not in _clientParsers:

--- a/src/twisted/newsfragments/12385.feature
+++ b/src/twisted/newsfragments/12385.feature
@@ -1,0 +1,1 @@
+Expose twisted.interned.endpoints.parseDescription to extract details from endpoint description string.

--- a/src/twisted/protocols/haproxy/test/test_parser.py
+++ b/src/twisted/protocols/haproxy/test/test_parser.py
@@ -10,8 +10,8 @@ from twisted.internet.endpoints import (
     TCP4ServerEndpoint,
     TCP6ServerEndpoint,
     UNIXServerEndpoint,
-    _parse as parseEndpoint,
     _WrapperServerEndpoint,
+    parseDescription,
     serverFromString,
 )
 from twisted.internet.testing import MemoryReactor
@@ -36,7 +36,7 @@ class UnparseEndpointTests(TestCase):
             order.)
         @type input: native L{str}
         """
-        self.assertEqual(unparseEndpoint(*parseEndpoint(input)), input)
+        self.assertEqual(unparseEndpoint(*parseDescription(input)), input)
 
     def test_basicUnparse(self) -> None:
         """

--- a/src/twisted/words/protocols/jabber/jstrports.py
+++ b/src/twisted/words/protocols/jabber/jstrports.py
@@ -7,7 +7,7 @@
 sufficient use cases get identified """
 
 
-from twisted.internet.endpoints import _parse
+from twisted.internet.endpoints import parseDescription
 
 
 def _parseTCPSSL(factory, domain, port):
@@ -23,7 +23,7 @@ _funcs = {"tcp": _parseTCPSSL, "unix": _parseUNIX, "ssl": _parseTCPSSL}
 
 
 def parse(description, factory):
-    args, kw = _parse(description)
+    args, kw = parseDescription(description)
     return (args[0].upper(),) + _funcs[args[0]](factory, *args[1:], **kw)
 
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12385

