### PR TITLE
[#12500] Immutable openssl context and friends

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,6 +207,7 @@ pydoctor_url_path = "/en/{rtd_version}/api/"
 intersphinx_mapping = {
     "py3": ("https://docs.python.org/3", None),
     "zopeinterface": ("https://zopeinterface.readthedocs.io/en/latest", None),
+    "pyOpenSSL": ("https://pyopenssl.readthedocs.io/en/latest", None),
 }
 # How long to cache remote inventories. Positive is a number of days,
 # negative means infinite. The default is 5 days, which should be fine

--- a/docs/core/examples/index.rst
+++ b/docs/core/examples/index.rst
@@ -104,5 +104,5 @@ Miscellaneous
 - :download:`wxacceptance.py` - acceptance tests for wxreactor
 - :download:`postfix.py` - test application for PostfixTCPMapServer
 - :download:`udpbroadcast.py` - broadcasting using UDP
-- :download:`tls_alpn_npn_client.py` - example of TLS next-protocol negotiation on the client side using NPN and ALPN.
-- :download:`tls_alpn_npn_server.py` - example of TLS next-protocol negotiation on the server side using NPN and ALPN.
+- :download:`tls_alpn_client.py` - example of TLS next-protocol negotiation on the client side using ALPN.
+- :download:`tls_alpn_server.py` - example of TLS next-protocol negotiation on the server side using ALPN.

--- a/docs/core/examples/tls_alpn_client.py
+++ b/docs/core/examples/tls_alpn_client.py
@@ -2,19 +2,19 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 """
-tls_alpn_npn_client
+tls_alpn_client
 ~~~~~~~~~~~~~~~~~~~
 
 This test script demonstrates the usage of the acceptableProtocols API as a
 client peer.
 
-It performs next protocol negotiation using NPN and ALPN.
+It performs next protocol negotiation using ALPN.
 
 It will print what protocol was negotiated and exit.
 The global variables are provided as input values.
 
 This is set up to run against the server from
-tls_alpn_npn_server.py from the directory that contains this example.
+tls_alpn_server.py from the directory that contains this example.
 
 It assumes that you have a self-signed server certificate, named
 `server-cert.pem` and located in the working directory.

--- a/docs/core/examples/tls_alpn_server.py
+++ b/docs/core/examples/tls_alpn_server.py
@@ -2,13 +2,13 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 """
-tls_alpn_npn_server
+tls_alpn_server
 ~~~~~~~~~~~~~~~~~~~
 
 This test script demonstrates the usage of the acceptableProtocols API as a
 server peer.
 
-It performs next protocol negotiation using NPN and ALPN.
+It performs next protocol negotiation using ALPN.
 
 It will print what protocol was negotiated for each connection that is made to
 it.
@@ -16,21 +16,21 @@ it.
 To exit the server, use CTRL+C on the command-line.
 
 Before using this, you should generate a new RSA private key and an associated
-X.509 certificate and place it in the working directory as `server-key.pem`
-and `server-cert.pem`.
+X.509 certificate and place it in the working directory as `server-key.pem` and
+`server-cert.pem`.
 
-You can generate a self signed certificate using OpenSSL:
+You can generate a self signed certificate using OpenSSL::
 
     openssl req -new -newkey rsa:2048 -days 3 -nodes -x509 \
         -keyout server-key.pem -out server-cert.pem
 
-To test this, use OpenSSL's s_client command, with either or both of the
--nextprotoneg and -alpn arguments. For example:
+To test this, use OpenSSL's s_client command with the -alpn argument.
+
+For example::
 
     openssl s_client -connect localhost:8080 -alpn h2,http/1.1
-    openssl s_client -connect localhost:8080 -nextprotoneg h2,http/1.1
 
-Alternatively, use the tls_alpn_npn_client.py script found in the examples
+Alternatively, use the tls_alpn_client.py script found in the examples
 directory.
 """
 
@@ -56,7 +56,7 @@ ACCEPTABLE_PROTOCOLS = [b"h2", b"http/1.1"]
 LISTEN_PORT = 8080
 
 
-class NPNPrinterProtocol(Protocol):
+class PrinterProtocol(Protocol):
     """
     This protocol accepts incoming connections and waits for data. When
     received, it prints what the negotiated protocol is, echoes the data back,
@@ -84,7 +84,7 @@ class NPNPrinterProtocol(Protocol):
 
 class ResponderFactory(Factory):
     def buildProtocol(self, addr):
-        return NPNPrinterProtocol()
+        return PrinterProtocol()
 
 
 privateKeyData = FilePath("server-key.pem").getContent()

--- a/docs/core/examples/tls_alpn_server.py
+++ b/docs/core/examples/tls_alpn_server.py
@@ -56,7 +56,7 @@ ACCEPTABLE_PROTOCOLS = [b"h2", b"http/1.1"]
 LISTEN_PORT = 8080
 
 
-class PrinterProtocol(Protocol):
+class ShowALPN(Protocol):
     """
     This protocol accepts incoming connections and waits for data. When
     received, it prints what the negotiated protocol is, echoes the data back,
@@ -84,7 +84,7 @@ class PrinterProtocol(Protocol):
 
 class ResponderFactory(Factory):
     def buildProtocol(self, addr):
-        return PrinterProtocol()
+        return ShowALPN()
 
 
 privateKeyData = FilePath("server-key.pem").getContent()

--- a/docs/core/howto/listings/ssl/wrapped_client.py
+++ b/docs/core/howto/listings/ssl/wrapped_client.py
@@ -1,0 +1,27 @@
+from sys import argv
+
+from twisted.internet.defer import Deferred
+from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
+from twisted.internet.interfaces import IReactorTCP, ITCPTransport
+from twisted.internet.protocol import Factory, Protocol
+from twisted.internet.ssl import optionsForClientTLS
+from twisted.internet.task import react
+from twisted.python.failure import Failure
+
+
+async def main(reactor: IReactorTCP, hostname: str = "example.com") -> None:
+    class ExampleHTTP(Protocol):
+        def makeConnection(self, transport: ITCPTransport) -> None:
+            transport.write(f"GET / HTTP/1.1\r\nHost: {hostname}\r\n\r\n".encode())
+
+        def dataReceived(self, data: bytes) -> None:
+            print(f"data: {data!r}")
+
+    tcpEndpoint = HostnameEndpoint(reactor, hostname, 443)
+    tlsEndpoint = wrapClientTLS(optionsForClientTLS(hostname), tcpEndpoint)
+    await tlsEndpoint.connect(Factory.forProtocol(ExampleHTTP))
+    await Deferred()
+
+
+if __name__ == "__main__":
+    react(main, argv[1:])

--- a/docs/core/howto/ssl.rst
+++ b/docs/core/howto/ssl.rst
@@ -5,16 +5,34 @@ Overview
 --------
 
 This document describes how to secure your communications using TLS (Transport Layer Security) --- also known as SSL (Secure Sockets Layer) --- in Twisted servers and clients.
-It assumes that you know what TLS is, what some of the major reasons to use it are, and how to generate your own certificates.
-It also assumes that you are comfortable with creating TCP servers and clients as described in the :doc:`server howto <servers>` and :doc:`client howto <clients>` .
-After reading this document you should be able to create servers and clients that can use TLS to encrypt their connections, switch from using an unencrypted channel to an encrypted one mid-connection, and require client authentication.
+TLS is the protocol underlying the HTTPS protocol, so many of these concepts are used to secure your web server as well.
 
-Using TLS in Twisted requires that you have `pyOpenSSL <https://github.com/pyca/pyopenssl>`_ installed. A quick test to verify that you do is to run ``from OpenSSL import SSL`` at a python prompt and not get an error.
+To read this document, you will need to understand some pre-requisites:
 
-Twisted provides TLS support as a transport --- that is, as an alternative to TCP.
-When using TLS, use of the TCP APIs you're already familiar with, ``TCP4ClientEndpoint`` and ``TCP4ServerEndpoint`` --- or ``reactor.listenTCP`` and ``reactor.connectTCP`` --- is replaced by use of parallel TLS APIs (many of which still use the legacy name "SSL" due to age and/or compatibility with older APIs).
-To create a TLS server, use :py:class:`SSL4ServerEndpoint <twisted.internet.endpoints.SSL4ServerEndpoint>` or :py:meth:`listenSSL <twisted.internet.interfaces.IReactorSSL.listenSSL>` .
-To create a TLS client, use :py:class:`SSL4ClientEndpoint <twisted.internet.endpoints.SSL4ClientEndpoint>` or :py:meth:`connectSSL <twisted.internet.interfaces.IReactorSSL.connectSSL>` .
+- You should already know how to create TCP servers and clients with Twisted as described in the :doc:`server howto <servers>` and :doc:`client howto <clients>`.
+- You should know how to create an :doc:`Endpoint <endpoints>` .
+- You should be able to obtain trusted TLS certificates, with something like
+  `certbot <https://certbot.eff.org/>`_ and `Let's Encrypt
+  <https://letsencrypt.org>`_
+
+After reading this document you should be able to:
+
+- create servers and clients that can use TLS to encrypt their connectios
+- switch from using an unencrypted channel to an encrypted one mid-connection,
+  and
+- require client authentication using client certificates.
+
+Using TLS in Twisted requires that you have various dependencies installed that are included in Twisted's ``tls`` optional dependency group.
+To ensure that you have the required additional libraries installed, please ``pip install 'twisted[tls]'`` .
+
+TLS Quick Start
+---------------
+
+To set up a TLS server, use the ``ssl:`` string endpoint prefix.
+If you're using a command-line tool with a ``--listen`` argument, such as ``twist web``, you can create an ``ssl:`` endpoint that serves your certificate on port 443.
+
+TLS Security Basics
+-------------------
 
 TLS provides transport layer security, but it's important to understand what "security" means.
 With respect to TLS it means three things:
@@ -26,16 +44,30 @@ With respect to TLS it means three things:
 
 Without identity, neither confidentiality nor integrity is possible.
 If you don't know who you're talking to, then you might as easily be talking to your bank or to a thief who wants to steal your bank password.
-Each of the APIs listed above with "SSL" in the name requires a configuration object called (for historical reasons) a ``contextFactory``.
-(Please pardon the somewhat awkward name.)
-The ``contextFactory`` serves three purposes:
 
-1. It provides the materials to prove your own identity to the other side of the connection: in other words, who you are.
-2. It expresses your requirements of the other side's identity: in other words, who you would like to talk to (and who you trust to tell you that you're talking to the right party).
-3. It allows you to specify certain specialized options about the way the TLS protocol itself operates.
+.. note::
+
+   Twisted's TLS support is currently based on PyOpenSSL (which is, in turn, based on OpenSSL) and inherits certain PyOpenSSL terminology and types.
+   Twisted will often refer to a TLS *connection*, which is a reference to an :py:class:`pyOpenSSL Connection <OpenSSL.SSL.Connection>`, or a *context*, which is a reference to an :py:class:`pyOpenSSL Context <OpenSSL.SSL.Context>`.
+   You should not need to know PyOpenSSL's API to use Twisted's TLS support, but it's useful to understand that:
+
+   1. A Connection is an object used to individually configure a single connection to a peer, and
+   2. a Context is an object that may be shared among many connections (particularly on a server), that describes common areas of configuration between multiple connections.
 
 The requirements of clients and servers are slightly different.
-Both *can* provide a certificate to prove their identity, but commonly, TLS *servers* provide a certificate, whereas TLS *clients* check the server's certificate (to make sure they're talking to the right server) and then later identify themselves to the server some other way, often by offering a shared secret such as a password or API key via an application protocol secured with TLS and not as part of TLS itself.
+Both *can* provide a certificate to prove their identity.
+Commonly, however, TLS *servers* provide a certificate, whereas TLS *clients* check the server's certificate (to make sure they're talking to the right server).
+Clients then later identify themselves to the server some other way, often by offering a shared secret (such as a password or API key) via an application protocol secured with TLS, not as part of TLS itself.
+
+Therefore, let's begin with a simple TLS client, that will connect to an existing server.
+
+We can wrap any stream client endpoint with :py:func:`twisted.internet.endpoints.wrapClientTLS`, which will run an encrypted TLS connection over whatever the underlying transport is.
+
+This example client uses a combination of :py:class:`twisted.internet.endpoints.HostnameEndpoint`,  :py:func:`twisted.internet.endpoints.wrapClientTLS`, and :py:func:`twisted.internet.ssl.optionsForClientTLS` to connect to ``example.com`` via TLS, and issue an extremely simple HTTPS request.
+
+:download:`echoserv_ssl.py <listings/ssl/wrapped_client.py>`
+
+.. literalinclude:: listings/ssl/wrapped_client.py
 
 Since these requirements are slightly different, there are different APIs to construct an appropriate ``contextFactory`` value for a client or a server.
 
@@ -119,37 +151,6 @@ For example:
    To *properly* validate your ``hostname`` parameter according to RFC6125, please also install the `"service_identity" <https://pypi.python.org/pypi/service_identity>`_ and `"idna" <https://pypi.python.org/pypi/idna>`_ packages from PyPI.
    Without this package, Twisted will currently make a conservative guess as to the correctness of the server's certificate, but this will reject a large number of potentially valid certificates.
    `service_identity` implements the standard correctly and it will be a required dependency for TLS in a future release of Twisted.
-
-Using startTLS
---------------
-
-If you want to switch from unencrypted to encrypted traffic
-mid-connection, you'll need to turn on TLS with :py:meth:`startTLS <twisted.internet.interfaces.ITLSTransport.startTLS>` on both
-ends of the connection at the same time via some agreed-upon signal like the
-reception of a particular message. You can readily verify the switch to an
-encrypted channel by examining the packet payloads with a tool like
-`Wireshark <https://www.wireshark.org/>`_ .
-
-startTLS server
-~~~~~~~~~~~~~~~
-
-:download:`starttls_server.py <../examples/starttls_server.py>`
-
-.. literalinclude:: ../examples/starttls_server.py
-
-startTLS client
-~~~~~~~~~~~~~~~
-
-:download:`starttls_client.py <../examples/starttls_client.py>`
-
-.. literalinclude:: ../examples/starttls_client.py
-
-``startTLS`` is a transport method that gets passed a ``contextFactory``.
-It is invoked at an agreed-upon time in the data reception method of the client and server protocols.
-The server uses ``PrivateCertificate.options`` to create a ``contextFactory`` which will use a particular certificate and private key (a common requirement for TLS servers).
-
-The client creates an uncustomized ``CertificateOptions`` which is all that's necessary for a TLS client to interact with a TLS server.
-
 
 Client authentication
 ---------------------
@@ -245,17 +246,11 @@ Additionally, it is possible to limit the acceptable ciphers for your connection
 Since Twisted uses a secure cipher configuration by default, it is discouraged to do so unless absolutely necessary.
 
 
-Application Layer Protocol Negotiation (ALPN) and Next Protocol Negotiation (NPN)
----------------------------------------------------------------------------------
+Application Layer Protocol Negotiation (ALPN)
+---------------------------------------------
 
-ALPN and NPN are TLS extensions that can be used by clients and servers to negotiate what application-layer protocol will be spoken once the encrypted connection is established.
+ALPN is a TLS extension that can be used by clients and servers to negotiate what application-layer protocol will be spoken once the encrypted connection is established.
 This avoids the need for extra custom round trips once the encrypted connection is established. It is implemented as a standard part of the TLS handshake.
-
-NPN is supported from OpenSSL version 1.0.1.
-ALPN is the newer of the two protocols, supported in OpenSSL versions 1.0.2 onward.
-These functions require pyOpenSSL version 0.15 or higher.
-To query the methods supported by your system,  use :py:func:`twisted.internet.ssl.protocolNegotiationMechanisms`.
-It will return a collection of flags indicating support for NPN and/or ALPN.
 
 :py:class:`twisted.internet.ssl.CertificateOptions` and :py:func:`twisted.internet.ssl.optionsForClientTLS` allow for selecting the protocols your program is willing to speak after the connection is established.
 
@@ -273,27 +268,51 @@ and for clients:
     from twisted.internet.ssl import optionsForClientTLS
     options = optionsForClientTLS(hostname=hostname, acceptableProtocols=[b'h2', b'http/1.1'])
 
-Twisted will attempt to use both ALPN and NPN, if they're available, to maximise compatibility with peers.
-If both ALPN and NPN are supported by the peer, the result from ALPN is preferred.
-
-For NPN, the client selects the protocol to use;
-For ALPN, the server does.
-If Twisted is acting as the peer who is supposed to select the protocol, it will prefer the earliest protocol in the list that is supported by both peers.
+If Twisted is acting as the server - which, in ALPN, is the peer who is supposed to select the protocol - it will prefer the earliest protocol in the list that is supported by both peers.
 
 To determine what protocol was negotiated, after the connection is done,  use :py:attr:`TLSMemoryBIOProtocol.negotiatedProtocol <twisted.protocols.tls.TLSMemoryBIOProtocol.negotiatedProtocol>`.
 It will return one of the protocol names passed to the ``acceptableProtocols`` parameter.
-It will return ``None`` if the peer did not offer ALPN or NPN.
+It will return ``None`` if the peer did not offer ALPN.
 
 It can also return ``None`` if no overlap could be found and the connection was established regardless (some peers will do this: Twisted will not).
 In this case, the protocol that should be used is whatever protocol would have been used if negotiation had not been attempted at all.
 
 .. warning::
-    If ALPN or NPN are used and no overlap can be found, then the remote peer may choose to terminate the connection.
+    If ALPN are used and no overlap can be found, then the remote peer may choose to terminate the connection.
     This may cause the TLS handshake to fail, or may result in the connection being torn down immediately after being made.
-    If Twisted is the selecting peer (that is, Twisted is the server and ALPN is being used, or Twisted is the client and NPN is being used), and no overlap can be found, Twisted will always choose to fail the handshake rather than allow an ambiguous connection to set up.
+    If Twisted is the selecting peer (that is, Twisted is the server and ALPN is being used), and no overlap can be found, Twisted will always choose to fail the handshake rather than allow an ambiguous connection to set up.
 
-An example of using this functionality can be found in :download:`this example script for clients </core/examples/tls_alpn_npn_client.py>` and :download:`this example script for servers </core/examples/tls_alpn_npn_server.py>`.
+An example of using this functionality can be found in :download:`this example script for clients </core/examples/tls_alpn_client.py>` and :download:`this example script for servers </core/examples/tls_alpn_server.py>`.
 
+Using startTLS
+--------------
+
+If you want to switch from unencrypted to encrypted traffic
+mid-connection, you'll need to turn on TLS with :py:meth:`startTLS <twisted.internet.interfaces.ITLSTransport.startTLS>` on both
+ends of the connection at the same time via some agreed-upon signal like the
+reception of a particular message. You can readily verify the switch to an
+encrypted channel by examining the packet payloads with a tool like
+`Wireshark <https://www.wireshark.org/>`_ .
+
+startTLS server
+~~~~~~~~~~~~~~~
+
+:download:`starttls_server.py <../examples/starttls_server.py>`
+
+.. literalinclude:: ../examples/starttls_server.py
+
+startTLS client
+~~~~~~~~~~~~~~~
+
+:download:`starttls_client.py <../examples/starttls_client.py>`
+
+.. literalinclude:: ../examples/starttls_client.py
+
+``startTLS`` is a transport method that gets passed a ``contextFactory``.
+It is invoked at an agreed-upon time in the data reception method of the client and server protocols.
+The server uses ``PrivateCertificate.options`` to create a ``contextFactory`` which will use a particular certificate and private key (a common requirement for TLS servers).
+
+The client creates an uncustomized ``CertificateOptions`` which is all that's necessary for a TLS client to interact with a TLS server.
 
 Related facilities
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,7 @@ dev = [
 ]
 
 tls = [
-    "pyOpenSSL @ git+https://github.com/pyca/pyopenssl.git@alex-patch-1",
-    # "pyopenssl >= 25.2.0",
+    "pyopenssl >= 25.2.0",
     # service_identity 18.1.0 added support for validating IP addresses in
     # certificate subjectAltNames
     "service_identity >= 18.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ dev = [
 ]
 
 tls = [
-    "pyopenssl >= 25.2.0",
+    "pyOpenSSL @ git+https://github.com/pyca/pyopenssl.git@alex-patch-1",
+    # "pyopenssl >= 25.2.0",
     # service_identity 18.1.0 added support for validating IP addresses in
     # certificate subjectAltNames
     "service_identity >= 18.1.0",
@@ -85,7 +86,7 @@ tls = [
 ]
 
 conch = [
-    "cryptography >= 3.3",
+    "cryptography >= 38",
     "appdirs >= 1.4.0",
     "bcrypt >= 3.2.1",
 ]

--- a/src/twisted/conch/client/direct.py
+++ b/src/twisted/conch/client/direct.py
@@ -46,7 +46,7 @@ class SSHClientFactory(protocol.ClientFactory):
         d, self.d = self.d, None
         d.errback(reason)
 
-    def buildProtocol(self, addr: IAddress) -> SSHClientTransport:
+    def buildProtocol(self, addr: IAddress | None) -> SSHClientTransport:
         trans = SSHClientTransport(self)
         if self.options["ciphers"]:
             trans.supportedCiphers = self.options["ciphers"]

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -1361,8 +1361,8 @@ class Key:
 
     @_mutuallyExclusiveArguments(
         [
-            ["extra", "comment"],
-            ["extra", "passphrase"],
+            ("extra", "comment"),
+            ("extra", "passphrase"),
         ]
     )
     def toString(self, type, extra=None, subtype=None, comment=None, passphrase=None):

--- a/src/twisted/conch/test/test_forwarding.py
+++ b/src/twisted/conch/test/test_forwarding.py
@@ -38,6 +38,7 @@ class TestSSHConnectForwardingChannel(unittest.TestCase):
         connector = reactor.connectors[0]
         protocol = factory.buildProtocol(None)
         transport = StringTransport(peerAddress=connector.getDestination())
+        assert protocol is not None
         protocol.makeConnection(transport)
 
     def test_channelOpenHostnameRequests(self) -> None:

--- a/src/twisted/internet/_service_identity.py
+++ b/src/twisted/internet/_service_identity.py
@@ -1,0 +1,39 @@
+"""
+Conditional imports to enable support for the L{service_identity} module back
+to version 18.1.0.
+"""
+
+from service_identity import VerificationError
+
+try:
+    __import__("service_identity.hazmat")
+except ImportError:
+    from sys import modules
+
+    for _oldAlias in "common", "_common":
+        try:
+            import service_identity
+
+            service_identity.hazmat = modules["service_identity.hazmat"] = getattr(
+                __import__(f"service_identity.{_oldAlias}"), _oldAlias
+            )
+        except ImportError:
+            pass
+from service_identity.hazmat import DNS_ID, IPAddress_ID, verify_service_identity
+
+try:
+    from service_identity.hazmat import ServiceID
+except ImportError:
+    ServiceID = object  # type:ignore[assignment,misc]
+try:
+    from service_identity.pyopenssl import extract_patterns
+except ImportError:
+    from service_identity.pyopenssl import extract_ids as extract_patterns
+__all__ = [
+    "DNS_ID",
+    "IPAddress_ID",
+    "extract_patterns",
+    "ServiceID",
+    "VerificationError",
+    "verify_service_identity",
+]

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1649,30 +1649,24 @@ class OpenSSLCertificateOptions:
 
         self._ecChooser.configureECDHCurve(ctx)
         if self._contextForServerName is not None:
-            ctx.set_tlsext_servername_callback(
-                contextFactoryToServernameCallback(self._contextForServerName)
-            )
+            ctxForName = self._contextForServerName
+
+            def contextSelectionCallback(connection: SSL.Connection) -> None:
+                servername = connection.get_servername()
+                try:
+                    newContext = ctxForName(servername)
+                except BaseException:
+                    _log.failure("while looking up SNI context")
+                    connection.get_app_data().abortConnection()
+                else:
+                    if newContext is not None:
+                        connection.set_context(newContext)
+
+            ctx.set_tlsext_servername_callback(contextSelectionCallback)
         setupForALPN(ctx, self._acceptableProtocols or ())
         if not skipCiphers:
             ctx.set_cipher_list(self._cipherString.encode("ascii"))
         return ctx
-
-
-def contextFactoryToServernameCallback(
-    factory: Callable[[bytes | None], SSL.Context | None],
-) -> Callable[[SSL.Connection], None]:
-    def contextSelectionCallback(connection: SSL.Connection) -> None:
-        servername = connection.get_servername()
-        try:
-            newContext = factory(servername)
-        except BaseException:
-            _log.failure("while looking up SNI context")
-            connection.get_app_data().abortConnection()
-        else:
-            if newContext is not None:
-                connection.set_context(newContext)
-
-    return contextSelectionCallback
 
 
 OpenSSLCertificateOptions.__getstate__ = deprecated(  # type:ignore[method-assign]

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -111,19 +111,6 @@ def _getExcludedTLSProtocols(oldest, newest):
     return excludedVersions
 
 
-def _usablePyOpenSSL(version):
-    """
-    Check pyOpenSSL version string whether we can use it for host verification.
-
-    @param version: A pyOpenSSL version string.
-    @type version: L{str}
-
-    @rtype: L{bool}
-    """
-    major, minor = (int(part) for part in version.split(".")[:2])
-    return (major, minor) >= (0, 12)
-
-
 class ProtocolNegotiationSupport(Flags):
     """
     L{ProtocolNegotiationSupport} defines flags which are used to indicate the

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1265,7 +1265,7 @@ class OpenSSLCertificateOptions:
         raiseMinimumTo: NamedConstant | None = None,
         insecurelyLowerMinimumTo: NamedConstant | None = None,
         lowerMaximumSecurityTo: NamedConstant | None = None,
-        callbackForServerName: (
+        contextForServerName: (
             Callable[[bytes | None], SSL.Context | None] | None
         ) = None,
     ) -> None:
@@ -1394,7 +1394,7 @@ class OpenSSLCertificateOptions:
             unless you are absolutely sure this is what you want.
         @type lowerMaximumSecurityTo: L{TLSVersion} constant
 
-        @param callbackForServerName: A callback to invoke with the server-name
+        @param contextForServerName: A callback to invoke with the server-name
             indication field in the client handshake, which returns the other
             context to switch to.
 
@@ -1552,7 +1552,7 @@ class OpenSSLCertificateOptions:
             trustRoot = IOpenSSLTrustRoot(trustRoot)
         self.trustRoot: IOpenSSLTrustRoot | None = trustRoot
         self._acceptableProtocols = acceptableProtocols
-        self._callbackForServerName = callbackForServerName
+        self._contextForServerName = contextForServerName
 
     def __getstate__(self):
         d = self.__dict__.copy()
@@ -1662,9 +1662,9 @@ class OpenSSLCertificateOptions:
             ctx.load_tmp_dh(self.dhParameters._dhFile.path)
 
         self._ecChooser.configureECDHCurve(ctx)
-        if self._callbackForServerName is not None:
+        if self._contextForServerName is not None:
             ctx.set_tlsext_servername_callback(
-                contextFactoryToServernameCallback(self._callbackForServerName)
+                contextFactoryToServernameCallback(self._contextForServerName)
             )
         setupForALPN(ctx, self._acceptableProtocols or ())
         if not skipCiphers:

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1581,8 +1581,7 @@ class OpenSSLCertificateOptions:
         """
         Construct an OpenSSL Connection for either client or server.
         """
-        if (ctx := self._context) is None:
-            ctx = self._makeContext()
+        ctx = self.getContext()
         cxn = Connection(ctx)
         if acceptable := protosFromProtocol(protocol, self._acceptableProtocols or ()):
             cxn.set_alpn_protos(acceptable)

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1682,6 +1682,7 @@ def contextFactoryToServernameCallback(
             newContext = factory(servername)
         except BaseException:
             _log.failure("while looking up SNI context")
+            connection.get_app_data().abortConnection()
         else:
             if newContext is not None:
                 connection.set_context(newContext)

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -8,12 +8,23 @@ import warnings
 from binascii import hexlify
 from functools import lru_cache
 from hashlib import md5
-from typing import Dict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 from zope.interface import Interface, implementer
 
 from OpenSSL import SSL, crypto
 from OpenSSL._util import lib as pyOpenSSLlib
+from OpenSSL.crypto import X509, PKey
+from OpenSSL.SSL import VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_PEER, Connection
 
 import attr
 from constantly import FlagConstant, Flags, NamedConstant, Names
@@ -27,6 +38,8 @@ from twisted.internet.interfaces import (
     ICipher,
     IOpenSSLClientConnectionCreator,
     IOpenSSLContextFactory,
+    IOpenSSLServerConnectionCreator,
+    IProtocolNegotiationFactory,
 )
 from twisted.logger import Logger
 from twisted.python.compat import nativeString
@@ -35,6 +48,17 @@ from twisted.python.failure import Failure
 from twisted.python.randbytes import secureRandom
 from twisted.python.util import nameToLabel
 from ._idna import _idnaBytes
+from ._service_identity import (
+    DNS_ID,
+    IPAddress_ID,
+    ServiceID,
+    VerificationError,
+    extract_patterns,
+    verify_service_identity,
+)
+
+if TYPE_CHECKING:
+    from twisted.protocols.tls import TLSMemoryBIOProtocol
 
 _log = Logger()
 
@@ -87,52 +111,6 @@ def _getExcludedTLSProtocols(oldest, newest):
     return excludedVersions
 
 
-class SimpleVerificationError(Exception):
-    """
-    Not a very useful verification error.
-    """
-
-
-def simpleVerifyHostname(connection, hostname):
-    """
-    Check only the common name in the certificate presented by the peer and
-    only for an exact match.
-
-    This is to provide I{something} in the way of hostname verification to
-    users who haven't installed C{service_identity}. This check is overly
-    strict, relies on a deprecated TLS feature (you're supposed to ignore the
-    commonName if the subjectAlternativeName extensions are present, I
-    believe), and lots of valid certificates will fail.
-
-    @param connection: the OpenSSL connection to verify.
-    @type connection: L{OpenSSL.SSL.Connection}
-
-    @param hostname: The hostname expected by the user.
-    @type hostname: L{unicode}
-
-    @raise twisted.internet.ssl.VerificationError: if the common name and
-        hostname don't match.
-    """
-    commonName = connection.get_peer_certificate().get_subject().commonName
-    if commonName != hostname:
-        raise SimpleVerificationError(repr(commonName) + "!=" + repr(hostname))
-
-
-def simpleVerifyIPAddress(connection, hostname):
-    """
-    Always fails validation of IP addresses
-
-    @param connection: the OpenSSL connection to verify.
-    @type connection: L{OpenSSL.SSL.Connection}
-
-    @param hostname: The hostname expected by the user.
-    @type hostname: L{unicode}
-
-    @raise twisted.internet.ssl.VerificationError: Always raised
-    """
-    raise SimpleVerificationError("Cannot verify certificate IP addresses")
-
-
 def _usablePyOpenSSL(version):
     """
     Check pyOpenSSL version string whether we can use it for host verification.
@@ -146,54 +124,18 @@ def _usablePyOpenSSL(version):
     return (major, minor) >= (0, 12)
 
 
-def _selectVerifyImplementation():
-    """
-    Determine if C{service_identity} is installed. If so, use it. If not, use
-    simplistic and incorrect checking as implemented in
-    L{simpleVerifyHostname}.
-
-    @return: 2-tuple of (C{verify_hostname}, C{VerificationError})
-    @rtype: L{tuple}
-    """
-
-    whatsWrong = (
-        "Without the service_identity module, Twisted can perform only "
-        "rudimentary TLS client hostname verification.  Many valid "
-        "certificate/hostname mappings may be rejected."
-    )
-
-    try:
-        from service_identity import VerificationError
-        from service_identity.pyopenssl import verify_hostname, verify_ip_address
-
-        return verify_hostname, verify_ip_address, VerificationError
-    except ImportError as e:
-        warnings.warn_explicit(
-            "You do not have a working installation of the "
-            "service_identity module: '" + str(e) + "'.  "
-            "Please install it from "
-            "<https://pypi.python.org/pypi/service_identity> and make "
-            "sure all of its dependencies are satisfied.  " + whatsWrong,
-            # Unfortunately the lineno is required.
-            category=UserWarning,
-            filename="",
-            lineno=0,
-        )
-
-    return simpleVerifyHostname, simpleVerifyIPAddress, SimpleVerificationError
-
-
-verifyHostname, verifyIPAddress, VerificationError = _selectVerifyImplementation()
-
-
 class ProtocolNegotiationSupport(Flags):
     """
     L{ProtocolNegotiationSupport} defines flags which are used to indicate the
-    level of NPN/ALPN support provided by the TLS backend.
+    level of ALPN support provided by the TLS backend.
 
-    @cvar NOSUPPORT: There is no support for NPN or ALPN. This is exclusive
-        with both L{NPN} and L{ALPN}.
-    @cvar NPN: The implementation supports Next Protocol Negotiation.
+    @cvar NOSUPPORT: There is no support for ALPN.  This is exclusive with
+        L{ALPN}.
+
+    @cvar NPN: The implementation supports Next Protocol Negotiation.  (This
+        flag is provided for compatibility only; Twisted no longer supports
+        Next Protocol Negotiation)
+
     @cvar ALPN: The implementation supports Application Layer Protocol
         Negotiation.
     """
@@ -211,28 +153,21 @@ ProtocolNegotiationSupport.NOSUPPORT = (
 )
 
 
-def protocolNegotiationMechanisms():
+def protocolNegotiationMechanisms() -> FlagConstant:
     """
-    Checks whether your versions of PyOpenSSL and OpenSSL are recent enough to
-    support protocol negotiation, and if they are, what kind of protocol
-    negotiation is supported.
+    Check whether the installed versions of pyOpenSSL and OpenSSL are recent
+    enough to support ALPN.
 
     @return: A combination of flags from L{ProtocolNegotiationSupport} that
         indicate which mechanisms for protocol negotiation are supported.
-    @rtype: L{constantly.FlagConstant}
     """
+    # TODO: deprecate this, as it will always return ALPN and only ALPN on all
+    # supported versions of OpenSSL.
     support = ProtocolNegotiationSupport.NOSUPPORT
     ctx = SSL.Context(SSL.SSLv23_METHOD)
 
     try:
-        ctx.set_npn_advertise_callback(lambda c: None)
-    except (AttributeError, NotImplementedError):
-        pass
-    else:
-        support |= ProtocolNegotiationSupport.NPN
-
-    try:
-        ctx.set_alpn_select_callback(lambda c: None)
+        ctx.set_alpn_select_callback(lambda connection, protocols: protocols[0])
     except (AttributeError, NotImplementedError):
         pass
     else:
@@ -334,13 +269,13 @@ class DistinguishedName(Dict[str, bytes]):
             value = value.encode("ascii")
         self[realAttr] = value
 
-    def inspect(self):
+    def inspect(self) -> str:
         """
         Return a multi-line, human-readable representation of this DN.
 
         @rtype: L{str}
         """
-        l = []
+        lines = []
         lablen = 0
 
         def uniqueValues(mapping):
@@ -351,11 +286,9 @@ class DistinguishedName(Dict[str, bytes]):
             lablen = max(len(label), lablen)
             v = getattr(self, k, None)
             if v is not None:
-                l.append((label, nativeString(v)))
+                lines.append((label, nativeString(v)))
         lablen += 2
-        for n, (label, attrib) in enumerate(l):
-            l[n] = label.rjust(lablen) + ": " + attrib
-        return "\n".join(l)
+        return "\n".join(label.rjust(lablen) + ": " + attrib for label, attrib in lines)
 
 
 DN = DistinguishedName
@@ -426,6 +359,9 @@ def _handleattrhelper(Class, transport, methodName):
     return Class(cert)
 
 
+_Self = TypeVar("_Self", bound="Certificate")
+
+
 class Certificate(CertBase):
     """
     An x509 certificate.
@@ -444,7 +380,12 @@ class Certificate(CertBase):
         return NotImplemented
 
     @classmethod
-    def load(Class, requestData, format=crypto.FILETYPE_ASN1, args=()):
+    def load(
+        Class: type[_Self],
+        requestData: bytes,
+        format: int = crypto.FILETYPE_ASN1,
+        args: tuple[Any, ...] = (),
+    ) -> _Self:
         """
         Load a certificate from an ASN.1- or PEM-format string.
 
@@ -465,7 +406,7 @@ class Certificate(CertBase):
         return self.dump(crypto.FILETYPE_PEM)
 
     @classmethod
-    def loadPEM(Class, data):
+    def loadPEM(Class, data: bytes) -> Certificate:
         """
         Load a certificate from a PEM-format data string.
 
@@ -761,7 +702,7 @@ class PublicKey:
 
 class KeyPair(PublicKey):
     @classmethod
-    def load(Class, data, format=crypto.FILETYPE_ASN1):
+    def load(Class, data: bytes, format: int = crypto.FILETYPE_ASN1) -> KeyPair:
         return Class(crypto.load_privatekey(format, data))
 
     def dump(self, format=crypto.FILETYPE_ASN1):
@@ -1039,38 +980,6 @@ def platformTrust():
     return OpenSSLDefaultPaths()
 
 
-def _tolerateErrors(wrapped):
-    """
-    Wrap up an C{info_callback} for pyOpenSSL so that if something goes wrong
-    the error is immediately logged and the connection is dropped if possible.
-
-    This wrapper exists because some versions of pyOpenSSL don't handle errors
-    from callbacks at I{all}, and those which do write tracebacks directly to
-    stderr rather than to a supplied logging system.  This reports unexpected
-    errors to the Twisted logging system.
-
-    Also, this terminates the connection immediately if possible because if
-    you've got bugs in your verification logic it's much safer to just give up.
-
-    @param wrapped: A valid C{info_callback} for pyOpenSSL.
-    @type wrapped: L{callable}
-
-    @return: A valid C{info_callback} for pyOpenSSL that handles any errors in
-        C{wrapped}.
-    @rtype: L{callable}
-    """
-
-    def infoCallback(connection: SSL.Connection, where: int, ret: int) -> object:
-        result = None
-        with _log.failuresHandled("Error during info_callback") as op:
-            result = wrapped(connection, where, ret)
-        if (f := op.failure) is not None:
-            connection.get_app_data().failVerification(f)
-        return result
-
-    return infoCallback
-
-
 @implementer(IOpenSSLClientConnectionCreator)
 class ClientTLSOptions:
     """
@@ -1080,16 +989,13 @@ class ClientTLSOptions:
     L{optionsForClientTLS} API.
 
     @ivar _ctx: The context to use for new connections.
-    @type _ctx: L{OpenSSL.SSL.Context}
 
     @ivar _hostname: The hostname to verify, as specified by the application,
         as some human-readable text.
-    @type _hostname: L{unicode}
 
     @ivar _hostnameBytes: The hostname to verify, decoded into IDNA-encoded
         bytes.  This is passed to APIs which think that hostnames are bytes,
         such as OpenSSL's SNI implementation.
-    @type _hostnameBytes: L{bytes}
 
     @ivar _hostnameASCII: The hostname, as transcoded into IDNA ASCII-range
         unicode code points.  This is pre-transcoded because the
@@ -1097,25 +1003,43 @@ class ClientTLSOptions:
         C{idna} package from PyPI for internationalized domain names, rather
         than working with Python's built-in (but sometimes broken) IDNA
         encoding.  ASCII values, however, will always work.
-    @type _hostnameASCII: L{unicode}
 
     @ivar _hostnameIsDnsName: Whether or not the C{_hostname} is a DNSName.
         Will be L{False} if C{_hostname} is an IP address or L{True} if
         C{_hostname} is a DNSName
-    @type _hostnameIsDnsName: L{bool}
+
+    @ivar _sendServerName: Whether the hostname will be sent via the TLS
+        U{Server Name Indication
+        <https://www.rfc-editor.org/rfc/rfc3546#section-3.1>} extension.
     """
 
-    def __init__(self, hostname, ctx):
+    _ctx: Optional[SSL.Context]
+    _hostname: str
+    _hostnameASCII: str
+    _hostnameIsDnsName: bool
+    _hostnameBytes: bytes
+    _sendServerName: bool
+
+    def __init__(
+        self,
+        hostname: str,
+        context: Optional[SSL.Context],
+        createContext: Callable[[], SSL.Context],
+        sendServerName: bool | None = None,
+    ) -> None:
         """
         Initialize L{ClientTLSOptions}.
 
         @param hostname: The hostname to verify as input by a human.
-        @type hostname: L{unicode}
 
-        @param ctx: an L{OpenSSL.SSL.Context} to use for new connections.
-        @type ctx: L{OpenSSL.SSL.Context}.
+        @param createContext: A function that will create an SSL context.
+
+        @param sendServerName: Should the server name be sent to the peer?
+            C{None} means "follow the specification", which will send it if
+            it's a valid DNS name and refrain from sending it if it's an IP
+            address; C{True} means always send, and C{False} means never send.
         """
-        self._ctx = ctx
+        self._createContext = createContext
         self._hostname = hostname
 
         if isIPAddress(hostname) or isIPv6Address(hostname):
@@ -1126,71 +1050,82 @@ class ClientTLSOptions:
             self._hostnameIsDnsName = True
 
         self._hostnameASCII = self._hostnameBytes.decode("ascii")
+        self._ctx = context
+        self._createContext = createContext
+        if sendServerName is None:
+            sendServerName = self._hostnameIsDnsName
+        self._sendServerName = sendServerName
 
-    def clientConnectionForTLS(self, tlsProtocol):
+    def clientConnectionForTLS(self, tlsProtocol: TLSMemoryBIOProtocol) -> Connection:
         """
         Create a TLS connection for a client.
 
-        @note: This will call C{set_app_data} on its connection.  If you're
-            delegating to this implementation of this method, don't ever call
-            C{set_app_data} or C{set_info_callback} on the returned connection,
-            or you'll break the implementation of various features of this
-            class.
-
         @param tlsProtocol: the TLS protocol initiating the connection.
-        @type tlsProtocol: L{twisted.protocols.tls.TLSMemoryBIOProtocol}
 
         @return: the configured client connection.
-        @rtype: L{OpenSSL.SSL.Connection}
         """
+        if self._ctx is None:
+            self._ctx = self._createContext()
         context = self._ctx
         connection = SSL.Connection(context, None)
-        connection.set_app_data(tlsProtocol)
-        connection.set_info_callback(
-            _tolerateErrors(self._identityVerifyingInfoCallback)
-        )
-        return connection
-
-    def _identityVerifyingInfoCallback(self, connection, where, ret):
-        """
-        U{info_callback
-        <http://pythonhosted.org/pyOpenSSL/api/ssl.html#OpenSSL.SSL.Context.set_info_callback>
-        } for pyOpenSSL that verifies the hostname in the presented certificate
-        matches the one passed to this L{ClientTLSOptions}.
-
-        @param connection: the connection which is handshaking.
-        @type connection: L{OpenSSL.SSL.Connection}
-
-        @param where: flags indicating progress through a TLS handshake.
-        @type where: L{int}
-
-        @param ret: ignored
-        @type ret: ignored
-        """
         # Literal IPv4 and IPv6 addresses are not permitted
         # as host names according to the RFCs
-        if where & SSL.SSL_CB_HANDSHAKE_START and self._hostnameIsDnsName:
+        if self._sendServerName:
             connection.set_tlsext_host_name(self._hostnameBytes)
-        elif where & SSL.SSL_CB_HANDSHAKE_DONE:
+        callback = _verifyCB(tlsProtocol, self._hostnameIsDnsName, self._hostnameASCII)
+        connection.set_verify(VERIFY_PEER | VERIFY_FAIL_IF_NO_PEER_CERT, callback)
+        return connection
+
+
+def _verifyCB(
+    tlsProtocol: TLSMemoryBIOProtocol, hostIsDNS: bool, hostnameASCII: str
+) -> Callable[[Connection, X509, int, int, bool], bool]:
+    svcid: ServiceID
+    if hostIsDNS:
+        svcid = DNS_ID(hostnameASCII)
+    else:
+        svcid = IPAddress_ID(hostnameASCII)
+
+    weakProtoRef: TLSMemoryBIOProtocol | None = tlsProtocol
+
+    def verifyCallback(
+        conn: Connection, cert: X509, err: int, depth: int, ok: bool
+    ) -> bool:
+        ourVerifyResult = ok
+        nonlocal weakProtoRef
+        try:
+            if depth != 0:
+                # We are only verifying the leaf certificate.
+                return ourVerifyResult
             try:
-                if self._hostnameIsDnsName:
-                    verifyHostname(connection, self._hostnameASCII)
-                else:
-                    verifyIPAddress(connection, self._hostnameASCII)
+                verify_service_identity(extract_patterns(cert), [svcid], [])
             except VerificationError:
+                ourVerifyResult = False
                 f = Failure()
-                transport = connection.get_app_data()
-                transport.failVerification(f)
+                assert weakProtoRef is not None
+                weakProtoRef.failVerification(f)
+        except BaseException:
+            # If we raise an exception *at all* during an OpenSSL callback, at
+            # best we lose the exception to getting dumped on stderr rather
+            # than getting logged, at worst it just disappears.  So we catch
+            # *everything* here so we can get it normally logged.
+            _log.failure("while verifying certificate")
+        # Ensure that no reference remains to the protocol.
+        weakProtoRef = None
+        return ourVerifyResult
+
+    return verifyCallback
 
 
 def optionsForClientTLS(
-    hostname,
-    trustRoot=None,
-    clientCertificate=None,
-    acceptableProtocols=None,
+    hostname: str,
+    trustRoot: Optional[Union[IOpenSSLTrustRoot, Certificate]] = None,
+    clientCertificate: Optional[PrivateCertificate] = None,
+    acceptableProtocols: Optional[Sequence[bytes]] = None,
     *,
-    extraCertificateOptions=None,
-):
+    extraCertificateOptions: Optional[dict[str, Any]] = None,
+    sendServerName: bool | None = None,
+) -> ClientTLSOptions:
     """
     Create a L{client connection creator <IOpenSSLClientConnectionCreator>} for
     use with APIs such as L{SSL4ClientEndpoint
@@ -1200,44 +1135,43 @@ def optionsForClientTLS(
 
     @since: 14.0
 
-    @param hostname: The expected name of the remote host. This serves two
+    @param hostname: The expected name of the remote host.  This serves two
         purposes: first, and most importantly, it verifies that the certificate
         received from the server correctly identifies the specified hostname.
         The second purpose is to use the U{Server Name Indication extension
         <https://en.wikipedia.org/wiki/Server_Name_Indication>} to indicate to
         the server which certificate should be used.
-    @type hostname: L{unicode}
 
-    @param trustRoot: Specification of trust requirements of peers. This may be
-        a L{Certificate} or the result of L{platformTrust}. By default it is
-        L{platformTrust} and you probably shouldn't adjust it unless you really
-        know what you're doing. Be aware that clients using this interface
-        I{must} verify the server; you cannot explicitly pass L{None} since
-        that just means to use L{platformTrust}.
-    @type trustRoot: L{IOpenSSLTrustRoot}
+    @param trustRoot: Specification of trust requirements of peers.  This may
+        be a L{Certificate} or the result of L{platformTrust}.  By default it
+        is L{platformTrust} and you probably shouldn't adjust it unless you
+        really know what you're doing.  Be aware that clients using this
+        interface I{must} verify the server; you cannot explicitly pass L{None}
+        since that just means to use L{platformTrust}.
 
     @param clientCertificate: The certificate and private key that the client
-        will use to authenticate to the server. If unspecified, the client will
-        not authenticate.
-    @type clientCertificate: L{PrivateCertificate}
+        will use to authenticate to the server.  If unspecified, the client
+        will not authenticate.
 
     @param acceptableProtocols: The protocols this peer is willing to speak
-        after the TLS negotiation has completed, advertised over both ALPN and
-        NPN. If this argument is specified, and no overlap can be found with
-        the other peer, the connection will fail to be established. If the
-        remote peer does not offer NPN or ALPN, the connection will be
-        established, but no protocol wil be negotiated. Protocols earlier in
-        the list are preferred over those later in the list.
-    @type acceptableProtocols: L{list} of L{bytes}
+        after the TLS negotiation has completed, advertised over ALPN.  If this
+        argument is specified, and no overlap can be found with the other peer,
+        the connection will fail to be established.  If the remote peer does
+        not offer ALPN, the connection will be established, but no protocol wil
+        be negotiated.  Protocols earlier in the list are preferred over those
+        later in the list.
 
-    @param extraCertificateOptions: A dictionary of additional keyword arguments
-        to be presented to L{CertificateOptions}. Please avoid using this unless
-        you absolutely need to; any time you need to pass an option here that is
-        a bug in this interface.
-    @type extraCertificateOptions: L{dict}
+    @param extraCertificateOptions: A dictionary of additional keyword
+        arguments to be presented to L{CertificateOptions}.  Please avoid using
+        this unless you absolutely need to; any time you need to pass an option
+        here that is a bug in this interface.
+
+    @param sendServerName: Should the server name be sent to the peer?  C{None}
+        means "follow the specification", which will send it if it's a valid
+        DNS name and refrain from sending it if it's an IP address; C{True}
+        means always send, and C{False} means never send.
 
     @return: A client connection creator.
-    @rtype: L{IOpenSSLClientConnectionCreator}
     """
     if extraCertificateOptions is None:
         extraCertificateOptions = {}
@@ -1253,15 +1187,23 @@ def optionsForClientTLS(
             privateKey=clientCertificate.privateKey.original,
             certificate=clientCertificate.original,
         )
+
     certificateOptions = OpenSSLCertificateOptions(
         trustRoot=trustRoot,
         acceptableProtocols=acceptableProtocols,
         **extraCertificateOptions,
     )
-    return ClientTLSOptions(hostname, certificateOptions.getContext())
+
+    return ClientTLSOptions(
+        hostname, None, certificateOptions._makeContext, sendServerName
+    )
 
 
-@implementer(IOpenSSLContextFactory)
+@implementer(
+    IOpenSSLServerConnectionCreator,
+    IOpenSSLClientConnectionCreator,
+    IOpenSSLContextFactory,
+)
 class OpenSSLCertificateOptions:
     """
     A L{CertificateOptions <twisted.internet.ssl.CertificateOptions>} specifies
@@ -1284,7 +1226,7 @@ class OpenSSLCertificateOptions:
 
     # Factory for creating contexts.  Configurable for testability.
     _contextFactory = SSL.Context
-    _context = None
+    _context: SSL.Context | None = None
 
     _OP_NO_TLSv1_3 = _tlsDisableFlags[TLSVersion.TLSv1_3]
 
@@ -1292,38 +1234,41 @@ class OpenSSLCertificateOptions:
 
     @_mutuallyExclusiveArguments(
         [
-            ["trustRoot", "requireCertificate"],
-            ["trustRoot", "verify"],
-            ["trustRoot", "caCerts"],
-            ["method", "insecurelyLowerMinimumTo"],
-            ["method", "raiseMinimumTo"],
-            ["raiseMinimumTo", "insecurelyLowerMinimumTo"],
-            ["method", "lowerMaximumSecurityTo"],
+            ("trustRoot", "requireCertificate"),
+            ("trustRoot", "verify"),
+            ("trustRoot", "caCerts"),
+            ("method", "insecurelyLowerMinimumTo"),
+            ("method", "raiseMinimumTo"),
+            ("raiseMinimumTo", "insecurelyLowerMinimumTo"),
+            ("method", "lowerMaximumSecurityTo"),
         ]
     )
     def __init__(
         self,
-        privateKey=None,
-        certificate=None,
-        method=None,
-        verify=False,
-        caCerts=None,
-        verifyDepth=9,
-        requireCertificate=True,
-        verifyOnce=True,
-        enableSingleUseKeys=True,
-        enableSessions=False,
-        fixBrokenPeers=False,
-        enableSessionTickets=False,
-        extraCertChain=None,
-        acceptableCiphers=None,
-        dhParameters=None,
-        trustRoot=None,
-        acceptableProtocols=None,
-        raiseMinimumTo=None,
-        insecurelyLowerMinimumTo=None,
-        lowerMaximumSecurityTo=None,
-    ):
+        privateKey: PKey | None = None,
+        certificate: X509 | None = None,
+        method: int | None = None,
+        verify: bool = False,
+        caCerts: list[X509] | None = None,
+        verifyDepth: int = 9,
+        requireCertificate: bool = True,
+        verifyOnce: bool = True,
+        enableSingleUseKeys: bool = True,
+        enableSessions: bool = False,
+        fixBrokenPeers: bool = False,
+        enableSessionTickets: bool = False,
+        extraCertChain: list[X509] | None = None,
+        acceptableCiphers: IAcceptableCiphers | None = None,
+        dhParameters: OpenSSLDiffieHellmanParameters | None = None,
+        trustRoot: IOpenSSLTrustRoot | None = None,
+        acceptableProtocols: list[bytes] | None = None,
+        raiseMinimumTo: NamedConstant | None = None,
+        insecurelyLowerMinimumTo: NamedConstant | None = None,
+        lowerMaximumSecurityTo: NamedConstant | None = None,
+        callbackForServerName: (
+            Callable[[bytes | None], SSL.Context | None] | None
+        ) = None,
+    ) -> None:
         """
         Create an OpenSSL context SSL connection context factory.
 
@@ -1397,7 +1342,6 @@ class OpenSSLCertificateOptions:
             verification chain if the certificate authority that signed your
             C{certificate} isn't widely supported.  Do I{not} add
             C{certificate} to it.
-        @type extraCertChain: C{list} of L{OpenSSL.crypto.X509}
 
         @param acceptableCiphers: Ciphers that are acceptable for connections.
             Uses a secure default if left L{None}.
@@ -1406,8 +1350,6 @@ class OpenSSLCertificateOptions:
         @param dhParameters: Key generation parameters that are required for
             Diffie-Hellman key exchange.  If this argument is left L{None},
             C{EDH} ciphers are I{disabled} regardless of C{acceptableCiphers}.
-        @type dhParameters: L{DiffieHellmanParameters
-            <twisted.internet.ssl.DiffieHellmanParameters>}
 
         @param trustRoot: Specification of trust requirements of peers.  If
             this argument is specified, the peer is verified.  It requires a
@@ -1419,16 +1361,13 @@ class OpenSSLCertificateOptions:
             those options in combination with this one will raise a
             L{TypeError}.
 
-        @type trustRoot: L{IOpenSSLTrustRoot}
-
         @param acceptableProtocols: The protocols this peer is willing to speak
-            after the TLS negotiation has completed, advertised over both ALPN
-            and NPN.  If this argument is specified, and no overlap can be
-            found with the other peer, the connection will fail to be
-            established.  If the remote peer does not offer NPN or ALPN, the
-            connection will be established, but no protocol wil be negotiated.
-            Protocols earlier in the list are preferred over those later in the
-            list.
+            after the TLS negotiation has completed, advertised over ALPN.  If
+            this argument is specified, and no overlap can be found with the
+            other peer, the connection will fail to be established.  If the
+            remote peer does not offer ALPN, the connection will be
+            established, but no protocol wil be negotiated.  Protocols earlier
+            in the list are preferred over those later in the list.
         @type acceptableProtocols: L{list} of L{bytes}
 
         @param raiseMinimumTo: The minimum TLS version that you want to use, or
@@ -1454,6 +1393,10 @@ class OpenSSLCertificateOptions:
             when communicating with newer peers.  DO NOT use this argument
             unless you are absolutely sure this is what you want.
         @type lowerMaximumSecurityTo: L{TLSVersion} constant
+
+        @param callbackForServerName: A callback to invoke with the server-name
+            indication field in the client handshake, which returns the other
+            context to switch to.
 
         @raise ValueError: when C{privateKey} or C{certificate} are set without
             setting the respective other.
@@ -1607,14 +1550,9 @@ class OpenSSLCertificateOptions:
             self.verify = True
             self.requireCertificate = True
             trustRoot = IOpenSSLTrustRoot(trustRoot)
-        self.trustRoot = trustRoot
-
-        if acceptableProtocols is not None and not protocolNegotiationMechanisms():
-            raise NotImplementedError(
-                "No support for protocol negotiation on this platform."
-            )
-
+        self.trustRoot: IOpenSSLTrustRoot | None = trustRoot
         self._acceptableProtocols = acceptableProtocols
+        self._callbackForServerName = callbackForServerName
 
     def __getstate__(self):
         d = self.__dict__.copy()
@@ -1627,15 +1565,52 @@ class OpenSSLCertificateOptions:
     def __setstate__(self, state):
         self.__dict__ = state
 
-    def getContext(self):
+    def getContext(self) -> SSL.Context:
         """
-        Return an L{OpenSSL.SSL.Context} object.
+        Create and cache an L{SSL.Context} based on the parameters in this
+        L{OpenSSLCertificateOptions}.
+
+        This is deprecated because it returns a cached, shared context which
+        cannot safely be shared, because the acceptable protocols may be
+        mutated.
         """
         if self._context is None:
             self._context = self._makeContext()
         return self._context
 
-    def _makeContext(self):
+    def serverConnectionForTLS(self, protocol: TLSMemoryBIOProtocol) -> SSL.Connection:
+        """
+        Construct a TLS connection for the server.
+        """
+        return self._makeTLSConnection(protocol)
+
+    def clientConnectionForTLS(self, protocol: TLSMemoryBIOProtocol) -> SSL.Connection:
+        """
+        Construct a TLS connection for the client.
+        """
+        return self._makeTLSConnection(protocol)
+
+    def _makeTLSConnection(self, protocol: TLSMemoryBIOProtocol) -> SSL.Connection:
+        """
+        Construct an OpenSSL Connection for either client or server.
+        """
+        if (ctx := self._context) is None:
+            ctx = self._makeContext()
+        cxn = Connection(ctx)
+        if acceptable := protosFromProtocol(protocol, self._acceptableProtocols or ()):
+            cxn.set_alpn_protos(acceptable)
+        return cxn
+
+    def _makeContext(self, skipCiphers: bool = False) -> SSL.Context:
+        """
+        Make a new context (with no caching) based on the settings of this
+        Options.
+
+        @param skipCiphers: Don't set the cipher list, so as to avoid creating
+            a Connection and preventing further mutation.  Just for a few small
+            tests, per the behavior described U{here
+            <https://github.com/twisted/twisted/issues/12500#issuecomment-3287771137>}.
+        """
         ctx = self._contextFactory(self.method)
         ctx.set_options(self._options)
         ctx.set_mode(self._mode)
@@ -1650,6 +1625,9 @@ class OpenSSLCertificateOptions:
 
         verifyFlags = SSL.VERIFY_NONE
         if self.verify:
+            assert (
+                self.trustRoot is not None
+            ), "when the verify flag is set, trustRoot must be set"
             verifyFlags = SSL.VERIFY_PEER
             if self.requireCertificate:
                 verifyFlags |= SSL.VERIFY_FAIL_IF_NO_PEER_CERT
@@ -1682,22 +1660,39 @@ class OpenSSLCertificateOptions:
 
         if self.dhParameters:
             ctx.load_tmp_dh(self.dhParameters._dhFile.path)
-        ctx.set_cipher_list(self._cipherString.encode("ascii"))
 
         self._ecChooser.configureECDHCurve(ctx)
-
-        if self._acceptableProtocols:
-            # Try to set NPN and ALPN. _acceptableProtocols cannot be set by
-            # the constructor unless at least one mechanism is supported.
-            _setAcceptableProtocols(ctx, self._acceptableProtocols)
-
+        if self._callbackForServerName is not None:
+            ctx.set_tlsext_servername_callback(
+                contextFactoryToServernameCallback(self._callbackForServerName)
+            )
+        setupForALPN(ctx, self._acceptableProtocols or ())
+        if not skipCiphers:
+            ctx.set_cipher_list(self._cipherString.encode("ascii"))
         return ctx
 
 
-OpenSSLCertificateOptions.__getstate__ = deprecated(
+def contextFactoryToServernameCallback(
+    factory: Callable[[bytes | None], SSL.Context | None],
+) -> Callable[[SSL.Connection], None]:
+    def contextSelectionCallback(connection: SSL.Connection) -> None:
+        # TODO: error handling?
+        servername = connection.get_servername()
+        try:
+            newContext = factory(servername)
+        except BaseException:
+            _log.failure("while looking up SNI context")
+        else:
+            if newContext is not None:
+                connection.set_context(newContext)
+
+    return contextSelectionCallback
+
+
+OpenSSLCertificateOptions.__getstate__ = deprecated(  # type:ignore[method-assign]
     Version("Twisted", 15, 0, 0), "a real persistence system"
 )(OpenSSLCertificateOptions.__getstate__)
-OpenSSLCertificateOptions.__setstate__ = deprecated(
+OpenSSLCertificateOptions.__setstate__ = deprecated(  # type:ignore[method-assign]
     Version("Twisted", 15, 0, 0), "a real persistence system"
 )(OpenSSLCertificateOptions.__setstate__)
 
@@ -1962,61 +1957,52 @@ class OpenSSLDiffieHellmanParameters:
         return cls(filePath)
 
 
-def _setAcceptableProtocols(context, acceptableProtocols):
+def protosFromProtocol(
+    tlsProto: TLSMemoryBIOProtocol | None, acceptableProtocols: Sequence[bytes]
+) -> Sequence[bytes]:
+    if tlsProto is None:
+        return ()
+    tlsFactory = tlsProto.factory
+    assert tlsFactory is not None
+    ipnf = IProtocolNegotiationFactory(tlsFactory.wrappedFactory, None)
+    allAcceptableProtocols = tuple(acceptableProtocols or ())
+    if ipnf is not None:
+        allAcceptableProtocols = (
+            tuple(ipnf.acceptableProtocols()) + allAcceptableProtocols
+        )
+    return allAcceptableProtocols
+
+
+def setupForALPN(context: SSL.Context, acceptableProtocols: Sequence[bytes]) -> None:
     """
-    Called to set up the L{OpenSSL.SSL.Context} for doing NPN and/or ALPN
-    negotiation.
+    Called to set up the L{OpenSSL.SSL.Context} for doing ALPN negotiation.
 
-    @param context: The context which is set up.
-    @type context: L{OpenSSL.SSL.Context}
+    @param context: The context which is being set up.
 
-    @param acceptableProtocols: The protocols this peer is willing to speak
-        after the TLS negotiation has completed, advertised over both ALPN and
-        NPN. If this argument is specified, and no overlap can be found with
-        the other peer, the connection will fail to be established. If the
-        remote peer does not offer NPN or ALPN, the connection will be
-        established, but no protocol wil be negotiated. Protocols earlier in
+    @param acceptableProtocols: The protocols that the host represented by
+        C{context} is willing to speak after TLS negotiation has completed,
+        which will be advertised by connections using this context, over ALPN.
+
+        If this argument is specified, and no overlap can be found with the
+        peer on a given connection, TLS negotiation of that connection will
+        fail, and it will not be established.
+
+        If a connection's peer does not offer ALPN, the connection will be
+        established, but no protocol will be negotiated.  Protocols earlier in
         the list are preferred over those later in the list.
-    @type acceptableProtocols: L{list} of L{bytes}
     """
 
-    def protoSelectCallback(conn, protocols):
-        """
-        NPN client-side and ALPN server-side callback used to select
-        the next protocol. Prefers protocols found earlier in
-        C{_acceptableProtocols}.
-
-        @param conn: The context which is set up.
-        @type conn: L{OpenSSL.SSL.Connection}
-
-        @param conn: Protocols advertised by the other side.
-        @type conn: L{list} of L{bytes}
-        """
-        overlap = set(protocols) & set(acceptableProtocols)
-
-        for p in acceptableProtocols:
+    def alpnSelect(conn: Connection, clientSentProtocols: Sequence[bytes]) -> bytes:
+        tlsProto = conn.get_app_data()
+        allAcceptableProtocols = protosFromProtocol(tlsProto, acceptableProtocols)
+        overlap = set(clientSentProtocols) & set(allAcceptableProtocols)
+        for p in allAcceptableProtocols:
             if p in overlap:
                 return p
         else:
+            # TODO: I think this should really be
+            # OpenSSL.SSL.NO_OVERLAPPING_PROTOCOLS which is a Python-specific
+            # sentinel object exposed by pyOpenSSL
             return b""
 
-    # If we don't actually have protocols to negotiate, don't set anything up.
-    # Depending on OpenSSL version, failing some of the selection callbacks can
-    # cause the handshake to fail, which is presumably not what was intended
-    # here.
-    if not acceptableProtocols:
-        return
-
-    supported = protocolNegotiationMechanisms()
-
-    if supported & ProtocolNegotiationSupport.NPN:
-
-        def npnAdvertiseCallback(conn):
-            return acceptableProtocols
-
-        context.set_npn_advertise_callback(npnAdvertiseCallback)
-        context.set_npn_select_callback(protoSelectCallback)
-
-    if supported & ProtocolNegotiationSupport.ALPN:
-        context.set_alpn_select_callback(protoSelectCallback)
-        context.set_alpn_protos(acceptableProtocols)
+    context.set_alpn_select_callback(alpnSelect)

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1959,10 +1959,12 @@ class OpenSSLDiffieHellmanParameters:
 
 
 def protosFromProtocol(
-    tlsProto: TLSMemoryBIOProtocol | None, acceptableProtocols: Sequence[bytes]
+    tlsProto: TLSMemoryBIOProtocol, acceptableProtocols: Sequence[bytes]
 ) -> Sequence[bytes]:
-    if tlsProto is None:
-        return ()
+    """
+    Get the union of the ALPN protocols from the given TLSMemoryBIOProtocol and
+    from the static list of acceptable protocols.
+    """
     tlsFactory = tlsProto.factory
     assert tlsFactory is not None
     ipnf = IProtocolNegotiationFactory(tlsFactory.wrappedFactory, None)

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -1662,7 +1662,6 @@ def contextFactoryToServernameCallback(
     factory: Callable[[bytes | None], SSL.Context | None],
 ) -> Callable[[SSL.Connection], None]:
     def contextSelectionCallback(connection: SSL.Connection) -> None:
-        # TODO: error handling?
         servername = connection.get_servername()
         try:
             newContext = factory(servername)

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -2373,20 +2373,19 @@ class ISSLTransport(ITCPTransport):
 
 class INegotiated(ISSLTransport):
     """
-    A TLS based transport that supports using ALPN/NPN to negotiate the
-    protocol to be used inside the encrypted tunnel.
+    A TLS based transport that supports using ALPN to negotiate the protocol to
+    be used inside the encrypted tunnel.
     """
 
-    negotiatedProtocol = Attribute(
+    negotiatedProtocol: bytes | None = Attribute(
         """
-        The protocol selected to be spoken using ALPN/NPN. The result from ALPN
-        is preferred to the result from NPN if both were used. If the remote
-        peer does not support ALPN or NPN, or neither NPN or ALPN are available
-        on this machine, will be L{None}. Otherwise, will be the name of the
-        selected protocol as C{bytes}. Note that until the handshake has
-        completed this property may incorrectly return L{None}: wait until data
-        has been received before trusting it (see
-        https://twistedmatrix.com/trac/ticket/6024).
+        The protocol selected to be spoken using ALPN.  If the remote peer does
+        not support ALPN, or ALPN is not available via local TLS libraries,
+        C{negotiatedProtocol} will be L{None}.  Otherwise,
+        C{negotiatedProtocol} will be the name of the selected protocol as
+        C{bytes}.  Until the TLS handshake has completed, this property may
+        incorrectly return L{None}: wait until data has been received before
+        trusting it.  See U{https://github.com/twisted/twisted/issues/6024}.
         """
     )
 

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -118,7 +118,7 @@ class Factory:
         directly.
         """
 
-    def buildProtocol(self, addr: IAddress) -> "Optional[Protocol]":
+    def buildProtocol(self, addr: IAddress | None) -> "Optional[Protocol]":
         """
         Create an instance of a subclass of Protocol.
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -39,7 +39,7 @@ from twisted.internet.address import (
     UNIXAddress,
     _ProcessAddress,
 )
-from twisted.internet.endpoints import StandardErrorBehavior
+from twisted.internet.endpoints import StandardErrorBehavior, _WrapperEndpoint
 from twisted.internet.error import ConnectingCancelledError
 from twisted.internet.interfaces import (
     IAddress,
@@ -4262,10 +4262,12 @@ class WrapperClientEndpointTests(unittest.TestCase):
         self.assertIs(proto.transport.transport, pump.clientIO)
 
 
-def connectionCreatorFromEndpoint(memoryReactor, tlsEndpoint):
+def tlsHostnameFromEndpoint(
+    memoryReactor: IReactorTCP, tlsEndpoint: _WrapperEndpoint
+) -> str:
     """
     Given a L{MemoryReactor} and the result of calling L{wrapClientTLS},
-    extract the L{IOpenSSLClientConnectionCreator} associated with it.
+    extract the hostname that TLS will be verified against.
 
     Implementation presently uses private attributes but could (and should) be
     refactored to just call C{.connect()} on the endpoint, when
@@ -4278,11 +4280,18 @@ def connectionCreatorFromEndpoint(memoryReactor, tlsEndpoint):
 
     @param tlsEndpoint: The result of calling L{wrapClientTLS}.
 
-    @return: the client connection creator associated with the endpoint
-        wrapper.
-    @rtype: L{IOpenSSLClientConnectionCreator}
+    @return: the IDNA-decoded str hostname.
     """
-    return tlsEndpoint._wrapperFactory(None)._connectionCreator
+    tlsMemoryBIOFactory: TLSMemoryBIOFactory = tlsEndpoint._wrapperFactory(
+        Factory.forProtocol(Protocol)
+    )
+    protocol = tlsMemoryBIOFactory.buildProtocol(None)
+    tlsExtServerNameBytes = tlsMemoryBIOFactory._creatorCallable(
+        protocol
+    ).get_servername()
+    assert tlsExtServerNameBytes is not None
+    hostname = tlsExtServerNameBytes.decode("idna")
+    return hostname
 
 
 @skipIf(skipSSL, skipSSLReason)
@@ -4338,8 +4347,8 @@ class WrapClientTLSParserTests(unittest.TestCase):
         self.assertEqual(
             endpoint._wrappedEndpoint._hostBytes, b"xn--xample-9ua.example.com"
         )
-        connectionCreator = connectionCreatorFromEndpoint(reactor, endpoint)
-        self.assertEqual(connectionCreator._hostname, "\xe9xample.example.com")
+        tlsHostname = tlsHostnameFromEndpoint(reactor, endpoint)
+        self.assertEqual(tlsHostname, "\xe9xample.example.com")
 
     def test_tls(self):
         """
@@ -4418,8 +4427,8 @@ class WrapClientTLSParserTests(unittest.TestCase):
         """
         reactor = object()
         endpoint = endpoints.clientFromString(reactor, b"tls:example.com:443")
-        creator = connectionCreatorFromEndpoint(reactor, endpoint)
-        self.assertEqual(creator._hostname, "example.com")
+        tlsHostname = tlsHostnameFromEndpoint(reactor, endpoint)
+        self.assertEqual(tlsHostname, "example.com")
         self.assertEqual(endpoint._wrappedEndpoint._hostBytes, b"example.com")
 
 
@@ -4454,7 +4463,7 @@ def replacingGlobals(function, **newGlobals):
     mergedGlobals = {}
     mergedGlobals.update(funcGlobals)
     mergedGlobals.update(newGlobals)
-    newFunction = FunctionType(codeObject, mergedGlobals)
+    newFunction = FunctionType(codeObject, mergedGlobals, argdefs=function.__defaults__)
     mergedGlobals[function.__name__] = newFunction
     return newFunction
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -1401,7 +1401,9 @@ class TCP4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
             address,
         )
 
-    def createClientEndpoint(self, reactor, clientFactory, **connectArgs):
+    def createClientEndpoint(
+        self, reactor: IReactorTCP, clientFactory: IProtocolFactory, **connectArgs: Any
+    ) -> tuple[IStreamClientEndpoint, tuple[object, ...], IAddress]:
         """
         Create an L{TCP4ClientEndpoint} and return the values needed to verify
         its behavior.

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -42,6 +42,7 @@ from twisted.internet.interfaces import (
     IHostResolution,
     IListeningPort,
     IProtocol,
+    IProtocolFactory,
     IPushProducer,
     IReactorCore,
     IReactorFDSet,
@@ -53,6 +54,7 @@ from twisted.internet.interfaces import (
     IResolutionReceiver,
     ITransport,
 )
+from twisted.internet.protocol import ClientFactory
 from twisted.internet.task import Clock
 from twisted.logger import ILogObserver, LogEvent, LogPublisher
 from twisted.protocols import basic
@@ -539,6 +541,8 @@ class MemoryReactor:
     """
 
     nameResolver: IHostnameResolver
+    tcpServers: list[tuple[int, IProtocolFactory, int, str]]
+    tcpClients: list[tuple[str, int, ClientFactory, int, str | None]]
 
     def __init__(self):
         """

--- a/src/twisted/newsfragments/12500.bugfix
+++ b/src/twisted/newsfragments/12500.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.ssl and twisted.protocols.tls no longer mutate the pyOpenSSL context after creating pyOpenSSL connections, maintaining compatibility with an upcoming version of pyOpenSSL and increasing reliability (possibly even fixing a very rare segfault)

--- a/src/twisted/newsfragments/4887.feature
+++ b/src/twisted/newsfragments/4887.feature
@@ -1,0 +1,1 @@
+twisted.internet.ssl.CertificateOptions has a new constructor argument, contextForServerName, which takes a callback that will get invoked when a client sends a server name indication, with the sent servername, and returns a new OpenSSL.SSL.Context that the connection will switch to.

--- a/src/twisted/newsfragments/9588.removal
+++ b/src/twisted/newsfragments/9588.removal
@@ -1,0 +1,2 @@
+Support for the obsolete TLS "Next Protocol Negotiation" has been removed from
+twisted.protocols.tls.

--- a/src/twisted/protocols/_tls_legacy.py
+++ b/src/twisted/protocols/_tls_legacy.py
@@ -1,0 +1,110 @@
+# -*- test-case-name: twisted.internet.test.test_endpoints.TLSEndpointsTests -*-
+"""
+Handler for the various legacy things that a C{contextFactory} can be.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Union
+from warnings import warn
+
+from OpenSSL.SSL import Connection, Context
+
+from twisted.internet.interfaces import (
+    IOpenSSLClientConnectionCreator,
+    IOpenSSLContextFactory,
+    IOpenSSLServerConnectionCreator,
+)
+
+if TYPE_CHECKING:
+    # Circular import.
+    from twisted.protocols.tls import TLSMemoryBIOProtocol
+
+SomeConnectionCreator = Union[
+    IOpenSSLContextFactory,
+    IOpenSSLClientConnectionCreator,
+    IOpenSSLServerConnectionCreator,
+]
+
+
+SingleArgFactory = Callable[["TLSMemoryBIOProtocol"], Connection]
+
+
+class LegacyContextFactoryWarning(Warning):
+    """
+    You should be using a newer TLS context configuration interface.
+    """
+
+
+def older(olderMethod: Callable[[], Context]) -> SingleArgFactory:
+    """
+    Compatibility shim for L{IOpenSSLContextFactory.getContext}-style method to
+    create(Client/Server)Creator.
+    """
+
+    def convert(p: TLSMemoryBIOProtocol) -> Connection:
+        context = olderMethod()
+        connection = Connection(context, None)
+        return connection
+
+    return convert
+
+
+def oldest(isClient: bool, creator: object) -> SingleArgFactory:
+    """
+    Comptibility shim that does largely the same thing as L{older} but for
+    things that don't even properly implement the old-style interface; check
+    explicitly for the method and try to provide a useful assert if the object
+    is just the wrong type rather than simply using an older API.
+    """
+    itype = "Client" if isClient else "Server"
+    warn(
+        f"{creator} does not explicitly provide any OpenSSL connection-"
+        f"creator {itype} interface; neither IOpenSSL{itype}ConnectionCreator,"
+        f" nor IOpenSSLContextFactory.",
+        LegacyContextFactoryWarning,
+        stacklevel=4,
+    )
+    getContext = getattr(creator, "getContext", None)
+    if getContext is None:
+        raise TypeError(f"{creator} does not even have a `getContext` method")
+    if not isinstance(getContext(), Context):
+        raise TypeError(f"{creator}'s `getContext` method doesn't return a `Context`")
+    return older(getContext)
+
+
+def _convertToAppropriateFactory(
+    isClient: bool, creator: SomeConnectionCreator
+) -> SingleArgFactory:
+    """
+    Upgrade a connection creator / context-factory-ish object into something
+    with a signature like the most recent interface for building OpenSSL
+    connection objects (i.e. like the methods on
+    L{IOpenSSLClientConnectionCreator} and L{IOpenSSLServerConnectionCreator}),
+    accounting for all the various interfaces older versions of Twisted used
+    for context configuration.
+    """
+    baseCallable = (
+        creator.clientConnectionForTLS
+        if (isClient and IOpenSSLClientConnectionCreator.providedBy(creator))
+        else (
+            creator.serverConnectionForTLS
+            if ((not isClient) and IOpenSSLServerConnectionCreator.providedBy(creator))
+            else (
+                older(creator.getContext)
+                if IOpenSSLContextFactory.providedBy(creator)
+                else oldest(isClient, creator)
+            )
+        )
+    )
+
+    def connectionFactory(protocol: TLSMemoryBIOProtocol) -> Connection:
+        connection = baseCallable(protocol)
+        if isClient:
+            connection.set_connect_state()
+        else:
+            connection.set_accept_state()
+        connection.set_app_data(protocol)
+        return connection
+
+    return connectionFactory

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -1422,9 +1422,6 @@ class TLSProducerTests(TestCase):
             def set_app_data(self, app_data):
                 self._app_data = app_data
 
-            def get_app_data(self):
-                return self._app_data
-
             def set_connect_state(self):
                 pass
 

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -8,7 +8,7 @@ Tests for L{twisted.protocols.tls}.
 from __future__ import annotations
 
 import gc
-from typing import Union
+from typing import Any, Union
 
 from zope.interface import Interface, directlyProvides, implementer
 from zope.interface.verify import verifyObject
@@ -16,8 +16,10 @@ from zope.interface.verify import verifyObject
 from hypothesis import given, strategies as st
 
 from twisted.internet import reactor
+from twisted.internet.interfaces import IOpenSSLContextFactory
 from twisted.internet.task import Clock, deferLater
 from twisted.python.compat import iterbytes
+from twisted.test.iosim import IOPump
 
 try:
     from OpenSSL import crypto
@@ -33,6 +35,7 @@ try:
         WantReadError,
     )
 
+    from twisted.protocols._tls_legacy import LegacyContextFactoryWarning
     from twisted.protocols.tls import (
         TLSMemoryBIOFactory,
         TLSMemoryBIOProtocol,
@@ -40,6 +43,7 @@ try:
         _ProducerMembrane,
         _PullToPush,
     )
+
 except ImportError:
     # Skip the whole test module if it can't be imported.
     skip = "pyOpenSSL 16.0.0 or newer required for twisted.protocol.tls"
@@ -55,7 +59,6 @@ from twisted.internet.interfaces import (
     IHandshakeListener,
     IOpenSSLClientConnectionCreator,
     IOpenSSLServerConnectionCreator,
-    IProtocolNegotiationFactory,
     IPushProducer,
     ISSLTransport,
     ISystemHandle,
@@ -72,6 +75,7 @@ from twisted.test.test_tcp import ConnectionLostNotifyingProtocol
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 
 
+@implementer(IOpenSSLContextFactory)
 class HandshakeCallbackContextFactory:
     """
     L{HandshakeCallbackContextFactory} is a factory for SSL contexts which
@@ -234,16 +238,18 @@ class TLSMemoryBIOFactoryTests(TestCase):
 
 
 def handshakingClientAndServer(
-    clientGreetingData=None, clientAbortAfterHandshake=False
-):
+    clientGreetingData: bytes | None = None,
+    clientAbortAfterHandshake: bool = False,
+    hostname: str = "example.com",
+) -> tuple[TLSMemoryBIOProtocol, TLSMemoryBIOProtocol, IOPump]:
     """
     Construct a client and server L{TLSMemoryBIOProtocol} connected by an IO
     pump.
 
     @param greetingData: The data which should be written in L{connectionMade}.
-    @type greetingData: L{bytes}
 
-    @return: 3-tuple of client, server, L{twisted.test.iosim.IOPump}
+    @return: 3-tuple of client protocol, server protocol, and a L{pump
+        <twisted.test.iosim.IOPump>} that can move the data between the two
     """
     authCert, serverCert = certificatesForAuthorityAndServer()
     clock = Clock()
@@ -278,7 +284,9 @@ def handshakingClientAndServer(
             pass
 
     clientF = TLSMemoryBIOFactory(
-        optionsForClientTLS("example.com", trustRoot=authCert),
+        # TODO: client TLS probably wants a custom hostname so we can validate
+        # that more than one gets picked up
+        optionsForClientTLS(hostname, trustRoot=authCert),
         isClient=True,
         wrappedFactory=ClientFactory.forProtocol(lambda: Client(999999)),
         clock=clock,
@@ -307,7 +315,7 @@ class DeterministicTLSMemoryBIOTests(SynchronousTestCase):
         L{connectedServerAndClient}, rather than returning L{Deferred}s.
     """
 
-    def test_handshakeNotification(self):
+    def test_handshakeNotification(self) -> None:
         """
         The completion of the TLS handshake calls C{handshakeCompleted} on
         L{Protocol} objects that provide L{IHandshakeListener}.  At the time
@@ -315,14 +323,16 @@ class DeterministicTLSMemoryBIOTests(SynchronousTestCase):
         have been initialized.
         """
         client, server, pump = handshakingClientAndServer()
-        self.assertEqual(client.wrappedProtocol.handshook, False)
-        self.assertEqual(server.wrappedProtocol.handshaked, False)
+        wrappedClient: Any = client.wrappedProtocol
+        wrappedServer: Any = server.wrappedProtocol
+        self.assertEqual(wrappedClient.handshook, False)
+        self.assertEqual(wrappedServer.handshaked, False)
         pump.flush()
-        self.assertEqual(client.wrappedProtocol.handshook, True)
-        self.assertEqual(server.wrappedProtocol.handshaked, True)
-        self.assertIsNot(client.wrappedProtocol.peerAfterHandshake, None)
+        self.assertEqual(wrappedClient.handshook, True)
+        self.assertEqual(wrappedServer.handshaked, True)
+        self.assertIsNot(wrappedClient.peerAfterHandshake, None)
 
-    def test_handshakeStopWriting(self):
+    def test_handshakeStopWriting(self) -> None:
         """
         If some data is written to the transport in C{connectionMade}, but
         C{handshakeDone} doesn't like something it sees about the handshake, it
@@ -330,18 +340,18 @@ class DeterministicTLSMemoryBIOTests(SynchronousTestCase):
         receives that data.
         """
         client, server, pump = handshakingClientAndServer(b"untrustworthy", True)
-        wrappedServerProtocol = server.wrappedProtocol
+        wrappedServerProtocol: Any = server.wrappedProtocol
         pump.flush()
         self.assertEqual(wrappedServerProtocol.received, [])
 
-    def test_smalWriteBuffering(self):
+    def test_smallWriteBuffering(self) -> None:
         """
         If a small amount data is written to the TLS transport, it is only
         delivered if time passes, indicating small-write buffering is in
         effect.
         """
         client, server, pump = handshakingClientAndServer()
-        wrappedServerProtocol = server.wrappedProtocol
+        wrappedServerProtocol: Any = server.wrappedProtocol
         pump.flush()
         self.assertEqual(wrappedServerProtocol.received, [])
         client.write(b"hel")
@@ -359,7 +369,7 @@ class TLSMemoryBIOTests(TestCase):
     L{ITransport}.
     """
 
-    def test_interfaces(self):
+    def test_interfaces(self) -> None:
         """
         L{TLSMemoryBIOProtocol} instances provide L{ISSLTransport} and
         L{ISystemHandle}.
@@ -368,7 +378,7 @@ class TLSMemoryBIOTests(TestCase):
         self.assertTrue(ISSLTransport.providedBy(proto))
         self.assertTrue(ISystemHandle.providedBy(proto))
 
-    def test_wrappedProtocolInterfaces(self):
+    def test_wrappedProtocolInterfaces(self) -> None:
         """
         L{TLSMemoryBIOProtocol} instances provide the interfaces provided by
         the transport they wrap.
@@ -391,7 +401,7 @@ class TLSMemoryBIOTests(TestCase):
         tlsProtocol.makeConnection(transport)
         self.assertTrue(ITransport.providedBy(tlsProtocol))
 
-    def test_getHandle(self):
+    def test_getHandle(self) -> None:
         """
         L{TLSMemoryBIOProtocol.getHandle} returns the L{OpenSSL.SSL.Connection}
         instance it uses to actually implement TLS.
@@ -414,7 +424,7 @@ class TLSMemoryBIOTests(TestCase):
         proto.makeConnection(transport)
         self.assertIsInstance(proto.getHandle(), Connection)
 
-    def test_makeConnection(self):
+    def test_makeConnection(self) -> None:
         """
         When L{TLSMemoryBIOProtocol} is connected to a transport, it connects
         the protocol it wraps to a transport.
@@ -434,7 +444,7 @@ class TLSMemoryBIOTests(TestCase):
         self.assertIsNot(clientProtocol.transport, transport)
         self.assertIs(clientProtocol.transport, sslProtocol)
 
-    def handshakeProtocols(self):
+    def handshakeProtocols(self) -> tuple[object, object, Deferred[None], object]:
         """
         Start handshake between TLS client and server.
         """
@@ -463,7 +473,7 @@ class TLSMemoryBIOTests(TestCase):
             connectionDeferred,
         )
 
-    def test_handshake(self):
+    def test_handshake(self) -> Deferred[None]:
         """
         The TLS handshake is performed when L{TLSMemoryBIOProtocol} is
         connected to a transport.
@@ -474,13 +484,13 @@ class TLSMemoryBIOTests(TestCase):
         # important here.
         return handshakeDeferred
 
-    def test_handshakeFailure(self):
+    def test_handshakeFailure(self) -> Deferred[list[Any]]:
         """
         L{TLSMemoryBIOProtocol} reports errors in the handshake process to the
         application-level protocol object using its C{connectionLost} method
         and disconnects the underlying transport.
         """
-        clientConnectionLost = Deferred()
+        clientConnectionLost: Deferred[None] = Deferred()
         clientFactory = ClientFactory()
         clientFactory.protocol = lambda: ConnectionLostNotifyingProtocol(
             clientConnectionLost
@@ -490,7 +500,7 @@ class TLSMemoryBIOTests(TestCase):
         wrapperFactory = TLSMemoryBIOFactory(clientContextFactory, True, clientFactory)
         sslClientProtocol = wrapperFactory.buildProtocol(None)
 
-        serverConnectionLost = Deferred()
+        serverConnectionLost: Deferred[None] = Deferred()
         serverFactory = ServerFactory()
         serverFactory.protocol = lambda: ConnectionLostNotifyingProtocol(
             serverConnectionLost
@@ -1076,7 +1086,7 @@ class TLSMemoryBIOTests(TestCase):
         disconnectDeferred.addCallback(disconnected)
         return disconnectDeferred
 
-    def test_noCircularReferences(self):
+    def test_noCircularReferences(self) -> None:
         """
         TLSMemoryBIOProtocol doesn't leave circular references that keep
         it in memory after connection is closed.
@@ -1393,7 +1403,7 @@ class TLSProducerTests(TestCase):
                     self.producer.pauseProducing()
                 StringTransport.write(self, data)
 
-        class TLSConnection:
+        class FakeTLSConnection:
             def __init__(self):
                 self.l = []
 
@@ -1408,6 +1418,12 @@ class TLSProducerTests(TestCase):
                 # otherwise just take in data:
                 self.l.append(data)
                 return len(data)
+
+            def set_app_data(self, app_data):
+                self._app_data = app_data
+
+            def get_app_data(self):
+                return self._app_data
 
             def set_connect_state(self):
                 pass
@@ -1426,7 +1442,7 @@ class TLSProducerTests(TestCase):
 
         transport = PausingStringTransport()
         clientProtocol, tlsProtocol, producer = self.setupStreamingProducer(
-            transport, fakeConnection=TLSConnection()
+            transport, fakeConnection=FakeTLSConnection()
         )
         self.assertEqual(producer.producerState, "producing")
 
@@ -1542,6 +1558,92 @@ class TLSProducerTests(TestCase):
         is called.
         """
         self.registerProducerAfterConnectionLost(False)
+
+    def test_maximumCompatibilityWarning(self) -> None:
+        """
+        Test for compatibility with very old style context factories (i.e. just
+        objects with a C{getContext} method) or broken context factories.
+        """
+
+        class ExtremelyOldStyle:
+            def __repr__(self):
+                return "extremely old style context factory"
+
+            def getContext(self) -> Context:
+                return Context(TLS_METHOD)
+
+        def f() -> None:
+            oldStyle: IOpenSSLContextFactory = (
+                ExtremelyOldStyle()  # type:ignore[assignment]
+            )
+            TLSMemoryBIOFactory(oldStyle, True, Factory.forProtocol(Protocol))
+
+        self.maxDiff = 999
+        expectedMessage = (
+            "extremely old style context factory does not explicitly provide "
+            "any OpenSSL connection-creator Client interface; neither "
+            "IOpenSSLClientConnectionCreator, nor IOpenSSLContextFactory."
+        )
+        self.assertWarns(LegacyContextFactoryWarning, expectedMessage, __file__, f)
+
+    def test_brokenContextFactoryErrors(self) -> None:
+        """
+        If a broken object is passed as a context factory, useful error
+        messages in TypeErrors should be returned.
+        """
+
+        class HasGetContextButBroken:
+            def __repr__(self) -> str:
+                return "has get context but broken"
+
+            def getContext(self) -> None:
+                ...
+
+        class JustBroken:
+            def __repr__(self) -> str:
+                return "just broken"
+
+        broken1: IOpenSSLContextFactory = (
+            HasGetContextButBroken()  # type:ignore[assignment]
+        )
+        broken2: IOpenSSLContextFactory = JustBroken()  # type:ignore[assignment]
+
+        def test1() -> None:
+            with self.assertRaises(TypeError) as te:
+                TLSMemoryBIOFactory(broken1, True, Factory.forProtocol(Protocol))
+            self.assertEqual(
+                str(te.exception),
+                "has get context but broken's `getContext` method doesn't return a `Context`",
+            )
+
+        def test2() -> None:
+            with self.assertRaises(TypeError) as te2:
+                TLSMemoryBIOFactory(broken2, True, Factory.forProtocol(Protocol))
+            self.assertEqual(
+                str(te2.exception),
+                "just broken does not even have a `getContext` method",
+            )
+
+        self.assertWarns(
+            LegacyContextFactoryWarning,
+            (
+                "has get context but broken does not explicitly provide any "
+                "OpenSSL connection-creator Client interface; neither "
+                "IOpenSSLClientConnectionCreator, nor IOpenSSLContextFactory."
+            ),
+            __file__,
+            test1,
+        )
+        self.assertWarns(
+            LegacyContextFactoryWarning,
+            (
+                "just broken does not explicitly provide any OpenSSL "
+                "connection-creator Client interface; neither "
+                "IOpenSSLClientConnectionCreator, nor IOpenSSLContextFactory."
+            ),
+            __file__,
+            test2,
+        )
 
 
 class NonStreamingProducerTests(TestCase):
@@ -1804,64 +1906,6 @@ class NonStreamingProducerTests(TestCase):
         nsProducer = NonStreamingProducer(consumer)
         streamingProducer = _PullToPush(nsProducer, consumer)
         self.assertTrue(verifyObject(IPushProducer, streamingProducer))
-
-
-@implementer(IProtocolNegotiationFactory)
-class ClientNegotiationFactory(ClientFactory):
-    """
-    A L{ClientFactory} that has a set of acceptable protocols for NPN/ALPN
-    negotiation.
-    """
-
-    def __init__(self, acceptableProtocols):
-        """
-        Create a L{ClientNegotiationFactory}.
-
-        @param acceptableProtocols: The protocols the client will accept
-            speaking after the TLS handshake is complete.
-        @type acceptableProtocols: L{list} of L{bytes}
-        """
-        self._acceptableProtocols = acceptableProtocols
-
-    def acceptableProtocols(self):
-        """
-        Returns a list of protocols that can be spoken by the connection
-        factory in the form of ALPN tokens, as laid out in the IANA registry
-        for ALPN tokens.
-
-        @return: a list of ALPN tokens in order of preference.
-        @rtype: L{list} of L{bytes}
-        """
-        return self._acceptableProtocols
-
-
-@implementer(IProtocolNegotiationFactory)
-class ServerNegotiationFactory(ServerFactory):
-    """
-    A L{ServerFactory} that has a set of acceptable protocols for NPN/ALPN
-    negotiation.
-    """
-
-    def __init__(self, acceptableProtocols):
-        """
-        Create a L{ServerNegotiationFactory}.
-
-        @param acceptableProtocols: The protocols the server will accept
-            speaking after the TLS handshake is complete.
-        @type acceptableProtocols: L{list} of L{bytes}
-        """
-        self._acceptableProtocols = acceptableProtocols
-
-    def acceptableProtocols(self):
-        """
-        Returns a list of protocols that can be spoken by the connection
-        factory in the form of ALPN tokens, as laid out in the IANA registry
-        for ALPN tokens.
-
-        @return: a list of ALPN tokens in order of preference.
-        @rtype: L{list} of L{bytes}
-        """
-        return self._acceptableProtocols
 
 
 class _AggregateSmallWritesTests(SynchronousTestCase):

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -42,19 +42,16 @@ from typing import Callable, Iterable, Optional, cast
 
 from zope.interface import directlyProvides, implementer, providedBy
 
-from OpenSSL.SSL import Connection, Error, SysCallError, WantReadError, ZeroReturnError
+from OpenSSL.SSL import Error, SysCallError, WantReadError, ZeroReturnError
 
 from twisted.internet._producer_helpers import _PullToPush
-from twisted.internet._sslverify import _setAcceptableProtocols
 from twisted.internet.interfaces import (
     IDelayedCall,
     IHandshakeListener,
     ILoggingContext,
     INegotiated,
-    IOpenSSLClientConnectionCreator,
-    IOpenSSLServerConnectionCreator,
     IProtocol,
-    IProtocolNegotiationFactory,
+    IProtocolFactory,
     IPushProducer,
     IReactorTime,
     ISystemHandle,
@@ -64,6 +61,7 @@ from twisted.internet.main import CONNECTION_LOST
 from twisted.internet.protocol import Protocol
 from twisted.protocols.policies import ProtocolWrapper, WrappingFactory
 from twisted.python.failure import Failure
+from ._tls_legacy import SomeConnectionCreator, _convertToAppropriateFactory
 
 
 @implementer(IPushProducer)
@@ -188,6 +186,15 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
     _producer = None
     _aborted = False
 
+    # we are a ProtocolWrapper and thus ->Protocol. in order LSP substitute to
+    # Protocol, self.factory must be (invariant: the attribute is read/write!)
+    # Factory[Self] | None. Thus, constraining it to TLSMemoryBIOFactory like
+    # this is invalid; a client of Protocol looking at an instance of
+    # TLSMemoryBIOProtocol might want to assign some arbitrary .factory and
+    # that would be wrong.
+
+    factory: TLSMemoryBIOFactory
+
     def __init__(self, factory, wrappedProtocol, _connectWrapped=True):
         ProtocolWrapper.__init__(self, factory, wrappedProtocol)
         self._connectWrapped = _connectWrapped
@@ -209,7 +216,7 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         Connect this wrapper to the given transport and initialize the
         necessary L{OpenSSL.SSL.Connection} with a memory BIO.
         """
-        self._tlsConnection = self.factory._createConnection(self)
+        self._tlsConnection = self.factory._creatorCallable(self)
         self._appSendBuffer = []
 
         # Add interfaces provided by the transport we are wrapping:
@@ -554,31 +561,14 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         return self._tlsConnection.get_peer_certificate()
 
     @property
-    def negotiatedProtocol(self):
+    def negotiatedProtocol(self) -> bytes | None:
         """
         @see: L{INegotiated.negotiatedProtocol}
         """
-        protocolName = None
-
-        try:
-            # If ALPN is not implemented that's ok, NPN might be.
-            protocolName = self._tlsConnection.get_alpn_proto_negotiated()
-        except (NotImplementedError, AttributeError):
-            pass
-
-        if protocolName not in (b"", None):
-            # A protocol was selected using ALPN.
-            return protocolName
-
-        try:
-            protocolName = self._tlsConnection.get_next_proto_negotiated()
-        except (NotImplementedError, AttributeError):
-            pass
-
-        if protocolName != b"":
-            return protocolName
-
-        return None
+        protocolName: bytes | None = self._tlsConnection.get_alpn_proto_negotiated()
+        if protocolName == b"":
+            return None
+        return protocolName
 
     def registerProducer(self, producer, streaming):
         # If we've already disconnected, nothing to do here:
@@ -613,81 +603,6 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         self.transport.unregisterProducer()
         if self.disconnecting and not self._appSendBuffer:
             self._shutdownTLS()
-
-
-@implementer(IOpenSSLClientConnectionCreator, IOpenSSLServerConnectionCreator)
-class _ContextFactoryToConnectionFactory:
-    """
-    Adapter wrapping a L{twisted.internet.interfaces.IOpenSSLContextFactory}
-    into a L{IOpenSSLClientConnectionCreator} or
-    L{IOpenSSLServerConnectionCreator}.
-
-    See U{https://twistedmatrix.com/trac/ticket/7215} for work that should make
-    this unnecessary.
-    """
-
-    def __init__(self, oldStyleContextFactory):
-        """
-        Construct a L{_ContextFactoryToConnectionFactory} with a
-        L{twisted.internet.interfaces.IOpenSSLContextFactory}.
-
-        Immediately call C{getContext} on C{oldStyleContextFactory} in order to
-        force advance parameter checking, since old-style context factories
-        don't actually check that their arguments to L{OpenSSL} are correct.
-
-        @param oldStyleContextFactory: A factory that can produce contexts.
-        @type oldStyleContextFactory:
-            L{twisted.internet.interfaces.IOpenSSLContextFactory}
-        """
-        oldStyleContextFactory.getContext()
-        self._oldStyleContextFactory = oldStyleContextFactory
-
-    def _connectionForTLS(self, protocol):
-        """
-        Create an L{OpenSSL.SSL.Connection} object.
-
-        @param protocol: The protocol initiating a TLS connection.
-        @type protocol: L{TLSMemoryBIOProtocol}
-
-        @return: a connection
-        @rtype: L{OpenSSL.SSL.Connection}
-        """
-        context = self._oldStyleContextFactory.getContext()
-        return Connection(context, None)
-
-    def serverConnectionForTLS(self, protocol):
-        """
-        Construct an OpenSSL server connection from the wrapped old-style
-        context factory.
-
-        @note: Since old-style context factories don't distinguish between
-            clients and servers, this is exactly the same as
-            L{_ContextFactoryToConnectionFactory.clientConnectionForTLS}.
-
-        @param protocol: The protocol initiating a TLS connection.
-        @type protocol: L{TLSMemoryBIOProtocol}
-
-        @return: a connection
-        @rtype: L{OpenSSL.SSL.Connection}
-        """
-        return self._connectionForTLS(protocol)
-
-    def clientConnectionForTLS(self, protocol):
-        """
-        Construct an OpenSSL server connection from the wrapped old-style
-        context factory.
-
-        @note: Since old-style context factories don't distinguish between
-            clients and servers, this is exactly the same as
-            L{_ContextFactoryToConnectionFactory.serverConnectionForTLS}.
-
-        @param protocol: The protocol initiating a TLS connection.
-        @type protocol: L{TLSMemoryBIOProtocol}
-
-        @return: a connection
-        @rtype: L{OpenSSL.SSL.Connection}
-        """
-        return self._connectionForTLS(protocol)
 
 
 class _AggregateSmallWrites:
@@ -801,31 +716,25 @@ class BufferingTLSTransport(TLSMemoryBIOProtocol):
         super().loseConnection()
 
 
-class TLSMemoryBIOFactory(WrappingFactory):
+class TLSMemoryBIOFactory(WrappingFactory[TLSMemoryBIOProtocol]):
     """
     L{TLSMemoryBIOFactory} adds TLS to connections.
 
-    @ivar _creatorInterface: the interface which L{_connectionCreator} is
-        expected to implement.
-    @type _creatorInterface: L{zope.interface.interfaces.IInterface}
-
-    @ivar _connectionCreator: a callable which creates an OpenSSL Connection
-        object.
-    @type _connectionCreator: 1-argument callable taking
-        L{TLSMemoryBIOProtocol} and returning L{OpenSSL.SSL.Connection}.
+    @ivar _creatorCallable: A callable for creating a L{Connection} from a
+        L{TLSMemoryBIOProtocol}.
     """
 
-    protocol = BufferingTLSTransport
+    protocol: type[TLSMemoryBIOProtocol] = BufferingTLSTransport
 
     noisy = False  # disable unnecessary logging.
 
     def __init__(
         self,
-        contextFactory,
-        isClient,
-        wrappedFactory,
-        clock=None,
-    ):
+        contextFactory: SomeConnectionCreator,
+        isClient: bool,
+        wrappedFactory: IProtocolFactory,
+        clock: Optional[IReactorTime] = None,
+    ) -> None:
         """
         Create a L{TLSMemoryBIOFactory}.
 
@@ -868,15 +777,9 @@ class TLSMemoryBIOFactory(WrappingFactory):
             application-level protocol.
         @type wrappedFactory: L{twisted.internet.interfaces.IProtocolFactory}
         """
-        WrappingFactory.__init__(self, wrappedFactory)
-        if isClient:
-            creatorInterface = IOpenSSLClientConnectionCreator
-        else:
-            creatorInterface = IOpenSSLServerConnectionCreator
-        self._creatorInterface = creatorInterface
-        if not creatorInterface.providedBy(contextFactory):
-            contextFactory = _ContextFactoryToConnectionFactory(contextFactory)
-        self._connectionCreator = contextFactory
+        super().__init__(wrappedFactory)
+
+        self._creatorCallable = _convertToAppropriateFactory(isClient, contextFactory)
 
         if clock is None:
             clock = _get_default_clock()
@@ -894,43 +797,3 @@ class TLSMemoryBIOFactory(WrappingFactory):
         else:
             logPrefix = self.wrappedFactory.__class__.__name__
         return f"{logPrefix} (TLS)"
-
-    def _applyProtocolNegotiation(self, connection):
-        """
-        Applies ALPN/NPN protocol neogitation to the connection, if the factory
-        supports it.
-
-        @param connection: The OpenSSL connection object to have ALPN/NPN added
-            to it.
-        @type connection: L{OpenSSL.SSL.Connection}
-
-        @return: Nothing
-        @rtype: L{None}
-        """
-        if IProtocolNegotiationFactory.providedBy(self.wrappedFactory):
-            protocols = self.wrappedFactory.acceptableProtocols()
-            context = connection.get_context()
-            _setAcceptableProtocols(context, protocols)
-
-        return
-
-    def _createConnection(self, tlsProtocol):
-        """
-        Create an OpenSSL connection and set it up good.
-
-        @param tlsProtocol: The protocol which is establishing the connection.
-        @type tlsProtocol: L{TLSMemoryBIOProtocol}
-
-        @return: an OpenSSL connection object for C{tlsProtocol} to use
-        @rtype: L{OpenSSL.SSL.Connection}
-        """
-        connectionCreator = self._connectionCreator
-        if self._creatorInterface is IOpenSSLClientConnectionCreator:
-            connection = connectionCreator.clientConnectionForTLS(tlsProtocol)
-            self._applyProtocolNegotiation(connection)
-            connection.set_connect_state()
-        else:
-            connection = connectionCreator.serverConnectionForTLS(tlsProtocol)
-            self._applyProtocolNegotiation(connection)
-            connection.set_accept_state()
-        return connection

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -565,7 +565,10 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         """
         @see: L{INegotiated.negotiatedProtocol}
         """
-        protocolName: bytes | None = self._tlsConnection.get_alpn_proto_negotiated()
+        tc = self._tlsConnection
+        if tc is None:
+            return None
+        protocolName: bytes | None = tc.get_alpn_proto_negotiated()
         if protocolName == b"":
             return None
         return protocolName

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -567,6 +567,8 @@ class TLSMemoryBIOProtocol(ProtocolWrapper):
         """
         tc = self._tlsConnection
         if tc is None:
+            # We have not yet established a TLS connection, so no application
+            # layer protocol has been negotiated.
             return None
         protocolName: bytes | None = tc.get_alpn_proto_negotiated()
         if protocolName == b"":

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -716,7 +716,7 @@ class BufferingTLSTransport(TLSMemoryBIOProtocol):
         super().loseConnection()
 
 
-class TLSMemoryBIOFactory(WrappingFactory[TLSMemoryBIOProtocol]):
+class TLSMemoryBIOFactory(WrappingFactory):
     """
     L{TLSMemoryBIOFactory} adds TLS to connections.
 

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -97,7 +97,7 @@ import sys
 from dis import findlinestarts
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Dict, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, cast
 from warnings import warn, warn_explicit
 
 from incremental import Version, getVersionString
@@ -730,30 +730,29 @@ def _passedSignature(signature, positional, keyword):
     return result
 
 
-def _mutuallyExclusiveArguments(argumentPairs):
+def _mutuallyExclusiveArguments(
+    argumentPairs: Sequence[tuple[str, str]]
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """
     Decorator which causes its decoratee to raise a L{TypeError} if two of the
     given arguments are passed at the same time.
 
     @param argumentPairs: pairs of argument identifiers, each pair indicating
         an argument that may not be passed in conjunction with another.
-    @type argumentPairs: sequence of 2-sequences of L{str}
 
     @return: A decorator, used like so::
 
             @_mutuallyExclusiveArguments([["tweedledum", "tweedledee"]])
             def function(tweedledum=1, tweedledee=2):
                 "Don't pass tweedledum and tweedledee at the same time."
-
-    @rtype: 1-argument callable taking a callable and returning a callable.
     """
 
-    def wrapper(wrappee):
+    def wrapper(wrappee: Callable[_P, _R]) -> Callable[_P, _R]:
         spec = inspect.signature(wrappee)
         _passed = _passedSignature
 
         @wraps(wrappee)
-        def wrapped(*args, **kwargs):
+        def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             arguments = _passed(spec, args, kwargs)
             for this, that in argumentPairs:
                 if this in arguments and that in arguments:

--- a/src/twisted/test/ssl_helpers.py
+++ b/src/twisted/test/ssl_helpers.py
@@ -9,9 +9,12 @@ pyOpenSSL is unavailable.
 """
 from __future__ import annotations
 
+from zope.interface import implementer
+
 from OpenSSL import SSL
 
 from twisted.internet import ssl
+from twisted.internet.interfaces import IOpenSSLContextFactory
 from twisted.python.compat import nativeString
 from twisted.python.filepath import FilePath
 
@@ -36,6 +39,7 @@ class ClientTLSContext(ssl.ClientContextFactory):
         return SSL.Context(SSL.SSLv23_METHOD)
 
 
+@implementer(IOpenSSLContextFactory)
 class ServerTLSContext:
     """
     SSL Context Factory for server-side connections.

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2641,6 +2641,17 @@ class ALPNTests(TestCase):
         self.assertIs(negotiatedProtocol, None)
         self.assertIs(lostReason, None)
 
+    def test_negotiateNoOverlap(self) -> None:
+        """
+        When negotiating with an empty acceptable protocols list, no protocol
+        is assigned but the connection is not lost.
+        """
+        negotiatedProtocol, lostReason = negotiateProtocol(
+            serverProtocols=[b"server-only"], clientProtocols=[b"client-only"]
+        )
+        self.assertIs(negotiatedProtocol, None)
+        self.assertIsNot(lostReason, None)
+
 
 class _NotSSLTransport:
     def getHandle(self):

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -6,11 +6,14 @@
 Tests for L{twisted.internet._sslverify}.
 """
 
+from __future__ import annotations
+
 import datetime
+import gc
 import itertools
-import sys
 import textwrap
-from unittest import skipIf
+from dataclasses import dataclass
+from weakref import ref
 
 from zope.interface import implementer
 
@@ -18,21 +21,23 @@ from incremental import Version
 
 from twisted.internet import defer, interfaces, protocol, reactor
 from twisted.internet._idna import _idnaText
+from twisted.internet.address import IPv4Address
 from twisted.internet.error import CertificateError, ConnectionClosed, ConnectionLost
+from twisted.internet.interfaces import (
+    IOpenSSLContextFactory,
+    IProtocolNegotiationFactory,
+)
 from twisted.internet.task import Clock
 from twisted.python.compat import nativeString
+from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.python.modules import getModule
 from twisted.python.reflect import requireModule
-from twisted.test.iosim import connectedServerAndClient
-from twisted.test.test_twisted import SetAsideModule
+from twisted.test.iosim import IOPump, connectedServerAndClient
 from twisted.trial import util
 from twisted.trial.unittest import SkipTest, SynchronousTestCase, TestCase
 
 skipSSL = ""
-skipSNI = ""
-skipNPN = ""
-skipALPN = ""
 
 if requireModule("OpenSSL"):
     import ipaddress
@@ -43,7 +48,10 @@ if requireModule("OpenSSL"):
     from cryptography import x509
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.asymmetric.rsa import (
+        RSAPrivateKey,
+        generate_private_key,
+    )
     from cryptography.hazmat.primitives.serialization import (
         Encoding,
         NoEncryption,
@@ -52,32 +60,21 @@ if requireModule("OpenSSL"):
     from cryptography.x509.oid import NameOID
 
     from twisted.internet import ssl
-
-    try:
-        ctx = SSL.Context(SSL.SSLv23_METHOD)
-        ctx.set_npn_advertise_callback(lambda c: None)
-    except (NotImplementedError, AttributeError):
-        skipNPN = (
-            "NPN is deprecated (and OpenSSL 1.0.1 or greater required for NPN"
-            " support)"
-        )
-
-    try:
-        ctx = SSL.Context(SSL.SSLv23_METHOD)
-        ctx.set_alpn_select_callback(lambda c: None)  # type: ignore[misc,arg-type]
-    except NotImplementedError:
-        skipALPN = "OpenSSL 1.0.2 or greater required for ALPN support"
 else:
     skipSSL = "OpenSSL is required for SSL tests."
-    skipSNI = skipSSL
-    skipNPN = skipSSL
-    skipALPN = skipSSL
 
 if not skipSSL:
     from twisted.internet import _sslverify as sslverify
-    from twisted.internet.ssl import VerificationError, platformTrust
-    from twisted.protocols.tls import TLSMemoryBIOFactory
-
+    from twisted.internet.ssl import (
+        VerificationError,
+        optionsForClientTLS,
+        platformTrust,
+    )
+    from twisted.protocols.tls import (
+        SomeConnectionCreator,
+        TLSMemoryBIOFactory,
+        TLSMemoryBIOProtocol,
+    )
 
 # A couple of static PEM-format certificates to be used by various tests.
 A_HOST_CERTIFICATE_PEM = """
@@ -150,7 +147,58 @@ def makeCertificate(**kw):
     return keypair, certificate
 
 
-def certificatesForAuthorityAndServer(serviceIdentity="example.com"):
+oneDay = datetime.timedelta(1, 0, 0)
+
+
+@dataclass
+class TestingAuthority:
+    name: x509.Name
+    cert: x509.Certificate
+    key: RSAPrivateKey
+
+    @classmethod
+    def create(
+        cls, aroundTimestamp: datetime.datetime = datetime.datetime.today()
+    ) -> TestingAuthority:
+        commonNameForCA = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
+        )
+        privateKeyForCA = generate_private_key(
+            public_exponent=65537, key_size=4096, backend=default_backend()
+        )
+        publicKeyForCA = privateKeyForCA.public_key()
+        caCertificate = (
+            x509.CertificateBuilder()
+            .subject_name(commonNameForCA)
+            .issuer_name(commonNameForCA)
+            .not_valid_before(aroundTimestamp - oneDay)
+            .not_valid_after(aroundTimestamp + oneDay)
+            .serial_number(x509.random_serial_number())
+            .public_key(publicKeyForCA)
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=9),
+                critical=True,
+            )
+            .sign(
+                private_key=privateKeyForCA,
+                algorithm=hashes.SHA256(),
+                backend=default_backend(),
+            )
+        )
+
+        return TestingAuthority(commonNameForCA, caCertificate, privateKeyForCA)
+
+    def authoritize(self, builder: x509.CertificateBuilder) -> x509.Certificate:
+        return builder.issuer_name(self.name).sign(
+            private_key=self.key,
+            algorithm=hashes.SHA256(),
+            backend=default_backend(),
+        )
+
+
+def certificatesForAuthorityAndServer(
+    serviceIdentity: str = "example.com",
+) -> tuple[sslverify.Certificate, sslverify.PrivateCertificate]:
     """
     Create a self-signed CA certificate and server certificate signed by the
     CA.
@@ -163,40 +211,15 @@ def certificatesForAuthorityAndServer(serviceIdentity="example.com"):
     @rtype: L{tuple} of (L{sslverify.Certificate},
         L{sslverify.PrivateCertificate})
     """
-    commonNameForCA = x509.Name(
-        [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
-    )
+    authority = TestingAuthority.create()
     commonNameForServer = x509.Name(
         [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example Server")]
     )
-    oneDay = datetime.timedelta(1, 0, 0)
-    privateKeyForCA = rsa.generate_private_key(
-        public_exponent=65537, key_size=4096, backend=default_backend()
-    )
-    publicKeyForCA = privateKeyForCA.public_key()
-    caCertificate = (
-        x509.CertificateBuilder()
-        .subject_name(commonNameForCA)
-        .issuer_name(commonNameForCA)
-        .not_valid_before(datetime.datetime.today() - oneDay)
-        .not_valid_after(datetime.datetime.today() + oneDay)
-        .serial_number(x509.random_serial_number())
-        .public_key(publicKeyForCA)
-        .add_extension(
-            x509.BasicConstraints(ca=True, path_length=9),
-            critical=True,
-        )
-        .sign(
-            private_key=privateKeyForCA,
-            algorithm=hashes.SHA256(),
-            backend=default_backend(),
-        )
-    )
-
-    privateKeyForServer = rsa.generate_private_key(
+    privateKeyForServer = generate_private_key(
         public_exponent=65537, key_size=4096, backend=default_backend()
     )
     publicKeyForServer = privateKeyForServer.public_key()
+    subjectAlternativeNames: list[x509.IPAddress | x509.DNSName]
 
     try:
         ipAddress = ipaddress.ip_address(serviceIdentity)
@@ -207,10 +230,9 @@ def certificatesForAuthorityAndServer(serviceIdentity="example.com"):
     else:
         subjectAlternativeNames = [x509.IPAddress(ipAddress)]
 
-    serverCertificate = (
+    serverBuilder = (
         x509.CertificateBuilder()
         .subject_name(commonNameForServer)
-        .issuer_name(commonNameForCA)
         .not_valid_before(datetime.datetime.today() - oneDay)
         .not_valid_after(datetime.datetime.today() + oneDay)
         .serial_number(x509.random_serial_number())
@@ -223,13 +245,11 @@ def certificatesForAuthorityAndServer(serviceIdentity="example.com"):
             x509.SubjectAlternativeName(subjectAlternativeNames),
             critical=True,
         )
-        .sign(
-            private_key=privateKeyForCA,
-            algorithm=hashes.SHA256(),
-            backend=default_backend(),
-        )
     )
-    caSelfCert = sslverify.Certificate.loadPEM(caCertificate.public_bytes(Encoding.PEM))
+    serverCertificate = authority.authoritize(serverBuilder)
+    caSelfCert = sslverify.Certificate.loadPEM(
+        authority.cert.public_bytes(Encoding.PEM)
+    )
     serverCert = sslverify.PrivateCertificate.loadPEM(
         b"\n".join(
             [
@@ -246,7 +266,61 @@ def certificatesForAuthorityAndServer(serviceIdentity="example.com"):
     return caSelfCert, serverCert
 
 
-def _loopbackTLSConnection(serverOpts, clientOpts):
+class GreetingServer(protocol.Protocol):
+    greeting = b"greetings!"
+
+    def connectionMade(self):
+        self.transport.write(self.greeting)
+
+
+class ListeningClient(protocol.Protocol):
+    data = b""
+    lostReason = None
+
+    def dataReceived(self, data):
+        self.data += data
+
+    def connectionLost(self, reason):
+        self.lostReason = reason
+
+
+@implementer(IProtocolNegotiationFactory)
+class IPNFactory(protocol.Factory):
+    """
+    A L{ClientFactory} that has a set of acceptable protocols for ALPN
+    negotiation.
+    """
+
+    def __init__(self, acceptableProtocols: list[bytes]) -> None:
+        """
+        Initialize this mixin.
+
+        @param acceptableProtocols: The protocols the client will accept
+            speaking after the TLS handshake is complete.
+        @type acceptableProtocols: L{list} of L{bytes}
+        """
+        self._acceptableProtocols = acceptableProtocols
+
+    def acceptableProtocols(self) -> list[bytes]:
+        """
+        Returns a list of protocols that can be spoken by the connection
+        factory in the form of ALPN tokens, as laid out in the IANA registry
+        for ALPN tokens.
+
+        @return: a list of ALPN tokens in order of preference.
+        @rtype: L{list} of L{bytes}
+        """
+        return self._acceptableProtocols
+
+
+def _loopbackTLSConnection(
+    serverOpts: SomeConnectionCreator,
+    clientOpts: SomeConnectionCreator,
+    serverNegotiationProtocols: list[bytes] | None = None,
+    clientNegotiationProtocols: list[bytes] | None = None,
+) -> tuple[
+    TLSMemoryBIOProtocol, TLSMemoryBIOProtocol, GreetingServer, ListeningClient, IOPump
+]:
     """
     Common implementation code for both L{loopbackTLSConnection} and
     L{loopbackTLSConnectionInMemory}. Creates a loopback TLS connection
@@ -265,28 +339,20 @@ def _loopbackTLSConnection(serverOpts, clientOpts):
     @rtype: L{tuple}
     """
 
-    class GreetingServer(protocol.Protocol):
-        greeting = b"greetings!"
-
-        def connectionMade(self):
-            self.transport.write(self.greeting)
-
-    class ListeningClient(protocol.Protocol):
-        data = b""
-        lostReason = None
-
-        def dataReceived(self, data):
-            self.data += data
-
-        def connectionLost(self, reason):
-            self.lostReason = reason
-
     clientWrappedProto = ListeningClient()
     serverWrappedProto = GreetingServer()
 
-    plainClientFactory = protocol.Factory()
+    plainClientFactory = (
+        protocol.Factory()
+        if clientNegotiationProtocols is None
+        else IPNFactory(clientNegotiationProtocols)
+    )
     plainClientFactory.protocol = lambda: clientWrappedProto
-    plainServerFactory = protocol.Factory()
+    plainServerFactory = (
+        protocol.Factory()
+        if serverNegotiationProtocols is None
+        else IPNFactory(serverNegotiationProtocols)
+    )
     plainServerFactory.protocol = lambda: serverWrappedProto
 
     clock = Clock()
@@ -307,7 +373,13 @@ def _loopbackTLSConnection(serverOpts, clientOpts):
     return sProto, cProto, serverWrappedProto, clientWrappedProto, pump
 
 
-def loopbackTLSConnection(trustRoot, privateKeyFile, chainedCertFile=None):
+def loopbackTLSConnection(
+    trustRoot: sslverify.IOpenSSLTrustRoot,
+    privateKeyFile: str,
+    chainedCertFile: str | None = None,
+) -> tuple[
+    TLSMemoryBIOProtocol, TLSMemoryBIOProtocol, GreetingServer, ListeningClient, IOPump
+]:
     """
     Create a loopback TLS connection with the given trust and keys.
 
@@ -325,6 +397,7 @@ def loopbackTLSConnection(trustRoot, privateKeyFile, chainedCertFile=None):
     @rtype: L{tuple}
     """
 
+    @implementer(IOpenSSLContextFactory)
     class ContextFactory:
         def getContext(self):
             """
@@ -348,15 +421,19 @@ def loopbackTLSConnection(trustRoot, privateKeyFile, chainedCertFile=None):
 
 
 def loopbackTLSConnectionInMemory(
-    trustRoot,
-    privateKey,
-    serverCertificate,
-    clientProtocols=None,
-    serverProtocols=None,
-    clientOptions=None,
-):
+    trustRoot: sslverify.IOpenSSLTrustRoot,
+    privateKey: PKey,
+    serverCertificate: X509,
+    serverProtocols: list[bytes] | None = None,
+    clientProtocols: list[bytes] | None = None,
+    clientOptions: type[ssl.CertificateOptions] | None = None,
+    protocolsFromFactory: bool = False,
+    viaFactory: bool = False,
+) -> tuple[
+    TLSMemoryBIOProtocol, TLSMemoryBIOProtocol, GreetingServer, ListeningClient, IOPump
+]:
     """
-    Create a loopback TLS connection with the given trust and keys. Like
+    Create a loopback TLS connection with the given trust and keys.  Like
     L{loopbackTLSConnection}, but using in-memory certificates and keys rather
     than writing them to disk.
 
@@ -368,16 +445,17 @@ def loopbackTLSConnectionInMemory(
     @type privateKey: L{str} (native string)
 
     @param serverCertificate: The certificate used by the server.
+
     @type chainedCertFile: L{str} (native string)
 
     @param clientProtocols: The protocols the client is willing to negotiate
-        using NPN/ALPN.
+        using ALPN.
 
     @param serverProtocols: The protocols the server is willing to negotiate
-        using NPN/ALPN.
+        using ALPN.
 
-    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to
-        use for the client. Defaults to C{OpenSSLCertificateOptions}.
+    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to use
+        for the client.  Defaults to C{OpenSSLCertificateOptions}.
 
     @return: 3-tuple of server-protocol, client-protocol, and L{IOPump}
     @rtype: L{tuple}
@@ -385,16 +463,25 @@ def loopbackTLSConnectionInMemory(
     if clientOptions is None:
         clientOptions = sslverify.OpenSSLCertificateOptions
 
-    clientCertOpts = clientOptions(
-        trustRoot=trustRoot, acceptableProtocols=clientProtocols
-    )
-    serverCertOpts = sslverify.OpenSSLCertificateOptions(
-        privateKey=privateKey,
-        certificate=serverCertificate,
-        acceptableProtocols=serverProtocols,
-    )
-
-    return _loopbackTLSConnection(serverCertOpts, clientCertOpts)
+    if viaFactory:
+        clientCertOpts = clientOptions(trustRoot=trustRoot)
+        serverCertOpts = sslverify.OpenSSLCertificateOptions(
+            privateKey=privateKey, certificate=serverCertificate
+        )
+        return _loopbackTLSConnection(
+            serverCertOpts, clientCertOpts, serverProtocols, clientProtocols
+        )
+    else:
+        clientCertOpts = clientOptions(
+            trustRoot=trustRoot,
+            acceptableProtocols=clientProtocols,
+        )
+        serverCertOpts = sslverify.OpenSSLCertificateOptions(
+            privateKey=privateKey,
+            certificate=serverCertificate,
+            acceptableProtocols=serverProtocols,
+        )
+        return _loopbackTLSConnection(serverCertOpts, clientCertOpts)
 
 
 def pathContainingDumpOf(testCase, *dumpables):
@@ -496,6 +583,9 @@ class FakeContext:
 
     def set_options(self, options):
         self._options |= options
+
+    def set_alpn_select_callback(self, callback):
+        self._alpn_select_callback = callback
 
     def use_certificate(self, certificate):
         self._certificate = certificate
@@ -1095,6 +1185,39 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         self.assertIn("lowerMaximumSecurityTo", e.exception.args[0])
         self.assertIn("exclusive", e.exception.args[0])
 
+    def test_verifyCallbackCrashNoRetain(self) -> None:
+        """
+        Since circular references go through CFFI here, the verification
+        callback has to be very careful to avoid creating any circular
+        references which OpenSSL will hold on to.  Make sure that the
+        TLSMemoryBIOProtocol is no longer referenced after the verification
+        callback runs, even if it explodes with a totally unexpected error.
+        """
+        f = protocol.Factory.forProtocol(protocol.Protocol)
+        proto = TLSMemoryBIOProtocol(
+            TLSMemoryBIOFactory(
+                optionsForClientTLS("just-testing"),
+                True,
+                f,
+            ),
+            f.buildProtocol(IPv4Address("TCP", "192.168.1.1", 8123)),
+        )
+        r = ref(proto)
+        # intentional type check failure
+        cb = sslverify._verifyCB(proto, True, "just-testing")
+        # consistency check: we still retain a reference.
+        self.assertIsNot(r(), None)
+        # testing internal bug-reporting here, so we intentionally break its
+        # type contract and expect some random explosion. Just specifying
+        # AttributeError here so if behavior changes and it's something else we
+        # get notified in the future.
+        cb(None, None, None, 0, None)  # type:ignore
+        self.flushLoggedErrors(AttributeError)
+        del proto
+        gc.collect()
+        it = r()
+        self.assertIs(it, None)
+
     def test_tlsVersionRangeInOrder(self):
         """
         Passing out of order TLS versions to C{insecurelyLowerMinimumTo} and
@@ -1612,7 +1735,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Enabling session tickets should not set the OP_NO_TICKET option.
         """
         opts = sslverify.OpenSSLCertificateOptions(enableSessionTickets=True)
-        ctx = opts.getContext()
+        ctx = opts._makeContext(skipCiphers=True)
         self.assertEqual(0, ctx.set_options(0) & 0x00004000)
 
     def test_certificateOptionsSessionTicketsDisabled(self):
@@ -1620,7 +1743,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Enabling session tickets should set the OP_NO_TICKET option.
         """
         opts = sslverify.OpenSSLCertificateOptions(enableSessionTickets=False)
-        ctx = opts.getContext()
+        ctx = opts._makeContext(skipCiphers=True)
         self.assertEqual(0x00004000, ctx.set_options(0) & 0x00004000)
 
     def test_allowedAnonymousClientConnection(self):
@@ -1971,12 +2094,12 @@ class ServiceIdentityTests(SynchronousTestCase):
         self,
         clientHostname,
         serverHostname,
-        serverContextSetup=lambda ctx: None,
+        *,
+        serverNameCallback=None,
         validCertificate=True,
         clientPresentsCertificate=False,
         validClientCertificate=True,
         serverVerifies=False,
-        buggyInfoCallback=False,
         fakePlatformTrust=False,
         useDefaultTrust=False,
     ):
@@ -1991,11 +2114,6 @@ class ServiceIdentityTests(SynchronousTestCase):
         @param serverHostname: The I{server's own idea} of the server's
             hostname; present in the certificate presented by the server.
         @type serverHostname: L{unicode}
-
-        @param serverContextSetup: a 1-argument callable invoked with the
-            L{OpenSSL.SSL.Context} after it's produced.
-        @type serverContextSetup: L{callable} taking L{OpenSSL.SSL.Context}
-            returning L{None}.
 
         @param validCertificate: Is the server's certificate valid?  L{True} if
             so, L{False} otherwise.
@@ -2013,11 +2131,6 @@ class ServiceIdentityTests(SynchronousTestCase):
         @param serverVerifies: Should the server verify the client's
             certificate?  Defaults to 'no'.
         @type serverVerifies: L{bool}
-
-        @param buggyInfoCallback: Should we patch the implementation so that
-            the C{info_callback} passed to OpenSSL to have a bug and raise an
-            exception (L{ZeroDivisionError})?  Defaults to 'no'.
-        @type buggyInfoCallback: L{bool}
 
         @param fakePlatformTrust: Should we fake the platformTrust to be the
             same as our fake server certificate authority, so that we can test
@@ -2052,28 +2165,11 @@ class ServiceIdentityTests(SynchronousTestCase):
         serverOpts = sslverify.OpenSSLCertificateOptions(
             privateKey=serverCert.privateKey.original,
             certificate=serverCert.original,
+            callbackForServerName=serverNameCallback,
             **other,
         )
-        serverContextSetup(serverOpts.getContext())
         if not validCertificate:
             serverCA, otherServer = certificatesForAuthorityAndServer(serverHostname)
-        if buggyInfoCallback:
-
-            def broken(*a, **k):
-                """
-                Raise an exception.
-
-                @param a: Arguments for an C{info_callback}
-
-                @param k: Keyword arguments for an C{info_callback}
-                """
-                1 / 0
-
-            self.patch(
-                sslverify.ClientTLSOptions,
-                "_identityVerifyingInfoCallback",
-                broken,
-            )
 
         signature = {"hostname": clientHostname}
         if passClientCert:
@@ -2279,7 +2375,6 @@ class ServiceIdentityTests(SynchronousTestCase):
         self.assertIsInstance(cErr, SSL.Error)
         self.assertIsInstance(sErr, SSL.Error)
 
-    @skipIf(skipSNI, skipSNI)
     def test_hostnameIsIndicated(self):
         """
         Specifying the C{hostname} argument to L{CertificateOptions} also sets
@@ -2289,18 +2384,16 @@ class ServiceIdentityTests(SynchronousTestCase):
         """
         names = []
 
-        def setupServerContext(ctx):
-            def servername_received(conn):
-                names.append(conn.get_servername().decode("ascii"))
-
-            ctx.set_tlsext_servername_callback(servername_received)
+        def serverNameCallback(name):
+            names.append(name.decode("ascii"))
 
         cProto, sProto, cWrapped, sWrapped, pump = self.serviceIdentitySetup(
-            "valid.example.com", "valid.example.com", setupServerContext
+            "valid.example.com",
+            "valid.example.com",
+            serverNameCallback=serverNameCallback,
         )
         self.assertEqual(names, ["valid.example.com"])
 
-    @skipIf(skipSNI, skipSNI)
     def test_hostnameEncoding(self):
         """
         Hostnames are encoded as IDNA.
@@ -2308,15 +2401,12 @@ class ServiceIdentityTests(SynchronousTestCase):
         names = []
         hello = "h\N{LATIN SMALL LETTER A WITH ACUTE}llo.example.com"
 
-        def setupServerContext(ctx):
-            def servername_received(conn):
-                serverIDNA = _idnaText(conn.get_servername())
-                names.append(serverIDNA)
-
-            ctx.set_tlsext_servername_callback(servername_received)
+        def serverNameCallback(name):
+            serverIDNA = _idnaText(name)
+            names.append(serverIDNA)
 
         cProto, sProto, cWrapped, sWrapped, pump = self.serviceIdentitySetup(
-            hello, hello, setupServerContext
+            hello, hello, serverNameCallback=serverNameCallback
         )
         self.assertEqual(names, [hello])
         self.assertEqual(cWrapped.data, b"greetings!")
@@ -2326,79 +2416,31 @@ class ServiceIdentityTests(SynchronousTestCase):
         self.assertIsNone(cErr)
         self.assertIsNone(sErr)
 
-    def test_fallback(self):
-        """
-        L{sslverify.simpleVerifyHostname} checks string equality on the
-        commonName of a connection's certificate's subject, doing nothing if it
-        matches and raising L{VerificationError} if it doesn't.
-        """
-        name = "something.example.com"
 
-        class Connection:
-            def get_peer_certificate(self):
-                """
-                Fake of L{OpenSSL.SSL.Connection.get_peer_certificate}.
-
-                @return: A certificate with a known common name.
-                @rtype: L{OpenSSL.crypto.X509}
-                """
-                cert = X509()
-                cert.get_subject().commonName = name
-                return cert
-
-        conn = Connection()
-        self.assertIs(
-            sslverify.simpleVerifyHostname(conn, "something.example.com"), None
-        )
-        self.assertRaises(
-            sslverify.SimpleVerificationError,
-            sslverify.simpleVerifyHostname,
-            conn,
-            "nonsense",
-        )
-
-    def test_surpriseFromInfoCallback(self):
-        """
-        pyOpenSSL isn't always so great about reporting errors.  If one occurs
-        in the verification info callback, it should be logged and the
-        connection should be shut down (if possible, anyway; the app_data could
-        be clobbered but there's no point testing for that).
-        """
-        cProto, sProto, cWrapped, sWrapped, pump = self.serviceIdentitySetup(
-            "correct-host.example.com",
-            "correct-host.example.com",
-            buggyInfoCallback=True,
-        )
-
-        self.assertEqual(cWrapped.data, b"")
-        self.assertEqual(sWrapped.data, b"")
-
-        cErr = cWrapped.lostReason.value
-        sErr = sWrapped.lostReason.value
-
-        self.assertIsInstance(cErr, ZeroDivisionError)
-        self.assertIsInstance(sErr, (ConnectionClosed, SSL.Error))
-        errors = self.flushLoggedErrors(ZeroDivisionError)
-        self.assertTrue(errors)
-
-
-def negotiateProtocol(serverProtocols, clientProtocols, clientOptions=None):
+def negotiateProtocol(
+    serverProtocols: list[bytes],
+    clientProtocols: list[bytes],
+    clientOptions: type[ssl.CertificateOptions] | None = None,
+    viaFactory: bool = False,
+) -> tuple[bytes | None, Failure | None]:
     """
     Create the TLS connection and negotiate a next protocol.
 
     @param serverProtocols: The protocols the server is willing to negotiate.
+
     @param clientProtocols: The protocols the client is willing to negotiate.
-    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to
-        use for the client. Defaults to C{OpenSSLCertificateOptions}.
+
+    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to use
+        for the client.  Defaults to C{OpenSSLCertificateOptions}.
+
+    @param viaFactory: whether to supply the client protocols or the server
+        protocols via the protocol factory rather than via the context factory.
+
     @return: A L{tuple} of the negotiated protocol and the reason the
         connection was lost.
     """
     caCertificate, serverCertificate = certificatesForAuthorityAndServer()
-    trustRoot = sslverify.OpenSSLCertificateAuthorities(
-        [
-            caCertificate.original,
-        ]
-    )
+    trustRoot = sslverify.OpenSSLCertificateAuthorities([caCertificate.original])
 
     sProto, cProto, sWrapped, cWrapped, pump = loopbackTLSConnectionInMemory(
         trustRoot=trustRoot,
@@ -2407,87 +2449,11 @@ def negotiateProtocol(serverProtocols, clientProtocols, clientOptions=None):
         clientProtocols=clientProtocols,
         serverProtocols=serverProtocols,
         clientOptions=clientOptions,
+        viaFactory=viaFactory,
     )
     pump.flush()
 
     return (cProto.negotiatedProtocol, cWrapped.lostReason)
-
-
-class NPNOrALPNTests(TestCase):
-    """
-    NPN and ALPN protocol selection.
-
-    These tests only run on platforms that have a PyOpenSSL version >= 0.15,
-    and OpenSSL version 1.0.1 or later.
-    """
-
-    if skipSSL:
-        skip = skipSSL
-    elif skipNPN:
-        skip = skipNPN
-
-    def test_nextProtocolMechanismsNPNIsSupported(self):
-        """
-        When at least NPN is available on the platform, NPN is in the set of
-        supported negotiation protocols.
-        """
-        supportedProtocols = sslverify.protocolNegotiationMechanisms()
-        self.assertTrue(sslverify.ProtocolNegotiationSupport.NPN in supportedProtocols)
-
-    def test_NPNAndALPNSuccess(self):
-        """
-        When both ALPN and NPN are used, and both the client and server have
-        overlapping protocol choices, a protocol is successfully negotiated.
-        Further, the negotiated protocol is the first one in the list.
-        """
-        protocols = [b"h2", b"http/1.1"]
-        negotiatedProtocol, lostReason = negotiateProtocol(
-            clientProtocols=protocols,
-            serverProtocols=protocols,
-        )
-        self.assertEqual(negotiatedProtocol, b"h2")
-        self.assertIsNone(lostReason)
-
-    def test_NPNAndALPNDifferent(self):
-        """
-        Client and server have different protocol lists: only the common
-        element is chosen.
-        """
-        serverProtocols = [b"h2", b"http/1.1", b"spdy/2"]
-        clientProtocols = [b"spdy/3", b"http/1.1"]
-        negotiatedProtocol, lostReason = negotiateProtocol(
-            clientProtocols=clientProtocols,
-            serverProtocols=serverProtocols,
-        )
-        self.assertEqual(negotiatedProtocol, b"http/1.1")
-        self.assertIsNone(lostReason)
-
-    def test_NPNAndALPNNoAdvertise(self):
-        """
-        When one peer does not advertise any protocols, the connection is set
-        up with no next protocol.
-        """
-        protocols = [b"h2", b"http/1.1"]
-        negotiatedProtocol, lostReason = negotiateProtocol(
-            clientProtocols=protocols,
-            serverProtocols=[],
-        )
-        self.assertIsNone(negotiatedProtocol)
-        self.assertIsNone(lostReason)
-
-    def test_NPNAndALPNNoOverlap(self):
-        """
-        When the client and server have no overlap of protocols, the connection
-        fails.
-        """
-        clientProtocols = [b"h2", b"http/1.1"]
-        serverProtocols = [b"spdy/3"]
-        negotiatedProtocol, lostReason = negotiateProtocol(
-            serverProtocols=clientProtocols,
-            clientProtocols=serverProtocols,
-        )
-        self.assertIsNone(negotiatedProtocol)
-        self.assertEqual(lostReason.type, SSL.Error)
 
 
 class ALPNTests(TestCase):
@@ -2496,15 +2462,10 @@ class ALPNTests(TestCase):
 
     These tests only run on platforms that have a PyOpenSSL version >= 0.15,
     and OpenSSL version 1.0.2 or later.
-
-    This covers only the ALPN specific logic, as any platform that has ALPN
-    will also have NPN and so will run the NPNAndALPNTest suite as well.
     """
 
     if skipSSL:
         skip = skipSSL
-    elif skipALPN:
-        skip = skipALPN
 
     def test_nextProtocolMechanismsALPNIsSupported(self):
         """
@@ -2514,56 +2475,35 @@ class ALPNTests(TestCase):
         supportedProtocols = sslverify.protocolNegotiationMechanisms()
         self.assertTrue(sslverify.ProtocolNegotiationSupport.ALPN in supportedProtocols)
 
-
-class NPNAndALPNAbsentTests(TestCase):
-    """
-    NPN/ALPN operations fail on platforms that do not support them.
-
-    These tests only run on platforms that have a PyOpenSSL version < 0.15,
-    an OpenSSL version earlier than 1.0.1, or an OpenSSL/cryptography built
-    without NPN support.
-    """
-
-    if skipSSL:
-        skip = skipSSL
-    elif not skipNPN or not skipALPN:
-        skip = "NPN and/or ALPN is present on this platform"
-
-    def test_nextProtocolMechanismsNoNegotiationSupported(self):
-        """
-        When neither NPN or ALPN are available on a platform, there are no
-        supported negotiation protocols.
-        """
-        supportedProtocols = sslverify.protocolNegotiationMechanisms()
-        self.assertFalse(supportedProtocols)
-
-    def test_NPNAndALPNNotImplemented(self):
-        """
-        A NotImplementedError is raised when using acceptableProtocols on a
-        platform that does not support either NPN or ALPN.
-        """
-        protocols = [b"h2", b"http/1.1"]
-        self.assertRaises(
-            NotImplementedError,
-            negotiateProtocol,
-            serverProtocols=protocols,
-            clientProtocols=protocols,
-        )
-
-    def test_NegotiatedProtocolReturnsNone(self):
-        """
-        negotiatedProtocol return L{None} even when NPN/ALPN aren't supported.
-        This works because, as neither are supported, negotiation isn't even
-        attempted.
-        """
-        serverProtocols = None
-        clientProtocols = None
+    def test_connectionCreatorNegotiation(self) -> None:
+        protocols = [b"a", b"b"]
         negotiatedProtocol, lostReason = negotiateProtocol(
-            clientProtocols=clientProtocols,
-            serverProtocols=serverProtocols,
+            clientProtocols=protocols,
+            serverProtocols=protocols,
         )
-        self.assertIsNone(negotiatedProtocol)
         self.assertIsNone(lostReason)
+        self.assertEqual(negotiatedProtocol, b"a")
+
+    def test_factoryNegotiation(self) -> None:
+        protocols = [b"a", b"b"]
+        negotiatedProtocol, lostReason = negotiateProtocol(
+            clientProtocols=protocols,
+            serverProtocols=protocols,
+            viaFactory=True,
+        )
+        self.assertIsNone(lostReason)
+        self.assertEqual(negotiatedProtocol, b"a")
+
+    def test_negotiateEmpty(self) -> None:
+        """
+        When negotiating with an empty acceptable protocols list, no protocol
+        is assigned but the connection is not lost.
+        """
+        negotiatedProtocol, lostReason = negotiateProtocol(
+            serverProtocols=[], clientProtocols=[]
+        )
+        self.assertIs(negotiatedProtocol, None)
+        self.assertIs(lostReason, None)
 
 
 class _NotSSLTransport:
@@ -3355,76 +3295,3 @@ class KeyPairTests(TestCase):
 
         certPEM = noTrailingNewlineKeyPemPath.getContent()
         ssl.Certificate.loadPEM(certPEM)
-
-
-class SelectVerifyImplementationTests(SynchronousTestCase):
-    """
-    Tests for L{_selectVerifyImplementation}.
-    """
-
-    if skipSSL:
-        skip = skipSSL
-
-    def test_dependencyMissing(self):
-        """
-        If I{service_identity} cannot be imported then
-        L{_selectVerifyImplementation} returns L{simpleVerifyHostname} and
-        L{SimpleVerificationError}.
-        """
-        with SetAsideModule("service_identity"):
-            sys.modules["service_identity"] = None
-
-            result = sslverify._selectVerifyImplementation()
-            expected = (
-                sslverify.simpleVerifyHostname,
-                sslverify.simpleVerifyIPAddress,
-                sslverify.SimpleVerificationError,
-            )
-            self.assertEqual(expected, result)
-
-    test_dependencyMissing.suppress = [  # type: ignore[attr-defined]
-        util.suppress(
-            message=(
-                "You do not have a working installation of the "
-                "service_identity module"
-            ),
-        ),
-    ]
-
-    def test_dependencyMissingWarning(self):
-        """
-        If I{service_identity} cannot be imported then
-        L{_selectVerifyImplementation} emits a L{UserWarning} advising the user
-        of the exact error.
-        """
-        with SetAsideModule("service_identity"):
-            sys.modules["service_identity"] = None
-
-            sslverify._selectVerifyImplementation()
-
-        [warning] = list(
-            warning
-            for warning in self.flushWarnings()
-            if warning["category"] == UserWarning
-        )
-
-        expectedMessage = (
-            "You do not have a working installation of the "
-            "service_identity module: "
-            "'import of service_identity halted; None in sys.modules'.  "
-            "Please install it from "
-            "<https://pypi.python.org/pypi/service_identity> "
-            "and make sure all of its dependencies are satisfied.  "
-            "Without the service_identity module, Twisted can perform only"
-            " rudimentary TLS client hostname verification.  Many valid "
-            "certificate/hostname mappings may be rejected."
-        )
-
-        self.assertEqual(warning["message"], expectedMessage)
-        # Make sure we're abusing the warning system to a sufficient
-        # degree: there is no filename or line number that makes sense for
-        # this warning to "blame" for the problem.  It is a system
-        # misconfiguration.  So the location information should be blank
-        # (or as blank as we can make it).
-        self.assertEqual(warning["filename"], "")
-        self.assertEqual(warning["lineno"], 0)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2374,7 +2374,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         When SNI is not sent by the client, the server name callback will not
         be invoked on the server.
         """
-        sent = []
+        sent: list[bytes] = []
         conf = self.serviceIdentitySetup(
             "correct-host.example.com",
             "correct-host.example.com",

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -296,7 +296,7 @@ class ListeningClient(protocol.Protocol):
 
 
 @implementer(IProtocolNegotiationFactory)
-class IPNFactory(protocol.Factory):
+class NegotiatingFactory(protocol.Factory):
     """
     A L{ClientFactory} that has a set of acceptable protocols for ALPN
     negotiation.
@@ -356,13 +356,13 @@ def _loopbackTLSConnection(
     plainClientFactory = (
         protocol.Factory()
         if clientNegotiationProtocols is None
-        else IPNFactory(clientNegotiationProtocols)
+        else NegotiatingFactory(clientNegotiationProtocols)
     )
     plainClientFactory.protocol = lambda: clientWrappedProto
     plainServerFactory = (
         protocol.Factory()
         if serverNegotiationProtocols is None
-        else IPNFactory(serverNegotiationProtocols)
+        else NegotiatingFactory(serverNegotiationProtocols)
     )
     plainServerFactory.protocol = lambda: serverWrappedProto
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2371,8 +2371,8 @@ class ServiceIdentityTests(SynchronousTestCase):
 
     def test_noSNICallback(self) -> None:
         """
-        When SNI is not sent by the client, the server name callback will not
-        be invoked on the server.
+        When SNI is not sent by the client, the server name callback will be
+        invoked with C{None}.
         """
         sent: list[bytes] = []
         conf = self.serviceIdentitySetup(
@@ -2389,7 +2389,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         sErr = sWrapped.lostReason
         self.assertIsNone(cErr)
         self.assertIsNone(sErr)
-        self.assertEqual(sent, [])
+        self.assertEqual(sent, [None])
 
     def test_validHostname(self):
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -13,6 +13,7 @@ import gc
 import itertools
 import textwrap
 from dataclasses import dataclass
+from typing import Iterable
 from weakref import ref
 
 from zope.interface import implementer
@@ -25,6 +26,7 @@ from twisted.internet.address import IPv4Address
 from twisted.internet.error import CertificateError, ConnectionClosed, ConnectionLost
 from twisted.internet.interfaces import (
     IOpenSSLContextFactory,
+    IProtocol,
     IProtocolNegotiationFactory,
 )
 from twisted.internet.task import Clock
@@ -188,6 +190,63 @@ class TestingAuthority:
 
         return TestingAuthority(commonNameForCA, caCertificate, privateKeyForCA)
 
+    def serverCertificate(
+        self, commonName: str, subjects: list[str]
+    ) -> sslverify.PrivateCertificate:
+        privateKeyForServer = generate_private_key(
+            public_exponent=65537, key_size=4096, backend=default_backend()
+        )
+        publicKeyForServer = privateKeyForServer.public_key()
+        commonNameForServer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, commonName)]
+        )
+
+        subjectAlternativeNames: list[x509.IPAddress | x509.DNSName] = []
+        for subject in subjects:
+            try:
+                ipAddress = ipaddress.ip_address(subject)
+            except ValueError:
+                subjectAlternativeNames.append(
+                    x509.DNSName(subject.encode("idna").decode("ascii"))
+                )
+            else:
+                subjectAlternativeNames.append(x509.IPAddress(ipAddress))
+
+        serverBuilder = (
+            x509.CertificateBuilder()
+            .subject_name(commonNameForServer)
+            .not_valid_before(datetime.datetime.today() - oneDay)
+            .not_valid_after(datetime.datetime.today() + oneDay)
+            .serial_number(x509.random_serial_number())
+            .public_key(publicKeyForServer)
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectAlternativeName(subjectAlternativeNames),
+                critical=True,
+            )
+        )
+        signedX509 = self.authoritize(serverBuilder)
+        serverCert: sslverify.PrivateCertificate = sslverify.PrivateCertificate.loadPEM(
+            b"\n".join(
+                [
+                    privateKeyForServer.private_bytes(
+                        Encoding.PEM,
+                        PrivateFormat.TraditionalOpenSSL,
+                        NoEncryption(),
+                    ),
+                    signedX509.public_bytes(Encoding.PEM),
+                ]
+            )
+        )
+
+        return serverCert
+
+    def authorityCertificate(self) -> sslverify.Certificate:
+        return sslverify.Certificate.loadPEM(self.cert.public_bytes(Encoding.PEM))
+
     def authoritize(self, builder: x509.CertificateBuilder) -> x509.Certificate:
         return builder.issuer_name(self.name).sign(
             private_key=self.key,
@@ -212,58 +271,10 @@ def certificatesForAuthorityAndServer(
         L{sslverify.PrivateCertificate})
     """
     authority = TestingAuthority.create()
-    commonNameForServer = x509.Name(
-        [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example Server")]
+    return (
+        authority.authorityCertificate(),
+        authority.serverCertificate("Testing Example Server", [serviceIdentity]),
     )
-    privateKeyForServer = generate_private_key(
-        public_exponent=65537, key_size=4096, backend=default_backend()
-    )
-    publicKeyForServer = privateKeyForServer.public_key()
-    subjectAlternativeNames: list[x509.IPAddress | x509.DNSName]
-
-    try:
-        ipAddress = ipaddress.ip_address(serviceIdentity)
-    except ValueError:
-        subjectAlternativeNames = [
-            x509.DNSName(serviceIdentity.encode("idna").decode("ascii"))
-        ]
-    else:
-        subjectAlternativeNames = [x509.IPAddress(ipAddress)]
-
-    serverBuilder = (
-        x509.CertificateBuilder()
-        .subject_name(commonNameForServer)
-        .not_valid_before(datetime.datetime.today() - oneDay)
-        .not_valid_after(datetime.datetime.today() + oneDay)
-        .serial_number(x509.random_serial_number())
-        .public_key(publicKeyForServer)
-        .add_extension(
-            x509.BasicConstraints(ca=False, path_length=None),
-            critical=True,
-        )
-        .add_extension(
-            x509.SubjectAlternativeName(subjectAlternativeNames),
-            critical=True,
-        )
-    )
-    serverCertificate = authority.authoritize(serverBuilder)
-    caSelfCert = sslverify.Certificate.loadPEM(
-        authority.cert.public_bytes(Encoding.PEM)
-    )
-    serverCert = sslverify.PrivateCertificate.loadPEM(
-        b"\n".join(
-            [
-                privateKeyForServer.private_bytes(
-                    Encoding.PEM,
-                    PrivateFormat.TraditionalOpenSSL,
-                    NoEncryption(),
-                ),
-                serverCertificate.public_bytes(Encoding.PEM),
-            ]
-        )
-    )
-
-    return caSelfCert, serverCert
 
 
 class GreetingServer(protocol.Protocol):
@@ -2081,6 +2092,27 @@ class TrustRootTests(TestCase):
         self.assertEqual(cWrapped.data, sWrapped.greeting)
 
 
+@dataclass
+class ServiceIdentitySetup:
+    clientProtocol: IProtocol
+    serverProtocol: IProtocol
+    clientWrappedProtocol: IProtocol
+    serverWrappedProtocol: IProtocol
+    pump: IOPump
+    authority: TestingAuthority
+
+    def __iter__(self) -> Iterable[object]:
+        return iter(
+            (
+                self.clientProtocol,
+                self.serverProtocol,
+                self.clientWrappedProtocol,
+                self.serverWrappedProtocol,
+                self.pump,
+            )
+        )
+
+
 class ServiceIdentityTests(SynchronousTestCase):
     """
     Tests for the verification of the peer's service's identity via the
@@ -2102,6 +2134,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         serverVerifies=False,
         fakePlatformTrust=False,
         useDefaultTrust=False,
+        immediately=True,
     ):
         """
         Connect a server and a client.
@@ -2146,12 +2179,17 @@ class ServiceIdentityTests(SynchronousTestCase):
             an L{IOPump} which, when its C{pump} and C{flush} methods are
             called, will move data between the created client and server
             protocol instances
-        @rtype: 5-L{tuple} of 4 L{IProtocol}s and L{IOPump}
+        @rtype: L{ServiceIdentitySetup}
         """
-        serverCA, serverCert = certificatesForAuthorityAndServer(serverHostname)
+        clientAuthority = TestingAuthority.create()
+        serverAuthority = TestingAuthority.create()
+        untrustedAuthority = TestingAuthority.create()
+        serverCA = serverAuthority.authorityCertificate()
+        serverCert = serverAuthority.serverCertificate("Valid Cert", [serverHostname])
         other = {}
         passClientCert = None
-        clientCA, clientCert = certificatesForAuthorityAndServer("client")
+        clientCA = clientAuthority.authorityCertificate()
+        clientCert = clientAuthority.serverCertificate("Client Cert", ["client"])
         if serverVerifies:
             other.update(trustRoot=clientCA)
 
@@ -2159,8 +2197,14 @@ class ServiceIdentityTests(SynchronousTestCase):
             if validClientCertificate:
                 passClientCert = clientCert
             else:
-                bogusCA, bogus = certificatesForAuthorityAndServer("client")
-                passClientCert = bogus
+                passClientCert = untrustedAuthority.serverCertificate(
+                    "Client Cert", ["client"]
+                )
+
+        if not validCertificate:
+            serverCert = untrustedAuthority.serverCertificate(
+                "Invalid Cert", [serverHostname]
+            )
 
         serverOpts = sslverify.OpenSSLCertificateOptions(
             privateKey=serverCert.privateKey.original,
@@ -2168,8 +2212,6 @@ class ServiceIdentityTests(SynchronousTestCase):
             contextForServerName=serverNameCallback,
             **other,
         )
-        if not validCertificate:
-            serverCA, otherServer = certificatesForAuthorityAndServer(serverHostname)
 
         signature = {"hostname": clientHostname}
         if passClientCert:
@@ -2232,10 +2274,19 @@ class ServiceIdentityTests(SynchronousTestCase):
             lambda: serverTLSFactory.buildProtocol(None),
             lambda: clientTLSFactory.buildProtocol(None),
             clock=clock,
+            greet=immediately,
         )
-        pump.flush()
+        if immediately:
+            pump.flush()
 
-        return cProto, sProto, clientWrappedProto, serverWrappedProto, pump
+        return ServiceIdentitySetup(
+            cProto,
+            sProto,
+            clientWrappedProto,
+            serverWrappedProto,
+            pump,
+            serverAuthority,
+        )
 
     def test_invalidHostname(self):
         """
@@ -2254,6 +2305,62 @@ class ServiceIdentityTests(SynchronousTestCase):
 
         self.assertIsInstance(cErr, VerificationError)
         self.assertIsInstance(sErr, ConnectionClosed)
+
+    def test_sniContextSwitch(self) -> None:
+        """
+        The C{contextForServerName} argument to L{sslverify.OpenSSLCertificateOptions}
+        returns a new L{SSL.Context} that will be used for the TLS connection
+        in response to the server name indication being sent.
+        """
+
+        def switchToCorrect(servername: bytes | None) -> SSL.Context:
+            options: sslverify.OpenSSLCertificateOptions = validCert.options()
+            return options.getContext()
+
+        conf = self.serviceIdentitySetup(
+            "correct-host.example.com",
+            "wrong-host.example.com",
+            serverNameCallback=switchToCorrect,
+            immediately=False,
+        )
+        validCert = conf.authority.serverCertificate(
+            "Correct Cert", ["correct-host.example.com"]
+        )
+        cProto, sProto, cWrapped, sWrapped, pump = conf
+        pump.flush()
+        self.assertEqual(cWrapped.data, b"greetings!")
+
+        cErr = cWrapped.lostReason
+        sErr = sWrapped.lostReason
+        self.assertIsNone(cErr)
+        self.assertIsNone(sErr)
+
+    def test_sniCallbackError(self) -> None:
+        """
+        The C{contextForServerName} argument to
+        L{sslverify.OpenSSLCertificateOptions} can raise an exception which
+        will log an error and immediately drop the connection.
+        """
+
+        def brokenCallback(servername: bytes | None) -> SSL.Context:
+            raise RuntimeError("here's an error")
+
+        conf = self.serviceIdentitySetup(
+            "valid.example.com",
+            "valid.example.com",
+            serverNameCallback=brokenCallback,
+        )
+        cProto, sProto, cWrapped, sWrapped, pump = conf
+        logged = self.flushLoggedErrors(RuntimeError)
+        self.assertEqual(len(logged), 1)
+        self.assertEqual(str(logged[0].value), "here's an error")
+        self.assertEqual(cWrapped.data, b"")
+
+        cErr = cWrapped.lostReason.value
+        sErr = sWrapped.lostReason.value
+
+        self.assertIsInstance(cErr, ConnectionLost)
+        self.assertIsInstance(sErr, ConnectionLost)
 
     def test_validHostname(self):
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2134,6 +2134,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         serverVerifies=False,
         fakePlatformTrust=False,
         useDefaultTrust=False,
+        clientSkipSNI=False,
         immediately=True,
     ):
         """
@@ -2220,6 +2221,8 @@ class ServiceIdentityTests(SynchronousTestCase):
             signature.update(trustRoot=serverCA)
         if fakePlatformTrust:
             self.patch(sslverify, "platformTrust", lambda: serverCA)
+        if clientSkipSNI:
+            signature.update(sendServerName=False)
 
         clientOpts = sslverify.optionsForClientTLS(**signature)
 
@@ -2313,7 +2316,10 @@ class ServiceIdentityTests(SynchronousTestCase):
         in response to the server name indication being sent.
         """
 
+        servers = []
+
         def switchToCorrect(servername: bytes | None) -> SSL.Context:
+            servers.append(servername)
             options: sslverify.OpenSSLCertificateOptions = validCert.options()
             return options.getContext()
 
@@ -2328,6 +2334,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         )
         cProto, sProto, cWrapped, sWrapped, pump = conf
         pump.flush()
+        self.assertEqual(servers, [b"correct-host.example.com"])
         self.assertEqual(cWrapped.data, b"greetings!")
 
         cErr = cWrapped.lostReason
@@ -2361,6 +2368,28 @@ class ServiceIdentityTests(SynchronousTestCase):
 
         self.assertIsInstance(cErr, ConnectionLost)
         self.assertIsInstance(sErr, ConnectionLost)
+
+    def test_noSNICallback(self) -> None:
+        """
+        When SNI is not sent by the client, the server name callback will not
+        be invoked on the server.
+        """
+        sent = []
+        conf = self.serviceIdentitySetup(
+            "correct-host.example.com",
+            "correct-host.example.com",
+            serverNameCallback=sent.append,
+            immediately=False,
+            clientSkipSNI=True,
+        )
+        cProto, sProto, cWrapped, sWrapped, pump = conf
+        pump.flush()
+        self.assertEqual(cWrapped.data, b"greetings!")
+        cErr = cWrapped.lostReason
+        sErr = sWrapped.lostReason
+        self.assertIsNone(cErr)
+        self.assertIsNone(sErr)
+        self.assertEqual(sent, [])
 
     def test_validHostname(self):
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2165,7 +2165,7 @@ class ServiceIdentityTests(SynchronousTestCase):
         serverOpts = sslverify.OpenSSLCertificateOptions(
             privateKey=serverCert.privateKey.original,
             certificate=serverCert.original,
-            callbackForServerName=serverNameCallback,
+            contextForServerName=serverNameCallback,
             **other,
         )
         if not validCertificate:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -334,16 +334,18 @@ def _loopbackTLSConnection(
 ]:
     """
     Common implementation code for both L{loopbackTLSConnection} and
-    L{loopbackTLSConnectionInMemory}. Creates a loopback TLS connection
-    using the provided server and client context factories.
+    L{loopbackTLSConnectionInMemory}.  Creates a loopback TLS connection using
+    the provided server and client context factories.
 
-    @param serverOpts: An OpenSSL context factory for the server.
-    @type serverOpts: C{OpenSSLCertificateOptions}, or any class with an
-        equivalent API.
+    @param serverOpts: An OpenSSL connection creator for the server.
 
-    @param clientOpts: An OpenSSL context factory for the client.
-    @type clientOpts: C{OpenSSLCertificateOptions}, or any class with an
-        equivalent API.
+    @param clientOpts: An OpenSSL connection creator for the client.
+
+    @param serverNegotiationProtocols: The ALPN protocols to specify via the
+        protocol factory L{IProtocolNegotiationFactory} hook on the server.
+
+    @param clientNegotiationProtocols: The ALPN protocols to specify via the
+        protocol factory L{IProtocolNegotiationFactory} hook on the client.
 
     @return: 5-tuple of server-tls-protocol, server-inner-protocol,
         client-tls-protocol, client-inner-protocol and L{IOPump}
@@ -437,8 +439,6 @@ def loopbackTLSConnectionInMemory(
     serverCertificate: X509,
     serverProtocols: list[bytes] | None = None,
     clientProtocols: list[bytes] | None = None,
-    clientOptions: type[ssl.CertificateOptions] | None = None,
-    protocolsFromFactory: bool = False,
     viaFactory: bool = False,
 ) -> tuple[
     TLSMemoryBIOProtocol, TLSMemoryBIOProtocol, GreetingServer, ListeningClient, IOPump
@@ -450,10 +450,8 @@ def loopbackTLSConnectionInMemory(
 
     @param trustRoot: the C{trustRoot} argument for the client connection's
         context.
-    @type trustRoot: L{sslverify.IOpenSSLTrustRoot}
 
     @param privateKey: The private key.
-    @type privateKey: L{str} (native string)
 
     @param serverCertificate: The certificate used by the server.
 
@@ -465,34 +463,29 @@ def loopbackTLSConnectionInMemory(
     @param serverProtocols: The protocols the server is willing to negotiate
         using ALPN.
 
-    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to use
-        for the client.  Defaults to C{OpenSSLCertificateOptions}.
+    @param viaFactory: If True, pass the protocols along via the
+        L{IProtocolNegotiationFactory} hook rather than the
+        C{acceptableProtocols} arguemnt to
+        L{sslverify.OpenSSLCertificateOptions}.
 
-    @return: 3-tuple of server-protocol, client-protocol, and L{IOPump}
-    @rtype: L{tuple}
+    @return: 5-tuple of server-tls-protocol, client-tls-protocol,
+        server-app-protocol, client-app-protocol, L{IOPump}
     """
-    if clientOptions is None:
-        clientOptions = sslverify.OpenSSLCertificateOptions
-
-    if viaFactory:
-        clientCertOpts = clientOptions(trustRoot=trustRoot)
-        serverCertOpts = sslverify.OpenSSLCertificateOptions(
-            privateKey=privateKey, certificate=serverCertificate
-        )
-        return _loopbackTLSConnection(
-            serverCertOpts, clientCertOpts, serverProtocols, clientProtocols
-        )
-    else:
-        clientCertOpts = clientOptions(
-            trustRoot=trustRoot,
-            acceptableProtocols=clientProtocols,
-        )
-        serverCertOpts = sslverify.OpenSSLCertificateOptions(
-            privateKey=privateKey,
-            certificate=serverCertificate,
-            acceptableProtocols=serverProtocols,
-        )
-        return _loopbackTLSConnection(serverCertOpts, clientCertOpts)
+    clientCertOpts = sslverify.OpenSSLCertificateOptions(
+        trustRoot=trustRoot,
+        acceptableProtocols=clientProtocols if not viaFactory else None,
+    )
+    serverCertOpts = sslverify.OpenSSLCertificateOptions(
+        privateKey=privateKey,
+        certificate=serverCertificate,
+        acceptableProtocols=serverProtocols if not viaFactory else None,
+    )
+    return _loopbackTLSConnection(
+        serverCertOpts,
+        clientCertOpts,
+        serverProtocols if viaFactory else None,
+        clientProtocols if viaFactory else None,
+    )
 
 
 def pathContainingDumpOf(testCase, *dumpables):
@@ -2556,7 +2549,6 @@ class ServiceIdentityTests(SynchronousTestCase):
 def negotiateProtocol(
     serverProtocols: list[bytes],
     clientProtocols: list[bytes],
-    clientOptions: type[ssl.CertificateOptions] | None = None,
     viaFactory: bool = False,
 ) -> tuple[bytes | None, Failure | None]:
     """
@@ -2565,9 +2557,6 @@ def negotiateProtocol(
     @param serverProtocols: The protocols the server is willing to negotiate.
 
     @param clientProtocols: The protocols the client is willing to negotiate.
-
-    @param clientOptions: The type of C{OpenSSLCertificateOptions} class to use
-        for the client.  Defaults to C{OpenSSLCertificateOptions}.
 
     @param viaFactory: whether to supply the client protocols or the server
         protocols via the protocol factory rather than via the context factory.
@@ -2584,7 +2573,6 @@ def negotiateProtocol(
         serverCertificate=serverCertificate.original,
         clientProtocols=clientProtocols,
         serverProtocols=serverProtocols,
-        clientOptions=clientOptions,
         viaFactory=viaFactory,
     )
     pump.flush()

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -664,7 +664,7 @@ class _HTTP11ClientFactory(protocol.Factory):
             self._quiescentCallback, self._metadata
         )
 
-    def buildProtocol(self, addr: IAddress) -> HTTP11ClientProtocol:
+    def buildProtocol(self, addr: IAddress | None) -> HTTP11ClientProtocol:
         return HTTP11ClientProtocol(self._quiescentCallback)
 
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -3434,7 +3434,7 @@ class HTTPFactory(protocol.ServerFactory):
         self._logDateTime = datetimeToLogString(self.reactor.seconds())
         self._logDateTimeCall = self.reactor.callLater(1, self._updateLogDateTime)
 
-    def buildProtocol(self, addr: IAddress) -> Protocol | None:
+    def buildProtocol(self, addr: IAddress | None) -> Protocol | None:
         p = protocol.ServerFactory.buildProtocol(self, addr)
 
         # This is a bit of a hack to ensure that the HTTPChannel timeouts

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -42,7 +42,6 @@ from twisted.python.components import proxyForInterface
 from twisted.python.deprecate import getDeprecationWarningString
 from twisted.python.failure import Failure
 from twisted.test.iosim import FakeTransport, IOPump
-from twisted.test.test_sslverify import certificatesForAuthorityAndServer
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.web import client, error, http_headers
 from twisted.web._newclient import (
@@ -96,10 +95,11 @@ except ImportError:
 else:
     ssl = _ssl
     sslPresent = True
-    from twisted.internet._sslverify import ClientTLSOptions, IOpenSSLTrustRoot
+    from twisted.internet._sslverify import IOpenSSLTrustRoot
     from twisted.internet.ssl import optionsForClientTLS
     from twisted.protocols import tls
     from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
+    from twisted.test.test_sslverify import certificatesForAuthorityAndServer
 
     @implementer(IOpenSSLTrustRoot)
     class CustomOpenSSLTrustRoot:
@@ -1442,15 +1442,6 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin, IntegrationTestingMi
         endpoint = self.makeEndpoint(port=expectedPort)
         self.assertEqual(endpoint._wrappedEndpoint._port, expectedPort)
 
-    def test_contextFactoryType(self):
-        """
-        L{Agent} wraps its connection creator creator and uses modern TLS APIs.
-        """
-        endpoint = self.makeEndpoint()
-        contextFactory = endpoint._wrapperFactory(None)._connectionCreator
-        self.assertIsInstance(contextFactory, ClientTLSOptions)
-        self.assertEqual(contextFactory._hostname, "example.com")
-
     def test_connectHTTPSCustomConnectionCreator(self):
         """
         If a custom L{WebClientConnectionCreator}-like object is passed to
@@ -1478,6 +1469,21 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin, IntegrationTestingMi
                 The connection started.  Record that fact.
                 """
                 self.connectState = True
+
+            def get_context(self):
+                """
+                Get the context object.
+                """
+
+            def set_app_data(self, app_data):
+                """
+                Set app data.
+                """
+
+            def get_app_data(self):
+                """
+                Get the app data.
+                """
 
         contextArgs = []
 
@@ -1570,8 +1576,8 @@ class AgentHTTPSTests(TestCase, FakeReactorAndConnectMixin, IntegrationTestingMi
         trustRoot = CustomOpenSSLTrustRoot()
         policy = BrowserLikePolicyForHTTPS(trustRoot=trustRoot)
         creator = policy.creatorForNetloc(b"thingy", 4321)
-        self.assertTrue(trustRoot.called)
         connection = creator.clientConnectionForTLS(None)
+        self.assertTrue(trustRoot.called)
         self.assertIs(trustRoot.context, connection.get_context())
 
     def integrationTest(self, hostName, expectedAddress, addressType):
@@ -3301,6 +3307,8 @@ class HostnameCachingHTTPSPolicyTests(TestCase):
         wrappedPolicy = BrowserLikePolicyForHTTPS(trustRoot=trustRoot)
         policy = HostnameCachingHTTPSPolicy(wrappedPolicy)
         creator = policy.creatorForNetloc(b"foo", 1589)
+        firstConnection = creator.clientConnectionForTLS(None)
+        self.assertIs(trustRoot.context, firstConnection.get_context())
         self.assertTrue(trustRoot.called)
         trustRoot.called = False
         self.assertEqual(1, len(policy._cache))

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -3945,7 +3945,7 @@ class RequestTests(unittest.TestCase, ResponseTestMixin):
         # If we set it to a text-based I/O (i.e.: anything other than an
         # io.BufferedBase) it stays exactly the same, no modification.
         self.assertIs(getBackLogFile, factory.logFile)
-        proto = factory.buildProtocol(None)  # type:ignore
+        proto = factory.buildProtocol(None)
 
         val = [b"GET /path HTTP/1.1\r\n", b"\r\n\r\n"]
 

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -19,7 +19,6 @@ from twisted.python import failure
 from twisted.python.compat import iterbytes
 from twisted.python.reflect import requireModule
 from twisted.test.test_internet import DummyProducer
-from twisted.test.test_sslverify import certificatesForAuthorityAndServer
 from twisted.trial import unittest
 from twisted.web import http
 from twisted.web.server import Site
@@ -2938,6 +2937,8 @@ class EndToEndTests(unittest.TestCase):
         """
         Twisted's HTTP/2 server can talk to a third-party HTTP/2 client.
         """
+        from twisted.test.test_sslverify import certificatesForAuthorityAndServer
+
         _, serverCert = certificatesForAuthorityAndServer("test.local")
         resource = Data(b"hello world", "application/octet-stream")
         resource.isLeaf = True


### PR DESCRIPTION
## Scope and purpose

Fixes #12500 
Fixes #9588 
Fixes #4887

In addition to fixing the mutability thing, this:

- add SNI support to OpenSSLCertificateOptions in the form of  callbackForServerName argument
- switch to using the 'verify' rather than 'info' callback for verification
- make OpenSSLCertificateOptions support IOpenSSLClientConnectionCreator /  IOpenSSLServerConnectionCreator directly rather than relying on compatibility  hacks in our own code
- eliminate long-dead NPN support (#9588)
- move responsibility for IProtocolNegotiationFactory from  twisted.protocols.tls to twisted.internet.ssl
- remove useless/invalid CN-only certificate verification path, hard-require  service_identity
