### PR TITLE
#12514 Fix `MemoryReactor.callWhenRunning` not invoking callbacks if already started

### DIFF
--- a/src/twisted/internet/test/test_testing.py
+++ b/src/twisted/internet/test/test_testing.py
@@ -306,6 +306,33 @@ class ReactorTests(TestCase):
 
         self.assertEqual(reactor.getWriters(), [])
 
+    def test_call_when_running(self) -> None:
+        """
+        L{MemoryReactor.callWhenRunning} calls the given callable when the
+        reactor is started, or immediately if the reactor has already been
+        started.
+        """
+        reactor = MemoryReactor()
+        called = []
+
+        def f(x: int) -> None:
+            called.append(x)
+
+        # Schedule some calls to be run when the reactor starts.
+        reactor.callWhenRunning(f, 1)
+        self.assertEqual(called, [])
+
+        # Start the reactor
+        reactor.run()
+
+        # We should see the scheduled calls run now.
+        self.assertEqual(called, [1])
+
+        # Schedule another call which should be called immediately if the reactor is
+        # already running.
+        reactor.callWhenRunning(f, 2)
+        self.assertEqual(called, [1, 2])
+
 
 class TestConsumer:
     """

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -669,8 +669,16 @@ class MemoryReactor:
         """
         Fake L{IReactorCore.callWhenRunning}.
         Keeps a list of invocations to make in C{self.whenRunningHooks}.
+
+        If the reactor has not started, the callable will be scheduled
+        to run when it does start. Otherwise, the callable will be invoked
+        immediately.
         """
-        self.whenRunningHooks.append((callable, args, kw))
+        if self.running:
+            callable(*args, **kw)
+            return None
+        else:
+            self.whenRunningHooks.append((callable, args, kw))
 
     def adoptStreamPort(self, fileno, addressFamily, factory):
         """

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -551,9 +551,9 @@ class MemoryReactor:
         self.hasInstalled = False
 
         self.running = False
-        self.hasRun = True
-        self.hasStopped = True
-        self.hasCrashed = True
+        self.hasRun = False
+        self.hasStopped = False
+        self.hasCrashed = False
 
         self.whenRunningHooks = []
         self.triggers = {}
@@ -674,7 +674,11 @@ class MemoryReactor:
         to run when it does start. Otherwise, the callable will be invoked
         immediately.
         """
-        if self.running:
+        # Normally, we would only key off of `self.running`, but the `MemoryReactor` is
+        # a bit unique in the fact that it stops itself immediately after calling
+        # `MemoryReactor.run()`. We're going to consider it good enough if the reactor
+        # has ever been started (`self.hasRun`).
+        if self.running or self.hasRun:
             callable(*args, **kw)
             return None
         else:

--- a/src/twisted/newsfragments/12514.bugfix
+++ b/src/twisted/newsfragments/12514.bugfix
@@ -1,0 +1,1 @@
+Fix `MemoryReactor.callWhenRunning` not invoking callbacks if already started.

--- a/src/twisted/newsfragments/12514.bugfix
+++ b/src/twisted/newsfragments/12514.bugfix
@@ -1,1 +1,1 @@
-Fix `MemoryReactor.callWhenRunning` not invoking callbacks if already started.
+`twisted.internet.testing.MemoryReactor.callWhenRunning` now invokes the callback immediately, if already started.


### PR DESCRIPTION
Fix `MemoryReactor.callWhenRunning` not invoking callbacks if already started

(noticed while working on https://github.com/element-hq/synapse/pull/18903)

## Scope and purpose

Previously, `MemoryReactor.callWhenRunning` wouldn't invoke any of the callbacks if the reactor had already started. It did invoke callbacks collected before the reactor started running.

The interface, `IReactorCore.callWhenRunning`, describes how should be behaving:

https://github.com/twisted/twisted/blob/ef6160aa2595adfba0c71da6db65b7a7252f23e9/src/twisted/internet/interfaces.py#L1475-L1491

This also matches how `ReactorBase` implements things:

https://github.com/twisted/twisted/blob/ef6160aa2595adfba0c71da6db65b7a7252f23e9/src/twisted/internet/base.py#L893-L905

---

Related to https://github.com/twisted/twisted/issues/3025


## Dev notes

https://docs.twisted.org/en/latest/development/dev-process.html

```shell
$ git clone https://github.com/twisted/twisted twisted
$ python3 -m venv ./venv
$ . venv/bin/activate
$ pip install -e '.[dev]'
```

```shell
$ trial twisted.internet.test.test_testing.ReactorTests
```

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
