### PR TITLE
#12489 Upgrade to tox 4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -505,7 +505,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox~=4
+        python -m pip install --upgrade pip 'tox>4'
         tox -e release-prepare
         mkdir dist
         cp .tox/.pkg/dist/* dist/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -505,9 +505,10 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox~=3.0 pep517
-        rm -rf dist/*
+        python -m pip install --upgrade pip tox~=4
         tox -e release-prepare
+        mkdir dist
+        cp .tox/.pkg/dist/* dist/
 
     - uses: twisted/python-info-action@v1
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -183,7 +183,7 @@ jobs:
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
           - python-version: 'pypy3.10-v7.3.13'
-            trial-target: 'twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
+            trial-target: '-- twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'
 
           # We run the full test suite with the GI reactor against an X virtual

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -507,8 +507,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip 'tox>4'
         tox -e release-prepare
-        mkdir dist
-        cp .tox/.pkg/dist/* dist/
 
     - uses: twisted/python-info-action@v1
 

--- a/tox.ini
+++ b/tox.ini
@@ -220,11 +220,15 @@ commands =
         {posargs:src}
 
 ;
-; Create sdist and wheel packages and run basic tests on them.
-; Makes the packages available in root `dist/` directory.
+; Create sdist and wheel packages and run basic validity checks on them.
+;
+; This does re-build the wheel one extra time, but tox does not build the sdist
+; itself, so it's easier to go through the official process of `build`.
 ;
 [testenv:release-prepare]
 deps =
     twine
+    build
 commands =
-    twine check .tox/.pkg/dist/*.*
+    python -m build
+    twine check dist/*.*

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
     mindeps: service_identity == 18.1.0
     mindeps: idna == 2.4
     # Conch
-    mindeps: cryptography == 3.3
+    mindeps: cryptography == 35.0.0
     mindeps: appdirs == 1.4.0
     mindeps: bcrypt == 3.2.1
     # HTTP

--- a/tox.ini
+++ b/tox.ini
@@ -225,13 +225,6 @@ commands =
 ;
 [testenv:release-prepare]
 deps =
-    pep517
     twine
-allowlist_externals =
-    cp
-    rm
 commands =
-    rm -rf {toxinidir}/dist
-    cp -r {distdir} {toxinidir}/dist # copy the wheel built by tox-wheel
-    {envpython} -m pep517.build --source --out-dir={toxinidir}/dist {toxinidir}
-    twine check {toxinidir}/dist/*.*
+    twine check .tox/.pkg/dist/*.*

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,11 @@
 ; See README.rst for example tox commands.
 ;
 [tox]
-minversion=3.24.1
+minversion=4
 requires=
     virtualenv>=20.7.2
     tox-wheel>=0.6.0
-    tox < 4
+    tox > 4
 skip_missing_interpreters=True
 envlist=lint, mypy,
     apidocs, narrativedocs, newsfragment,
@@ -40,6 +40,8 @@ sources = src/ docs/conch/examples docs/mail/examples docs/names/examples docs/p
 # If you remove the wheels from here, then also update the release
 # process to generate its own wheels.
 wheel = True
+package = wheel
+wheel_build_env = .pkg
 parallel_show_output = True
 ;; dependencies managed by extras in pyproject.toml
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -227,7 +227,7 @@ commands =
 deps =
     pep517
     twine
-whitelist_externals =
+allowlist_externals =
     cp
     rm
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@
 minversion=4
 requires=
     virtualenv>=20.7.2
-    tox-wheel>=0.6.0
     tox > 4
 skip_missing_interpreters=True
 envlist=lint, mypy,


### PR DESCRIPTION
## Scope and purpose

Fixes #12489

This upgrades to tox 4 and does a couple of minor build modernization things that I encountered while testing it. My local machine does not lock up and die at the end of the test run any more. Let's see how CI feels about it.