### PR TITLE
#12480 Handle bytes-like objects in dns queries in the dynamic dns client example

### DIFF
--- a/docs/names/howto/listings/names/override_server.py
+++ b/docs/names/howto/listings/names/override_server.py
@@ -26,7 +26,7 @@ class DynamicResolver:
     query type and name.
     """
 
-    _pattern = "workstation"
+    _pattern = b"workstation"
     _network = "172.0.2"
 
     def _dynamicResponseRequired(self, query):
@@ -34,7 +34,7 @@ class DynamicResolver:
         Check the query to determine if a dynamic response is required.
         """
         if query.type == dns.A:
-            labels = query.name.name.split(".")
+            labels = query.name.name.split(b".")
             if labels[0].startswith(self._pattern):
                 return True
 
@@ -45,12 +45,12 @@ class DynamicResolver:
         Calculate the response to a query.
         """
         name = query.name.name
-        labels = name.split(".")
+        labels = name.split(b".")
         parts = labels[0].split(self._pattern)
         lastOctet = int(parts[1])
         answer = dns.RRHeader(
             name=name,
-            payload=dns.Record_A(address=b"%s.%s" % (self._network, lastOctet)),
+            payload=dns.Record_A(address=f"{self._network}.{lastOctet}".encode()),
         )
         answers = [answer]
         authority = []

--- a/src/twisted/newsfragments/12480.doc
+++ b/src/twisted/newsfragments/12480.doc
@@ -1,1 +1,1 @@
-Handle bytes-like objects in dns queries in the dynamic dns client example
+The example code from the documentation describing how to create a custom DNS server was updated to Python3.

--- a/src/twisted/newsfragments/12480.doc
+++ b/src/twisted/newsfragments/12480.doc
@@ -1,0 +1,1 @@
+Handle bytes-like objects in dns queries in the dynamic dns client example


### PR DESCRIPTION
## Scope and purpose

Fixes #12480

Change the dynamic DNS example in the documentation such that it supports bytes-like objects in queries.

This can be tested by running:
```
python override_server.py
```
And then:
```
dig -p 10053 @127.0.0.1 workstation1.example.com A +short
```