### PR TITLE
12412 allow opting out of parsing of multipart and form-encoding upload parsing in twisted.web

### DIFF
--- a/docs/web/howto/using-twistedweb.rst
+++ b/docs/web/howto/using-twistedweb.rst
@@ -119,7 +119,7 @@ site:
     reactor.run()
 
 By default Twisted Web will parse form submissions posted in HTTP request bodies into memory, which can use a lot of memory for large uploads.
-If you want to implement your own parsing logic, you can disable Twisted Web's logic by passing ``parsePOSTFormSubmission=True` to the ``Site()`` constructor.
+If you want to implement your own parsing logic, you can disable Twisted Web's logic by passing ``parsePOSTFormSubmission=True`` to the ``Site()`` constructor.
 
 
 

--- a/docs/web/howto/using-twistedweb.rst
+++ b/docs/web/howto/using-twistedweb.rst
@@ -119,7 +119,7 @@ site:
     reactor.run()
 
 By default Twisted Web will parse form submissions posted in HTTP request bodies into memory, which can use a lot of memory for large uploads.
-If you want to implement your own parsing logic, you can disable Twisted Web's logic by passing ``parsePOSTFormSubmission=True`` to the ``Site()`` constructor.
+If you want to implement your own parsing logic, you can disable Twisted Web's logic by passing ``parsePOSTFormSubmission=False`` to the ``Site()`` constructor.
 
 
 

--- a/docs/web/howto/using-twistedweb.rst
+++ b/docs/web/howto/using-twistedweb.rst
@@ -118,7 +118,8 @@ site:
     endpoint.listen(site)
     reactor.run()
 
-
+By default Twisted Web will parse form submissions posted in HTTP request bodies into memory, which can use a lot of memory for large uploads.
+If you want to implement your own parsing logic, you can disable Twisted Web's logic by passing ``parsePOSTFormSubmission=True` to the ``Site()`` constructor.
 
 
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -926,19 +926,19 @@ class Request:
     _forceSSL = 0
     _disconnected = False
     _log = Logger()
-    _parseBody: bool
+    _parsePOSTFormSubmission: bool
 
     def __init__(
         self,
         channel: HTTPChannel,
         queued: object = _QUEUED_SENTINEL,
-        parseBody: bool = True,
+        parsePOSTFormSubmission: bool = True,
     ) -> None:
         """
         @param channel: the channel we're connected to.
         @param queued: (deprecated) are we in the request queue, or can we
             start writing to the transport?
-        @param parseBody: If C{True}, the default, parse MIME multipart and
+        @param parsePOSTFormSubmission: If C{True}, the default, parse MIME multipart and
             URL-encoded body uploads into C{request.args}. This can use large
             amounts of memory for large uploads.
         """
@@ -961,7 +961,7 @@ class Request:
             queued = False
 
         self.queued = queued
-        self._parseBody = parseBody
+        self._parsePOSTFormSubmission = parsePOSTFormSubmission
 
     def _cleanup(self):
         """
@@ -1079,7 +1079,12 @@ class Request:
         if ctype is not None:
             ctype = ctype[0]
 
-        if self.method == b"POST" and ctype and clength and self._parseBody:
+        if (
+            self.method == b"POST"
+            and ctype
+            and clength
+            and self._parsePOSTFormSubmission
+        ):
             mfd = b"multipart/form-data"
             key = _parseContentType(ctype)
             if key == b"application/x-www-form-urlencoded":

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -906,6 +906,11 @@ class Request:
 
     @ivar _log: A logger instance for request related messages.
     @type _log: L{twisted.logger.Logger}
+
+    @ivar parseBody: If C{True}, the default, parse MIME multipart and
+        URL-encoded body uploads into C{request.args}. This can use large
+        amounts of memory for large uploads.
+    @type parseBody: C{bool}
     """
 
     producer = None
@@ -926,6 +931,7 @@ class Request:
     _forceSSL = 0
     _disconnected = False
     _log = Logger()
+    parseBody: bool = True
 
     def __init__(self, channel: HTTPChannel, queued: object = _QUEUED_SENTINEL) -> None:
         """
@@ -1069,7 +1075,7 @@ class Request:
         if ctype is not None:
             ctype = ctype[0]
 
-        if self.method == b"POST" and ctype and clength:
+        if self.method == b"POST" and ctype and clength and self.parseBody:
             mfd = b"multipart/form-data"
             key = _parseContentType(ctype)
             if key == b"application/x-www-form-urlencoded":

--- a/src/twisted/web/newsfragments/12412.feature
+++ b/src/twisted/web/newsfragments/12412.feature
@@ -1,1 +1,1 @@
-``twisted.web.server.Site`` can now be created with a ``parseBody=False`` parameter to disable parsing of HTTP request bodies.
+``twisted.web.server.Site`` can now be created with a ``parsePOSTFormSubmission=False`` parameter to disable parsing of HTTP request bodies.

--- a/src/twisted/web/newsfragments/12412.feature
+++ b/src/twisted/web/newsfragments/12412.feature
@@ -1,0 +1,1 @@
+A new twisted.web.server.Site.parseBody flag allows disabling parsing of HTTP request bodies.

--- a/src/twisted/web/newsfragments/12412.feature
+++ b/src/twisted/web/newsfragments/12412.feature
@@ -1,1 +1,1 @@
-A new twisted.web.server.Site.parseBody flag allows disabling parsing of HTTP request bodies.
+``twisted.web.server.Site`` can now be created with a ``parseBody=False`` parameter to disable parsing of HTTP request bodies.

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -36,7 +36,6 @@ from twisted.web.error import UnsupportedMethod
 from twisted.web.http import (
     NO_CONTENT,
     NOT_MODIFIED,
-    HTTPChannel,
     HTTPFactory,
     Request as _HTTPRequest,
     datetimeToString,
@@ -98,7 +97,7 @@ class Request(Copyable, http.Request, components.Componentized):
     _encoder = None
     _log = Logger()
 
-    def __init__(self, channel: HTTPChannel, *args, **kw):
+    def __init__(self, channel, *args, **kw):
         _HTTPRequest.__init__(self, channel, *args, **kw)
         components.Componentized.__init__(self)
         # Disable parsing bodies if that's what the Site set:

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -97,7 +97,12 @@ class Request(Copyable, http.Request, components.Componentized):
     _encoder = None
     _log = Logger()
 
-    def __init__(self, channel, *args, parseBody: Optional[bool] = None, **kw):
+    def __init__(self, channel, *args, parseBody=None, **kw):
+        """
+        @param parseBody: By default, get this setting from the L{Site}, but
+            can also be set explicitly. If C{False}, don't parse HTTP bodies.
+        @type parseBody: C{None} or C{bool}
+        """
         if parseBody is None:
             parseBodyBool = channel.site._parseBody
         else:
@@ -790,9 +795,7 @@ class Site(HTTPFactory):
     _entropy = os.urandom
     _parseBody: bool
 
-    def __init__(
-        self, resource, requestFactory=None, *args, parseBody: bool = True, **kwargs
-    ):
+    def __init__(self, resource, requestFactory=None, *args, parseBody=True, **kwargs):
         """
         @param resource: The root of the resource hierarchy.  All request
             traversal for requests received by this factory will begin at this
@@ -804,6 +807,7 @@ class Site(HTTPFactory):
         @param parseBody: If C{True}, the default, parse MIME multipart and
             URL-encoded body uploads into C{request.args}. This can use large
             amounts of memory for large uploads.
+        @type parseBody: C{bool}
 
         @see: L{twisted.web.http.HTTPFactory.__init__}
         """

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -97,17 +97,23 @@ class Request(Copyable, http.Request, components.Componentized):
     _encoder = None
     _log = Logger()
 
-    def __init__(self, channel, *args, parseBody=None, **kw):
+    def __init__(self, channel, *args, parsePOSTFormSubmission=None, **kw):
         """
-        @param parseBody: By default, get this setting from the L{Site}, but
+        @param parsePOSTFormSubmission: By default, get this setting from the L{Site}, but
             can also be set explicitly. If C{False}, don't parse HTTP bodies.
-        @type parseBody: C{None} or C{bool}
+        @type parsePOSTFormSubmission: C{None} or C{bool}
         """
-        if parseBody is None:
-            parseBodyBool = channel.site._parseBody
+        if parsePOSTFormSubmission is None:
+            parsePOSTFormSubmissionBool = channel.site._parsePOSTFormSubmission
         else:
-            parseBodyBool = parseBody
-        _HTTPRequest.__init__(self, channel, *args, parseBody=parseBodyBool, **kw)
+            parsePOSTFormSubmissionBool = parsePOSTFormSubmission
+        _HTTPRequest.__init__(
+            self,
+            channel,
+            *args,
+            parsePOSTFormSubmission=parsePOSTFormSubmissionBool,
+            **kw,
+        )
         components.Componentized.__init__(self)
 
     def getStateToCopyFor(self, issuer):
@@ -793,9 +799,16 @@ class Site(HTTPFactory):
     sessionFactory = Session
     sessionCheckTime = 1800
     _entropy = os.urandom
-    _parseBody: bool
+    _parsePOSTFormSubmission: bool
 
-    def __init__(self, resource, requestFactory=None, *args, parseBody=True, **kwargs):
+    def __init__(
+        self,
+        resource,
+        requestFactory=None,
+        *args,
+        parsePOSTFormSubmission=True,
+        **kwargs,
+    ):
         """
         @param resource: The root of the resource hierarchy.  All request
             traversal for requests received by this factory will begin at this
@@ -804,10 +817,10 @@ class Site(HTTPFactory):
         @param requestFactory: Overwrite for default requestFactory.
         @type requestFactory: C{callable} or C{class}.
 
-        @param parseBody: If C{True}, the default, parse MIME multipart and
+        @param parsePOSTFormSubmission: If C{True}, the default, parse MIME multipart and
             URL-encoded body uploads into C{request.args}. This can use large
             amounts of memory for large uploads.
-        @type parseBody: C{bool}
+        @type parsePOSTFormSubmission: C{bool}
 
         @see: L{twisted.web.http.HTTPFactory.__init__}
         """
@@ -816,7 +829,7 @@ class Site(HTTPFactory):
         self.resource = resource
         if requestFactory is not None:
             self.requestFactory = requestFactory
-        self._parseBody = parseBody
+        self._parsePOSTFormSubmission = parsePOSTFormSubmission
 
     def _openLogFile(self, path):
         from twisted.python import logfile

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2544,7 +2544,7 @@ abasdfg
 
         # Now check the disabled case:
         channel = self.runRequest(
-            req, partial(MyRequest, parseBody=False), success=False
+            req, partial(MyRequest, parsePOSTFormSubmission=False), success=False
         )
         self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
         self.assertEqual(len(processed), 2)
@@ -2592,7 +2592,7 @@ Content-Length: """
         # Now check the disabled case:
         channel = self.runRequest(
             req.encode("ascii") + body,
-            partial(MyRequest, parseBody=False),
+            partial(MyRequest, parsePOSTFormSubmission=False),
             success=False,
         )
         self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -8,6 +8,7 @@ Test HTTP support.
 import base64
 import calendar
 import random
+from functools import partial
 from io import BytesIO, TextIOWrapper
 from itertools import cycle
 from typing import Sequence, Union
@@ -2542,9 +2543,9 @@ abasdfg
         self.assertEqual(processed[0].args, {b"text": [b"abasdfg"]})
 
         # Now check the disabled case:
-        self.assertEqual(MyRequest.parseBody, True)
-        MyRequest.parseBody = False
-        channel = self.runRequest(req, MyRequest, success=False)
+        channel = self.runRequest(
+            req, partial(MyRequest, parseBody=False), success=False
+        )
         self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
         self.assertEqual(len(processed), 2)
         self.assertEqual(processed[1].args, {})
@@ -2589,9 +2590,11 @@ Content-Length: """
         self.assertEqual(processed[0].args, {b"uploadedfile": [b"abasdfg"]})
 
         # Now check the disabled case:
-        self.assertEqual(MyRequest.parseBody, True)
-        MyRequest.parseBody = False
-        channel = self.runRequest(req.encode("ascii") + body, MyRequest, success=False)
+        channel = self.runRequest(
+            req.encode("ascii") + body,
+            partial(MyRequest, parseBody=False),
+            success=False,
+        )
         self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
         self.assertEqual(len(processed), 2)
         self.assertEqual(processed[1].args, {})

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2552,8 +2552,8 @@ abasdfg
 
     def test_multipartFileData(self):
         """
-        If the request has a Content-Type of C{multipart/form-data}, and
-        C{Request.PARSE_MULTIPART_UPLOADS} is true, the form data is parseable
+        If the request has a Content-Type of C{multipart/form-data}, the
+        C{Request} is told to parse the body, and the form data is parseable
         and contains files, the file portions will be added to the request's
         args.
         """

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -957,6 +957,22 @@ class RequestTests(unittest.TestCase):
         self.assertEqual([12345], lengths)
         self.assertIs(contentFile, request.content)
 
+    def test_parseBodySetFromSite(self):
+        """
+        C{Request.parseBody} is set to match C{Site.parseBody}.
+        """
+        site = server.Site(resource.Resource())
+        self.assertEqual(site.parseBody, True)
+        channel = DummyChannel()
+        channel.site = site
+
+        request = server.Request(channel)
+        self.assertEqual(request.parseBody, True)
+
+        site.parseBody = False
+        request = server.Request(channel)
+        self.assertEqual(request.parseBody, False)
+
 
 class GzipEncoderTests(unittest.TestCase):
     def setUp(self):

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -957,7 +957,7 @@ class RequestTests(unittest.TestCase):
         self.assertEqual([12345], lengths)
         self.assertIs(contentFile, request.content)
 
-    def test_parseBodySetFromSite(self):
+    def test_parseBodySetFromSite(self) -> None:
         """
         C{Request._parseBody} is set to match C{Site._parseBody}.
         """

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -957,27 +957,27 @@ class RequestTests(unittest.TestCase):
         self.assertEqual([12345], lengths)
         self.assertIs(contentFile, request.content)
 
-    def test_parseBodySetFromSite(self) -> None:
+    def test_parsePOSTFormSubmissionSetFromSite(self) -> None:
         """
-        C{Request._parseBody} is set to match C{Site._parseBody}.
+        C{Request._parsePOSTFormSubmission} is set to match C{Site._parsePOSTFormSubmission}.
         """
         site = server.Site(resource.Resource())
-        self.assertEqual(site._parseBody, True)
+        self.assertEqual(site._parsePOSTFormSubmission, True)
         channel = DummyChannel()
         channel.site = site
 
         request = server.Request(channel)
-        self.assertEqual(request._parseBody, True)
+        self.assertEqual(request._parsePOSTFormSubmission, True)
 
-        site = server.Site(resource.Resource(), parseBody=False)
-        self.assertEqual(site._parseBody, False)
+        site = server.Site(resource.Resource(), parsePOSTFormSubmission=False)
+        self.assertEqual(site._parsePOSTFormSubmission, False)
         channel.site = site
         request = server.Request(channel)
-        self.assertEqual(request._parseBody, False)
+        self.assertEqual(request._parsePOSTFormSubmission, False)
 
         # Can also set it directly:
-        request = server.Request(channel, parseBody=True)
-        self.assertEqual(request._parseBody, True)
+        request = server.Request(channel, parsePOSTFormSubmission=True)
+        self.assertEqual(request._parsePOSTFormSubmission, True)
 
 
 class GzipEncoderTests(unittest.TestCase):

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -969,9 +969,15 @@ class RequestTests(unittest.TestCase):
         request = server.Request(channel)
         self.assertEqual(request._parseBody, True)
 
-        site._parseBody = False
+        site = server.Site(resource.Resource(), parseBody=False)
+        self.assertEqual(site._parseBody, False)
+        channel.site = site
         request = server.Request(channel)
         self.assertEqual(request._parseBody, False)
+
+        # Can also set it directly:
+        request = server.Request(channel, parseBody=True)
+        self.assertEqual(request._parseBody, True)
 
 
 class GzipEncoderTests(unittest.TestCase):

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -959,19 +959,19 @@ class RequestTests(unittest.TestCase):
 
     def test_parseBodySetFromSite(self):
         """
-        C{Request.parseBody} is set to match C{Site.parseBody}.
+        C{Request._parseBody} is set to match C{Site._parseBody}.
         """
         site = server.Site(resource.Resource())
-        self.assertEqual(site.parseBody, True)
+        self.assertEqual(site._parseBody, True)
         channel = DummyChannel()
         channel.site = site
 
         request = server.Request(channel)
-        self.assertEqual(request.parseBody, True)
+        self.assertEqual(request._parseBody, True)
 
-        site.parseBody = False
+        site._parseBody = False
         request = server.Request(channel)
-        self.assertEqual(request.parseBody, False)
+        self.assertEqual(request._parseBody, False)
 
 
 class GzipEncoderTests(unittest.TestCase):


### PR DESCRIPTION
## Scope and purpose

Fixes #12412 

Gives users the ability to parse HTTP body uploads themselves without having to pay the costs of twisted.web's parsing of bodies.
