### PR TITLE
explicit configuration file for sphinx per https://about.readthedocs.…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ sphinx:
   # the errors in one go.
   # This can be re-enable once RTD is updated with https://github.com/readthedocs/readthedocs.org/issues/7116
   fail_on_warning: False
+  configuration: docs/conf.py
 
 # We don't proofread all the output formats, and we don't know if anyone really
 # uses some of them.  Is anyone actually printing the docs out as a PDF?  If a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,12 @@ all-non-platform = [
 
 macos-platform = [
     "twisted[all-non-platform]",
-    "pyobjc-core",
-    "pyobjc-framework-CFNetwork",
-    "pyobjc-framework-Cocoa",
+    "pyobjc-core < 11; python_version < '3.9'",
+    "pyobjc-core; python_version >= '3.9'",
+    "pyobjc-framework-CFNetwork < 11; python_version < '3.9'",
+    "pyobjc-framework-CFNetwork; python_version >= '3.9'",
+    "pyobjc-framework-Cocoa < 11; python_version < '3.9'",
+    "pyobjc-framework-Cocoa; python_version >= '3.9'",
 ]
 
 windows-platform = [


### PR DESCRIPTION
…com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

## Scope and purpose

Fixes #12419 

