### PR TITLE
#12499 readBody from twisted.web.client cancel exception fix

### DIFF
--- a/src/twisted/newsfragments/12499.bugfix
+++ b/src/twisted/newsfragments/12499.bugfix
@@ -1,0 +1,1 @@
+In case of cancelling deferred returned from twisted.web.client.readBody() suppressed unhandled exception in twisted.web.client_ReadBodyProtocol.connectionLost method

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1770,7 +1770,10 @@ class _ReadBodyProtocol(protocol.Protocol):
                 )
             )
         else:
-            self.deferred.errback(reason)
+            try:
+                self.deferred.errback(reason)
+            except defer.AlreadyCalledError:  # after abortConnection. I don't know why
+                pass
 
 
 def readBody(response: IResponse) -> defer.Deferred[bytes]:

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1749,6 +1749,7 @@ class _ReadBodyProtocol(protocol.Protocol):
         self.status = status
         self.message = message
         self.dataBuffer = []
+        self.canceled = False
 
     def dataReceived(self, data):
         """
@@ -1770,11 +1771,13 @@ class _ReadBodyProtocol(protocol.Protocol):
                 )
             )
         else:
-            try:
+            if self.canceled:
+                try:
+                    self.deferred.errback(reason)
+                except defer.AlreadyCalledError:
+                    pass
+            else:
                 self.deferred.errback(reason)
-            except defer.AlreadyCalledError:
-                pass
-
 
 def readBody(response: IResponse) -> defer.Deferred[bytes]:
     """
@@ -1800,6 +1803,7 @@ def readBody(response: IResponse) -> defer.Deferred[bytes]:
         abort = getAbort()
         if abort is not None:
             abort()
+        protocol.canceled = True
 
     d: defer.Deferred[bytes] = defer.Deferred(cancel)
     protocol = _ReadBodyProtocol(response.code, response.phrase, d)

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1772,7 +1772,7 @@ class _ReadBodyProtocol(protocol.Protocol):
         else:
             try:
                 self.deferred.errback(reason)
-            except defer.AlreadyCalledError:  # after abortConnection. I don't know why
+            except defer.AlreadyCalledError:
                 pass
 
 

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -1779,6 +1779,7 @@ class _ReadBodyProtocol(protocol.Protocol):
             else:
                 self.deferred.errback(reason)
 
+
 def readBody(response: IResponse) -> defer.Deferred[bytes]:
     """
     Get the body of an L{IResponse} and return it as a byte string.

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -3216,6 +3216,24 @@ class ReadBodyTests(TestCase):
         self.failureResultOf(deferred, defer.CancelledError)
         self.assertTrue(response.transport.aborting)
 
+    def test_cancelWithConnectionLost(self):
+        """
+        When cancelling the L{Deferred} returned by L{client.readBody}, the
+        CancelledError failure is sent repeatedly in response protocol. Exception
+        defer.AlreadyCalledError should be suppressed
+        """
+        response = DummyResponse()
+        deferred = client.readBody(response)
+        deferred.cancel()
+
+        try:
+            response.protocol.connectionLost(Failure(defer.CancelledError))
+        except defer.AlreadyCalledError:
+            self.fail()
+
+        self.failureResultOf(deferred, defer.CancelledError)
+        self.assertTrue(response.transport.aborting)
+
     def test_withPotentialDataLoss(self):
         """
         If the full body of the L{IResponse} passed to L{client.readBody} is

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -3229,11 +3229,11 @@ class ReadBodyTests(TestCase):
         # For example due to a timeout or some other
         # conditions.
         deferred.cancel()
-
-        try:
-            response.protocol.connectionLost(Failure(defer.CancelledError))
-        except defer.AlreadyCalledError:
-            self.fail()
+        # At some point the connection used by the response
+        # to read the body will get lost.
+        # This happend after the `readBody` deferred is
+        # cancelled by the user.
+        response.protocol.connectionLost(Failure(Exception('We are lost')))
 
         self.failureResultOf(deferred, defer.CancelledError)
         self.assertTrue(response.transport.aborting)

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -3224,6 +3224,10 @@ class ReadBodyTests(TestCase):
         """
         response = DummyResponse()
         deferred = client.readBody(response)
+        # It is cancelled by the user before we get the
+        # full body.
+        # For example due to a timeout or some other
+        # conditions.
         deferred.cancel()
 
         try:

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -3233,7 +3233,7 @@ class ReadBodyTests(TestCase):
         # to read the body will get lost.
         # This happend after the `readBody` deferred is
         # cancelled by the user.
-        response.protocol.connectionLost(Failure(Exception('We are lost')))
+        response.protocol.connectionLost(Failure(Exception("We are lost")))
 
         self.failureResultOf(deferred, defer.CancelledError)
         self.assertTrue(response.transport.aborting)


### PR DESCRIPTION
## Scope and purpose

Fixes #12499

Shortly: readBody from twisted.web.client cannot be correctly canceled (without unhandled exception)

Reproduce steps are mentioned in issue #12499 
