### PR TITLE
#12493 Prefer types in `typing` module instead of `typing_extensions`

### DIFF
--- a/src/twisted/_threads/_pool.py
+++ b/src/twisted/_threads/_pool.py
@@ -10,9 +10,7 @@ L{twisted.python.threadpool}.
 
 from queue import Queue
 from threading import Lock, Thread, local as LocalStorage
-from typing import Callable, Optional
-
-from typing_extensions import Protocol
+from typing import Callable, Optional, Protocol
 
 from twisted.python.log import err
 from ._ithreads import IWorker

--- a/src/twisted/application/runner/test/test_pidfile.py
+++ b/src/twisted/application/runner/test/test_pidfile.py
@@ -8,11 +8,9 @@ Tests for L{twisted.application.runner._pidfile}.
 import errno
 from functools import wraps
 from os import getpid, name as SYSTEM_NAME
-from typing import Any, Callable, Optional
+from typing import Any, Callable, NoReturn, Optional
 
 from zope.interface.verify import verifyObject
-
-from typing_extensions import NoReturn
 
 import twisted.trial.unittest
 from twisted.python.filepath import FilePath

--- a/src/twisted/conch/checkers.py
+++ b/src/twisted/conch/checkers.py
@@ -11,12 +11,23 @@ import binascii
 import errno
 import sys
 from base64 import decodebytes
-from typing import IO, Any, Callable, Iterable, Iterator, Mapping, Optional, Tuple, cast
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    Tuple,
+    cast,
+)
 
 from zope.interface import Interface, implementer, providedBy
 
 from incremental import Version
-from typing_extensions import Literal, Protocol
 
 from twisted.conch import error
 from twisted.conch.ssh import keys

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -13,7 +13,7 @@ import unicodedata
 import warnings
 from base64 import b64encode, decodebytes, encodebytes
 from hashlib import md5, sha256
-from typing import Any
+from typing import Any, Literal
 
 import bcrypt
 from constantly import NamedConstant, Names
@@ -27,7 +27,6 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
     load_ssh_public_key,
 )
-from typing_extensions import Literal
 
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_to_bytes

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -17,7 +17,7 @@ import struct
 import types
 import zlib
 from hashlib import md5, sha1, sha256, sha384, sha512
-from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Tuple, Union
 
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
@@ -30,8 +30,6 @@ try:
 except ImportError:
     # Deprecated path, will be removed in cryptography 48.0.0
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
-
-from typing_extensions import Literal
 
 from twisted import __version__ as twisted_version
 from twisted.conch.ssh import _kex, address, keys

--- a/src/twisted/conch/test/test_ckeygen.py
+++ b/src/twisted/conch/test/test_ckeygen.py
@@ -11,9 +11,7 @@ import os
 import subprocess
 import sys
 from io import StringIO
-from typing import Callable
-
-from typing_extensions import NoReturn
+from typing import Callable, NoReturn
 
 from twisted.conch.test.keydata import (
     privateECDSA_openssh,

--- a/src/twisted/internet/_signals.py
+++ b/src/twisted/internet/_signals.py
@@ -39,12 +39,12 @@ import os
 import signal
 import socket
 from types import FrameType
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Protocol, Sequence
 
 from zope.interface import Attribute, Interface, implementer
 
 from attrs import define, frozen
-from typing_extensions import Protocol, TypeAlias
+from typing_extensions import TypeAlias
 
 from twisted.internet.interfaces import IReadDescriptor
 from twisted.python import failure, log, util

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -7,13 +7,12 @@ Address objects for network connections.
 
 
 import os
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 from warnings import warn
 
 from zope.interface import implementer
 
 import attr
-from typing_extensions import Literal
 
 from twisted.internet.interfaces import IAddress
 from twisted.python.filepath import _asFilesystemBytes, _coerceToFilesystemEncoding

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -29,6 +29,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Literal,
     Mapping,
     NoReturn,
     Optional,
@@ -43,7 +44,7 @@ from typing import (
 
 import attr
 from incremental import Version
-from typing_extensions import Concatenate, Literal, ParamSpec, Self
+from typing_extensions import Concatenate, ParamSpec, Self
 
 from twisted.internet.interfaces import IDelayedCall, IReactorTime
 from twisted.logger import Logger

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -14,12 +14,12 @@ import os
 import socket
 import struct
 import sys
+import typing
 from typing import Any, Callable, ClassVar, List, Optional, Union
 
 from zope.interface import Interface, implementer
 
 import attr
-import typing_extensions
 
 from twisted.internet.interfaces import (
     IHalfCloseableProtocol,
@@ -960,7 +960,7 @@ class _IFileDescriptorReservation(Interface):
         """
 
 
-class _HasClose(typing_extensions.Protocol):
+class _HasClose(typing.Protocol):
     def close(self) -> object:
         ...
 

--- a/src/twisted/internet/test/test_defer_await.py
+++ b/src/twisted/internet/test/test_defer_await.py
@@ -7,8 +7,7 @@ Tests for C{await} support in Deferreds.
 """
 
 import types
-
-from typing_extensions import NoReturn
+from typing import NoReturn
 
 from twisted.internet.defer import (
     Deferred,

--- a/src/twisted/internet/test/test_reactormixins.py
+++ b/src/twisted/internet/test/test_reactormixins.py
@@ -2,9 +2,9 @@
 Tests L{twisted.internet.test.reactormixins}, the reactor-testing support
 module.
 """
+from typing import NoReturn
 
 from hamcrest import assert_that, equal_to, has_length
-from typing_extensions import NoReturn
 
 # Trial should expose matches_result publically.
 # https://github.com/twisted/twisted/issues/11709

--- a/src/twisted/internet/test/test_testing.py
+++ b/src/twisted/internet/test/test_testing.py
@@ -6,11 +6,9 @@ Tests for L{twisted.internet.testing}.
 """
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Protocol
 
 from zope.interface.verify import verifyObject
-
-from typing_extensions import Protocol
 
 from twisted.internet.address import IPv4Address
 from twisted.internet.interfaces import (

--- a/src/twisted/names/test/test_hosts.py
+++ b/src/twisted/names/test/test_hosts.py
@@ -6,7 +6,7 @@ Tests for the I{hosts(5)}-based resolver, L{twisted.names.hosts}.
 """
 from __future__ import annotations
 
-from typing_extensions import Protocol
+from typing import Protocol
 
 from twisted.internet.defer import gatherResults
 from twisted.names.dns import (

--- a/src/twisted/positioning/test/test_nmea.py
+++ b/src/twisted/positioning/test/test_nmea.py
@@ -7,12 +7,11 @@ from __future__ import annotations
 
 import datetime
 from operator import attrgetter
-from typing import Callable, Iterable, TypedDict
+from typing import Callable, Iterable, Literal, Protocol, TypedDict
 
 from zope.interface import implementer
 
 from constantly import NamedConstant
-from typing_extensions import Literal, Protocol
 
 from twisted.positioning import base, ipositioning, nmea
 from twisted.positioning.base import Angles

--- a/src/twisted/protocols/haproxy/_v2parser.py
+++ b/src/twisted/protocols/haproxy/_v2parser.py
@@ -9,12 +9,11 @@ IProxyParser implementation for version two of the PROXY protocol.
 
 import binascii
 import struct
-from typing import Callable, Tuple, Type, Union
+from typing import Callable, Literal, Tuple, Type, Union
 
 from zope.interface import implementer
 
 from constantly import ValueConstant, Values
-from typing_extensions import Literal
 
 from twisted.internet import address
 from twisted.python import compat

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -50,6 +50,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
@@ -60,8 +61,6 @@ from typing import (
 )
 
 from zope.interface import Attribute, Interface, implementer
-
-from typing_extensions import Literal
 
 from twisted.python.compat import cmp, comparable
 from twisted.python.runtime import platform

--- a/src/twisted/python/test/strategies.py
+++ b/src/twisted/python/test/strategies.py
@@ -4,9 +4,9 @@
 """
 Hypothesis strategies for values related to L{twisted.python}.
 """
+from typing import Literal
 
 from hypothesis.strategies import SearchStrategy, characters, text
-from typing_extensions import Literal
 
 
 def systemdDescriptorNames() -> SearchStrategy[str]:

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -7,9 +7,7 @@ Tests for L{twisted.python.url}.
 """
 from __future__ import annotations
 
-from typing import Iterable
-
-from typing_extensions import Protocol
+from typing import Iterable, Protocol
 
 from twisted.trial.unittest import SynchronousTestCase
 from ..url import URL

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -12,9 +12,9 @@ instead of creating a thread pool directly.
 from __future__ import annotations
 
 from threading import Thread, current_thread
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, Protocol, TypeVar
 
-from typing_extensions import ParamSpec, Protocol, TypedDict
+from typing_extensions import ParamSpec, TypedDict
 
 from twisted._threads import pool as _pool
 from twisted.python import context, log

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -21,6 +21,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Literal,
     Tuple,
     TypeVar,
     Union,
@@ -29,7 +30,7 @@ from zipfile import ZipFile
 
 from zope.interface import implementer
 
-from typing_extensions import Literal, Self
+from typing_extensions import Self
 
 from twisted.python.compat import cmp, comparable
 from twisted.python.filepath import (

--- a/src/twisted/test/test_lockfile.py
+++ b/src/twisted/test/test_lockfile.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import errno
 import os
+from typing import NoReturn
 from unittest import skipIf, skipUnless
-
-from typing_extensions import NoReturn
 
 from twisted.python import lockfile
 from twisted.python.reflect import requireModule

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -13,11 +13,9 @@ import sys
 import time
 import warnings
 from io import IOBase, StringIO
-from typing import Callable, List
+from typing import Callable, List, Protocol
 
 from zope.interface import implementer
-
-from typing_extensions import Protocol
 
 from twisted.logger import (
     ILogObserver,

--- a/src/twisted/test/test_modules.py
+++ b/src/twisted/test/test_modules.py
@@ -13,9 +13,7 @@ import sys
 import zipfile
 from importlib.abc import PathEntryFinder
 from types import ModuleType
-from typing import Any, Generator
-
-from typing_extensions import Protocol
+from typing import Any, Generator, Protocol
 
 import twisted
 from twisted.python import modules

--- a/src/twisted/test/test_monkey.py
+++ b/src/twisted/test/test_monkey.py
@@ -6,7 +6,7 @@ Tests for L{twisted.python.monkey}.
 """
 from __future__ import annotations
 
-from typing_extensions import NoReturn
+from typing import NoReturn
 
 from twisted.python.monkey import MonkeyPatcher
 from twisted.trial import unittest

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -15,12 +15,21 @@ import stat
 import sys
 import time
 from pprint import pformat
-from typing import IO, AnyStr, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    IO,
+    AnyStr,
+    Callable,
+    Dict,
+    List,
+    NoReturn,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from unittest import skipIf
 
 from zope.interface.verify import verifyObject
-
-from typing_extensions import NoReturn
 
 from twisted.python import filepath
 from twisted.python.filepath import FileMode, OtherAnyStr

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -8,9 +8,7 @@ import io
 import pickle
 import sys
 import textwrap
-from typing import Any, Callable, List, Tuple
-
-from typing_extensions import NoReturn
+from typing import Any, Callable, List, NoReturn, Tuple
 
 # Twisted Imports
 from twisted.persisted import aot, crefutil, styles

--- a/src/twisted/test/test_randbytes.py
+++ b/src/twisted/test/test_randbytes.py
@@ -6,9 +6,7 @@ Test cases for L{twisted.python.randbytes}.
 """
 from __future__ import annotations
 
-from typing import Callable
-
-from typing_extensions import NoReturn, Protocol
+from typing import Callable, NoReturn, Protocol
 
 from twisted.python import randbytes
 from twisted.trial import unittest

--- a/src/twisted/test/test_rebuild.py
+++ b/src/twisted/test/test_rebuild.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import types
-
-from typing_extensions import NoReturn
+from typing import NoReturn
 
 from twisted.python import rebuild
 from twisted.trial.unittest import TestCase

--- a/src/twisted/trial/_dist/test/matchers.py
+++ b/src/twisted/trial/_dist/test/matchers.py
@@ -11,7 +11,7 @@ __all__ = [
     "IsSequenceOf",
 ]
 
-from typing import Any, List, Sequence, Tuple, TypeVar
+from typing import Any, List, Protocol, Sequence, Tuple, TypeVar
 
 from hamcrest import (
     contains_exactly,
@@ -25,7 +25,6 @@ from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.core.allof import AllOf
 from hamcrest.core.description import Description
 from hamcrest.core.matcher import Matcher
-from typing_extensions import Protocol
 
 from twisted.python.failure import Failure
 

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -10,13 +10,23 @@ This module implements the worker classes.
 """
 
 import os
-from typing import Any, Awaitable, Callable, Dict, List, Optional, TextIO, TypeVar
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    TextIO,
+    TypeVar,
+)
 from unittest import TestCase
 
 from zope.interface import implementer
 
 from attrs import frozen
-from typing_extensions import Protocol, TypedDict
+from typing_extensions import TypedDict
 
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.internet.error import ProcessDone

--- a/src/twisted/trial/_dist/workerreporter.py
+++ b/src/twisted/trial/_dist/workerreporter.py
@@ -10,11 +10,10 @@ Test reporter forwarding test results over trial distributed AMP commands.
 """
 
 from types import TracebackType
-from typing import Callable, List, Optional, Sequence, Type, TypeVar
+from typing import Callable, List, Literal, Optional, Sequence, Type, TypeVar
 from unittest import TestCase as PyUnitTestCase
 
 from attrs import Factory, define
-from typing_extensions import Literal
 
 from twisted.internet.defer import Deferred, maybeDeferred
 from twisted.protocols.amp import AMP, MAX_VALUE_LENGTH

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -37,12 +37,12 @@ import unittest as pyunit
 import warnings
 from contextlib import contextmanager
 from importlib.machinery import SourceFileLoader
-from typing import Callable, Generator, List, Optional, TextIO, Type, Union
+from typing import Callable, Generator, List, Optional, Protocol, TextIO, Type, Union
 
 from zope.interface import implementer
 
 from attrs import define
-from typing_extensions import ParamSpec, Protocol, TypeAlias, TypeGuard
+from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 
 from twisted.internet import defer
 from twisted.python import failure, filepath, log, modules, reflect

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -14,13 +14,12 @@ import os
 import time
 import warnings
 from html import escape
-from typing import Any, Callable, Dict, Sequence
+from typing import Any, Callable, Dict, Literal, Sequence
 from urllib.parse import quote, unquote
 
 from zope.interface import implementer
 
 from incremental import Version
-from typing_extensions import Literal
 
 from twisted.internet import abstract, interfaces
 from twisted.python import components, filepath, log

--- a/src/twisted/web/test/test_xml.py
+++ b/src/twisted/web/test/test_xml.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 from importlib import reload
 from io import BytesIO
-
-from typing_extensions import Literal
+from typing import Literal
 
 from twisted.trial.unittest import TestCase
 from twisted.web import domhelpers, microdom, sux


### PR DESCRIPTION

## Scope and purpose

In Python 3.9+ the following types are now available in the built-in `typing` module: `Protocol`, `NoReturn`, and `Literal`. The changes are only to help clean up the project. No bugs being fixed or functionality changed.

Fixes #12493 

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
