### PR TITLE
Optimize Deferred._runCallbacks() to not create chain list unnecessarily

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1035,11 +1035,13 @@ class Deferred(Awaitable[_SelfResultT]):
         # added its _continuation() to the callbacks list of a second Deferred
         # and then that second Deferred being fired.  ie, if ever had _chainedTo
         # set to something other than None, you might end up on this stack.
-        chain: List[Deferred[Any]] = [self]
+        #
+        # As an optimization, the front element of the chain is always stored
+        # in current. This way array operations are avoided in many cases.
+        chain: Optional[List[Deferred[Any]]] = None
+        current = self
 
-        while chain:
-            current = chain[-1]
-
+        while True:
             if current.paused:
                 # This Deferred isn't going to produce a result at all.  All the
                 # Deferreds up the chain waiting on it will just have to...
@@ -1068,9 +1070,13 @@ class Deferred(Awaitable[_SelfResultT]):
                     current.result = None
                     # Making sure to update _debugInfo
                     if current._debugInfo is not None:
-                        current._debugInfo.failResult = None
+                        current._debugInfo.failResult = None  # type: ignore[assignment]
                     chainee.paused -= 1
-                    chain.append(chainee)
+                    if chain is None:
+                        chain = [current]
+                    else:
+                        chain.append(current)
+                    current = chainee
                     # Delay cleaning this Deferred and popping it from the chain
                     # until after we've dealt with chainee.
                     finished = False
@@ -1152,7 +1158,9 @@ class Deferred(Awaitable[_SelfResultT]):
 
                 # This Deferred is done, pop it from the chain and move back up
                 # to the Deferred which supplied us with our result.
-                chain.pop()
+                if not chain:
+                    break
+                current = chain.pop()
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
The current code effectively stores the first element of the chain in the current variable for the duration of the loop iteration. It is possible to optimize this code by not storing the first element in the first place. As a result, the creation of the list and operations with it may be avoided in many cases.
