### PR TITLE
refs #12500 -- put set info callback on connection rather than context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dev = [
 ]
 
 tls = [
-    "pyopenssl >= 21.0.0",
+    "pyopenssl >= 25.2.0",
     # service_identity 18.1.0 added support for validating IP addresses in
     # certificate subjectAltNames
     "service_identity >= 18.1.0",

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1126,7 +1126,6 @@ class ClientTLSOptions:
             self._hostnameIsDnsName = True
 
         self._hostnameASCII = self._hostnameBytes.decode("ascii")
-        ctx.set_info_callback(_tolerateErrors(self._identityVerifyingInfoCallback))
 
     def clientConnectionForTLS(self, tlsProtocol):
         """
@@ -1147,6 +1146,9 @@ class ClientTLSOptions:
         context = self._ctx
         connection = SSL.Connection(context, None)
         connection.set_app_data(tlsProtocol)
+        connection.set_info_callback(
+            _tolerateErrors(self._identityVerifyingInfoCallback)
+        )
         return connection
 
     def _identityVerifyingInfoCallback(self, connection, where, ret):

--- a/src/twisted/newsfragments/12505.misc
+++ b/src/twisted/newsfragments/12505.misc
@@ -1,0 +1,1 @@
+raised minimum pyOpenSSL version to 25.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -80,13 +80,13 @@ deps =
     mindeps: Automat == 0.8.0
     mindeps: hyperlink == 17.1.1
     mindeps: attrs == 21.3.0
-    mindeps: typing_extensions == 4.2.0
+    mindeps: typing_extensions == 4.9.0
     # TLS
-    mindeps: pyopenssl == 21.0.0
+    mindeps: pyopenssl == 25.2.0
     mindeps: service_identity == 18.1.0
     mindeps: idna == 2.4
     # Conch
-    mindeps: cryptography == 35.0.0
+    mindeps: cryptography == 45.0.7
     mindeps: appdirs == 1.4.0
     mindeps: bcrypt == 3.2.1
     # HTTP


### PR DESCRIPTION
this avoids mutating a connection that may be reused, which will be prohibited in future pyOpenSSL releases (and is already unsound)
