### PR TITLE
#12423 Fix web.http not parsing multiple files in multipart form-data

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -108,6 +108,7 @@ import os
 import re
 import tempfile
 import warnings
+from collections import defaultdict
 from email import message_from_bytes
 from email.message import EmailMessage, Message
 from io import BufferedIOBase, BytesIO, TextIOWrapper
@@ -323,7 +324,7 @@ def _getMultiPartArgs(content: bytes, ctype: bytes) -> dict[bytes, list[bytes]]:
     """
     Parse the content of a multipart/form-data request.
     """
-    result = {}
+    result = defaultdict(list)
     multiPartHeaders = b"MIME-Version: 1.0\r\n" + b"Content-Type: " + ctype + b"\r\n"
     msg = message_from_bytes(multiPartHeaders + content)
     if not msg.is_multipart():
@@ -339,7 +340,7 @@ def _getMultiPartArgs(content: bytes, ctype: bytes) -> dict[bytes, list[bytes]]:
         if not name:
             continue
         payload: bytes = part.get_payload(decode=True)  # type:ignore[assignment]
-        result[name.encode("utf8")] = [payload]
+        result[name.encode("utf8")].append(payload)
     return result
 
 

--- a/src/twisted/web/newsfragments/12423.bugfix
+++ b/src/twisted/web/newsfragments/12423.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http.Request.requestReceived now handles multiple files in multipart/form-data with the same "name" parameter. This was a regression introduced in Twisted 24.3.0. (#12423)

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2550,12 +2550,12 @@ abasdfg
         self.assertEqual(len(processed), 2)
         self.assertEqual(processed[1].args, {})
 
-    def test_multipartFileData(self):
+    def test_multipartFilesData(self):
         """
         If the request has a Content-Type of C{multipart/form-data}, the
-        C{Request} is told to parse the body, and the form data is parseable
-        and contains files, the file portions will be added to the request's
-        args.
+        C{Request} is told to parse the body, if the form data is parseable
+        and contains files, each of the file portions will be added to the
+        request's args in the same order.
         """
         processed = []
 
@@ -2566,10 +2566,14 @@ abasdfg
                 self.finish()
 
         body = b"""-----------------------------738837029596785559389649595
-Content-Disposition: form-data; name="uploadedfile"; filename="test"
+Content-Disposition: form-data; name="uploadedfiles"; filename="testC"
 Content-Type: application/octet-stream
 
 abasdfg
+-----------------------------738837029596785559389649595
+Content-Disposition: form-data; name="uploadedfiles"; filename="testB"
+
+qwerty
 -----------------------------738837029596785559389649595--
 """
 
@@ -2587,7 +2591,7 @@ Content-Length: """
         channel = self.runRequest(req.encode("ascii") + body, MyRequest, success=False)
         self.assertEqual(channel.transport.value(), b"HTTP/1.0 200 OK\r\n\r\ndone")
         self.assertEqual(len(processed), 1)
-        self.assertEqual(processed[0].args, {b"uploadedfile": [b"abasdfg"]})
+        self.assertEqual(processed[0].args, {b"uploadedfiles": [b"abasdfg", b"qwerty"]})
 
         # Now check the disabled case:
         channel = self.runRequest(


### PR DESCRIPTION
## Scope and purpose

Fixes #12423 

Fixes a regression in twisted.web.http due to replacement of cgi.parse_multipart in commit https://github.com/twisted/twisted/commit/4579398f6b089f93181ba2f912e2524bd1f43c5e resulted in multipart/form-data requests with multiple files and same name parameter would be parsed to contain only a single file.
