### PR TITLE
#12525 Use latest pyobjc version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,9 +110,9 @@ all-non-platform = [
 
 macos-platform = [
     "twisted[all-non-platform]",
-    "pyobjc-core; python_version >= '3.9'",
-    "pyobjc-framework-CFNetwork; python_version >= '3.9'",
-    "pyobjc-framework-Cocoa; python_version >= '3.9'",
+    "pyobjc-core >= 12 ; python_version >= '3.10'",
+    "pyobjc-framework-CFNetwork >= 12; python_version >= '3.10'",
+    "pyobjc-framework-Cocoa >= 12; python_version >= '3.10'",
 ]
 
 windows-platform = [


### PR DESCRIPTION
## Scope and purpose

Fixes #12525

Changlog for pyobjc project at 
https://pyobjc.readthedocs.io/en/latest/changelog.html

This tries to somehow define the minimum version of pyobjc that we support


------

The exact verion is not pinned ... and for tests, we use latest version and not the minimum version.

But I don't know how we test this in "cost effective" way


----------

We have mindeps for OS independent tests

https://github.com/twisted/twisted/blob/0bcfe05608a62351d63e54caa9f8407c609e55fb/tox.ini#L70-L98