### PR TITLE
#12458 Fix `rebuild()` to handle changing `sys.modules` gracefully

### DIFF
--- a/src/twisted/newsfragments/12458.bugfix
+++ b/src/twisted/newsfragments/12458.bugfix
@@ -1,0 +1,1 @@
+twisted.python.rebuild.rebuild() now handles changes to ``sys.modules`` gracefully. Prior to the change, it could possibly raise a "dictionary changed size during iteration" error if the module list changed.

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -210,7 +210,10 @@ def rebuild(module, doLog=1):
         log.msg("")
         log.msg(f"  (fixing   {str(module.__name__)}): ")
     modcount = 0
-    for mk, mod in sys.modules.items():
+    # note: sys.modules can change throughout iteration
+    # https://github.com/twisted/twisted/issues/12458
+    for mk in list(sys.modules):
+        mod = sys.modules.get(mk)
         modcount = modcount + 1
         if mod == module or mod is None:
             continue


### PR DESCRIPTION
## Scope and purpose

Copy keys from `sys.modules` before starting to iterate over it in the `rebuild()` function, and handle missing modules gracefully, in order to fix possible "directionary changed size during iteration" errors.  In particular, this can happen when iterating over the `py` module.

Fixes #12458
