### PR TITLE
#12426 fix `asyncio.get_event_loop` call on Python 3.14

### DIFF
--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -50,7 +50,7 @@ class AsyncioSelectorReactor(PosixReactorBase):
             try:
                 _eventloop: AbstractEventLoop = get_running_loop()
             except RuntimeError:
-                _eventloop: AbstractEventLoop = new_event_loop()
+                _eventloop = new_event_loop()
             set_event_loop(_eventloop)
         else:
             _eventloop = eventloop

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -9,7 +9,7 @@ asyncio-based reactor implementation.
 
 import errno
 import sys
-from asyncio import AbstractEventLoop, get_event_loop
+from asyncio import AbstractEventLoop, get_running_loop, new_event_loop, set_event_loop
 from typing import Dict, Optional, Type
 
 from zope.interface import implementer
@@ -47,7 +47,11 @@ class AsyncioSelectorReactor(PosixReactorBase):
 
     def __init__(self, eventloop: Optional[AbstractEventLoop] = None):
         if eventloop is None:
-            _eventloop: AbstractEventLoop = get_event_loop()
+            try:
+                _eventloop: AbstractEventLoop = get_running_loop()
+            except RuntimeError:
+                _eventloop: AbstractEventLoop = new_event_loop()
+            set_event_loop(_eventloop)
         else:
             _eventloop = eventloop
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12426 (most probably)

I implemented the workaround suggested in https://github.com/twisted/twisted/issues/12426#issuecomment-2907990838, it fixes the affected tests.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
