### PR TITLE
#12390 Add support for timeouts for functions added via addCleanup

### DIFF
--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -209,7 +209,11 @@ class TestCase(SynchronousTestCase):
         while len(self._cleanups) > 0:
             func, args, kwargs = self._cleanups.pop()
             try:
-                yield func(*args, **kwargs)
+                yield self._run(
+                    lambda: func(*args, **kwargs),
+                    f"cleanup function {func.__name__}",
+                    result,
+                )
             except Exception:
                 failures.append(failure.Failure())
 
@@ -313,6 +317,9 @@ class TestCase(SynchronousTestCase):
 
         If the function C{f} returns a Deferred, C{TestCase} will wait until the
         Deferred has fired before proceeding to the next function.
+
+        If the function takes more than C{timeout} settings, then the test will
+        raise an error.
         """
         return super().addCleanup(f, *args, **kwargs)
 

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -83,7 +83,7 @@ class TestCase(SynchronousTestCase):
 
     failUnlessFailure = assertFailure
 
-    def _run(self, methodName, result):
+    def _run(self, method, methodName, result):
         from twisted.internet import reactor
 
         timeout = self.getTimeout()
@@ -113,7 +113,6 @@ class TestCase(SynchronousTestCase):
         onTimeout = utils.suppressWarnings(
             onTimeout, util.suppress(category=DeprecationWarning)
         )
-        method = getattr(self, methodName)
         if inspect.isgeneratorfunction(method):
             exc = TypeError(
                 "{!r} is a generator function and therefore will never run".format(
@@ -132,7 +131,7 @@ class TestCase(SynchronousTestCase):
         return self.run(*args, **kwargs)
 
     def deferSetUp(self, ignored, result):
-        d = self._run("setUp", result)
+        d = self._run(self.setUp, "setUp", result)
         d.addCallbacks(
             self.deferTestMethod,
             self._ebDeferSetUp,
@@ -151,7 +150,7 @@ class TestCase(SynchronousTestCase):
         return self.deferRunCleanups(None, result)
 
     def deferTestMethod(self, ignored, result):
-        d = self._run(self._testMethodName, result)
+        d = self._run(getattr(self, self._testMethodName), self._testMethodName, result)
         d.addCallbacks(
             self._cbDeferTestMethod,
             self._ebDeferTestMethod,
@@ -186,7 +185,7 @@ class TestCase(SynchronousTestCase):
             result.addError(self, f)
 
     def deferTearDown(self, ignored, result):
-        d = self._run("tearDown", result)
+        d = self._run(self.tearDown, "tearDown", result)
         d.addErrback(self._ebDeferTearDown, result)
         return d
 

--- a/src/twisted/trial/newsfragments/12390.bugfix
+++ b/src/twisted/trial/newsfragments/12390.bugfix
@@ -1,0 +1,1 @@
+twisted.trial.unittest.TestCase.addCleanup will cause the test to fail if the returned deferred is not resolved before the test's timeout.

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -186,6 +186,34 @@ class TimeoutTests(unittest.TestCase):
 
     test_timeoutZero.timeout = 0  # type: ignore[attr-defined]
 
+    def test_addCleanupPassDefault(self):
+        """
+        A cleanup can return a deferred.
+        The cleanup is successuful as long as the deferred is resolve sooner than the default
+        test case timeout (DEFAULT_TIMEOUT_DURATION seconds)
+        """
+
+        def cleanup():
+            d = defer.Deferred()
+            reactor.callLater(0, d.callback, "success")
+            return d
+
+        self.addCleanup(cleanup)
+
+    def test_addCleanupTimeout(self):
+        """
+        A cleanup can return a deferred.
+        When the deferred returned by addCleanup is not resolved sooner than the
+        test's timeout, the test is considered failed.
+        """
+
+        def cleanup():
+            return defer.Deferred()
+
+        self.addCleanup(cleanup)
+
+    test_addCleanupTimeout.timeout = 0.1  # type: ignore[attr-defined]
+
     def test_expectedFailure(self):
         return defer.Deferred()
 

--- a/src/twisted/trial/test/test_deferred.py
+++ b/src/twisted/trial/test/test_deferred.py
@@ -210,6 +210,28 @@ class TimeoutTests(TestTester):
         assert isinstance(result.errors[0][1], Failure)
         self._wasTimeout(result.errors[0][1])
 
+    def test_addCleanupPassDefault(self) -> None:
+        """
+        See L{twisted.trial.test.detests.TimeoutTests.test_addCleanupPassDefault}
+        """
+        result = self.runTest("test_addCleanupPassDefault")
+        self.assertTrue(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+
+    def test_addCleanupTimeout(self) -> None:
+        """
+        See L{twisted.trial.test.detests.TimeoutTests.test_addCleanupTimeout}
+
+        TODO: current test does not mock reactor and thus the test spends real time
+        until the timeout fires.
+        """
+        result = self.runTest("test_addCleanupTimeout")
+        self.assertFalse(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+        self.assertEqual(len(result.errors), 1)
+        assert isinstance(result.errors[0][1], Failure)
+        self._wasTimeout(result.errors[0][1])
+
     def test_skip(self) -> None:
         result = self.runTest("test_skip")
         self.assertTrue(result.wasSuccessful())


### PR DESCRIPTION
## Scope and purpose

Fixes #12390

User-defined test functionality is currently run via `TestCase._run` to support terminating the user code if test case timeout is exceeded. The only exception is functions added via `addCleanup`. This PR changes `TestCase` to run these functions via `_run` too thus supporting timeouts for them.

