### PR TITLE
#12407 Deprecate Deferred.callbacks attribute

### DIFF
--- a/src/twisted/newsfragments/12407.removal
+++ b/src/twisted/newsfragments/12407.removal
@@ -1,0 +1,1 @@
+twisted.internet.defer.Deferred.callbacks attribute has been deprecated.

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -310,7 +310,9 @@ def deprecated(
     return deprecationDecorator
 
 
-def deprecatedProperty(version, replacement=None):
+def deprecatedProperty(
+    version: Version, replacement: str | Callable[..., object] | None = None
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """
     Return a decorator that marks a property as deprecated. To deprecate a
     regular callable or class, see L{deprecated}.

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -218,6 +218,18 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.assertEqual(self.callbackResults, (("hello",), {}))
         self.assertEqual(self.callback2Results, (("hello",), {}))
 
+    def test_callbacksAttributeDeprecated(self) -> None:
+        deferred: Deferred[str] = Deferred()
+        deferred.callbacks
+
+        warnings = self.flushWarnings()
+        self.assertEqual(1, len(warnings))
+        self.assertIs(DeprecationWarning, warnings[0]["category"])
+        self.assertIn(
+            "twisted.internet.defer.Deferred.callbacks was deprecated in Twisted",
+            warnings[0]["message"],
+        )
+
     def test_addCallbacksNoneErrback(self) -> None:
         """
         If given None for an errback, addCallbacks uses a pass-through.


### PR DESCRIPTION
## Scope and purpose

Fixes #12407.

Per @glyph in https://github.com/twisted/twisted/pull/12406#discussion_r1895067517:

> It is absolutely a mistake that we exposed .called and .callbacks as public attributes in the first place, and something we should eventually correct.

