### PR TITLE
#11972 Fixes bug in BindAuthority zone file loading

### DIFF
--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -9,7 +9,6 @@ Authoritative resolvers.
 
 import os
 import time
-from typing import AnyStr
 
 from twisted.internet import defer
 from twisted.names import common, dns, error
@@ -303,12 +302,11 @@ class BindAuthority(FileAuthority):
     Supports only C{$ORIGIN} and C{$TTL} directives.
     """
 
-    def loadFile(self, filename: AnyStr) -> None:
+    def loadFile(self, filename: bytes | str) -> None:
         """
         Load records from C{filename}.
 
         @param filename: file to read from
-        @type filename: bytes or str C{AnyStr}
         """
         fp = FilePath(filename)
         # Not the best way to set an origin. It can be set using $ORIGIN

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -7,6 +7,8 @@ Authoritative resolvers.
 """
 
 
+from __future__ import annotations
+
 import os
 import time
 

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -302,7 +302,7 @@ class BindAuthority(FileAuthority):
     Supports only C{$ORIGIN} and C{$TTL} directives.
     """
 
-    def loadFile(self, filename: bytes | str) -> None:
+    def loadFile(self, filename):
         """
         Load records from C{filename}.
 
@@ -311,7 +311,7 @@ class BindAuthority(FileAuthority):
         fp = FilePath(filename)
         # Not the best way to set an origin. It can be set using $ORIGIN
         # though.
-        self.origin = nativeString(fp.basename()) + "."
+        self.origin = fp.asTextMode().basename() + "."
 
         lines = fp.getContent().splitlines(True)
         lines = self.stripComments(lines)

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -7,8 +7,6 @@ Authoritative resolvers.
 """
 
 
-from __future__ import annotations
-
 import os
 import time
 

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -312,7 +312,7 @@ class BindAuthority(FileAuthority):
         fp = FilePath(filename)
         # Not the best way to set an origin. It can be set using $ORIGIN
         # though.
-        self.origin = nativeString(fp.basename() + b".")
+        self.origin = nativeString(fp.basename()) + "."
 
         lines = fp.getContent().splitlines(True)
         lines = self.stripComments(lines)

--- a/src/twisted/names/authority.py
+++ b/src/twisted/names/authority.py
@@ -9,6 +9,7 @@ Authoritative resolvers.
 
 import os
 import time
+from typing import AnyStr
 
 from twisted.internet import defer
 from twisted.names import common, dns, error
@@ -302,12 +303,12 @@ class BindAuthority(FileAuthority):
     Supports only C{$ORIGIN} and C{$TTL} directives.
     """
 
-    def loadFile(self, filename):
+    def loadFile(self, filename: AnyStr) -> None:
         """
         Load records from C{filename}.
 
         @param filename: file to read from
-        @type filename: L{bytes}
+        @type filename: bytes or str C{AnyStr}
         """
         fp = FilePath(filename)
         # Not the best way to set an origin. It can be set using $ORIGIN

--- a/src/twisted/names/newsfragments/11972.bugfix
+++ b/src/twisted/names/newsfragments/11972.bugfix
@@ -1,0 +1,1 @@
+twisted.names now does not throw an error when attempting to load bind zone file.

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -12,7 +12,6 @@ import socket
 from functools import partial, reduce
 from io import BytesIO
 from struct import pack
-from typing import AnyStr
 
 from twisted.internet import defer, error, reactor
 from twisted.internet.defer import succeed
@@ -1213,31 +1212,39 @@ class BindAuthorityTests(unittest.TestCase):
     Tests for L{twisted.names.authority.BindAuthority}.
     """
 
-    def loadBindString(self, s: bytes, path: AnyStr) -> authority.BindAuthority:
+    def loadBindString(
+        self, s: bytes, pathtype: str = "str"
+    ) -> authority.BindAuthority:
         """
         Create a new L{twisted.names.authority.BindAuthority} from C{s}.
 
         @param s: A string with BIND zone data.
         @type s: bytes
 
+        @param pathtype: A pathtype of a file to use for loading the BIND zone file . Can be 'str' or 'bytes'.
+        @type path: Str
+
         @return: a new bind authority
         @rtype: L{twisted.names.authority.BindAuthority}
         """
+        if pathtype == "bytes":
+            path = FilePath(self.mktemp()).asBytesMode().path
+        else:
+            path = self.mktemp()
+        # Convert path to FilePath which handles both str and bytes
         fp = FilePath(path)
         fp.setContent(s)
 
         return authority.BindAuthority(fp.path)
 
     def setUp(self) -> None:
-        path = FilePath(self.mktemp()).asBytesMode().path
-        self.auth = self.loadBindString(sampleBindZone, path)
+        self.auth = self.loadBindString(sampleBindZone)
 
     def test_loadBindZonePathAsString(self) -> None:
         """
         L{BindAuthority} loads a BIND zone with filepath as type string.
         """
-        path = self.mktemp()
-        authority = self.loadBindString(sampleBindZone, path)
+        authority = self.loadBindString(sampleBindZone)
 
         self.assertIsInstance(
             authority, BindAuthority, "Loaded object is not a BindAuthority"
@@ -1251,8 +1258,7 @@ class BindAuthorityTests(unittest.TestCase):
         """
         L{BindAuthority} loads a BIND zone with filepath as type bytes.
         """
-        path = FilePath(self.mktemp()).asBytesMode().path
-        authority = self.loadBindString(sampleBindZone, path)
+        authority = self.loadBindString(sampleBindZone, "bytes")
 
         self.assertIsInstance(
             authority, BindAuthority, "Loaded object is not a BindAuthority"
@@ -1351,19 +1357,17 @@ class BindAuthorityTests(unittest.TestCase):
         """
         loadBindString raises NotImplementedError on invalid records.
         """
-        path = FilePath(self.mktemp()).asBytesMode().path
         with self.assertRaises(NotImplementedError) as e:
-            self.loadBindString(b"example.com. IN LOL 192.168.0.1", path)
+            self.loadBindString(b"example.com. IN LOL 192.168.0.1")
         self.assertEqual("Record type 'LOL' not supported", e.exception.args[0])
 
     def test_invalidDirectives(self):
         """
         $INCLUDE and $GENERATE raise NotImplementedError.
         """
-        path = FilePath(self.mktemp()).asBytesMode().path
         for directive in (b"$INCLUDE", b"$GENERATE"):
             with self.assertRaises(NotImplementedError) as e:
-                self.loadBindString(directive + b" doesNotMatter", path)
+                self.loadBindString(directive + b" doesNotMatter")
             self.assertEqual(
                 nativeString(directive + b" directive not implemented"),
                 e.exception.args[0],

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -1246,9 +1246,6 @@ class BindAuthorityTests(unittest.TestCase):
         self.assertTrue(authority.records, "No records were loaded from the BIND zone")
 
         self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
-        self.assertGreater(
-            len(authority.records), 0, "No domains were parsed into records"
-        )
 
     def test_loadBindZonePathAsBytes(self) -> None:
         """
@@ -1264,9 +1261,6 @@ class BindAuthorityTests(unittest.TestCase):
         self.assertTrue(authority.records, "No records were loaded from the BIND zone")
 
         self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
-        self.assertGreater(
-            len(authority.records), 0, "No domains were parsed into records"
-        )
 
     def test_ttl(self):
         """

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -12,6 +12,7 @@ import socket
 from functools import partial, reduce
 from io import BytesIO
 from struct import pack
+from typing import AnyStr
 
 from twisted.internet import defer, error, reactor
 from twisted.internet.defer import succeed
@@ -21,6 +22,7 @@ from twisted.internet.testing import (
     waitUntilAllDisconnected,
 )
 from twisted.names import authority, client, common, dns, server
+from twisted.names.authority import BindAuthority
 from twisted.names.client import Resolver
 from twisted.names.dns import SOA, Message, Query, Record_A, Record_SOA, RRHeader
 from twisted.names.error import DomainError
@@ -1211,7 +1213,7 @@ class BindAuthorityTests(unittest.TestCase):
     Tests for L{twisted.names.authority.BindAuthority}.
     """
 
-    def loadBindString(self, s):
+    def loadBindString(self, s: bytes, path: AnyStr) -> authority.BindAuthority:
         """
         Create a new L{twisted.names.authority.BindAuthority} from C{s}.
 
@@ -1221,13 +1223,50 @@ class BindAuthorityTests(unittest.TestCase):
         @return: a new bind authority
         @rtype: L{twisted.names.authority.BindAuthority}
         """
-        fp = FilePath(self.mktemp().encode("ascii"))
+        fp: FilePath[AnyStr] = FilePath(path)
         fp.setContent(s)
 
         return authority.BindAuthority(fp.path)
 
     def setUp(self):
-        self.auth = self.loadBindString(sampleBindZone)
+        path = self.mktemp().encode("ascii")
+        self.auth = self.loadBindString(sampleBindZone, path)
+
+    def test_loadBindZonePathAsString(self):
+        """
+        L{BindAuthority} loads a BIND zone with filepath as type string.
+        """
+        path = self.mktemp()
+        authority = self.loadBindString(sampleBindZone, path)
+
+        self.assertIsInstance(
+            authority, BindAuthority, "Loaded object is not a BindAuthority"
+        )
+
+        self.assertTrue(authority.records, "No records were loaded from the BIND zone")
+
+        self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
+        self.assertGreater(
+            len(authority.records), 0, "No domains were parsed into records"
+        )
+
+    def test_loadBindZonePathAsBytes(self):
+        """
+        L{BindAuthority} loads a BIND zone with filepath as type bytes.
+        """
+        path = self.mktemp().encode("ascii")
+        authority = self.loadBindString(sampleBindZone, path)
+
+        self.assertIsInstance(
+            authority, BindAuthority, "Loaded object is not a BindAuthority"
+        )
+
+        self.assertTrue(authority.records, "No records were loaded from the BIND zone")
+
+        self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
+        self.assertGreater(
+            len(authority.records), 0, "No domains were parsed into records"
+        )
 
     def test_ttl(self):
         """
@@ -1318,17 +1357,19 @@ class BindAuthorityTests(unittest.TestCase):
         """
         loadBindString raises NotImplementedError on invalid records.
         """
+        path = self.mktemp().encode("ascii")
         with self.assertRaises(NotImplementedError) as e:
-            self.loadBindString(b"example.com. IN LOL 192.168.0.1")
+            self.loadBindString(b"example.com. IN LOL 192.168.0.1", path)
         self.assertEqual("Record type 'LOL' not supported", e.exception.args[0])
 
     def test_invalidDirectives(self):
         """
         $INCLUDE and $GENERATE raise NotImplementedError.
         """
+        path = self.mktemp().encode("ascii")
         for directive in (b"$INCLUDE", b"$GENERATE"):
             with self.assertRaises(NotImplementedError) as e:
-                self.loadBindString(directive + b" doesNotMatter")
+                self.loadBindString(directive + b" doesNotMatter", path)
             self.assertEqual(
                 nativeString(directive + b" directive not implemented"),
                 e.exception.args[0],

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -1212,25 +1212,23 @@ class BindAuthorityTests(unittest.TestCase):
     Tests for L{twisted.names.authority.BindAuthority}.
     """
 
-    def loadBindString(
-        self, s: bytes, pathtype: str = "str"
-    ) -> authority.BindAuthority:
+    def loadBindString(self, s: bytes, asText: bool = True) -> authority.BindAuthority:
         """
         Create a new L{twisted.names.authority.BindAuthority} from C{s}.
 
         @param s: A string with BIND zone data.
-        @type s: bytes
+        @type s: L{bytes}
 
-        @param pathtype: A pathtype of a file to use for loading the BIND zone file . Can be 'str' or 'bytes'.
-        @type path: Str
+        @param asText: If True, treat path as text file, else as binary.
+        @type asText: L{bool}
 
         @return: a new bind authority
         @rtype: L{twisted.names.authority.BindAuthority}
         """
-        if pathtype == "bytes":
-            path = FilePath(self.mktemp()).asBytesMode().path
-        else:
+        if asText:
             path = self.mktemp()
+        else:
+            path = FilePath(self.mktemp()).asBytesMode().path
         # Convert path to FilePath which handles both str and bytes
         fp = FilePath(path)
         fp.setContent(s)
@@ -1238,25 +1236,26 @@ class BindAuthorityTests(unittest.TestCase):
         return authority.BindAuthority(fp.path)
 
     def setUp(self) -> None:
-        self.auth = self.loadBindString(sampleBindZone)
+        self.auth = self.loadBindString(sampleBindZone, asText=True)
 
     def test_loadBindZonePathAsString(self) -> None:
         """
         L{BindAuthority} loads a BIND zone with filepath as type string.
         """
+        authority = self.loadBindString(sampleBindZone, asText=True)
         self.assertIsInstance(
-            self.auth, BindAuthority, "Loaded object is not a BindAuthority"
+            authority, BindAuthority, "Loaded object is not a BindAuthority"
         )
 
-        self.assertTrue(self.auth.records, "No records were loaded from the BIND zone")
+        self.assertTrue(authority.records, "No records were loaded from the BIND zone")
 
-        self.assertIsInstance(self.auth.records, dict, "Records is not a dictionary")
+        self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
 
     def test_loadBindZonePathAsBytes(self) -> None:
         """
         L{BindAuthority} loads a BIND zone with filepath as type bytes.
         """
-        authority = self.loadBindString(sampleBindZone, "bytes")
+        authority = self.loadBindString(sampleBindZone, asText=False)
 
         self.assertIsInstance(
             authority, BindAuthority, "Loaded object is not a BindAuthority"

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -1244,15 +1244,13 @@ class BindAuthorityTests(unittest.TestCase):
         """
         L{BindAuthority} loads a BIND zone with filepath as type string.
         """
-        authority = self.loadBindString(sampleBindZone)
-
         self.assertIsInstance(
-            authority, BindAuthority, "Loaded object is not a BindAuthority"
+            self.auth, BindAuthority, "Loaded object is not a BindAuthority"
         )
 
-        self.assertTrue(authority.records, "No records were loaded from the BIND zone")
+        self.assertTrue(self.auth.records, "No records were loaded from the BIND zone")
 
-        self.assertIsInstance(authority.records, dict, "Records is not a dictionary")
+        self.assertIsInstance(self.auth.records, dict, "Records is not a dictionary")
 
     def test_loadBindZonePathAsBytes(self) -> None:
         """

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -1223,16 +1223,16 @@ class BindAuthorityTests(unittest.TestCase):
         @return: a new bind authority
         @rtype: L{twisted.names.authority.BindAuthority}
         """
-        fp: FilePath[AnyStr] = FilePath(path)
+        fp = FilePath(path)
         fp.setContent(s)
 
         return authority.BindAuthority(fp.path)
 
-    def setUp(self):
-        path = self.mktemp().encode("ascii")
+    def setUp(self) -> None:
+        path = FilePath(self.mktemp()).asBytesMode().path
         self.auth = self.loadBindString(sampleBindZone, path)
 
-    def test_loadBindZonePathAsString(self):
+    def test_loadBindZonePathAsString(self) -> None:
         """
         L{BindAuthority} loads a BIND zone with filepath as type string.
         """
@@ -1250,11 +1250,11 @@ class BindAuthorityTests(unittest.TestCase):
             len(authority.records), 0, "No domains were parsed into records"
         )
 
-    def test_loadBindZonePathAsBytes(self):
+    def test_loadBindZonePathAsBytes(self) -> None:
         """
         L{BindAuthority} loads a BIND zone with filepath as type bytes.
         """
-        path = self.mktemp().encode("ascii")
+        path = FilePath(self.mktemp()).asBytesMode().path
         authority = self.loadBindString(sampleBindZone, path)
 
         self.assertIsInstance(
@@ -1357,7 +1357,7 @@ class BindAuthorityTests(unittest.TestCase):
         """
         loadBindString raises NotImplementedError on invalid records.
         """
-        path = self.mktemp().encode("ascii")
+        path = FilePath(self.mktemp()).asBytesMode().path
         with self.assertRaises(NotImplementedError) as e:
             self.loadBindString(b"example.com. IN LOL 192.168.0.1", path)
         self.assertEqual("Record type 'LOL' not supported", e.exception.args[0])

--- a/src/twisted/names/test/test_names.py
+++ b/src/twisted/names/test/test_names.py
@@ -1360,7 +1360,7 @@ class BindAuthorityTests(unittest.TestCase):
         """
         $INCLUDE and $GENERATE raise NotImplementedError.
         """
-        path = self.mktemp().encode("ascii")
+        path = FilePath(self.mktemp()).asBytesMode().path
         for directive in (b"$INCLUDE", b"$GENERATE"):
             with self.assertRaises(NotImplementedError) as e:
                 self.loadBindString(directive + b" doesNotMatter", path)


### PR DESCRIPTION
## Scope and purpose

Fixes #11972
This fixes an issues where bind style zone files are not loaded at all, due to an error in how the origin is generated, leading to a concat error. 

`twistd -n dns --bindzone example.com`

`TypeError: can only concatenate str (not "bytes") to str` 

see #11972 for more details

Since nativeString handles both C{bytes} and C{str}, it is now concatenating based on nativeString's output. 

All tests pass locally but I did not write an explicit test to cover this since file I/O in tests is discouraged, and I am assuming that this may be the only way to tests this. 