### PR TITLE
Optimize twisted.trial.unittest.TestCase

### DIFF
--- a/src/twisted/newsfragments/todo.removal
+++ b/src/twisted/newsfragments/todo.removal
@@ -1,0 +1,2 @@
+reactor crash, iterate and stop methods now raise exception when run in tests.
+Calling these methods from tests has already been deprecated for more than a decade.

--- a/src/twisted/newsfragments/todo2.feature
+++ b/src/twisted/newsfragments/todo2.feature
@@ -1,0 +1,1 @@
+The overhead of running tests via twisted.trial.unittest.TestCase has been reduced by more than 30%.

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -11,7 +11,7 @@ Maintainer: Jonathan Lange
 
 import inspect
 import warnings
-from typing import Callable
+from typing import Callable, Optional
 
 from zope.interface import implementer
 
@@ -400,20 +400,22 @@ class TestCase(SynchronousTestCase):
 
         from twisted.internet import reactor
 
-        results = []
+        hadResult: Optional[bool] = False
 
         def append(any):
-            if results is not None:
-                results.append(any)
+            nonlocal hadResult
+            if hadResult is not None:
+                hadResult = True
 
         def crash(ign):
-            if results is not None:
+            nonlocal hadResult
+            if hadResult is not None:
                 _reactorCrash()
 
         _waitIsRunning = True
         try:
             d.addBoth(append)
-            if results:
+            if hadResult:
                 # d might have already been fired, in which case append is
                 # called synchronously. Avoid any reactor stuff.
                 return
@@ -424,7 +426,7 @@ class TestCase(SynchronousTestCase):
             # that crasher also reported an error. Just return.
             # _timedOut is most likely to be set when d has fired but hasn't
             # completed its callback chain (see self._run)
-            if results or self._timedOut:  # defined in run() and _run()
+            if hadResult or self._timedOut:  # defined in run() and _run()
                 return
 
             # If the timeout didn't happen, and we didn't get a result or
@@ -442,5 +444,5 @@ class TestCase(SynchronousTestCase):
             # that it should really try to stop as soon as possible.
             raise KeyboardInterrupt()
         finally:
-            results = None
+            hadResult = None
             _waitIsRunning = False

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -73,6 +73,12 @@ class TestCase(SynchronousTestCase):
         # Cached suppressions list
         self._twistedPrivateSuppressions = self._getSuppress()
 
+        # Some reactor methods are deprecated during test run and are patched
+        # while test is running.
+        self._twistedPrivateReactorCrash = None
+        self._twistedPrivateReactorIterate = None
+        self._twistedPrivateReactorStop = None
+
     def assertFailure(self, deferred, *expectedFailures):
         """
         Fail if C{deferred} does not errback with one of C{expectedFailures}.
@@ -258,24 +264,6 @@ class TestCase(SynchronousTestCase):
         except BaseException:
             result.addError(self, failure.Failure())
 
-    def _makeReactorMethod(self, name):
-        """
-        Create a method which wraps the reactor method C{name}. The new
-        method issues a deprecation warning and calls the original.
-        """
-
-        def _(*a, **kw):
-            warnings.warn(
-                "reactor.%s cannot be used inside unit tests. "
-                "In the future, using %s will fail the test and may "
-                "crash or hang the test run." % (name, name),
-                stacklevel=2,
-                category=DeprecationWarning,
-            )
-            return self._reactorMethods[name](*a, **kw)
-
-        return _
-
     def _deprecateReactor(self, reactor):
         """
         Deprecate C{iterate}, C{crash} and C{stop} on C{reactor}. That is,
@@ -284,10 +272,43 @@ class TestCase(SynchronousTestCase):
 
         @param reactor: The Twisted reactor.
         """
-        self._reactorMethods = {}
-        for name in ["crash", "iterate", "stop"]:
-            self._reactorMethods[name] = getattr(reactor, name)
-            setattr(reactor, name, self._makeReactorMethod(name))
+        self._twistedPrivateReactorCrash = reactor.crash
+        self._twistedPrivateReactorIterate = reactor.iterate
+        self._twistedPrivateReactorStop = reactor.stop
+
+        def crash():
+            warnings.warn(
+                "reactor.crash cannot be used inside unit tests. "
+                "In the future, using crash will fail the test and may "
+                "crash or hang the test run.",
+                stacklevel=2,
+                category=DeprecationWarning,
+            )
+            return self._twistedPrivateReactorCrash()
+
+        def iterate(delay=0):
+            warnings.warn(
+                "reactor.iterate cannot be used inside unit tests. "
+                "In the future, using iterate will fail the test and may "
+                "crash or hang the test run.",
+                stacklevel=2,
+                category=DeprecationWarning,
+            )
+            return self._twistedPrivateReactorIterate(delay=delay)
+
+        def stop():
+            warnings.warn(
+                "reactor.stop cannot be used inside unit tests. "
+                "In the future, using stop will fail the test and may "
+                "crash or hang the test run.",
+                stacklevel=2,
+                category=DeprecationWarning,
+            )
+            return self._twistedPrivateReactorStop()
+
+        reactor.crash = crash
+        reactor.iterate = iterate
+        reactor.stop = stop
 
     def _undeprecateReactor(self, reactor):
         """
@@ -296,9 +317,9 @@ class TestCase(SynchronousTestCase):
 
         @param reactor: The Twisted reactor.
         """
-        for name, method in self._reactorMethods.items():
-            setattr(reactor, name, method)
-        self._reactorMethods = {}
+        reactor.crash = self._twistedPrivateReactorCrash
+        reactor.iterate = self._twistedPrivateReactorIterate
+        reactor.stop = self._twistedPrivateReactorStop
 
     def _runFixturesAndTest(self, result):
         """

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -70,6 +70,9 @@ class TestCase(SynchronousTestCase):
         # It is run only if setUp succeeded
         self._twistedPrivateNeedsTearDown = False
 
+        # Cached suppressions list
+        self._twistedPrivateSuppressions = self._getSuppress()
+
     def assertFailure(self, deferred, *expectedFailures):
         """
         Fail if C{deferred} does not errback with one of C{expectedFailures}.
@@ -128,9 +131,14 @@ class TestCase(SynchronousTestCase):
                 "{!r} is a generator function and therefore will never run".format(func)
             )
             return defer.fail(exc)
-        d = defer.maybeDeferred(
-            utils.runWithWarningsSuppressed, self._getSuppress(), func
-        )
+
+        if self._twistedPrivateSuppressions:
+            d = defer.maybeDeferred(
+                utils.runWithWarningsSuppressed, self._twistedPrivateSuppressions, func
+            )
+        else:
+            d = defer.maybeDeferred(func)
+
         call = self._twistedPrivateScheduler.callLater(timeout, onTimeout, d)
         d.addBoth(lambda x: call.active() and call.cancel() or x)
         return d

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -29,6 +29,80 @@ _P = ParamSpec("_P")
 
 _waitIsRunning: List[None] = []
 
+# Some tests initiate multiple TestCase instances that all run at the same
+# time, so reactor method deprecation must be tracked at global scope.
+_reactorDeprecatedCount = 0
+_reactorCrash = None
+_reactorIterate = None
+_reactorStop = None
+
+def _deprecateReactor(reactor):
+    """
+    Deprecate C{iterate}, C{crash} and C{stop} on C{reactor}. That is,
+    each method is wrapped in a function that issues a deprecation
+    warning, then calls the original.
+
+    @param reactor: The Twisted reactor.
+    """
+    global _reactorDeprecatedCount
+    global _reactorCrash
+    global _reactorIterate
+    global _reactorStop
+
+    _reactorDeprecatedCount += 1
+    if _reactorDeprecatedCount != 1:
+        return
+
+    _reactorCrash = reactor.crash
+    _reactorIterate = reactor.iterate
+    _reactorStop = reactor.stop
+
+    def crash():
+        warnings.warn(
+            "reactor.crash cannot be used inside unit tests. "
+            "In the future, using crash will fail the test and may "
+            "crash or hang the test run.",
+            stacklevel=2,
+            category=DeprecationWarning,
+        )
+        return _reactorCrash()
+
+    def iterate(delay=0):
+        warnings.warn(
+            "reactor.iterate cannot be used inside unit tests. "
+            "In the future, using iterate will fail the test and may "
+            "crash or hang the test run.",
+            stacklevel=2,
+            category=DeprecationWarning,
+        )
+        return _reactorIterate(delay=delay)
+
+    reactor.crash = crash
+    reactor.iterate = iterate
+    # stop is not supported when in tests, run crash() instead
+    reactor.stop = crash
+
+
+def _undeprecateReactor(reactor):
+    """
+    Restore the deprecated reactor methods. Undoes what
+    L{_deprecateReactor} did.
+
+    @param reactor: The Twisted reactor.
+    """
+    global _reactorDeprecatedCount
+    global _reactorCrash
+    global _reactorIterate
+    global _reactorStop
+
+    _reactorDeprecatedCount -= 1
+    if _reactorDeprecatedCount != 0:
+        return
+
+    reactor.crash = _reactorCrash
+    reactor.iterate = _reactorIterate
+    reactor.stop = _reactorStop
+
 
 @implementer(itrial.ITestCase)
 class TestCase(SynchronousTestCase):
@@ -73,11 +147,10 @@ class TestCase(SynchronousTestCase):
         # Cached suppressions list
         self._twistedPrivateSuppressions = self._getSuppress()
 
-        # Some reactor methods are deprecated during test run and are patched
-        # while test is running.
-        self._twistedPrivateReactorCrash = None
-        self._twistedPrivateReactorIterate = None
-        self._twistedPrivateReactorStop = None
+    @property
+    def _twistedPrivateReactorIterate(self):
+        global _reactorIterate
+        return _reactorIterate
 
     def assertFailure(self, deferred, *expectedFailures):
         """
@@ -121,7 +194,7 @@ class TestCase(SynchronousTestCase):
                 # if the deferred has been called already but the *back chain
                 # is still unfinished, crash the reactor and report timeout
                 # error ourself.
-                self._twistedPrivateReactorCrash()
+                _reactorCrash()
                 self._timedOut = True  # see self._wait
                 todo = self.getTodo()
                 if todo is not None and todo.expected(f):
@@ -261,54 +334,6 @@ class TestCase(SynchronousTestCase):
         except BaseException:
             result.addError(self, failure.Failure())
 
-    def _deprecateReactor(self, reactor):
-        """
-        Deprecate C{iterate}, C{crash} and C{stop} on C{reactor}. That is,
-        each method is wrapped in a function that issues a deprecation
-        warning, then calls the original.
-
-        @param reactor: The Twisted reactor.
-        """
-        self._twistedPrivateReactorCrash = reactor.crash
-        self._twistedPrivateReactorIterate = reactor.iterate
-        self._twistedPrivateReactorStop = reactor.stop
-
-        def crash():
-            warnings.warn(
-                "reactor.crash cannot be used inside unit tests. "
-                "In the future, using crash will fail the test and may "
-                "crash or hang the test run.",
-                stacklevel=2,
-                category=DeprecationWarning,
-            )
-            return self._twistedPrivateReactorCrash()
-
-        def iterate(delay=0):
-            warnings.warn(
-                "reactor.iterate cannot be used inside unit tests. "
-                "In the future, using iterate will fail the test and may "
-                "crash or hang the test run.",
-                stacklevel=2,
-                category=DeprecationWarning,
-            )
-            return self._twistedPrivateReactorIterate(delay=delay)
-
-        reactor.crash = crash
-        reactor.iterate = iterate
-        # stop is not supported when in tests, run crash() instead
-        reactor.stop = crash
-
-    def _undeprecateReactor(self, reactor):
-        """
-        Restore the deprecated reactor methods. Undoes what
-        L{_deprecateReactor} did.
-
-        @param reactor: The Twisted reactor.
-        """
-        reactor.crash = self._twistedPrivateReactorCrash
-        reactor.iterate = self._twistedPrivateReactorIterate
-        reactor.stop = self._twistedPrivateReactorStop
-
     def _runFixturesAndTest(self, result):
         """
         Really run C{setUp}, the test method, and C{tearDown}.  Any of these may
@@ -318,7 +343,7 @@ class TestCase(SynchronousTestCase):
         """
         from twisted.internet import reactor
 
-        self._deprecateReactor(reactor)
+        _deprecateReactor(reactor)
         self._timedOut = False
         try:
             d = defer.Deferred.fromCoroutine(self._deferSetUp(result))
@@ -328,7 +353,7 @@ class TestCase(SynchronousTestCase):
                 self._cleanUp(result)
                 self._classCleanUp(result)
         finally:
-            self._undeprecateReactor(reactor)
+            _undeprecateReactor(reactor)
 
     # f should be a positional only argument but that is a breaking change
     # see https://github.com/twisted/twisted/issues/11967
@@ -388,7 +413,7 @@ class TestCase(SynchronousTestCase):
 
         def crash(ign):
             if results is not None:
-                self._twistedPrivateReactorCrash()
+                _reactorCrash()
 
         _waitIsRunning.append(None)
         try:

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -36,6 +36,21 @@ _reactorCrash = None
 _reactorIterate = None
 _reactorStop = None
 
+
+# Defining these functions here is faster than redefining as e.g. lambdas where
+# they are called.
+def _removedReactorCrash():  # pragma: no cover
+    raise RuntimeError("reactor.crash cannot be used inside unit tests")
+
+
+def _removedReactorIterate(delay=0):  # pragma: no cover
+    raise RuntimeError("reactor.iterate cannot be used inside unit tests")
+
+
+def _removedReactorStop():  # pragma: no cover
+    raise RuntimeError("reactor.stop cannot be used inside unit tests")
+
+
 def _deprecateReactor(reactor):
     """
     Deprecate C{iterate}, C{crash} and C{stop} on C{reactor}. That is,
@@ -57,30 +72,9 @@ def _deprecateReactor(reactor):
     _reactorIterate = reactor.iterate
     _reactorStop = reactor.stop
 
-    def crash():
-        warnings.warn(
-            "reactor.crash cannot be used inside unit tests. "
-            "In the future, using crash will fail the test and may "
-            "crash or hang the test run.",
-            stacklevel=2,
-            category=DeprecationWarning,
-        )
-        return _reactorCrash()
-
-    def iterate(delay=0):
-        warnings.warn(
-            "reactor.iterate cannot be used inside unit tests. "
-            "In the future, using iterate will fail the test and may "
-            "crash or hang the test run.",
-            stacklevel=2,
-            category=DeprecationWarning,
-        )
-        return _reactorIterate(delay=delay)
-
-    reactor.crash = crash
-    reactor.iterate = iterate
-    # stop is not supported when in tests, run crash() instead
-    reactor.stop = crash
+    reactor.crash = _removedReactorCrash
+    reactor.iterate = _removedReactorIterate
+    reactor.stop = _removedReactorStop
 
 
 def _undeprecateReactor(reactor):

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -11,7 +11,7 @@ Maintainer: Jonathan Lange
 
 import inspect
 import warnings
-from typing import Callable, List
+from typing import Callable
 
 from zope.interface import implementer
 
@@ -27,7 +27,7 @@ from twisted.trial._synctest import FailTest, SkipTest, SynchronousTestCase
 
 _P = ParamSpec("_P")
 
-_waitIsRunning: List[None] = []
+_waitIsRunning: bool = False
 
 # Some tests initiate multiple TestCase instances that all run at the same
 # time, so reactor method deprecation must be tracked at global scope.
@@ -394,6 +394,7 @@ class TestCase(SynchronousTestCase):
 
     def _wait(self, d):
         """Take a Deferred that only ever callbacks. Block until it happens."""
+        global _waitIsRunning
         if _waitIsRunning:
             raise RuntimeError("_wait is not reentrant")
 
@@ -409,7 +410,7 @@ class TestCase(SynchronousTestCase):
             if results is not None:
                 _reactorCrash()
 
-        _waitIsRunning.append(None)
+        _waitIsRunning = True
         try:
             d.addBoth(append)
             if results:
@@ -442,4 +443,4 @@ class TestCase(SynchronousTestCase):
             raise KeyboardInterrupt()
         finally:
             results = None
-            _waitIsRunning.pop()
+            _waitIsRunning = False

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -121,7 +121,7 @@ class TestCase(SynchronousTestCase):
                 # if the deferred has been called already but the *back chain
                 # is still unfinished, crash the reactor and report timeout
                 # error ourself.
-                self._twistedPrivateScheduler.crash()
+                self._twistedPrivateReactorCrash()
                 self._timedOut = True  # see self._wait
                 todo = self.getTodo()
                 if todo is not None and todo.expected(f):
@@ -129,9 +129,6 @@ class TestCase(SynchronousTestCase):
                 else:
                     result.addError(self, f)
 
-        onTimeout = utils.suppressWarnings(
-            onTimeout, util.suppress(category=DeprecationWarning)
-        )
         if inspect.isgeneratorfunction(func):
             exc = TypeError(
                 "{!r} is a generator function and therefore will never run".format(func)
@@ -400,24 +397,7 @@ class TestCase(SynchronousTestCase):
 
         def crash(ign):
             if results is not None:
-                reactor.crash()
-
-        crash = utils.suppressWarnings(
-            crash,
-            util.suppress(
-                message=r"reactor\.crash cannot be used.*", category=DeprecationWarning
-            ),
-        )
-
-        def stop():
-            reactor.crash()
-
-        stop = utils.suppressWarnings(
-            stop,
-            util.suppress(
-                message=r"reactor\.crash cannot be used.*", category=DeprecationWarning
-            ),
-        )
+                self._twistedPrivateReactorCrash()
 
         running.append(None)
         try:
@@ -427,7 +407,7 @@ class TestCase(SynchronousTestCase):
                 # called synchronously. Avoid any reactor stuff.
                 return
             d.addBoth(crash)
-            reactor.stop = stop
+            reactor.stop = self._twistedPrivateReactorCrash
             try:
                 reactor.run()
             finally:

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -27,7 +27,7 @@ from twisted.trial._synctest import FailTest, SkipTest, SynchronousTestCase
 
 _P = ParamSpec("_P")
 
-_wait_is_running: List[None] = []
+_waitIsRunning: List[None] = []
 
 
 @implementer(itrial.ITestCase)
@@ -382,9 +382,9 @@ class TestCase(SynchronousTestCase):
             )
             return util.DEFAULT_TIMEOUT_DURATION
 
-    def _wait(self, d, running=_wait_is_running):
+    def _wait(self, d):
         """Take a Deferred that only ever callbacks. Block until it happens."""
-        if running:
+        if _waitIsRunning:
             raise RuntimeError("_wait is not reentrant")
 
         from twisted.internet import reactor
@@ -399,7 +399,7 @@ class TestCase(SynchronousTestCase):
             if results is not None:
                 self._twistedPrivateReactorCrash()
 
-        running.append(None)
+        _waitIsRunning.append(None)
         try:
             d.addBoth(append)
             if results:
@@ -436,4 +436,4 @@ class TestCase(SynchronousTestCase):
             raise KeyboardInterrupt()
         finally:
             results = None
-            running.pop()
+            _waitIsRunning.pop()

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -293,19 +293,10 @@ class TestCase(SynchronousTestCase):
             )
             return self._twistedPrivateReactorIterate(delay=delay)
 
-        def stop():
-            warnings.warn(
-                "reactor.stop cannot be used inside unit tests. "
-                "In the future, using stop will fail the test and may "
-                "crash or hang the test run.",
-                stacklevel=2,
-                category=DeprecationWarning,
-            )
-            return self._twistedPrivateReactorStop()
-
         reactor.crash = crash
         reactor.iterate = iterate
-        reactor.stop = stop
+        # stop is not supported when in tests, run crash() instead
+        reactor.stop = crash
 
     def _undeprecateReactor(self, reactor):
         """
@@ -407,11 +398,7 @@ class TestCase(SynchronousTestCase):
                 # called synchronously. Avoid any reactor stuff.
                 return
             d.addBoth(crash)
-            reactor.stop = self._twistedPrivateReactorCrash
-            try:
-                reactor.run()
-            finally:
-                del reactor.stop
+            reactor.run()
 
             # If the reactor was crashed elsewhere due to a timeout, hopefully
             # that crasher also reported an error. Just return.

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -546,9 +546,7 @@ class Reporter(TestResult):
          - [1]: C{defer.__iter__}
          - [2]: C{defer.raiseException}
          - [3]: C{defer.maybeDeferred}
-         - [4]: C{utils.runWithWarningsSuppressed}
-         - [5]: C{utils.runWithWarningsSuppressed}
-         - [6:-2]: code in the test method which failed
+         - [4:-2]: code in the test method which failed
          - [-1]: C{_synctest.fail}
 
         When a method fails inside a C{Deferred} (i.e., when the test method
@@ -609,7 +607,7 @@ class Reporter(TestResult):
         if frames[:2] == syncCase:
             newFrames = newFrames[2:]
         elif frames[:3] == asyncCase:
-            newFrames = newFrames[6:]
+            newFrames = newFrames[4:]
         elif frames[:3] == deferCase:
             newFrames = newFrames[3:]
 

--- a/src/twisted/trial/test/detests.py
+++ b/src/twisted/trial/test/detests.py
@@ -204,6 +204,19 @@ class TimeoutTests(unittest.TestCase):
     test_expectedFailure.timeout = 0.1  # type: ignore[attr-defined]
     test_expectedFailure.todo = "i will get it right, eventually"  # type: ignore[attr-defined]
 
+    def test_expectedFailureCalledButTimeout(self):
+        d = defer.Deferred()
+
+        def doesNotFinish(_):
+            return defer.Deferred()
+
+        d.addBoth(doesNotFinish)
+        d.callback(None)
+        return d
+
+    test_expectedFailureCalledButTimeout.timeout = 0.1  # type: ignore[attr-defined]
+    test_expectedFailureCalledButTimeout.todo = "i will get it right, eventually"  # type: ignore[attr-defined]
+
     def test_skip(self):
         return defer.Deferred()
 

--- a/src/twisted/trial/test/erroneous.py
+++ b/src/twisted/trial/test/erroneous.py
@@ -199,7 +199,7 @@ class DelayedCall(unittest.TestCase):
         delayed call error gets reported.
         """
         reactor.callLater(0, self.go)
-        reactor.iterate(0.01)
+        self._twistedPrivateReactorIterate(0.01)
         self.fail("Deliberate failure to mask the hidden exception")
 
     testHiddenException.suppress = [  # type: ignore[attr-defined]

--- a/src/twisted/trial/test/test_deferred.py
+++ b/src/twisted/trial/test/test_deferred.py
@@ -246,6 +246,24 @@ class TimeoutTests(TestTester):
             "(test_expectedFailure) still running at 0.1 secs",
         )
 
+    def test_todoWhenCalled(self) -> None:
+        """
+        See L{twisted.trial.test.detests.TimeoutTests.test_expectedFailureCalledButTimeout}
+
+        Handling of expected failures must support the case when the Deferred
+        returned from test has got initial result, but its callback chain
+        hasn't finished before timeout.
+        """
+        result = self.runTest("test_expectedFailureCalledButTimeout")
+        self.assertTrue(result.wasSuccessful())
+        self.assertEqual(result.testsRun, 1)
+        self.assertEqual(len(result.expectedFailures), 1)
+        assert isinstance(result.expectedFailures[0][1], Failure)
+        self._wasTimeout(
+            result.expectedFailures[0][1],
+            "(test_expectedFailureCalledButTimeout) still running at 0.1 secs",
+        )
+
     def test_errorPropagation(self) -> None:
         result = self.runTest("test_errorPropagation")
         self.assertFalse(result.wasSuccessful())

--- a/src/twisted/trial/test/test_util.py
+++ b/src/twisted/trial/test/test_util.py
@@ -188,6 +188,16 @@ class StubErrorReporter:
         self.errors.append((test, error))
 
 
+class StubTestCase:
+    """
+    A subset of L{twisted.trial.unittest.TestCase} which contains attributes
+    accessed by L{_Janitor}.
+    """
+
+    def __init__(self, reactor: StubReactor) -> None:
+        self._twistedPrivateReactorIterate = reactor.iterate
+
+
 class JanitorTests(SynchronousTestCase):
     """
     Tests for L{_Janitor}!
@@ -202,7 +212,7 @@ class JanitorTests(SynchronousTestCase):
         """
         reactor = StubReactor([])
         jan = _Janitor(None, None, reactor=reactor)
-        jan._cleanPending()
+        jan._cleanPending(reactor.iterate)
         self.assertEqual(reactor.iterations, [0, 0])
 
     def test_cleanPendingCancelsCalls(self) -> None:
@@ -217,7 +227,7 @@ class JanitorTests(SynchronousTestCase):
         delayedCall = DelayedCall(300, func, (), {}, cancelled.append, lambda x: None)
         reactor = StubReactor([delayedCall])
         jan = _Janitor(None, None, reactor=reactor)
-        jan._cleanPending()
+        jan._cleanPending(reactor.iterate)
         self.assertEqual(cancelled, [delayedCall])
 
     def test_cleanPendingReturnsDelayedCallStrings(self) -> None:
@@ -234,7 +244,7 @@ class JanitorTests(SynchronousTestCase):
         delayedCallString = str(delayedCall)
         reactor = StubReactor([delayedCall])
         jan = _Janitor(None, None, reactor=reactor)
-        strings = jan._cleanPending()
+        strings = jan._cleanPending(reactor.iterate)
         self.assertEqual(strings, [delayedCallString])
 
     def test_cleanReactorRemovesSelectables(self) -> None:
@@ -298,7 +308,7 @@ class JanitorTests(SynchronousTestCase):
         on the result if there are no pending calls.
         """
         reactor = StubReactor([])
-        test = object()
+        test = StubTestCase(reactor)
         reporter = StubErrorReporter()
         jan = _Janitor(test, reporter, reactor=reactor)
         self.assertTrue(jan.postCaseCleanup())
@@ -315,7 +325,7 @@ class JanitorTests(SynchronousTestCase):
         )
         delayedCallString = str(delayedCall)
         reactor = StubReactor([delayedCall], [])
-        test = object()
+        test = StubTestCase(reactor)
         reporter = StubErrorReporter()
         jan = _Janitor(test, reporter, reactor=reactor)
         self.assertFalse(jan.postCaseCleanup())
@@ -328,7 +338,7 @@ class JanitorTests(SynchronousTestCase):
         if there are no pending calls or selectables.
         """
         reactor = StubReactor([])
-        test = object()
+        test = StubTestCase(reactor)
         reporter = StubErrorReporter()
         jan = _Janitor(test, reporter, reactor=reactor)
         jan.postClassCleanup()
@@ -344,7 +354,7 @@ class JanitorTests(SynchronousTestCase):
         )
         delayedCallString = str(delayedCall)
         reactor = StubReactor([delayedCall], [])
-        test = object()
+        test = StubTestCase(reactor)
         reporter = StubErrorReporter()
         jan = _Janitor(test, reporter, reactor=reactor)
         jan.postClassCleanup()
@@ -358,7 +368,7 @@ class JanitorTests(SynchronousTestCase):
         """
         selectable = "SELECTABLE HERE"
         reactor = StubReactor([], [selectable])
-        test = object()
+        test = StubTestCase(reactor)
         reporter = StubErrorReporter()
         jan = _Janitor(test, reporter, reactor=reactor)
         jan.postClassCleanup()

--- a/src/twisted/trial/util.py
+++ b/src/twisted/trial/util.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, TextIO, TypeVar
 
 from typing_extensions import ParamSpec
 
-from twisted.internet import interfaces, utils
+from twisted.internet import interfaces
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.python.lockfile import FilesystemLock
@@ -97,7 +97,7 @@ class _Janitor:
         Called by L{unittest.TestCase} after a test to catch any logged errors
         or pending L{DelayedCall<twisted.internet.base.DelayedCall>}s.
         """
-        calls = self._cleanPending()
+        calls = self._cleanPending(self.test._twistedPrivateReactorIterate)
         if calls:
             aggregate = DirtyReactorAggregateError(calls)
             self.result.addError(self.test, Failure(aggregate))
@@ -112,7 +112,7 @@ class _Janitor:
         L{DelayedCall<twisted.internet.base.DelayedCall>}s, open sockets etc.
         """
         selectables = self._cleanReactor()
-        calls = self._cleanPending()
+        calls = self._cleanPending(self.test._twistedPrivateReactorIterate)
         if selectables or calls:
             aggregate = DirtyReactorAggregateError(calls, selectables)
             self.result.addError(self.test, Failure(aggregate))
@@ -128,15 +128,18 @@ class _Janitor:
             from twisted.internet import reactor
         return reactor
 
-    def _cleanPending(self):
+    def _cleanPending(self, iterateMethod):
         """
         Cancel all pending calls and return their string representations.
+
+        @param iterateMethod reactor.iterate() method. It is passed explicitly
+        because it is disabled in tests.
         """
         reactor = self._getReactor()
 
         # flush short-range timers
-        reactor.iterate(0)
-        reactor.iterate(0)
+        iterateMethod(0)
+        iterateMethod(0)
 
         delayedCallStrings = []
         for p in reactor.getDelayedCalls():
@@ -147,17 +150,6 @@ class _Janitor:
                 print("WEIRDNESS! pending timed call not active!")
             delayedCallStrings.append(delayedString)
         return delayedCallStrings
-
-    _cleanPending = utils.suppressWarnings(
-        _cleanPending,
-        (
-            ("ignore",),
-            {
-                "category": DeprecationWarning,
-                "message": r"reactor\.iterate cannot be used.*",
-            },
-        ),
-    )
 
     def _cleanThreads(self):
         reactor = self._getReactor()


### PR DESCRIPTION
This PR introduces a several optimizations for twisted.trial.unittest.TestCase. The optimizations are best reviewed one by one.

As part of optimizations, reactor stop, iterate and crash now raise exception instead of a warning. Calling these functions from tests has been deprecated 18 years ago in 40dcfe64dc3cb3dfd768b1ef2cbf56093c9a9631.