### PR TITLE
Miscellaneous Deferred optimizations

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -219,8 +219,8 @@ def maybeDeferred(
 
     if type(result) in _DEFERRED_SUBCLASSES:
         return result  # type: ignore[return-value]
-    elif isinstance(result, Failure):
-        return fail(result)
+    elif hasattr(result, "_twistedPrivateIsFailure"):
+        return fail(result)  # type: ignore[arg-type]
     elif type(result) is CoroutineType:
         # A note on how we identify this case ...
         #
@@ -924,7 +924,7 @@ class Deferred(Awaitable[_SelfResultT]):
         """
         if fail is None:
             fail = Failure(captureVars=self.debug)
-        elif not isinstance(fail, Failure):
+        elif not hasattr(fail, "_twistedPrivateIsFailure"):
             fail = Failure(fail)
 
         self._startRunCallbacks(fail)
@@ -1054,7 +1054,7 @@ class Deferred(Awaitable[_SelfResultT]):
             current._chainedTo = None
             while current._callbacks:
                 item = current._callbacks.pop(0)
-                if not isinstance(current.result, Failure):
+                if not hasattr(current.result, "_twistedPrivateIsFailure"):
                     callback, args, kwargs = item[0]
                 else:
                     # type note: Callback signature also works for Errbacks in
@@ -1142,12 +1142,12 @@ class Deferred(Awaitable[_SelfResultT]):
                 # processed right now has been.  The current Deferred is waiting on
                 # another Deferred or for more callbacks.  Before finishing with it,
                 # make sure its _debugInfo is in the proper state.
-                if isinstance(current.result, Failure):
+                if hasattr(current.result, "_twistedPrivateIsFailure"):
                     # Stash the Failure in the _debugInfo for unhandled error
                     # reporting.
                     if current._debugInfo is None:
                         current._debugInfo = DebugInfo()
-                    current._debugInfo.failResult = current.result
+                    current._debugInfo.failResult = current.result  # type: ignore[assignment]
                 else:
                     # Clear out any Failure in the _debugInfo, since the result
                     # is no longer a Failure.
@@ -1187,12 +1187,12 @@ class Deferred(Awaitable[_SelfResultT]):
                 yield self
                 continue
 
-            if isinstance(result, Failure):
+            if hasattr(result, "_twistedPrivateIsFailure"):
                 # Clear the failure on debugInfo so it doesn't raise "unhandled
                 # exception"
                 assert self._debugInfo is not None
                 self._debugInfo.failResult = None
-                result.raiseException()
+                result.raiseException()  # type: ignore[union-attr]
             else:
                 return result  # type: ignore[return-value]
 
@@ -1566,8 +1566,8 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
             if succeeded == SUCCESS and self.fireOnOneCallback:
                 self.callback((result, index))  # type: ignore[arg-type]
             elif succeeded == FAILURE and self.fireOnOneErrback:
-                assert isinstance(result, Failure)
-                self.errback(Failure(FirstError(result, index)))
+                assert hasattr(result, "_twistedPrivateIsFailure")
+                self.errback(Failure(FirstError(result, index)))  # type: ignore[arg-type]
             elif self.finishedCount == len(self.resultList):
                 # At this point, None values in self.resultList have been
                 # replaced by result values, so we cast it to
@@ -1847,7 +1847,7 @@ def _inlineCallbacks(
     while 1:
         try:
             # Send the last result back as the result of the yield expression.
-            isFailure = isinstance(result, Failure)
+            isFailure = hasattr(result, "_twistedPrivateIsFailure")
 
             if isFailure:
                 result = context.run(

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -217,7 +217,7 @@ def maybeDeferred(
     except BaseException:
         return fail(Failure(captureVars=Deferred.debug))
 
-    if type(result) in _DEFERRED_SUBCLASSES:
+    if hasattr(result, "_twistedPrivateIsDeferred"):
         return result  # type: ignore[return-value]
     elif hasattr(result, "_twistedPrivateIsFailure"):
         return fail(result)  # type: ignore[arg-type]
@@ -436,6 +436,12 @@ class Deferred(Awaitable[_SelfResultT]):
     # recursive running of callbacks when a reentrant call to add a callback is
     # used.
     _runningCallbacks = False
+
+    # Used to optimize isinstance(obj, Deferred) by
+    # hasattr(obj, "_twistedPrivateIsDeferred"). Note that the name of the
+    # attribute must be unique across user codebase as well in order for this
+    # kind of isinstance optimization to work.
+    _twistedPrivateIsDeferred = None
 
     # Keep this class attribute for now, for compatibility with code that
     # sets it directly.
@@ -969,9 +975,9 @@ class Deferred(Awaitable[_SelfResultT]):
                 # There was no canceller, or the canceller didn't call
                 # callback or errback.
                 self.errback(Failure(CancelledError()))
-        elif isinstance(self.result, Deferred):
+        elif hasattr(self.result, "_twistedPrivateIsDeferred"):
             # Waiting for another deferred -- cancel it instead.
-            self.result.cancel()
+            self.result.cancel()  # type: ignore[attr-defined]
 
     def _startRunCallbacks(self, result: object) -> None:
         if self.called:
@@ -1108,8 +1114,7 @@ class Deferred(Awaitable[_SelfResultT]):
                     # expensive, so we avoid it unless self.debug is set.
                     current.result = Failure(captureVars=self.debug)
                 else:
-                    # isinstance() with Awaitable subclass is expensive:
-                    if type(current.result) in _DEFERRED_SUBCLASSES:
+                    if hasattr(current.result, "_twistedPrivateIsDeferred"):
                         # Can't use cast() cause it's in the performance hot path:
                         currentResult: Deferred[_SelfResultT] = current.result  # type: ignore[assignment]
                         # The result is another Deferred.  If it has a result,
@@ -1117,7 +1122,7 @@ class Deferred(Awaitable[_SelfResultT]):
                         resultResult = getattr(currentResult, "result", _NO_RESULT)
                         if (
                             resultResult is _NO_RESULT
-                            or type(resultResult) in _DEFERRED_SUBCLASSES
+                            or hasattr(resultResult, "_twistedPrivateIsDeferred")
                             or currentResult.paused
                         ):
                             # Nope, it didn't.  Pause and chain.
@@ -1332,14 +1337,6 @@ class Deferred(Awaitable[_SelfResultT]):
             return _cancellableInlineCallbacks(coro)
         raise NotACoroutineError(f"{coro!r} is not a coroutine")
 
-    def __init_subclass__(cls: Type[Deferred[Any]], **kwargs: Any):
-        # Whenever a subclass is created, record it in L{_DEFERRED_SUBCLASSES}
-        # so we can emulate C{isinstance()} more efficiently.
-        _DEFERRED_SUBCLASSES.append(cls)
-
-
-_DEFERRED_SUBCLASSES = [Deferred]
-
 
 def ensureDeferred(
     coro: Union[
@@ -1358,11 +1355,11 @@ def ensureDeferred(
 
     @param coro: The coroutine object to schedule, or a L{Deferred}.
     """
-    if type(coro) in _DEFERRED_SUBCLASSES:
+    if hasattr(coro, "_twistedPrivateIsDeferred"):
         return coro  # type: ignore[return-value]
     else:
         try:
-            return Deferred.fromCoroutine(coro)  # type: ignore[arg-type]
+            return Deferred.fromCoroutine(coro)
         except NotACoroutineError:
             # It's not a coroutine. Raise an exception, but say that it's also
             # not a Deferred so the error makes sense.
@@ -1955,7 +1952,7 @@ def _inlineCallbacks(
             status.deferred.callback(callbackValue)
             return
 
-        isDeferred = type(result) in _DEFERRED_SUBCLASSES
+        isDeferred = hasattr(result, "_twistedPrivateIsDeferred")
         # iscoroutine() is pretty expensive in this context, so avoid calling
         # it unnecessarily:
         if not isDeferred and (iscoroutine(result) or inspect.isgenerator(result)):

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1766,8 +1766,8 @@ def returnValue(val: object) -> NoReturn:
     raise _DefGen_Return(val)
 
 
-@attr.s(auto_attribs=True)
-class _CancellationStatus(Generic[_SelfResultT]):
+@attr.s(auto_attribs=True, slots=True)
+class _InlineCallbackStatus(Generic[_SelfResultT]):
     """
     Cancellation status of an L{inlineCallbacks} invocation.
 
@@ -1779,16 +1779,17 @@ class _CancellationStatus(Generic[_SelfResultT]):
 
     deferred: Deferred[_SelfResultT]
     waitingOn: Optional[Deferred[_SelfResultT]] = None
+    waiting: bool = True
+    result: Optional[object] = None
 
 
 def _gotResultInlineCallbacks(
     r: object,
-    waiting: List[Any],
     gen: Union[
         Generator[Deferred[Any], Any, _T],
         Coroutine[Deferred[Any], Any, _T],
     ],
-    status: _CancellationStatus[_T],
+    status: _InlineCallbackStatus[_T],
     context: _Context,
 ) -> None:
     """
@@ -1798,12 +1799,12 @@ def _gotResultInlineCallbacks(
     @param waiting: Whether the L{_inlineCallbacks} was waiting, and the result.
     @param gen: a generator object returned by calling a function or method
         decorated with C{@}L{inlineCallbacks}
-    @param status: a L{_CancellationStatus} tracking the current status of C{gen}
+    @param status: a L{_InlineCallbackStatus} tracking the current status of C{gen}
     @param context: the contextvars context to run `gen` in
     """
-    if waiting[0]:
-        waiting[0] = False
-        waiting[1] = r
+    if status.waiting:
+        status.waiting = False
+        status.result = r
     else:
         _inlineCallbacks(r, gen, status, context)
 
@@ -1815,7 +1816,7 @@ def _inlineCallbacks(
         Generator[Deferred[Any], Any, _T],
         Coroutine[Deferred[Any], Any, _T],
     ],
-    status: _CancellationStatus[_T],
+    status: _InlineCallbackStatus[_T],
     context: _Context,
 ) -> None:
     """
@@ -1834,7 +1835,7 @@ def _inlineCallbacks(
     @param gen: a generator object returned by calling a function or method
         decorated with C{@}L{inlineCallbacks}
 
-    @param status: a L{_CancellationStatus} tracking the current status of C{gen}
+    @param status: a L{_InlineCallbackStatus} tracking the current status of C{gen}
 
     @param context: the contextvars context to run `gen` in
     """
@@ -1843,8 +1844,8 @@ def _inlineCallbacks(
     # loop and the waiting variable solve that by manually unfolding the
     # recursion.
 
-    # waiting for result?  # result
-    waiting: List[Any] = [True, None]
+    status.waiting = True
+    status.result = None
 
     stopIteration: bool = False
     callbackValue: Any = None
@@ -1971,33 +1972,33 @@ def _inlineCallbacks(
             # We don't cast() to Deferred because that does more work in the hot path
 
             # a deferred was yielded, get the result.
-            result.addBoth(_gotResultInlineCallbacks, waiting, gen, status, context)  # type: ignore[attr-defined]
-            if waiting[0]:
+            result.addBoth(_gotResultInlineCallbacks, gen, status, context)  # type: ignore[attr-defined]
+            if status.waiting:
                 # Haven't called back yet, set flag so that we get reinvoked
                 # and return from the loop
-                waiting[0] = False
+                status.waiting = False
                 status.waitingOn = result  # type: ignore[assignment]
                 return
 
-            result = waiting[1]
+            result = status.result
             # Reset waiting to initial values for next loop.  gotResult uses
             # waiting, but this isn't a problem because gotResult is only
             # executed once, and if it hasn't been executed yet, the return
             # branch above would have been taken.
 
-            waiting[0] = True
-            waiting[1] = None
+            status.waiting = True
+            status.result = None
 
 
 def _addCancelCallbackToDeferred(
-    it: Deferred[_T], status: _CancellationStatus[_T]
+    it: Deferred[_T], status: _InlineCallbackStatus[_T]
 ) -> None:
     """
     Helper for L{_cancellableInlineCallbacks} to add
     L{_handleCancelInlineCallbacks} as the first errback.
 
     @param it: The L{Deferred} to add the errback to.
-    @param status: a L{_CancellationStatus} tracking the current status of C{gen}
+    @param status: a L{_InlineCallbackStatus} tracking the current status of C{gen}
     """
     it._callbacks, tmp = [], it._callbacks
     it = it.addErrback(_handleCancelInlineCallbacks, status)
@@ -2006,7 +2007,7 @@ def _addCancelCallbackToDeferred(
 
 
 def _handleCancelInlineCallbacks(
-    result: Failure, status: _CancellationStatus[_T], /
+    result: Failure, status: _InlineCallbackStatus[_T], /
 ) -> Deferred[_T]:
     """
     Propagate the cancellation of an C{@}L{inlineCallbacks} to the
@@ -2014,7 +2015,7 @@ def _handleCancelInlineCallbacks(
 
     @param result: An L{_InternalInlineCallbacksCancelledError} from
         C{cancel()}.
-    @param status: a L{_CancellationStatus} tracking the current status of C{gen}
+    @param status: a L{_InlineCallbackStatus} tracking the current status of C{gen}
     @return: A new L{Deferred} that the C{@}L{inlineCallbacks} generator
         can callback or errback through.
     """
@@ -2046,7 +2047,7 @@ def _cancellableInlineCallbacks(
     """
 
     deferred: Deferred[_T] = Deferred(lambda d: _addCancelCallbackToDeferred(d, status))
-    status = _CancellationStatus(deferred)
+    status = _InlineCallbackStatus(deferred)
 
     _inlineCallbacks(None, gen, status, _copy_context())
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1045,11 +1045,13 @@ class Deferred(Awaitable[_SelfResultT]):
         # added its _continuation() to the callbacks list of a second Deferred
         # and then that second Deferred being fired.  ie, if ever had _chainedTo
         # set to something other than None, you might end up on this stack.
-        chain: List[Deferred[Any]] = [self]
+        #
+        # As an optimization, the front element of the chain is always stored
+        # in current. This way array operations are avoided in many cases.
+        chain: Optional[List[Deferred[Any]]] = None
+        current = self
 
-        while chain:
-            current = chain[-1]
-
+        while True:
             if current.paused:
                 # This Deferred isn't going to produce a result at all.  All the
                 # Deferreds up the chain waiting on it will just have to...
@@ -1080,7 +1082,11 @@ class Deferred(Awaitable[_SelfResultT]):
                     if current._debugInfo is not None:
                         current._debugInfo.failResult = None
                     chainee.paused -= 1
-                    chain.append(chainee)
+                    if chain is None:
+                        chain = [current]
+                    else:
+                        chain.append(current)
+                    current = chainee  # type: ignore[assignment]
                     # Delay cleaning this Deferred and popping it from the chain
                     # until after we've dealt with chainee.
                     finished = False
@@ -1161,7 +1167,9 @@ class Deferred(Awaitable[_SelfResultT]):
 
                 # This Deferred is done, pop it from the chain and move back up
                 # to the Deferred which supplied us with our result.
-                chain.pop()
+                if not chain:
+                    break
+                current = chain.pop()
 
     def __str__(self) -> str:
         """

--- a/src/twisted/newsfragments/12398.feature
+++ b/src/twisted/newsfragments/12398.feature
@@ -1,1 +1,1 @@
-twisted.internet.defer.Deferred processing is sligtly faster.
+twisted.internet.defer.Deferred and twisted.python.failure.Failure processing are sligtly faster. This was implemented by using a the private twisted.internet.defer.Deferred._twistedPrivateIsDeferred attribute to detect a Deferred instance and twisted.python.failure.Failure._twistedPrivateIsFailure to detect a Failure instance.

--- a/src/twisted/newsfragments/12398.feature
+++ b/src/twisted/newsfragments/12398.feature
@@ -1,0 +1,1 @@
+twisted.internet.defer.Deferred processing is sligtly faster.

--- a/src/twisted/python/failure.py
+++ b/src/twisted/python/failure.py
@@ -252,6 +252,12 @@ class Failure(BaseException):
     pickled = 0
     _parents = None
 
+    # Used to optimize isinstance(obj, Failure) by
+    # hasattr(obj, "_twistedPrivateIsFailure"). Note that the name of the
+    # attribute must be unique across user codebase as well in order for this
+    # kind of isinstance optimization to work.
+    _twistedPrivateIsFailure = None
+
     def __init__(self, exc_value=None, exc_type=None, exc_tb=None, captureVars=False):
         """
         Initialize me with an explanation of the error.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -1833,23 +1833,6 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # been freed.
         self.assertIsNone(weakCanceller())
 
-    def test_DEFERRED_SUBCLASSES(self) -> None:
-        """
-        C{_DEFERRED_SUBCLASSES} includes all subclasses of L{Deferred}.
-        """
-        self.assertEqual(defer._DEFERRED_SUBCLASSES[:2], [Deferred, DeferredList])
-
-        class D2(Deferred[int]):
-            pass
-
-        self.assertEqual(defer._DEFERRED_SUBCLASSES[-1], D2)
-        defer._DEFERRED_SUBCLASSES.pop(-1)
-
-        # There are other potential subclasses, e.g. twisted.persisted.crefutil
-        # has a Deferred subclass:
-        for klass in defer._DEFERRED_SUBCLASSES:
-            self.assertTrue(issubclass(klass, Deferred))
-
 
 class DummyCanceller:
     """


### PR DESCRIPTION
Fixes #12398 
Fixes #12401 

This PR includes multiple unrelated optimizations for Deferred functionality. I chose to create single PR instead of multiple small ones because small progressions and regressions are currently not visible in results presented as a comment by codspeed. It is important to see cumulative impact, as some optimizations do have small regressions which are solved by other optimizations and vice-versa.