### PR TITLE
#12441 Fix HelperTests.test_refuteCryptedPassword on RHEL/CentOS 10.

### DIFF
--- a/src/twisted/conch/test/test_checkers.py
+++ b/src/twisted/conch/test/test_checkers.py
@@ -100,8 +100,9 @@ class HelperTests(TestCase):
         passed to it does not match the encrypted password passed to it.
         """
         password = "string secret"
+        salt = "somesalt"
         wrong = "secret string"
-        crypted = crypt.crypt(password, password)
+        crypted = crypt.crypt(password, salt)
         self.assertFalse(
             checkers.verifyCryptedPassword(crypted, wrong),
             "{!r} not supposed to be valid encrypted password for {}".format(


### PR DESCRIPTION
## Scope and purpose

Fixes #12441

It seems that using a space in the value of the salt isn't ok. See the output of these command on the system python from RHEL/CentOS 10 (python 3.12):

With a space inside the salt:
```
[root@1c8c39c3af64 /]# python3 -c 'import crypt; password = "string secret"; salt = "string secret"; print(crypt.crypt(password, salt))' <string>:1: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13 Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python3.12/crypt.py", line 86, in crypt
    return _crypt.crypt(word, salt)
           ^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 22] Invalid argument
```

Without space inside the salt:
```
[root@1c8c39c3af64 /]# python3 -c 'import crypt; password = "string secret"; salt = "somesalt"; print(crypt.crypt(password, salt))'
<string>:1: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
soNjU7bEB6dXw
```
