### PR TITLE
#12478 Fix initial delay for ReconnectingClientFactory

### DIFF
--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -415,7 +415,6 @@ class ReconnectingClientFactory(ClientFactory):
                 log.msg("Abandoning %s after %d retries." % (connector, self.retries))
             return
 
-        self.delay = min(self.delay * self.factor, self.maxDelay)
         if self.jitter:
             self.delay = random.normalvariate(self.delay, self.delay * self.jitter)
 
@@ -437,6 +436,8 @@ class ReconnectingClientFactory(ClientFactory):
 
             self.clock = reactor
         self._callID = self.clock.callLater(self.delay, reconnector)
+
+        self.delay = min(self.delay * self.factor, self.maxDelay)
 
     def stopTrying(self):
         """

--- a/src/twisted/newsfragments/12478.bugfix
+++ b/src/twisted/newsfragments/12478.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.protocol.ReconnectingClientFactory: Don't multiply by ``factor`` for initial delay, but use ``initialDelay`` directly.

--- a/src/twisted/test/test_factories.py
+++ b/src/twisted/test/test_factories.py
@@ -137,3 +137,25 @@ class ReconnectingFactoryTests(TestCase):
 
         factory.clientConnectionLost(FakeConnector(), None)
         self.assertEqual(len(clock.calls), 1)
+
+    def test_initialDelay(self):
+        """
+        Test that the first delay for reconnection is equal to the ``initialDelay``
+        attribute.
+        """
+        clock = Clock()
+        factory = ReconnectingClientFactory()
+        factory.clock = clock
+        # Remove jitter to make it easier to check the result.
+        factory.jitter = None
+
+        # Trigger a failed connection.
+        factory.clientConnectionLost(FakeConnector(), None)
+
+        # The first retry is scheduled based only on the initial delay value. Check that
+        # the actual delay for the scheduled retry call is equal to the initial delay
+        # given by ``ReconnectingClientFactory.initialDelay``.
+        self.assertEqual(len(clock.calls), 1)
+        actualDelay = clock.calls[0].getTime()
+        expectedDelay = factory.initialDelay
+        self.assertEqual(actualDelay, expectedDelay)


### PR DESCRIPTION
The initial delay was already multiplied by ``factor``, but that should only be done for subsequent delays. Before this commit, the initial delay was too long, being equal to ``initialDelay * factor`` instead of just ``initialDelay``.

## Scope and purpose

Fixes #12478

Please refer to the issue for details.