### PR TITLE
Import twisted.logger.rsyslog.RemoteSyslogObserver

### DIFF
--- a/src/twisted/logger/rsyslog.py
+++ b/src/twisted/logger/rsyslog.py
@@ -1,0 +1,111 @@
+import os
+import socket
+from datetime import datetime
+
+from zope.interface import implementer
+
+from twisted.logger import ILogObserver, LogLevel, LogEvent
+
+
+@implementer(ILogObserver)
+class RemoteSyslogObserver:
+    """
+    Log observer that forwards to an RFC 3164 remote syslog server.
+
+    @cvar severities: translates Twisted's C{LogLevel}s to syslog's.
+    """
+
+    severities = {
+        # no LogLevel equivalent for LOG_EMERG (0)
+        # no LogLevel equivalent for LOG_ALERT (1)
+        LogLevel.critical: 2,  # LOG_CRIT
+        LogLevel.error: 3,  # LOG_ERR
+        LogLevel.warn: 4,  # LOG_WARNING
+        # no LogLevel equivalent for LOG_NOTICE (5)
+        LogLevel.info: 6,  # LOG_INFO
+        LogLevel.debug: 7,  # LOG_DEBUG
+    }
+
+    def __init__(
+        self,
+        server: str,
+        facility: int = 8,
+        *,
+        port: int = 514,
+        protocol: int = socket.SOCK_DGRAM,
+        pid: int|None = None,
+        client_name: str|None = None,
+        encoding: str = "ASCII",
+    ):
+        """
+        @param server: Hostname or address of the remote syslog server.
+
+        @param facility: Syslog facility number. See Python's C{syslog} module.
+            Defaults to LOG_USER.
+
+        @param port: Port the remote syslog server is listening on. Defaults to
+            514.
+
+        @param protocol: Protocol to use (TCP or UDP). Use C{socket.SOCK_DGRAM}
+            or C{socket.SOCK_STREAM}. Defaults to UDP.
+
+        @param pid: Optionally overwrite the process ID sent in syslog messages.
+            Defaults to the actual PID.
+
+        @param client_name: Optionally overwrite the client identifier sent in
+            syslog messages. Defaults to the actual hostname.
+
+        @param encoding: Encoding to use for log messages. Unrepresentable
+            characters are dropped from the message.
+        """
+        # NOTE: facility=8 is LOG_USER.
+        self.socket = None
+        self.server = server
+        self.port = port
+        self.protocol = protocol
+        self.facility = facility  # syslog.LOG_* (already is n * 8)
+        if self.facility & 0b111 != 0:
+            raise ValueError("syslog facility must have lowest three bits cleared")
+        if pid is None:
+            pid = os.getpid()
+        self.pid = pid
+        if client_name is None:
+            client_name, _, _ = (socket.getfqdn() or socket.gethostname()).partition(
+                "."
+            )
+        self.client_name = client_name
+        self.encoding = encoding
+
+    def __call__(self, event: LogEvent) -> None:
+        """
+        Forward an event over syslog.
+
+        @param event: An event.
+        """
+        # message is broken up into lines, sent separately (as in twisted.python.syslog)
+        for i, message in enumerate(event["log_format"].splitlines()):
+            leader = "\t" if i else ""
+            self._send(leader + message, event)
+
+    def _send(self, message: str, event: LogEvent) -> None:
+        severity = self.severities[event["log_level"]]
+        program = event["log_namespace"]
+
+        d = "<%d>%s %s %s[%d]: %s\n" % (
+            self.facility + severity,
+            datetime.fromtimestamp(event["log_time"]).strftime("%b %d %H:%M:%S"),
+            self.client_name,
+            program,
+            self.pid,
+            message,
+        )
+
+        try:
+            if not self.socket:
+                self.socket = socket.socket(socket.AF_INET, self.protocol)
+                self.socket.connect((self.server, self.port))
+            self.socket.sendall(d.encode(self.encoding, "ignore")[:1024])
+        except socket.error:
+            if self.socket is not None:
+                self.socket.close()
+                self.socket = None

--- a/src/twisted/logger/rsyslog.py
+++ b/src/twisted/logger/rsyslog.py
@@ -1,10 +1,21 @@
 import os
-import socket
+import platform
 from datetime import datetime
+from typing import Optional
 
 from zope.interface import implementer
 
-from twisted.logger import ILogObserver, LogLevel, LogEvent
+from twisted.internet import protocol, reactor
+from twisted.logger import ILogObserver, LogEvent, LogLevel
+
+
+class UDPSyslog(protocol.DatagramProtocol):
+    def __init__(self, address: tuple[str, int]):
+        self.address = address
+        reactor.listenUDP(0, self)
+
+    def send(self, data: bytes) -> None:
+        self.transport.write(data, self.address)
 
 
 @implementer(ILogObserver)
@@ -32,9 +43,9 @@ class RemoteSyslogObserver:
         facility: int = 8,
         *,
         port: int = 514,
-        protocol: int = socket.SOCK_DGRAM,
-        pid: int|None = None,
-        client_name: str|None = None,
+        handler: type[UDPSyslog] = UDPSyslog,
+        pid: Optional[int] = None,
+        client_name: Optional[str] = None,
         encoding: str = "ASCII",
     ):
         """
@@ -46,8 +57,7 @@ class RemoteSyslogObserver:
         @param port: Port the remote syslog server is listening on. Defaults to
             514.
 
-        @param protocol: Protocol to use (TCP or UDP). Use C{socket.SOCK_DGRAM}
-            or C{socket.SOCK_STREAM}. Defaults to UDP.
+        @param handler: Class implementing C{UDPSyslog}.
 
         @param pid: Optionally overwrite the process ID sent in syslog messages.
             Defaults to the actual PID.
@@ -59,10 +69,7 @@ class RemoteSyslogObserver:
             characters are dropped from the message.
         """
         # NOTE: facility=8 is LOG_USER.
-        self.socket = None
-        self.server = server
-        self.port = port
-        self.protocol = protocol
+        self.handler = handler((server, port))
         self.facility = facility  # syslog.LOG_* (already is n * 8)
         if self.facility & 0b111 != 0:
             raise ValueError("syslog facility must have lowest three bits cleared")
@@ -70,9 +77,7 @@ class RemoteSyslogObserver:
             pid = os.getpid()
         self.pid = pid
         if client_name is None:
-            client_name, _, _ = (socket.getfqdn() or socket.gethostname()).partition(
-                "."
-            )
+            client_name, _, _ = platform.node().partition(".")
         self.client_name = client_name
         self.encoding = encoding
 
@@ -82,30 +87,20 @@ class RemoteSyslogObserver:
 
         @param event: An event.
         """
+        severity = self.severities[event["log_level"]]
+        program = event["log_namespace"]
+        timestamp = datetime.fromtimestamp(event["log_time"]).strftime("%b %d %H:%M:%S")
+
         # message is broken up into lines, sent separately (as in twisted.python.syslog)
         for i, message in enumerate(event["log_format"].splitlines()):
             leader = "\t" if i else ""
-            self._send(leader + message, event)
+            d = "<%d>%s %s %s[%d]: %s\n" % (
+                self.facility + severity,
+                timestamp,
+                self.client_name,
+                program,
+                self.pid,
+                leader + message,
+            )
 
-    def _send(self, message: str, event: LogEvent) -> None:
-        severity = self.severities[event["log_level"]]
-        program = event["log_namespace"]
-
-        d = "<%d>%s %s %s[%d]: %s\n" % (
-            self.facility + severity,
-            datetime.fromtimestamp(event["log_time"]).strftime("%b %d %H:%M:%S"),
-            self.client_name,
-            program,
-            self.pid,
-            message,
-        )
-
-        try:
-            if not self.socket:
-                self.socket = socket.socket(socket.AF_INET, self.protocol)
-                self.socket.connect((self.server, self.port))
-            self.socket.sendall(d.encode(self.encoding, "ignore")[:1024])
-        except socket.error:
-            if self.socket is not None:
-                self.socket.close()
-                self.socket = None
+            self.handler.send(d.encode(self.encoding, "ignore")[:1024])

--- a/src/twisted/logger/rsyslog.py
+++ b/src/twisted/logger/rsyslog.py
@@ -33,7 +33,9 @@ class UDPSyslogTransport(protocol.DatagramProtocol):
     UDP Transport for C{RemoteSyslogObserver}.
     """
 
-    def __init__(self, address: tuple[str, int], *, maxDatagramBytes: int = 1024, reactor = None):
+    def __init__(
+        self, address: tuple[str, int], *, maxDatagramBytes: int = 1024, reactor=None
+    ):
         """
         @param address: host and port of the remote syslog server.
 
@@ -51,7 +53,7 @@ class UDPSyslogTransport(protocol.DatagramProtocol):
             self._reactor.listenUDP(0, self)
 
         self._reactor.callFromThread(
-            self.transport.write, data[:self.maxDatagramBytes], self.address
+            self.transport.write, data[: self.maxDatagramBytes], self.address
         )
 
 
@@ -80,7 +82,7 @@ class RemoteSyslogObserver:
     def __init__(
         self,
         transport: ISyslogTransport,
-        facility: int = 8, # LOG_USER
+        facility: int = 8,  # LOG_USER
         *,
         pid: Optional[int] = None,
         client_name: Optional[str] = None,

--- a/src/twisted/logger/rsyslog.py
+++ b/src/twisted/logger/rsyslog.py
@@ -3,19 +3,56 @@ import platform
 from datetime import datetime
 from typing import Optional
 
-from zope.interface import implementer
+from zope.interface import Interface, implementer
 
-from twisted.internet import protocol, reactor
+from twisted.internet import protocol
 from twisted.logger import ILogObserver, LogEvent, LogLevel
 
 
-class UDPSyslog(protocol.DatagramProtocol):
-    def __init__(self, address: tuple[str, int]):
+def rsyslog(server="localhost", port=514, protocol="udp", facility=8):
+    if protocol == "udp":
+        transport = UDPSyslogTransport((server, port))
+    else:
+        raise ValueError("Invalid Protocol")
+
+    return RemoteSyslogObserver(transport, facility)
+
+
+class ISyslogTransport(Interface):
+    def send(self, data: bytes) -> None:
+        """
+        Sends a single syslog message.
+
+        @param data: encoded message to send.
+        """
+
+
+@implementer(ISyslogTransport)
+class UDPSyslogTransport(protocol.DatagramProtocol):
+    """
+    UDP Transport for C{RemoteSyslogObserver}.
+    """
+
+    def __init__(self, address: tuple[str, int], *, maxDatagramBytes: int = 1024, reactor = None):
+        """
+        @param address: host and port of the remote syslog server.
+
+        @param maxDatagramBytes: override maximum length of transported messages.
+        """
         self.address = address
-        reactor.listenUDP(0, self)
+        self.maxDatagramBytes = maxDatagramBytes
+
+        if reactor is None:
+            from twisted.internet import reactor
+        self._reactor = reactor
 
     def send(self, data: bytes) -> None:
-        self.transport.write(data, self.address)
+        if not self.transport:
+            self._reactor.listenUDP(0, self)
+
+        self._reactor.callFromThread(
+            self.transport.write, data[:self.maxDatagramBytes], self.address
+        )
 
 
 @implementer(ILogObserver)
@@ -25,6 +62,9 @@ class RemoteSyslogObserver:
 
     @cvar severities: translates Twisted's C{LogLevel}s to syslog's.
     """
+
+    # NOTE: we avoid importing Python's syslog module just for its LOG_*
+    # constants, since that is not available on non-Unix systems.
 
     severities = {
         # no LogLevel equivalent for LOG_EMERG (0)
@@ -39,25 +79,18 @@ class RemoteSyslogObserver:
 
     def __init__(
         self,
-        server: str,
-        facility: int = 8,
+        transport: ISyslogTransport,
+        facility: int = 8, # LOG_USER
         *,
-        port: int = 514,
-        handler: type[UDPSyslog] = UDPSyslog,
         pid: Optional[int] = None,
         client_name: Optional[str] = None,
         encoding: str = "ASCII",
     ):
         """
-        @param server: Hostname or address of the remote syslog server.
+        @param transport: Instance of a class implementing C{ISyslogTransport}.
 
         @param facility: Syslog facility number. See Python's C{syslog} module.
             Defaults to LOG_USER.
-
-        @param port: Port the remote syslog server is listening on. Defaults to
-            514.
-
-        @param handler: Class implementing C{UDPSyslog}.
 
         @param pid: Optionally overwrite the process ID sent in syslog messages.
             Defaults to the actual PID.
@@ -68,8 +101,7 @@ class RemoteSyslogObserver:
         @param encoding: Encoding to use for log messages. Unrepresentable
             characters are dropped from the message.
         """
-        # NOTE: facility=8 is LOG_USER.
-        self.handler = handler((server, port))
+        self.transport = transport
         self.facility = facility  # syslog.LOG_* (already is n * 8)
         if self.facility & 0b111 != 0:
             raise ValueError("syslog facility must have lowest three bits cleared")
@@ -103,4 +135,4 @@ class RemoteSyslogObserver:
                 leader + message,
             )
 
-            self.handler.send(d.encode(self.encoding, "ignore")[:1024])
+            self.transport.send(d.encode(self.encoding, "ignore"))

--- a/src/twisted/logger/test/test_rsyslog.py
+++ b/src/twisted/logger/test/test_rsyslog.py
@@ -1,0 +1,53 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+Test cases for L{twisted.logger.rsyslog}.
+"""
+
+from twisted.internet import protocol
+from twisted.logger import Logger, LogPublisher
+from twisted.logger.rsyslog import RemoteSyslogObserver
+from twisted.trial.unittest import TestCase
+from twisted.internet.test.reactormixins import ReactorBuilder
+
+
+class RsyslogReceiver(protocol.DatagramProtocol):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.received = []
+
+    def datagramReceived(self, data, addr):
+        self.received.append(data)
+
+
+class RemoteSyslogTests(TestCase):
+    """
+    Tests for L{RemoteSyslogObserver}.
+    """
+
+    def setUp(self):
+        reactor = self.buildReactor()
+        self.rx = RsyslogReceiver()
+        self.p = reactor.listenUDP(0, self.rx, interface="127.0.0.1")
+        self.port = self.p.getHost().port
+
+    def tearDown(self):
+        return self.p.stopListening()
+
+    def test_capture(self) -> None:
+        """
+        Events logged are forwarded to an rsyslog server.
+        """
+        obs = LogPublisher()
+        self.log = Logger("rsyslog", observer=obs)
+        obs.addObserver(RemoteSyslogObserver("127.0.0.1", port=self.port))
+
+        self.log.debug("Capture this, please")
+        self.log.info("Capture this too, please")
+
+        self.assertTrue(len(self.rx.received) == 2)
+        self.assertEqual(self.rx.received[0], b"")
+        self.assertEqual(self.rx.received[1], b"")
+
+globals().update(ReactorBuilder.makeTestCaseClasses())

--- a/src/twisted/logger/test/test_rsyslog.py
+++ b/src/twisted/logger/test/test_rsyslog.py
@@ -6,10 +6,10 @@ Test cases for L{twisted.logger.rsyslog}.
 """
 
 from twisted.internet import protocol
+from twisted.internet.test.reactormixins import ReactorBuilder
 from twisted.logger import Logger, LogPublisher
 from twisted.logger.rsyslog import RemoteSyslogObserver
 from twisted.trial.unittest import TestCase
-from twisted.internet.test.reactormixins import ReactorBuilder
 
 
 class RsyslogReceiver(protocol.DatagramProtocol):
@@ -49,5 +49,6 @@ class RemoteSyslogTests(TestCase):
         self.assertTrue(len(self.rx.received) == 2)
         self.assertEqual(self.rx.received[0], b"")
         self.assertEqual(self.rx.received[1], b"")
+
 
 globals().update(ReactorBuilder.makeTestCaseClasses())

--- a/src/twisted/newsfragments/12464.feature
+++ b/src/twisted/newsfragments/12464.feature
@@ -1,0 +1,1 @@
+The new module twisted.logger.rsyslog allows sending syslog messages directly to a remote server, without local syslog support.


### PR DESCRIPTION
## Scope and purpose

Fixes #12464

The twisted.python.syslog.SyslogObserver can only forwards logs to the local syslog (which is fine per se). RemoteSyslogObserver directly sends Syslog messages over the network, without going through local syslog. 

* Happy to receive feedback now, will un-draft this PR once I have written tests and documentation for it (unless instructed otherwise)
* I usually amend my commit(s) instead of adding additional fixup commits for addressing review comments. If you would prefer the latter, just say so.