### PR TITLE
12462 - remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use. 
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.9.0'
+          - python-version: '3.9'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
             runs-on: 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use. 
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.9.22'
+          - python-version: '3.9.0'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
             runs-on: 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use. 
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.9'
+          - python-version: '3.9.12'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
             runs-on: 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use. 
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.8.12'
+          - python-version: '3.9.22'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
             runs-on: 'ubuntu-22.04'
@@ -124,13 +124,10 @@ jobs:
           # We go with latest micro release for the smallest minor release
           # that we support.
           # This is also used to run tests with minimum dependency versions.
-          - python-version: '3.8'
+          - python-version: '3.9'
             noipv6: '-noipv6'
             tox-env: 'mindeps-withcov-posix'
             job-name: 'minimum-deps-noipv6'
-
-          # Just Python 3.8 with default settings.
-          - python-version: '3.8'
 
           # Just Python 3.9 with default settings.
           - python-version: '3.9'
@@ -145,7 +142,7 @@ jobs:
           - python-version: '3.13'
 
           # Newest Intel macOS and oldest Python (major) supported versions.
-          - python-version: '3.8'
+          - python-version: '3.9'
             runs-on: 'macos-13'
             job-name: 'macos-13-default-tests'
             tox-env: 'macos-withcov-alldeps'
@@ -157,7 +154,7 @@ jobs:
             tox-env: 'macos-withcov-alldeps'
 
           # Windows, minimum Python version with select reactor.
-          - python-version: '3.8'
+          - python-version: '3.9'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-select'
@@ -192,7 +189,7 @@ jobs:
           # We run the full test suite with the GI reactor against an X virtual
           # framebuffer server.  This covers our integration with the version
           # of Gtk packaged within our selected version of Linux above.
-          - python-version: '3.8'
+          - python-version: '3.9'
             tox-env: 'alldeps-gtk-withcov-posix'
             platform-deps: 'gtk-platform'
             tox-wrapper: 'xvfb-run -a'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [
 description = "An asynchronous networking framework written in Python"
 license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-requires-python = ">=3.9.0"
+requires-python = ">=3.9.12"
 authors = [
     { name = "Twisted Matrix Community", email = "twisted@python.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,13 @@ dynamic = [
 description = "An asynchronous networking framework written in Python"
 license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 authors = [
     { name = "Twisted Matrix Community", email = "twisted@python.org" },
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -283,7 +282,7 @@ include = [
         showcontent = false
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,11 +110,8 @@ all-non-platform = [
 
 macos-platform = [
     "twisted[all-non-platform]",
-    "pyobjc-core < 11; python_version < '3.9'",
     "pyobjc-core; python_version >= '3.9'",
-    "pyobjc-framework-CFNetwork < 11; python_version < '3.9'",
     "pyobjc-framework-CFNetwork; python_version >= '3.9'",
-    "pyobjc-framework-Cocoa < 11; python_version < '3.9'",
     "pyobjc-framework-Cocoa; python_version >= '3.9'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ osx-platform = [
 
 gtk-platform = [
     "twisted[all-non-platform]",
-    "pygobject",
+    "pygobject < 3.52.1",
 ]
 
 mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ include = [
         showcontent = false
 
 [tool.black]
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ tls = [
 conch = [
     "cryptography >= 3.3",
     "appdirs >= 1.4.0",
-    "bcrypt >= 3.1.3",
+    "bcrypt >= 3.2.1",
 ]
 
 serial = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ osx-platform = [
 
 gtk-platform = [
     "twisted[all-non-platform]",
+    "pygobject; python_version >= '3.10'",
     "pygobject < 3.52.1; python_version < '3.10'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ osx-platform = [
 
 gtk-platform = [
     "twisted[all-non-platform]",
-    "pygobject < 3.52.1",
+    "pygobject < 3.52.1; python_version < '3.10'",
 ]
 
 mypy = [

--- a/src/twisted/newsfragments/12462.removal
+++ b/src/twisted/newsfragments/12462.removal
@@ -1,0 +1,1 @@
+Remove support for python3.8.

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ deps =
     # Conch
     mindeps: cryptography == 3.3
     mindeps: appdirs == 1.4.0
-    mindeps: bcrypt == 3.1.3
+    mindeps: bcrypt == 3.2.1
     # HTTP
     mindeps: h2 == 3.2
     mindeps: priority == 1.1.0


### PR DESCRIPTION
## Scope and purpose

Fixes #12462 

Removes support for Python 3.8 from supported versions and CICD.

