### PR TITLE
#12454 Handle upcoming 3DES deprecation in the cryptography library.

### DIFF
--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -26,12 +26,10 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 try:
-    from cryptography.hazmat.decrepit.ciphers import (  # type: ignore[attr-defined]
-        TripleDES,
-    )
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
-    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 
 from typing_extensions import Literal
 

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -26,7 +26,7 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 try:
-    from cryptography.hazmat.decrepit.ciphers import TripleDES
+    from cryptography.hazmat.decrepit.ciphers import TripleDES  # type: ignore[attr-defined]
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -24,6 +24,13 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+try:
+    from cryptography.hazmat.primitives.decrepit.ciphers import TripleDES
+except ImportError:
+    # Deprecated path, will be removed in cryptography 48.0.0
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+
 from typing_extensions import Literal
 
 from twisted import __version__ as twisted_version
@@ -107,14 +114,14 @@ class SSHCiphers:
     """
 
     cipherMap = {
-        b"3des-cbc": (algorithms.TripleDES, 24, modes.CBC),
+        b"3des-cbc": (TripleDES, 24, modes.CBC),
         b"aes256-cbc": (algorithms.AES, 32, modes.CBC),
         b"aes192-cbc": (algorithms.AES, 24, modes.CBC),
         b"aes128-cbc": (algorithms.AES, 16, modes.CBC),
         b"aes128-ctr": (algorithms.AES, 16, modes.CTR),
         b"aes192-ctr": (algorithms.AES, 24, modes.CTR),
         b"aes256-ctr": (algorithms.AES, 32, modes.CTR),
-        b"3des-ctr": (algorithms.TripleDES, 24, modes.CTR),
+        b"3des-ctr": (TripleDES, 24, modes.CTR),
         b"none": (None, 0, modes.CBC),
     }
     macMap = {

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -31,7 +31,7 @@ try:
     )
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
-    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
 
 from typing_extensions import Literal
 

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -26,7 +26,7 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 try:
-    from cryptography.hazmat.primitives.decrepit.ciphers import TripleDES
+    from cryptography.hazmat.decrepit.ciphers import TripleDES
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -26,8 +26,8 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 try:
-    from cryptography.hazmat.decrepit.ciphers import (
-        TripleDES,  # type: ignore[attr-defined]
+    from cryptography.hazmat.decrepit.ciphers import (  # type: ignore[attr-defined]
+        TripleDES,
     )
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -26,7 +26,9 @@ from cryptography.hazmat.primitives.asymmetric import dh, ec, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 try:
-    from cryptography.hazmat.decrepit.ciphers import TripleDES  # type: ignore[attr-defined]
+    from cryptography.hazmat.decrepit.ciphers import (
+        TripleDES,  # type: ignore[attr-defined]
+    )
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES

--- a/src/twisted/newsfragments/12454.misc
+++ b/src/twisted/newsfragments/12454.misc
@@ -1,0 +1,1 @@
+Add support for 3DES deprecation in future cryptography release.


### PR DESCRIPTION
Fixes #12454

Since cryptography 43.0.0 we have this change in the cryptograhy library

Moved [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id107) and [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.ARC4`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id109) into [:doc:`/hazmat/decrepit/index`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id111) and deprecated them in the cipher module. They will be removed from the cipher module in 48.0.0.

------

The plan is to stop exporting the old name in 48.0.0

This prepares the code for future upgrade