### PR TITLE
#10261 Do not chmod preexisting UNIX socket

### DIFF
--- a/docs/core/howto/systemd.rst
+++ b/docs/core/howto/systemd.rst
@@ -285,11 +285,11 @@ Note the following important directives and changes:
 
 ExecStart
 
-  The ``domain=INET`` endpoint argument makes ``twistd`` treat the inherited file descriptor as an IPv4 socket.
+  The ``domain=INET`` endpoint argument makes ``twistd`` treat the inherited file descriptor as an IPv4 TCP socket.
 
   The ``name=my-web-port`` endpoint argument makes ``twistd`` adopt the file descriptor inherited from ``systemd`` named ``my-web-port``.
 
-  Socket activation is also technically possible with other socket families and types, but Twisted currently only accepts IPv4 and IPv6 TCP sockets. See :ref:`limitations` below.
+  Use ``domain=INET6`` instead for an IPv6 TCP socket or ``domain=UNIX`` for a UNIX socket. Datagram sockets are not suported. See :ref:`limitations` below.
 
 Requires
 

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -7,7 +7,7 @@ Tests for implementations of L{IReactorUNIX}.
 
 
 from hashlib import md5
-from os import close, fstat, stat, unlink, urandom
+from os import chmod, close, fstat, stat, unlink, urandom
 from pprint import pformat
 from socket import AF_INET, SOCK_STREAM, SOL_SOCKET, socket
 from stat import S_IMODE
@@ -235,6 +235,23 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         the mode specified.
         """
         self._modeTest("listenUNIX", self.mktemp(), ServerFactory())
+
+    @skipIf(platformType != "posix", "UNIX sockets only supported on POSIX.")
+    def test_preexistingSocketMode(self):
+        "startListening must not change mode of preexisting socket."
+        sock = socket(AF_UNIX)
+        # self.mktemp() often returns a path which is too long to be used.
+        path = mktemp(suffix=".sock", dir=".")
+        sock.bind(path)
+        self.addCleanup(unlink, path)
+        self.addCleanup(sock.close)
+        mode = 0o600
+        chmod(path, mode)
+
+        reactor = self.buildReactor()
+        unixPort = reactor.adoptStreamPort(sock.fileno(), sock.family, ServerFactory())
+        unixPort.stopListening()
+        self.assertEqual(S_IMODE(stat(path).st_mode), mode)
 
     @skipIf(
         not platform.isLinux(),

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -349,6 +349,7 @@ class Port(_UNIXPort, tcp.Port):
         self.mode = mode
         self.wantPID = wantPID
         self._preexistingSocket = None
+        self._socketIsOurFile = False
 
     @classmethod
     def _fromListeningDescriptor(cls, reactor, fd, factory):
@@ -367,6 +368,7 @@ class Port(_UNIXPort, tcp.Port):
         port = socket.fromfd(fd, cls.addressFamily, cls.socketType)
         self = cls(port.getsockname(), factory, reactor=reactor)
         self._preexistingSocket = port
+        self._socketIsOurFile = _inFilesystemNamespace(self.port)
         return self
 
     def __repr__(self) -> str:
@@ -426,7 +428,7 @@ class Port(_UNIXPort, tcp.Port):
         except OSError as le:
             raise error.CannotListenError(None, self.port, le)
         else:
-            if _inFilesystemNamespace(self.port):
+            if self._socketIsOurFile:
                 # Make the socket readable and writable to the world.
                 os.chmod(self.port, self.mode)
             skt.listen(self.backlog)
@@ -451,7 +453,7 @@ class Port(_UNIXPort, tcp.Port):
         )
 
     def connectionLost(self, reason):
-        if _inFilesystemNamespace(self.port):
+        if self._socketIsOurFile:
             os.unlink(self.port)
         if self.lockFile is not None:
             self.lockFile.unlock()

--- a/src/twisted/newsfragments/10261.bugfix
+++ b/src/twisted/newsfragments/10261.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.unix.Port(...).startListening() no longer calls chmod on preexisting sockets, and .connectionLost() no longer unlinks them.


### PR DESCRIPTION
## Scope and purpose

Fixes #10261

The first commit is a somewhat unrelated doc fix.

The second commit skips the UNIX socket chmod when inheriting a preexisting socket (instead of creating a new one). This is for the systemd case where the twisted process may not have permission to chmod the socket (and the user has no way to specify the mode, and is presumably happy with the permissions systemd created the socket with).

As an aside, similar code applies to datagram sockets, but I have never used one of those.