### PR TITLE
#12531 internet: update type annotations for Python 3.9+ (1/2)

### DIFF
--- a/src/twisted/internet/_baseprocess.py
+++ b/src/twisted/internet/_baseprocess.py
@@ -7,7 +7,7 @@ Cross-platform process-related functionality used by different
 L{IReactorProcess} implementations.
 """
 
-from typing import Optional
+from __future__ import annotations
 
 from twisted.logger import Logger
 from twisted.python.deprecate import getWarningMethod
@@ -23,8 +23,8 @@ _missingProcessExited = (
 
 
 class BaseProcess:
-    pid: Optional[int] = None
-    status: Optional[int] = None
+    pid: int | None = None
+    status: int | None = None
     lostProcess = 0
     proto = None
 

--- a/src/twisted/internet/_glibbase.py
+++ b/src/twisted/internet/_glibbase.py
@@ -11,9 +11,10 @@ import gireactor or gtk3reactor for GObject Introspection based applications,
 or glib2reactor or gtk2reactor for applications using legacy static bindings.
 """
 
+from __future__ import annotations
 
 import sys
-from typing import Any, Callable, Dict, Set
+from typing import Any, Callable
 
 from zope.interface import implementer
 
@@ -135,9 +136,9 @@ class GlibReactorBase(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
 
     def __init__(self, glib_module: Any, gtk_module: Any, useGtk: bool = False) -> None:
         self._simtag = None
-        self._reads: Set[IReadDescriptor] = set()
-        self._writes: Set[IWriteDescriptor] = set()
-        self._sources: Dict[FileDescriptor, int] = {}
+        self._reads: set[IReadDescriptor] = set()
+        self._writes: set[IWriteDescriptor] = set()
+        self._sources: dict[FileDescriptor, int] = {}
         self._glib = glib_module
 
         self._POLL_DISCONNECTED = (

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -6,8 +6,6 @@
 Helpers for working with producers.
 """
 
-from typing import List
-
 from zope.interface import implementer
 
 from twisted.internet.interfaces import IPushProducer
@@ -17,7 +15,7 @@ from twisted.logger import Logger
 _log = Logger()
 
 # This module exports nothing public, it's for internal Twisted use only.
-__all__: List[str] = []
+__all__: list[str] = []
 
 
 @implementer(IPushProducer)

--- a/src/twisted/internet/_resolver.py
+++ b/src/twisted/internet/_resolver.py
@@ -8,7 +8,9 @@ IPv6-aware hostname resolution.
 @see: L{IHostnameResolver}
 """
 
+from __future__ import annotations
 
+from collections.abc import Sequence
 from socket import (
     AF_INET,
     AF_INET6,
@@ -20,19 +22,11 @@ from socket import (
     gaierror,
     getaddrinfo,
 )
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    List,
-    NoReturn,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Callable, NoReturn, Union
 
 from zope.interface import implementer
+
+from typing_extensions import TypeAlias
 
 from twisted.internet._idna import _idnaBytes
 from twisted.internet.address import IPv4Address, IPv6Address
@@ -95,13 +89,13 @@ _socktypeToType = {
 }
 
 
-_GETADDRINFO_RESULT = List[
-    Tuple[
+_GETADDRINFO_RESULT: TypeAlias = list[
+    tuple[
         AddressFamily,
         SocketKind,
         int,
         str,
-        Union[Tuple[str, int], Tuple[str, int, int, int]],
+        Union[tuple[str, int], tuple[str, int, int, int]],
     ]
 ]
 
@@ -116,7 +110,7 @@ class GAIResolver:
     def __init__(
         self,
         reactor: IReactorThreads,
-        getThreadPool: Optional[Callable[[], "ThreadPool"]] = None,
+        getThreadPool: Callable[[], ThreadPool] | None = None,
         getaddrinfo: Callable[[str, int, int, int], _GETADDRINFO_RESULT] = getaddrinfo,
     ):
         """
@@ -146,7 +140,7 @@ class GAIResolver:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -213,7 +207,7 @@ class SimpleResolverComplexifier:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -274,7 +268,7 @@ class FirstOneWins:
     An L{IResolutionReceiver} which fires a L{Deferred} with its first result.
     """
 
-    def __init__(self, deferred: "Deferred[str]"):
+    def __init__(self, deferred: Deferred[str]):
         """
         @param deferred: The L{Deferred} to fire when the first resolution
             result arrives.
@@ -327,7 +321,7 @@ class ComplexResolverSimplifier:
         """
         self._nameResolver = nameResolver
 
-    def getHostByName(self, name: str, timeouts: Sequence[int] = ()) -> "Deferred[str]":
+    def getHostByName(self, name: str, timeouts: Sequence[int] = ()) -> Deferred[str]:
         """
         See L{IResolverSimple.getHostByName}
 
@@ -337,6 +331,6 @@ class ComplexResolverSimplifier:
 
         @return: see L{IResolverSimple.getHostByName}
         """
-        result: "Deferred[str]" = Deferred()
+        result: Deferred[str] = Deferred()
         self._nameResolver.resolveHostName(FirstOneWins(result), name, 0, [IPv4Address])
         return result

--- a/src/twisted/internet/_signals.py
+++ b/src/twisted/internet/_signals.py
@@ -38,8 +38,9 @@ import errno
 import os
 import signal
 import socket
+from collections.abc import Sequence
 from types import FrameType
-from typing import Callable, Optional, Protocol, Sequence
+from typing import Callable, Optional, Protocol
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -213,7 +214,7 @@ class _ChildSignalHandling:
 
     _addInternalReader: Callable[[IReadDescriptor], object]
     _removeInternalReader: Callable[[IReadDescriptor], object]
-    _childWaker: Optional[_SIGCHLDWaker] = None
+    _childWaker: _SIGCHLDWaker | None = None
 
     def install(self) -> None:
         """

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -6,18 +6,10 @@ from __future__ import annotations
 
 import warnings
 from binascii import hexlify
+from collections.abc import Sequence
 from functools import lru_cache
 from hashlib import md5
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from zope.interface import Interface, implementer
 
@@ -178,7 +170,7 @@ _x509names = {
 }
 
 
-class DistinguishedName(Dict[str, bytes]):
+class DistinguishedName(dict[str, bytes]):
     """
     Identify and describe an entity.
 
@@ -998,7 +990,7 @@ class ClientTLSOptions:
         <https://www.rfc-editor.org/rfc/rfc3546#section-3.1>} extension.
     """
 
-    _ctx: Optional[SSL.Context]
+    _ctx: SSL.Context | None
     _hostname: str
     _hostnameASCII: str
     _hostnameIsDnsName: bool
@@ -1008,7 +1000,7 @@ class ClientTLSOptions:
     def __init__(
         self,
         hostname: str,
-        context: Optional[SSL.Context],
+        context: SSL.Context | None,
         createContext: Callable[[], SSL.Context],
         sendServerName: bool | None = None,
     ) -> None:
@@ -1104,11 +1096,11 @@ def _verifyCB(
 
 def optionsForClientTLS(
     hostname: str,
-    trustRoot: Optional[Union[IOpenSSLTrustRoot, Certificate]] = None,
-    clientCertificate: Optional[PrivateCertificate] = None,
-    acceptableProtocols: Optional[Sequence[bytes]] = None,
+    trustRoot: IOpenSSLTrustRoot | Certificate | None = None,
+    clientCertificate: PrivateCertificate | None = None,
+    acceptableProtocols: Sequence[bytes] | None = None,
     *,
-    extraCertificateOptions: Optional[dict[str, Any]] = None,
+    extraCertificateOptions: dict[str, Any] | None = None,
     sendServerName: bool | None = None,
 ) -> ClientTLSOptions:
     """

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -8,8 +8,8 @@ Support for generic select()able objects.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from socket import AF_INET, AF_INET6, inet_pton
-from typing import Iterable, List, Optional, Union
 
 from zope.interface import implementer
 
@@ -182,7 +182,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
 
     SEND_LIMIT = 128 * 1024
 
-    def __init__(self, reactor: Optional[interfaces.IReactorFDSet] = None):
+    def __init__(self, reactor: interfaces.IReactorFDSet | None = None):
         """
         @param reactor: An L{IReactorFDSet} provider which this descriptor will
             use to get readable and writeable event notifications.  If no value
@@ -194,7 +194,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             reactor = _reactor  # type: ignore[assignment]
         self.reactor = reactor
         # will be added to dataBuffer in doWrite
-        self._tempDataBuffer: List[bytes] = []
+        self._tempDataBuffer: list[bytes] = []
         self._tempDataLen = 0
 
     def connectionLost(self, reason):
@@ -215,7 +215,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.stopReading()
         self.stopWriting()
 
-    def writeSomeData(self, data: bytes) -> Union[int, BaseException]:
+    def writeSomeData(self, data: bytes) -> int | BaseException:
         """
         Write as much as possible of the given data, immediately.
 

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -6,8 +6,10 @@ Address objects for network connections.
 """
 
 
+from __future__ import annotations
+
 import os
-from typing import Literal, Optional, Union
+from typing import Literal
 from warnings import warn
 
 from zope.interface import implementer
@@ -36,7 +38,7 @@ class IPv4Address:
     @type port: C{int}
     """
 
-    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+    type: Literal["TCP"] | Literal["UDP"] = attr.ib(
         validator=attr.validators.in_(["TCP", "UDP"])
     )
     host: str
@@ -68,13 +70,13 @@ class IPv6Address:
     @type scopeID: L{int} or L{str}
     """
 
-    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+    type: Literal["TCP"] | Literal["UDP"] = attr.ib(
         validator=attr.validators.in_(["TCP", "UDP"])
     )
     host: str
     port: int
     flowInfo: int = 0
-    scopeID: Union[str, int] = 0
+    scopeID: str | int = 0
 
 
 @implementer(IAddress)
@@ -111,9 +113,7 @@ class UNIXAddress:
     @type name: C{bytes}
     """
 
-    name: Optional[bytes] = attr.ib(
-        converter=attr.converters.optional(_asFilesystemBytes)
-    )
+    name: bytes | None = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))
 
     if getattr(os.path, "samefile", None) is not None:
 

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -7,10 +7,11 @@ asyncio-based reactor implementation.
 """
 
 
+from __future__ import annotations
+
 import errno
 import sys
 from asyncio import AbstractEventLoop, get_running_loop, new_event_loop, set_event_loop
-from typing import Dict, Optional, Type
 
 from zope.interface import implementer
 
@@ -45,7 +46,7 @@ class AsyncioSelectorReactor(PosixReactorBase):
     _asyncClosed = False
     _log = Logger()
 
-    def __init__(self, eventloop: Optional[AbstractEventLoop] = None):
+    def __init__(self, eventloop: AbstractEventLoop | None = None):
         if eventloop is None:
             try:
                 _eventloop: AbstractEventLoop = get_running_loop()
@@ -67,8 +68,8 @@ class AsyncioSelectorReactor(PosixReactorBase):
                 )
 
         self._asyncioEventloop: AbstractEventLoop = _eventloop
-        self._writers: Dict[Type[FileDescriptor], int] = {}
-        self._readers: Dict[Type[FileDescriptor], int] = {}
+        self._writers: dict[type[FileDescriptor], int] = {}
+        self._readers: dict[type[FileDescriptor], int] = {}
         self._continuousPolling = _ContinuousPolling(self)
 
         self._scheduledAt = None

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -7,27 +7,17 @@ Very basic functionality for a Reactor implementation.
 """
 
 
+from __future__ import annotations
+
 import builtins
 import socket  # needed only for sync-dns
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from heapq import heapify, heappop, heappush
 from traceback import format_stack
 from types import FrameType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    NewType,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, NewType, cast
 
 from zope.interface import classImplements, implementer
 
@@ -89,19 +79,19 @@ class DelayedCall:
     # enable .debug to record creator call stack, and it will be logged if
     # an exception occurs while the function is being run
     debug = False
-    _repr: Optional[str] = None
+    _repr: str | None = None
 
     # In debug mode, the call stack at the time of instantiation.
-    creator: Optional[Sequence[str]] = None
+    creator: Sequence[str] | None = None
 
     def __init__(
         self,
         time: float,
         func: Callable[..., Any],
         args: Sequence[object],
-        kw: Dict[str, object],
-        cancel: Callable[["DelayedCall"], None],
-        reset: Callable[["DelayedCall"], None],
+        kw: dict[str, object],
+        cancel: Callable[[DelayedCall], None],
+        reset: Callable[[DelayedCall], None],
         seconds: Callable[[], float] = runtimeSeconds,
     ) -> None:
         """
@@ -213,7 +203,7 @@ class DelayedCall:
         """
         return not (self.cancelled or self.called)
 
-    def __le__(self, other: "DelayedCall") -> bool:
+    def __le__(self, other: DelayedCall) -> bool:
         """
         Implement C{<=} operator between two L{DelayedCall} instances.
 
@@ -222,7 +212,7 @@ class DelayedCall:
         """
         return self.time <= other.time
 
-    def __lt__(self, other: "DelayedCall") -> bool:
+    def __lt__(self, other: DelayedCall) -> bool:
         """
         Implement C{<} operator between two L{DelayedCall} instances.
 
@@ -293,10 +283,10 @@ class ThreadedResolver:
         delivered.
     """
 
-    def __init__(self, reactor: "ReactorBase") -> None:
+    def __init__(self, reactor: ReactorBase) -> None:
         self.reactor = reactor
-        self._runningQueries: Dict[
-            Deferred[str], Tuple[Deferred[str], IDelayedCall]
+        self._runningQueries: dict[
+            Deferred[str], tuple[Deferred[str], IDelayedCall]
         ] = {}
 
     def _fail(self, name: str, err: str) -> Failure:
@@ -309,7 +299,7 @@ class ThreadedResolver:
         userDeferred.errback(self._fail(name, "timeout error"))
 
     def _checkTimeout(
-        self, result: Union[str, Failure], name: str, lookupDeferred: Deferred[str]
+        self, result: str | Failure, name: str, lookupDeferred: Deferred[str]
     ) -> None:
         try:
             userDeferred, cancelCall = self._runningQueries[lookupDeferred]
@@ -371,12 +361,12 @@ class BlockingResolver:
 
 
 _ThreePhaseEventTriggerCallable = Callable[..., Any]
-_ThreePhaseEventTrigger = Tuple[
-    _ThreePhaseEventTriggerCallable, Tuple[object, ...], Dict[str, object]
+_ThreePhaseEventTrigger = tuple[
+    _ThreePhaseEventTriggerCallable, tuple[object, ...], dict[str, object]
 ]
 _ThreePhaseEventTriggerHandle = NewType(
     "_ThreePhaseEventTriggerHandle",
-    Tuple[str, _ThreePhaseEventTriggerCallable, Tuple[object, ...], Dict[str, object]],
+    tuple[str, _ThreePhaseEventTriggerCallable, tuple[object, ...], dict[str, object]],
 )
 
 
@@ -411,9 +401,9 @@ class _ThreePhaseEvent:
     """
 
     def __init__(self) -> None:
-        self.before: List[_ThreePhaseEventTrigger] = []
-        self.during: List[_ThreePhaseEventTrigger] = []
-        self.after: List[_ThreePhaseEventTrigger] = []
+        self.before: list[_ThreePhaseEventTrigger] = []
+        self.during: list[_ThreePhaseEventTrigger] = []
+        self.after: list[_ThreePhaseEventTrigger] = []
         self.state = "BASE"
 
     def addTrigger(
@@ -494,7 +484,7 @@ class _ThreePhaseEvent:
         """
         self.state = "BEFORE"
         self.finishedBefore = []
-        beforeResults: List[Deferred[object]] = []
+        beforeResults: list[Deferred[object]] = []
         while self.before:
             callable, args, kwargs = self.before.pop(0)
             self.finishedBefore.append((callable, args, kwargs))
@@ -568,8 +558,8 @@ class PluggableResolverMixin:
         return self._nameResolver
 
 
-_SystemEventID = NewType("_SystemEventID", Tuple[str, _ThreePhaseEventTriggerHandle])
-_ThreadCall = Tuple[Callable[..., Any], Tuple[object, ...], Dict[str, object]]
+_SystemEventID = NewType("_SystemEventID", tuple[str, _ThreePhaseEventTriggerHandle])
+_ThreadCall = tuple[Callable[..., Any], tuple[object, ...], dict[str, object]]
 
 _DEFAULT_DELAYED_CALL_LOGGING_HANDLER = _log.failureHandler("while handling timed call")
 
@@ -622,10 +612,10 @@ class ReactorBase(PluggableResolverMixin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.threadCallQueue: List[_ThreadCall] = []
-        self._eventTriggers: Dict[str, _ThreePhaseEvent] = {}
-        self._pendingTimedCalls: List[DelayedCall] = []
-        self._newTimedCalls: List[DelayedCall] = []
+        self.threadCallQueue: list[_ThreadCall] = []
+        self._eventTriggers: dict[str, _ThreePhaseEvent] = {}
+        self._pendingTimedCalls: list[DelayedCall] = []
+        self._newTimedCalls: list[DelayedCall] = []
         self._cancellations = 0
         self.running = False
         self._started = False
@@ -633,7 +623,7 @@ class ReactorBase(PluggableResolverMixin):
         self._startedBefore = False
         # reactor internal readers, e.g. the waker.
         # Using Any as the type here… unable to find a suitable defined interface
-        self._internalReaders: Set[Any] = set()
+        self._internalReaders: set[Any] = set()
         self.waker: Any = None
 
         # Arrange for the running attribute to change to True at the right time
@@ -726,7 +716,7 @@ class ReactorBase(PluggableResolverMixin):
         # if the waker isn't installed, the reactor isn't running, and
         # therefore doesn't need to be woken up
 
-    def doIteration(self, delay: Optional[float]) -> None:
+    def doIteration(self, delay: float | None) -> None:
         """
         Do one iteration over the readers and writers which have been added.
         """
@@ -754,17 +744,17 @@ class ReactorBase(PluggableResolverMixin):
             reflect.qual(self.__class__) + " did not implement removeWriter"
         )
 
-    def removeAll(self) -> List[Union[IReadDescriptor, IWriteDescriptor]]:
+    def removeAll(self) -> list[IReadDescriptor | IWriteDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement removeAll"
         )
 
-    def getReaders(self) -> List[IReadDescriptor]:
+    def getReaders(self) -> list[IReadDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement getReaders"
         )
 
-    def getWriters(self) -> List[IWriteDescriptor]:
+    def getWriters(self) -> list[IWriteDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement getWriters"
         )
@@ -804,7 +794,7 @@ class ReactorBase(PluggableResolverMixin):
         self.running = False
         self.addSystemEventTrigger("during", "startup", self._reallyStartRunning)
 
-    def sigInt(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigInt(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGINT interrupt.
 
@@ -815,7 +805,7 @@ class ReactorBase(PluggableResolverMixin):
         self.callFromThread(self.stop)
         self._exitSignal = number
 
-    def sigBreak(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigBreak(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGBREAK interrupt.
 
@@ -826,7 +816,7 @@ class ReactorBase(PluggableResolverMixin):
         self.callFromThread(self.stop)
         self._exitSignal = number
 
-    def sigTerm(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigTerm(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGTERM interrupt.
 
@@ -892,7 +882,7 @@ class ReactorBase(PluggableResolverMixin):
 
     def callWhenRunning(
         self, callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> Optional[_SystemEventID]:
+    ) -> _SystemEventID | None:
         """
         See twisted.internet.interfaces.IReactorCore.callWhenRunning.
         """
@@ -1021,7 +1011,7 @@ class ReactorBase(PluggableResolverMixin):
                 heappush(self._pendingTimedCalls, call)
         self._newTimedCalls = []
 
-    def timeout(self) -> Optional[float]:
+    def timeout(self) -> float | None:
         """
         Determine the longest time the reactor may sleep (waiting on I/O
         notification, perhaps) before it must wake up to service a time-related
@@ -1251,7 +1241,7 @@ class BaseConnector(ABC):
             self.transport.loseConnection()
 
     @abstractmethod
-    def _makeTransport(self) -> "Client":
+    def _makeTransport(self) -> Client:
         pass
 
     def connect(self) -> None:
@@ -1263,7 +1253,7 @@ class BaseConnector(ABC):
         if not self.factoryStarted:
             self.factory.doStart()
             self.factoryStarted = 1
-        self.transport: Optional[Client] = self._makeTransport()
+        self.transport: Client | None = self._makeTransport()
         if self.timeout is not None:
             self.timeoutID = self.reactor.callLater(
                 self.timeout, self.transport.failIfNotConnected, error.TimeoutError()
@@ -1288,7 +1278,7 @@ class BaseConnector(ABC):
                 pass
             del self.timeoutID
 
-    def buildProtocol(self, addr: IAddress) -> Optional[IProtocol]:
+    def buildProtocol(self, addr: IAddress) -> IProtocol | None:
         self.state = "connected"
         self.cancelTimeout()
         return self.factory.buildProtocol(addr)
@@ -1340,9 +1330,9 @@ class BasePort(abstract.FileDescriptor):
         fdesc._setCloseOnExec(s.fileno())
         return s
 
-    def doWrite(self) -> Optional[Failure]:
+    def doWrite(self) -> Failure | None:
         """Raises a RuntimeError"""
         raise RuntimeError("doWrite called on a %s" % reflect.qual(self.__class__))
 
 
-__all__: List[str] = []
+__all__: list[str] = []

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -14,6 +14,7 @@ import traceback
 import warnings
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop, Future, iscoroutine
+from collections.abc import Awaitable, Coroutine, Generator, Iterable, Mapping, Sequence
 from contextvars import Context as _Context, copy_context as _copy_context
 from enum import Enum
 from functools import wraps
@@ -22,20 +23,10 @@ from types import CoroutineType, GeneratorType, MappingProxyType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
-    Coroutine,
-    Generator,
     Generic,
-    Iterable,
-    List,
     Literal,
-    Mapping,
     NoReturn,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -44,7 +35,7 @@ from typing import (
 
 import attr
 from incremental import Version
-from typing_extensions import Concatenate, ParamSpec, Self
+from typing_extensions import Concatenate, ParamSpec, Self, TypeAlias
 
 from twisted.internet.interfaces import IDelayedCall, IReactorTime
 from twisted.logger import Logger
@@ -99,7 +90,7 @@ def logError(err: Failure) -> Failure:
     return err
 
 
-def succeed(result: _T) -> "Deferred[_T]":
+def succeed(result: _T) -> Deferred[_T]:
     """
     Return a L{Deferred} that has already had C{.callback(result)} called.
 
@@ -123,7 +114,7 @@ def succeed(result: _T) -> "Deferred[_T]":
     return d
 
 
-def fail(result: Optional[Union[Failure, BaseException]] = None) -> "Deferred[Any]":
+def fail(result: Failure | BaseException | None = None) -> Deferred[Any]:
     """
     Return a L{Deferred} that has already had C{.errback(result)} called.
 
@@ -141,7 +132,7 @@ def fail(result: Optional[Union[Failure, BaseException]] = None) -> "Deferred[An
 
 def execute(
     callable: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     """
     Create a L{Deferred} from a callable and arguments.
 
@@ -160,7 +151,7 @@ def execute(
 @overload
 def maybeDeferred(
     f: Callable[_P, Deferred[_T]], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
@@ -169,22 +160,22 @@ def maybeDeferred(
     f: Callable[_P, Coroutine[Deferred[Any], Any, _T]],
     *args: _P.args,
     **kwargs: _P.kwargs,
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
 @overload
 def maybeDeferred(
     f: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
 def maybeDeferred(
-    f: Callable[_P, Union[Deferred[_T], Coroutine[Deferred[Any], Any, _T], _T]],
+    f: Callable[_P, Deferred[_T] | Coroutine[Deferred[Any], Any, _T] | _T],
     *args: _P.args,
     **kwargs: _P.kwargs,
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     """
     Invoke a function that may or may not return a L{Deferred} or coroutine.
 
@@ -247,7 +238,7 @@ def maybeDeferred(
     Version("Twisted", 17, 1, 0),
     replacement="twisted.internet.defer.Deferred.addTimeout",
 )
-def timeout(deferred: "Deferred[object]") -> None:
+def timeout(deferred: Deferred[object]) -> None:
     deferred.errback(Failure(TimeoutError("Callback timed out")))
 
 
@@ -319,20 +310,20 @@ _CONTINUE = _Sentinel._CONTINUE
 
 # type note: this should be Callable[[object, ...], object] but mypy doesn't allow.
 #     Callable[[object], object] is next best, but disallows valid callback signatures
-DeferredCallback = Callable[..., object]
+DeferredCallback: TypeAlias = Callable[..., object]
 # type note: this should be Callable[[Failure, ...], object] but mypy doesn't allow.
 #     Callable[[Failure], object] is next best, but disallows valid callback signatures
-DeferredErrback = Callable[..., object]
+DeferredErrback: TypeAlias = Callable[..., object]
 
-_CallbackOrderedArguments = Tuple[object, ...]
-_CallbackKeywordArguments = Mapping[str, object]
-_CallbackChain = Tuple[
-    Tuple[
+_CallbackOrderedArguments: TypeAlias = tuple[object, ...]
+_CallbackKeywordArguments: TypeAlias = Mapping[str, object]
+_CallbackChain: TypeAlias = tuple[
+    tuple[
         Union[DeferredCallback, Literal[_Sentinel._CONTINUE]],
         _CallbackOrderedArguments,
         _CallbackKeywordArguments,
     ],
-    Tuple[
+    tuple[
         Union[DeferredErrback, DeferredCallback, Literal[_Sentinel._CONTINUE]],
         _CallbackOrderedArguments,
         _CallbackKeywordArguments,
@@ -351,9 +342,9 @@ class DebugInfo:
     Deferred debug helper.
     """
 
-    failResult: Optional[Failure] = None
-    creator: Optional[List[str]] = None
-    invoker: Optional[List[str]] = None
+    failResult: Failure | None = None
+    creator: list[str] | None = None
+    invoker: list[str] | None = None
 
     def _getDebugTracebacks(self) -> str:
         info = ""
@@ -427,7 +418,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
     called = False
     paused = 0
-    _debugInfo: Optional[DebugInfo] = None
+    _debugInfo: DebugInfo | None = None
     _suppressAlreadyCalled = False
 
     # Are we currently running a user-installed callback?  Meant to prevent
@@ -439,10 +430,10 @@ class Deferred(Awaitable[_SelfResultT]):
     # sets it directly.
     debug = False
 
-    _chainedTo: "Optional[Deferred[Any]]" = None
+    _chainedTo: Deferred[Any] | None = None
 
     def __init__(
-        self, canceller: Optional[Callable[["Deferred[Any]"], None]] = None
+        self, canceller: Callable[[Deferred[Any]], None] | None = None
     ) -> None:
         """
         Initialize a L{Deferred}.
@@ -467,42 +458,42 @@ class Deferred(Awaitable[_SelfResultT]):
         @type canceller: a 1-argument callable which takes a L{Deferred}. The
             return result is ignored.
         """
-        self._callbacks: List[_CallbackChain] = []
+        self._callbacks: list[_CallbackChain] = []
         self._canceller = canceller
         if self.debug:
             self._debugInfo = DebugInfo()
             self._debugInfo.creator = traceback.format_stack()[:-1]
 
     @deprecatedProperty(Version("Twisted", 25, 5, 0))
-    def callbacks(self) -> List[_CallbackChain]:
+    def callbacks(self) -> list[_CallbackChain]:
         return self._callbacks
 
     def addCallbacks(
         self,
-        callback: Union[
-            Callable[..., _NextResultT],
-            Callable[..., Deferred[_NextResultT]],
-            Callable[..., Failure],
-            Callable[
+        callback: (
+            Callable[..., _NextResultT]
+            | Callable[..., Deferred[_NextResultT]]
+            | Callable[..., Failure]
+            | Callable[
                 ...,
-                Union[_NextResultT, Deferred[_NextResultT], Failure],
-            ],
-        ],
-        errback: Union[
-            Callable[..., _NextResultT],
-            Callable[..., Deferred[_NextResultT]],
-            Callable[..., Failure],
-            Callable[
+                _NextResultT | Deferred[_NextResultT] | Failure,
+            ]
+        ),
+        errback: (
+            Callable[..., _NextResultT]
+            | Callable[..., Deferred[_NextResultT]]
+            | Callable[..., Failure]
+            | Callable[
                 ...,
-                Union[_NextResultT, Deferred[_NextResultT], Failure],
-            ],
-            None,
-        ] = None,
-        callbackArgs: Tuple[Any, ...] = (),
+                _NextResultT | Deferred[_NextResultT] | Failure,
+            ]
+            | None
+        ) = None,
+        callbackArgs: tuple[Any, ...] = (),
         callbackKeywords: Mapping[str, Any] = _NONE_KWARGS,
         errbackArgs: _CallbackOrderedArguments = (),
         errbackKeywords: _CallbackKeywordArguments = _NONE_KWARGS,
-    ) -> "Deferred[_NextResultT]":
+    ) -> Deferred[_NextResultT]:
         """
         Add a pair of callbacks (success and error) to this L{Deferred}.
 
@@ -570,7 +561,7 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         callback: Callable[
             Concatenate[_SelfResultT, _P],
-            Union[Failure, Deferred[_NextResultT]],
+            Failure | Deferred[_NextResultT],
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -580,7 +571,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addCallback(
         self,
-        callback: Callable[Concatenate[_SelfResultT, _P], Union[Failure, _NextResultT]],
+        callback: Callable[Concatenate[_SelfResultT, _P], Failure | _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -600,7 +591,7 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         callback: Callable[
             Concatenate[_SelfResultT, _P],
-            Union[Deferred[_NextResultT], _NextResultT],
+            Deferred[_NextResultT] | _NextResultT,
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -616,7 +607,7 @@ class Deferred(Awaitable[_SelfResultT]):
     ) -> Deferred[_NextResultT]:
         ...
 
-    def addCallback(self, callback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addCallback(self, callback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding just a callback.
 
@@ -637,7 +628,7 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], Deferred[_NextResultT]],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         ...
 
     @overload
@@ -646,7 +637,7 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], Failure],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT]]":
+    ) -> Deferred[_SelfResultT]:
         ...
 
     @overload
@@ -655,10 +646,10 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         ...
 
-    def addErrback(self, errback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addErrback(self, errback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding just an errback.
 
@@ -676,7 +667,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addBoth(
         self,
-        callback: Callable[Concatenate[Union[_SelfResultT, Failure], _P], Failure],
+        callback: Callable[Concatenate[_SelfResultT | Failure, _P], Failure],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -686,8 +677,8 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P],
-            Union[Failure, Deferred[_NextResultT]],
+            Concatenate[_SelfResultT | Failure, _P],
+            Failure | Deferred[_NextResultT],
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -698,7 +689,7 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P], Union[Failure, _NextResultT]
+            Concatenate[_SelfResultT | Failure, _P], Failure | _NextResultT
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -709,7 +700,7 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P], Deferred[_NextResultT]
+            Concatenate[_SelfResultT | Failure, _P], Deferred[_NextResultT]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -720,8 +711,8 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P],
-            Union[Deferred[_NextResultT], _NextResultT],
+            Concatenate[_SelfResultT | Failure, _P],
+            Deferred[_NextResultT] | _NextResultT,
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -731,7 +722,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addBoth(
         self,
-        callback: Callable[Concatenate[Union[_SelfResultT, Failure], _P], _NextResultT],
+        callback: Callable[Concatenate[_SelfResultT | Failure, _P], _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -746,7 +737,7 @@ class Deferred(Awaitable[_SelfResultT]):
     ) -> Deferred[_SelfResultT]:
         ...
 
-    def addBoth(self, callback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addBoth(self, callback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding a single callable as both a callback
         and an errback.
@@ -769,13 +760,14 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         timeout: float,
         clock: IReactorTime,
-        onTimeoutCancel: Optional[
+        onTimeoutCancel: None
+        | (
             Callable[
-                [Union[_SelfResultT, Failure], float],
-                Union[_NextResultT, Failure],
+                [_SelfResultT | Failure, float],
+                _NextResultT | Failure,
             ]
-        ] = None,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+        ) = None,
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         """
         Time out this L{Deferred} by scheduling it to be cancelled after
         C{timeout} seconds.
@@ -813,8 +805,8 @@ class Deferred(Awaitable[_SelfResultT]):
         delayedCall = clock.callLater(timeout, timeItOut)
 
         def convertCancelled(
-            result: Union[_SelfResultT, Failure],
-        ) -> Union[_SelfResultT, _NextResultT, Failure]:
+            result: _SelfResultT | Failure,
+        ) -> _SelfResultT | _NextResultT | Failure:
             # if C{deferred} was timed out, call the translation function,
             # if provided, otherwise just use L{cancelledToTimedOutError}
             if timedOut[0]:
@@ -831,12 +823,12 @@ class Deferred(Awaitable[_SelfResultT]):
         # Note: Mypy cannot infer this type, apparently thanks to the ambiguity
         # of _SelfResultT / _NextResultT both being unbound.  Explicitly
         # annotating it seems to do the trick though.
-        converted: Deferred[Union[_SelfResultT, _NextResultT]] = self.addBoth(
+        converted: Deferred[_SelfResultT | _NextResultT] = self.addBoth(
             convertCancelled
         )
         return converted.addBoth(cancelTimeout)
 
-    def chainDeferred(self, d: "Deferred[_SelfResultT]") -> "Deferred[None]":
+    def chainDeferred(self, d: Deferred[_SelfResultT]) -> Deferred[None]:
         """
         Chain another L{Deferred} to this L{Deferred}.
 
@@ -863,7 +855,7 @@ class Deferred(Awaitable[_SelfResultT]):
         d._chainedTo = self
         return self.addCallbacks(d.callback, d.errback)
 
-    def callback(self, result: Union[_SelfResultT, Failure]) -> None:
+    def callback(self, result: _SelfResultT | Failure) -> None:
         """
         Run all success callbacks that have been added to this L{Deferred}.
 
@@ -888,7 +880,7 @@ class Deferred(Awaitable[_SelfResultT]):
         """
         self._startRunCallbacks(result)
 
-    def errback(self, fail: Optional[Union[Failure, BaseException]] = None) -> None:
+    def errback(self, fail: Failure | BaseException | None = None) -> None:
         """
         Run all error callbacks that have been added to this L{Deferred}.
 
@@ -1037,7 +1029,7 @@ class Deferred(Awaitable[_SelfResultT]):
         # added its _continuation() to the callbacks list of a second Deferred
         # and then that second Deferred being fired.  ie, if ever had _chainedTo
         # set to something other than None, you might end up on this stack.
-        chain: List[Deferred[Any]] = [self]
+        chain: list[Deferred[Any]] = [self]
 
         while chain:
             current = chain[-1]
@@ -1196,7 +1188,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
     __await__ = __iter__
 
-    def asFuture(self, loop: AbstractEventLoop) -> "Future[_SelfResultT]":
+    def asFuture(self, loop: AbstractEventLoop) -> Future[_SelfResultT]:
         """
         Adapt this L{Deferred} into a L{Future} which is bound to C{loop}.
 
@@ -1213,7 +1205,7 @@ class Deferred(Awaitable[_SelfResultT]):
         """
         future = loop.create_future()
 
-        def checkCancel(futureAgain: "Future[_SelfResultT]") -> None:
+        def checkCancel(futureAgain: Future[_SelfResultT]) -> None:
             if futureAgain.cancelled():
                 self.cancel()
 
@@ -1231,7 +1223,7 @@ class Deferred(Awaitable[_SelfResultT]):
         return future
 
     @classmethod
-    def fromFuture(cls, future: "Future[_SelfResultT]") -> "Deferred[_SelfResultT]":
+    def fromFuture(cls, future: Future[_SelfResultT]) -> Deferred[_SelfResultT]:
         """
         Adapt a L{Future} to a L{Deferred}.
 
@@ -1268,7 +1260,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
         def uncancel(
             result: _SelfResultT,
-        ) -> Union[_SelfResultT, Deferred[_SelfResultT]]:
+        ) -> _SelfResultT | Deferred[_SelfResultT]:
             if result is futureCancel:
                 nonlocal actual
                 actual = Deferred()
@@ -1283,11 +1275,8 @@ class Deferred(Awaitable[_SelfResultT]):
     @classmethod
     def fromCoroutine(
         cls,
-        coro: Union[
-            Coroutine[Deferred[Any], Any, _T],
-            Generator[Deferred[Any], Any, _T],
-        ],
-    ) -> "Deferred[_T]":
+        coro: (Coroutine[Deferred[Any], Any, _T] | Generator[Deferred[Any], Any, _T]),
+    ) -> Deferred[_T]:
         """
         Schedule the execution of a coroutine that awaits on L{Deferred}s,
         wrapping it in a L{Deferred} that will fire on success/failure of the
@@ -1330,7 +1319,7 @@ class Deferred(Awaitable[_SelfResultT]):
             return _cancellableInlineCallbacks(coro)
         raise NotACoroutineError(f"{coro!r} is not a coroutine")
 
-    def __init_subclass__(cls: Type[Deferred[Any]], **kwargs: Any):
+    def __init_subclass__(cls: type[Deferred[Any]], **kwargs: Any):
         # Whenever a subclass is created, record it in L{_DEFERRED_SUBCLASSES}
         # so we can emulate C{isinstance()} more efficiently.
         _DEFERRED_SUBCLASSES.append(cls)
@@ -1340,11 +1329,11 @@ _DEFERRED_SUBCLASSES = [Deferred]
 
 
 def ensureDeferred(
-    coro: Union[
-        Coroutine[Deferred[Any], Any, _T],
-        Generator[Deferred[Any], Any, _T],
-        Deferred[_T],
-    ],
+    coro: (
+        Coroutine[Deferred[Any], Any, _T]
+        | Generator[Deferred[Any], Any, _T]
+        | Deferred[_T]
+    )
 ) -> Deferred[_T]:
     """
     Schedule the execution of a coroutine that awaits/yields from L{Deferred}s,
@@ -1411,9 +1400,9 @@ class FirstError(Exception):
         return -1
 
 
-_DeferredListSingleResultT = Tuple[_SelfResultT, int]
-_DeferredListResultItemT = Tuple[bool, _SelfResultT]
-_DeferredListResultListT = List[_DeferredListResultItemT[_SelfResultT]]
+_DeferredListSingleResultT = tuple[_SelfResultT, int]
+_DeferredListResultItemT = tuple[bool, _SelfResultT]
+_DeferredListResultListT = list[_DeferredListResultItemT[_SelfResultT]]
 
 if TYPE_CHECKING:
     # The result type is different depending on whether fireOnOneCallback
@@ -1444,10 +1433,10 @@ if TYPE_CHECKING:
         fireOnOneCallback: bool = False,
         fireOnOneErrback: bool = False,
         consumeErrors: bool = False,
-    ) -> Union[
-        Deferred[_DeferredListSingleResultT[_SelfResultT]],
-        Deferred[_DeferredListResultListT[_SelfResultT]],
-    ]:
+    ) -> (
+        Deferred[_DeferredListSingleResultT[_SelfResultT]]
+        | Deferred[_DeferredListResultListT[_SelfResultT]]
+    ):
         ...
 
     DeferredList = _DeferredList
@@ -1519,7 +1508,7 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
         # Note this contains optional result values as the DeferredList is
         # processing its results, even though the callback result will not,
         # which is why we aren't using _DeferredListResultListT here.
-        self.resultList: List[Optional[_DeferredListResultItemT[Any]]] = [None] * len(
+        self.resultList: list[_DeferredListResultItemT[Any] | None] = [None] * len(
             self._deferredList
         )
         """
@@ -1553,7 +1542,7 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
 
     def _cbDeferred(
         self, result: _SelfResultT, index: int, succeeded: bool
-    ) -> Optional[_SelfResultT]:
+    ) -> _SelfResultT | None:
         """
         (internal) Callback for when one of my deferreds fires.
         """
@@ -1598,8 +1587,8 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
 
 
 def _parseDeferredListResult(
-    resultList: List[_DeferredListResultItemT[_T]], fireOnOneErrback: bool = False, /
-) -> List[_T]:
+    resultList: list[_DeferredListResultItemT[_T]], fireOnOneErrback: bool = False, /
+) -> list[_T]:
     if __debug__:
         for result in resultList:
             assert result is not None
@@ -1610,7 +1599,7 @@ def _parseDeferredListResult(
 
 def gatherResults(
     deferredList: Iterable[Deferred[_T]], consumeErrors: bool = False
-) -> Deferred[List[_T]]:
+) -> Deferred[list[_T]]:
     """
     Returns, via a L{Deferred}, a list with the results of the given
     L{Deferred}s - in effect, a "join" of multiple deferred operations.
@@ -1643,7 +1632,7 @@ class FailureGroup(Exception):
     """
 
     def __init__(self, failures: Sequence[Failure]) -> None:
-        super(FailureGroup, self).__init__()
+        super().__init__()
         self.failures = failures
 
 
@@ -1662,7 +1651,7 @@ def race(ds: Sequence[Deferred[_T]]) -> Deferred[tuple[int, _T]]:
     # shouldn't be.  Even though it "completed" it isn't really done - the
     # caller will still be using it for something.  If we cancelled it,
     # cancellation could propagate down to them.
-    winner: Optional[Deferred[_T]] = None
+    winner: Deferred[_T] | None = None
 
     # The cancellation function for the Deferred this function returns.
     def cancel(result: Deferred[_T]) -> None:
@@ -1771,16 +1760,13 @@ class _CancellationStatus(Generic[_SelfResultT]):
     """
 
     deferred: Deferred[_SelfResultT]
-    waitingOn: Optional[Deferred[_SelfResultT]] = None
+    waitingOn: Deferred[_SelfResultT] | None = None
 
 
 def _gotResultInlineCallbacks(
     r: object,
-    waiting: List[Any],
-    gen: Union[
-        Generator[Deferred[Any], Any, _T],
-        Coroutine[Deferred[Any], Any, _T],
-    ],
+    waiting: list[Any],
+    gen: (Generator[Deferred[Any], Any, _T] | Coroutine[Deferred[Any], Any, _T]),
     status: _CancellationStatus[_T],
     context: _Context,
 ) -> None:
@@ -1804,10 +1790,7 @@ def _gotResultInlineCallbacks(
 @_extraneous
 def _inlineCallbacks(
     result: object,
-    gen: Union[
-        Generator[Deferred[Any], Any, _T],
-        Coroutine[Deferred[Any], Any, _T],
-    ],
+    gen: (Generator[Deferred[Any], Any, _T] | Coroutine[Deferred[Any], Any, _T]),
     status: _CancellationStatus[_T],
     context: _Context,
 ) -> None:
@@ -1837,7 +1820,7 @@ def _inlineCallbacks(
     # recursion.
 
     # waiting for result?  # result
-    waiting: List[Any] = [True, None]
+    waiting: list[Any] = [True, None]
 
     stopIteration: bool = False
     callbackValue: Any = None
@@ -2015,10 +1998,7 @@ def _handleCancelInlineCallbacks(
 
 
 def _cancellableInlineCallbacks(
-    gen: Union[
-        Generator[Deferred[Any], object, _T],
-        Coroutine[Deferred[Any], object, _T],
-    ],
+    gen: (Generator[Deferred[Any], object, _T] | Coroutine[Deferred[Any], object, _T])
 ) -> Deferred[_T]:
     """
     Make an C{@}L{inlineCallbacks} cancellable.
@@ -2132,7 +2112,7 @@ def inlineCallbacks(
 
 class _ConcurrencyPrimitive(ABC):
     def __init__(self: Self) -> None:
-        self.waiting: List[Deferred[Self]] = []
+        self.waiting: list[Deferred[Self]] = []
 
     def _releaseAndReturn(self, r: _T) -> _T:
         self.release()
@@ -2167,7 +2147,7 @@ class _ConcurrencyPrimitive(ABC):
     def run(
         self: Self,
         /,
-        f: Callable[_P, Union[Deferred[_T], Coroutine[Deferred[Any], Any, _T], _T]],
+        f: Callable[_P, Deferred[_T] | Coroutine[Deferred[Any], Any, _T] | _T],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_T]:
@@ -2202,9 +2182,9 @@ class _ConcurrencyPrimitive(ABC):
 
     def __aexit__(
         self,
-        __exc_type: Optional[Type[BaseException]],
-        __exc_value: Optional[BaseException],
-        __traceback: Optional[TracebackType],
+        __exc_type: type[BaseException] | None,
+        __exc_value: BaseException | None,
+        __traceback: TracebackType | None,
     ) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the
@@ -2377,11 +2357,9 @@ class DeferredQueue(Generic[_T]):
         for no limit.
     """
 
-    def __init__(
-        self, size: Optional[int] = None, backlog: Optional[int] = None
-    ) -> None:
-        self.waiting: List[Deferred[_T]] = []
-        self.pending: List[_T] = []
+    def __init__(self, size: int | None = None, backlog: int | None = None) -> None:
+        self.waiting: list[Deferred[_T]] = []
+        self.pending: list[_T] = []
         self.size = size
         self.backlog = backlog
 
@@ -2455,10 +2433,10 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
     """
 
     _interval = 1
-    _tryLockCall: Optional[IDelayedCall] = None
-    _timeoutCall: Optional[IDelayedCall] = None
+    _tryLockCall: IDelayedCall | None = None
+    _timeoutCall: IDelayedCall | None = None
 
-    def __init__(self, name: str, scheduler: Optional[IReactorTime] = None) -> None:
+    def __init__(self, name: str, scheduler: IReactorTime | None = None) -> None:
         """
         @param name: The name of the lock to acquire
         @param scheduler: An object which provides L{IReactorTime}
@@ -2472,7 +2450,7 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
 
         self._scheduler = scheduler
 
-    def deferUntilLocked(self, timeout: Optional[float] = None) -> Deferred[None]:
+    def deferUntilLocked(self, timeout: float | None = None) -> Deferred[None]:
         """
         Wait until we acquire this lock.  This method is not safe for
         concurrent use.
@@ -2492,7 +2470,7 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
                 )
             )
 
-        def _cancelLock(reason: Union[Failure, Exception]) -> None:
+        def _cancelLock(reason: Failure | Exception) -> None:
             """
             Cancel a L{DeferredFilesystemLock.deferUntilLocked} call.
 

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -18,27 +18,15 @@ import os
 import re
 import socket
 import warnings
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Iterable,
-    List,
-    Optional,
-    Protocol as TypingProtocol,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from collections.abc import Iterable, Sequence
+from typing import Any, Callable, ClassVar, Protocol as TypingProtocol, TypeVar, Union
 from unicodedata import normalize
 
 from zope.interface import directlyProvides, implementer
 
 from constantly import NamedConstant, Names
 from incremental import Version
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, TypeAlias
 
 from twisted.internet import defer, error, fdesc, interfaces, threads
 from twisted.internet.abstract import isIPv6Address
@@ -753,15 +741,15 @@ class TCP6ClientEndpoint:
             return defer.fail()
 
 
-_gairesult = List[
-    Tuple[
+_gairesult: TypeAlias = list[
+    tuple[
         socket.AddressFamily,
         socket.SocketKind,
         int,
         str,
         Union[
-            Tuple[str, int],
-            Tuple[str, int, int, int],
+            tuple[str, int],
+            tuple[str, int, int, int],
         ],
     ]
 ]
@@ -798,7 +786,7 @@ class _SimpleHostnameResolver:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -1641,8 +1629,8 @@ class _SystemdParser:
         self,
         reactor: IReactorSocket,
         domain: str,
-        index: Optional[str] = None,
-        name: Optional[str] = None,
+        index: str | None = None,
+        name: str | None = None,
     ) -> AdoptedStreamServerEndpoint:
         """
         Internal parser function for L{_parseServer} to convert the string

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -8,20 +8,8 @@ Maintainer: Itamar Shtull-Trauring
 """
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Callable,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, AnyStr, Callable
 
 from zope.interface import Attribute, Interface
 
@@ -104,7 +92,7 @@ class IConnector(Interface):
 
 
 class IResolverSimple(Interface):
-    def getHostByName(name: str, timeout: Sequence[int] = ()) -> "Deferred[str]":
+    def getHostByName(name: str, timeout: Sequence[int] = ()) -> Deferred[str]:
         """
         Resolve the domain name C{name} into an IP address.
 
@@ -192,7 +180,7 @@ class IHostnameResolver(Interface):
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -222,8 +210,8 @@ class IHostnameResolver(Interface):
 
 class IResolver(IResolverSimple):
     def query(
-        query: "Query", timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+        query: Query, timeout: Sequence[int]
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Dispatch C{query} to the method which can handle its type.
 
@@ -243,7 +231,7 @@ class IResolver(IResolverSimple):
 
     def lookupAddress(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an A record lookup.
 
@@ -262,7 +250,7 @@ class IResolver(IResolverSimple):
 
     def lookupAddress6(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an A6 record lookup.
 
@@ -281,7 +269,7 @@ class IResolver(IResolverSimple):
 
     def lookupIPV6Address(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AAAA record lookup.
 
@@ -300,7 +288,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailExchange(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MX record lookup.
 
@@ -319,7 +307,7 @@ class IResolver(IResolverSimple):
 
     def lookupNameservers(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an NS record lookup.
 
@@ -338,7 +326,7 @@ class IResolver(IResolverSimple):
 
     def lookupCanonicalName(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a CNAME record lookup.
 
@@ -357,7 +345,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailBox(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MB record lookup.
 
@@ -376,7 +364,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailGroup(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MG record lookup.
 
@@ -395,7 +383,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailRename(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MR record lookup.
 
@@ -414,7 +402,7 @@ class IResolver(IResolverSimple):
 
     def lookupPointer(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a PTR record lookup.
 
@@ -433,7 +421,7 @@ class IResolver(IResolverSimple):
 
     def lookupAuthority(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an SOA record lookup.
 
@@ -452,7 +440,7 @@ class IResolver(IResolverSimple):
 
     def lookupNull(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a NULL record lookup.
 
@@ -471,7 +459,7 @@ class IResolver(IResolverSimple):
 
     def lookupWellKnownServices(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a WKS record lookup.
 
@@ -490,7 +478,7 @@ class IResolver(IResolverSimple):
 
     def lookupHostInfo(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a HINFO record lookup.
 
@@ -509,7 +497,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailboxInfo(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MINFO record lookup.
 
@@ -528,7 +516,7 @@ class IResolver(IResolverSimple):
 
     def lookupText(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a TXT record lookup.
 
@@ -547,7 +535,7 @@ class IResolver(IResolverSimple):
 
     def lookupResponsibility(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an RP record lookup.
 
@@ -566,7 +554,7 @@ class IResolver(IResolverSimple):
 
     def lookupAFSDatabase(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AFSDB record lookup.
 
@@ -585,7 +573,7 @@ class IResolver(IResolverSimple):
 
     def lookupService(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an SRV record lookup.
 
@@ -604,7 +592,7 @@ class IResolver(IResolverSimple):
 
     def lookupAllRecords(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an ALL_RECORD lookup.
 
@@ -623,7 +611,7 @@ class IResolver(IResolverSimple):
 
     def lookupSenderPolicy(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a SPF record lookup.
 
@@ -642,7 +630,7 @@ class IResolver(IResolverSimple):
 
     def lookupNamingAuthorityPointer(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a NAPTR record lookup.
 
@@ -661,7 +649,7 @@ class IResolver(IResolverSimple):
 
     def lookupZone(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AXFR record lookup.
 
@@ -689,10 +677,10 @@ class IResolver(IResolverSimple):
 class IReactorTCP(Interface):
     def listenTCP(
         port: int,
-        factory: "ServerFactory",
+        factory: ServerFactory,
         backlog: int = 50,
         interface: str = "",
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
 
@@ -714,9 +702,9 @@ class IReactorTCP(Interface):
     def connectTCP(
         host: str,
         port: int,
-        factory: "ClientFactory",
+        factory: ClientFactory,
         timeout: float = 30.0,
-        bindAddress: Optional[Tuple[str, int]] = None,
+        bindAddress: tuple[str, int] | None = None,
     ) -> IConnector:
         """
         Connect a TCP client.
@@ -741,10 +729,10 @@ class IReactorSSL(Interface):
     def connectSSL(
         host: str,
         port: int,
-        factory: "ClientFactory",
-        contextFactory: "ClientContextFactory",
+        factory: ClientFactory,
+        contextFactory: ClientContextFactory,
         timeout: float,
-        bindAddress: Optional[Tuple[str, int]],
+        bindAddress: tuple[str, int] | None,
     ) -> IConnector:
         """
         Connect a client Protocol to a remote SSL socket.
@@ -763,11 +751,11 @@ class IReactorSSL(Interface):
 
     def listenSSL(
         port: int,
-        factory: "ServerFactory",
-        contextFactory: "IOpenSSLContextFactory",
+        factory: ServerFactory,
+        contextFactory: IOpenSSLContextFactory,
         backlog: int,
         interface: str,
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
         The connection is a SSL one, using contexts created by the context
@@ -788,7 +776,7 @@ class IReactorUNIX(Interface):
 
     def connectUNIX(
         address: str,
-        factory: "ClientFactory",
+        factory: ClientFactory,
         timeout: float = 30,
         checkPID: bool = False,
     ) -> IConnector:
@@ -808,11 +796,11 @@ class IReactorUNIX(Interface):
 
     def listenUNIX(
         address: str,
-        factory: "Factory",
+        factory: Factory,
         backlog: int = 50,
         mode: int = 0o666,
         wantPID: bool = False,
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Listen on a UNIX socket.
 
@@ -836,10 +824,10 @@ class IReactorUNIXDatagram(Interface):
 
     def connectUNIXDatagram(
         address: str,
-        protocol: "ConnectedDatagramProtocol",
+        protocol: ConnectedDatagramProtocol,
         maxPacketSize: int,
         mode: int,
-        bindAddress: Optional[Tuple[str, int]],
+        bindAddress: tuple[str, int] | None,
     ) -> IConnector:
         """
         Connect a client protocol to a datagram UNIX socket.
@@ -857,8 +845,8 @@ class IReactorUNIXDatagram(Interface):
         """
 
     def listenUNIXDatagram(
-        address: str, protocol: "DatagramProtocol", maxPacketSize: int, mode: int
-    ) -> "IListeningPort":
+        address: str, protocol: DatagramProtocol, maxPacketSize: int, mode: int
+    ) -> IListeningPort:
         """
         Listen on a datagram UNIX socket.
 
@@ -880,7 +868,7 @@ class IReactorWin32Events(Interface):
     @since: 10.2
     """
 
-    def addEvent(event: object, fd: "FileDescriptor", action: str) -> None:
+    def addEvent(event: object, fd: FileDescriptor, action: str) -> None:
         """
         Add a new win32 event to the event loop.
 
@@ -906,8 +894,8 @@ class IReactorUDP(Interface):
     """
 
     def listenUDP(
-        port: int, protocol: "DatagramProtocol", interface: str, maxPacketSize: int
-    ) -> "IListeningPort":
+        port: int, protocol: DatagramProtocol, interface: str, maxPacketSize: int
+    ) -> IListeningPort:
         """
         Connects a given L{DatagramProtocol} to the given numeric UDP port.
 
@@ -932,7 +920,7 @@ class IReactorMulticast(Interface):
 
     def listenMulticast(
         port: int,
-        protocol: "DatagramProtocol",
+        protocol: DatagramProtocol,
         interface: str = "",
         maxPacketSize: int = 8192,
         listenMultiple: bool = False,
@@ -1002,8 +990,8 @@ class IReactorSocket(Interface):
     """
 
     def adoptStreamPort(
-        fileDescriptor: int, addressFamily: "AddressFamily", factory: "ServerFactory"
-    ) -> "IListeningPort":
+        fileDescriptor: int, addressFamily: AddressFamily, factory: ServerFactory
+    ) -> IListeningPort:
         """
         Add an existing listening I{SOCK_STREAM} socket to the reactor to
         monitor for new connections to accept and handle.
@@ -1030,7 +1018,7 @@ class IReactorSocket(Interface):
         """
 
     def adoptStreamConnection(
-        fileDescriptor: int, addressFamily: "AddressFamily", factory: "ServerFactory"
+        fileDescriptor: int, addressFamily: AddressFamily, factory: ServerFactory
     ) -> None:
         """
         Add an existing connected I{SOCK_STREAM} socket to the reactor to
@@ -1060,10 +1048,10 @@ class IReactorSocket(Interface):
 
     def adoptDatagramPort(
         fileDescriptor: int,
-        addressFamily: "AddressFamily",
-        protocol: "DatagramProtocol",
+        addressFamily: AddressFamily,
+        protocol: DatagramProtocol,
         maxPacketSize: int,
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Add an existing listening I{SOCK_DGRAM} socket to the reactor to
         monitor for read and write readiness.
@@ -1092,16 +1080,16 @@ class IReactorSocket(Interface):
 
 class IReactorProcess(Interface):
     def spawnProcess(
-        processProtocol: "IProcessProtocol",
-        executable: Union[bytes, str],
-        args: Sequence[Union[bytes, str]],
-        env: Optional[Mapping[AnyStr, AnyStr]] = None,
-        path: Union[None, bytes, str] = None,
-        uid: Optional[int] = None,
-        gid: Optional[int] = None,
+        processProtocol: IProcessProtocol,
+        executable: bytes | str,
+        args: Sequence[bytes | str],
+        env: Mapping[AnyStr, AnyStr] | None = None,
+        path: None | bytes | str = None,
+        uid: int | None = None,
+        gid: int | None = None,
         usePTY: bool = False,
-        childFDs: Optional[Mapping[int, Union[int, str]]] = None,
-    ) -> "IProcessTransport":
+        childFDs: Mapping[int, int | str] | None = None,
+    ) -> IProcessTransport:
         """
         Spawn a process, with a process protocol.
 
@@ -1202,7 +1190,7 @@ class IReactorTime(Interface):
 
     def callLater(
         delay: float, callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> "IDelayedCall":
+    ) -> IDelayedCall:
         """
         Call a function later.
 
@@ -1217,7 +1205,7 @@ class IReactorTime(Interface):
                  C{reset()} methods.
         """
 
-    def getDelayedCalls() -> Sequence["IDelayedCall"]:
+    def getDelayedCalls() -> Sequence[IDelayedCall]:
         """
         See L{twisted.internet.interfaces.IReactorTime.getDelayedCalls}
         """
@@ -1331,7 +1319,7 @@ class IReactorThreads(IReactorFromThreads, IReactorInThreads):
     Internally, this should use a thread pool and dispatch methods to them.
     """
 
-    def getThreadPool() -> "ThreadPool":
+    def getThreadPool() -> ThreadPool:
         """
         Return the threadpool used by L{IReactorInThreads.callInThread}.
         Create it first if necessary.
@@ -1354,7 +1342,7 @@ class IReactorCore(Interface):
         "I{during shutdown} and C{False} the rest of the time."
     )
 
-    def resolve(name: str, timeout: Sequence[int] = (1, 3, 11, 45)) -> "Deferred[str]":
+    def resolve(name: str, timeout: Sequence[int] = (1, 3, 11, 45)) -> Deferred[str]:
         """
         Asynchronously resolve a hostname to a single IPv4 address.
 
@@ -1474,7 +1462,7 @@ class IReactorCore(Interface):
 
     def callWhenRunning(
         callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> Optional[Any]:
+    ) -> Any | None:
         """
         Call a function when the reactor is running.
 
@@ -1566,7 +1554,7 @@ class IReactorFDSet(Interface):
     (or at least similarly opaque IDs returned from a .fileno() method)
     """
 
-    def addReader(reader: "IReadDescriptor") -> None:
+    def addReader(reader: IReadDescriptor) -> None:
         """
         I add reader to the set of file descriptors to get read events for.
 
@@ -1575,7 +1563,7 @@ class IReactorFDSet(Interface):
                        L{removeReader}.
         """
 
-    def addWriter(writer: "IWriteDescriptor") -> None:
+    def addWriter(writer: IWriteDescriptor) -> None:
         """
         I add writer to the set of file descriptors to get write events for.
 
@@ -1584,17 +1572,17 @@ class IReactorFDSet(Interface):
                        L{removeWriter}.
         """
 
-    def removeReader(reader: "IReadDescriptor") -> None:
+    def removeReader(reader: IReadDescriptor) -> None:
         """
         Removes an object previously added with L{addReader}.
         """
 
-    def removeWriter(writer: "IWriteDescriptor") -> None:
+    def removeWriter(writer: IWriteDescriptor) -> None:
         """
         Removes an object previously added with L{addWriter}.
         """
 
-    def removeAll() -> List[Union["IReadDescriptor", "IWriteDescriptor"]]:
+    def removeAll() -> list[IReadDescriptor | IWriteDescriptor]:
         """
         Remove all readers and writers.
 
@@ -1604,7 +1592,7 @@ class IReactorFDSet(Interface):
                  which were removed.
         """
 
-    def getReaders() -> List["IReadDescriptor"]:
+    def getReaders() -> list[IReadDescriptor]:
         """
         Return the list of file descriptors currently monitored for input
         events by the reactor.
@@ -1612,7 +1600,7 @@ class IReactorFDSet(Interface):
         @return: the list of file descriptors monitored for input events.
         """
 
-    def getWriters() -> List["IWriteDescriptor"]:
+    def getWriters() -> list[IWriteDescriptor]:
         """
         Return the list file descriptors currently monitored for output events
         by the reactor.
@@ -1635,7 +1623,7 @@ class IListeningPort(Interface):
                                   port number).
         """
 
-    def stopListening() -> Optional["Deferred[None]"]:
+    def stopListening() -> Deferred[None] | None:
         """
         Stop listening on this port.
 
@@ -1703,7 +1691,7 @@ class IReadDescriptor(IFileDescriptor):
     This interface is generally used in conjunction with L{IReactorFDSet}.
     """
 
-    def doRead() -> Optional[Failure]:
+    def doRead() -> Failure | None:
         """
         Some data is available for reading on your descriptor.
 
@@ -1720,7 +1708,7 @@ class IWriteDescriptor(IFileDescriptor):
     This interface is generally used in conjunction with L{IReactorFDSet}.
     """
 
-    def doWrite() -> Optional[Failure]:
+    def doWrite() -> Failure | None:
         """
         Some data can be written to your descriptor.
 
@@ -1775,7 +1763,7 @@ class IConsumer(Interface):
     A consumer consumes data from a producer.
     """
 
-    def registerProducer(producer: "IProducer", streaming: bool) -> None:
+    def registerProducer(producer: IProducer, streaming: bool) -> None:
         """
         Register to receive data from a producer.
 
@@ -1905,7 +1893,7 @@ class IProtocol(Interface):
         of one of those).
         """
 
-    def makeConnection(transport: "ITransport") -> None:
+    def makeConnection(transport: ITransport) -> None:
         """
         Make a connection to a transport and a server.
         """
@@ -1928,7 +1916,7 @@ class IProcessProtocol(Interface):
     Interface for process-related event handlers.
     """
 
-    def makeConnection(process: "IProcessTransport") -> None:
+    def makeConnection(process: IProcessTransport) -> None:
         """
         Called when the process has been created.
 
@@ -2060,7 +2048,7 @@ class IProtocolFactory(Interface):
     Interface for protocol factories.
     """
 
-    def buildProtocol(addr: IAddress) -> Optional[IProtocol]:
+    def buildProtocol(addr: IAddress) -> IProtocol | None:
         """
         Called when a connection has been established to addr.
 
@@ -2203,12 +2191,12 @@ class ITCPTransport(ITransport):
         to allow detection of lost peers in a non-infinite amount of time.
         """
 
-    def getHost() -> Union["IPv4Address", "IPv6Address"]:
+    def getHost() -> IPv4Address | IPv6Address:
         """
         Returns L{IPv4Address} or L{IPv6Address}.
         """
 
-    def getPeer() -> Union["IPv4Address", "IPv6Address"]:
+    def getPeer() -> IPv4Address | IPv6Address:
         """
         Returns L{IPv4Address} or L{IPv6Address}.
         """
@@ -2255,8 +2243,8 @@ class IOpenSSLServerConnectionCreator(Interface):
     """
 
     def serverConnectionForTLS(
-        tlsProtocol: "TLSMemoryBIOProtocol",
-    ) -> "OpenSSLConnection":
+        tlsProtocol: TLSMemoryBIOProtocol,
+    ) -> OpenSSLConnection:
         """
         Create a connection for the given server protocol.
 
@@ -2279,8 +2267,8 @@ class IOpenSSLClientConnectionCreator(Interface):
     """
 
     def clientConnectionForTLS(
-        tlsProtocol: "TLSMemoryBIOProtocol",
-    ) -> "OpenSSLConnection":
+        tlsProtocol: TLSMemoryBIOProtocol,
+    ) -> OpenSSLConnection:
         """
         Create a connection for the given client protocol.
 
@@ -2301,7 +2289,7 @@ class IProtocolNegotiationFactory(Interface):
     @see: L{twisted.internet.ssl}
     """
 
-    def acceptableProtocols() -> List[bytes]:
+    def acceptableProtocols() -> list[bytes]:
         """
         Returns a list of protocols that can be spoken by the connection
         factory in the form of ALPN tokens, as laid out in the IANA registry
@@ -2321,7 +2309,7 @@ class IOpenSSLContextFactory(Interface):
     @see: L{twisted.internet.ssl}
     """
 
-    def getContext() -> "OpenSSLContext":
+    def getContext() -> OpenSSLContext:
         """
         Returns a TLS context object, suitable for securing a TLS connection.
         This context object will be appropriately customized for the connection
@@ -2339,9 +2327,9 @@ class ITLSTransport(ITCPTransport):
     """
 
     def startTLS(
-        contextFactory: Union[
-            IOpenSSLClientConnectionCreator, IOpenSSLServerConnectionCreator
-        ]
+        contextFactory: (
+            IOpenSSLClientConnectionCreator | IOpenSSLServerConnectionCreator
+        ),
     ) -> None:
         """
         Initiate TLS negotiation.
@@ -2403,7 +2391,7 @@ class IAcceptableCiphers(Interface):
     A list of acceptable ciphers for a TLS context.
     """
 
-    def selectCiphers(availableCiphers: Tuple[ICipher]) -> Tuple[ICipher]:
+    def selectCiphers(availableCiphers: tuple[ICipher]) -> tuple[ICipher]:
         """
         Choose which ciphers to allow to be negotiated on a TLS connection.
 
@@ -2468,7 +2456,7 @@ class IProcessTransport(ITransport):
         Close stdin, stderr and stdout.
         """
 
-    def signalProcess(signalID: Union[str, int]) -> None:
+    def signalProcess(signalID: str | int) -> None:
         """
         Send a signal to the process.
 
@@ -2515,7 +2503,7 @@ class IUDPTransport(Interface):
     Transport for UDP DatagramProtocols.
     """
 
-    def write(packet: bytes, addr: Optional[Tuple[str, int]]) -> None:
+    def write(packet: bytes, addr: tuple[str, int] | None) -> None:
         """
         Write packet to given address.
 
@@ -2540,14 +2528,14 @@ class IUDPTransport(Interface):
         @param port: port to connect to.
         """
 
-    def getHost() -> Union["IPv4Address", "IPv6Address"]:
+    def getHost() -> IPv4Address | IPv6Address:
         """
         Get this port's host address.
 
         @return: an address describing the listening port.
         """
 
-    def stopListening() -> Optional["Deferred[None]"]:
+    def stopListening() -> Deferred[None] | None:
         """
         Stop listening on this port.
 
@@ -2580,7 +2568,7 @@ class IUNIXDatagramTransport(Interface):
         Write packet to given address.
         """
 
-    def getHost() -> "UNIXAddress":
+    def getHost() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
@@ -2596,12 +2584,12 @@ class IUNIXDatagramConnectedTransport(Interface):
         Write packet to address we are connected to.
         """
 
-    def getHost() -> "UNIXAddress":
+    def getHost() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
 
-    def getPeer() -> "UNIXAddress":
+    def getPeer() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
@@ -2648,7 +2636,7 @@ class IMulticastTransport(IUDPTransport):
         Set time to live on multicast packets.
         """
 
-    def joinGroup(addr: str, interface: str = "") -> "Deferred[None]":
+    def joinGroup(addr: str, interface: str = "") -> Deferred[None]:
         """
         Join a multicast group. Returns L{Deferred} of success or failure.
 
@@ -2656,7 +2644,7 @@ class IMulticastTransport(IUDPTransport):
         L{error.MulticastJoinError}.
         """
 
-    def leaveGroup(addr: str, interface: str = "") -> "Deferred[None]":
+    def leaveGroup(addr: str, interface: str = "") -> Deferred[None]:
         """
         Leave multicast group, return L{Deferred} of success.
         """
@@ -2670,7 +2658,7 @@ class IStreamClientEndpoint(Interface):
     @since: 10.1
     """
 
-    def connect(protocolFactory: IProtocolFactory) -> "Deferred[IProtocol]":
+    def connect(protocolFactory: IProtocolFactory) -> Deferred[IProtocol]:
         """
         Connect the C{protocolFactory} to the location specified by this
         L{IStreamClientEndpoint} provider.
@@ -2691,7 +2679,7 @@ class IStreamServerEndpoint(Interface):
     @since: 10.1
     """
 
-    def listen(protocolFactory: IProtocolFactory) -> "Deferred[IListeningPort]":
+    def listen(protocolFactory: IProtocolFactory) -> Deferred[IListeningPort]:
         """
         Listen with C{protocolFactory} at the location specified by this
         L{IStreamServerEndpoint} provider.

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import socket
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 from zope.interface import classImplements, implementer
 
@@ -370,7 +370,7 @@ class PosixReactorBase(_DisconnectSelectableMixin, ReactorBase):
         self,
         host: str,
         port: int,
-        factory: "ClientFactory",
+        factory: ClientFactory,
         timeout: float = 30.0,
         bindAddress: tuple[str, int] | None = None,
     ) -> IConnector:

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -20,7 +20,7 @@ import stat
 import sys
 import traceback
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 _PS_CLOSE: int
 _PS_DUP2: int
@@ -66,7 +66,7 @@ else:
 # here for backwards compatibility:
 ProcessExitedAlready = error.ProcessExitedAlready
 
-reapProcessHandlers: Dict[int, _BaseProcess] = {}
+reapProcessHandlers: dict[int, _BaseProcess] = {}
 
 
 def reapAllProcesses() -> None:
@@ -285,7 +285,7 @@ class _BaseProcess(BaseProcess):
     Base class for Process and PTYProcess.
     """
 
-    status: Optional[int] = None
+    status: int | None = None
     pid = None
 
     def reapProcess(self):
@@ -632,11 +632,11 @@ def _listOpenFDs():
 
 
 def _getFileActions(
-    fdState: List[Tuple[int, bool]],
-    childToParentFD: Dict[int, int],
+    fdState: list[tuple[int, bool]],
+    childToParentFD: dict[int, int],
     doClose: int,
     doDup2: int,
-) -> List[Tuple[int, ...]]:
+) -> list[tuple[int, ...]]:
     """
     Get the C{file_actions} parameter for C{posix_spawn} based on the
     parameters describing the current process state.
@@ -649,7 +649,7 @@ def _getFileActions(
     @param doDup2: the integer to use for the 'dup2' instruction
     """
     fdStateDict = dict(fdState)
-    parentToChildren: Dict[int, List[int]] = defaultdict(list)
+    parentToChildren: dict[int, list[int]] = defaultdict(list)
     for inChild, inParent in childToParentFD.items():
         parentToChildren[inParent].append(inChild)
     allocated = set(fdStateDict)
@@ -664,7 +664,7 @@ def _getFileActions(
         allocated.add(nextFD)
         return nextFD
 
-    result: List[Tuple[int, ...]] = []
+    result: list[tuple[int, ...]] = []
     relocations = {}
     for inChild, inParent in sorted(childToParentFD.items()):
         # The parent FD will later be reused by a child FD.

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -11,7 +11,7 @@ Twisted.  The Protocol class contains some introductory material.
 from __future__ import annotations
 
 import random
-from typing import Any, Callable, Generic, Optional, Protocol as TypingProtocol
+from typing import Any, Callable, Generic, Protocol as TypingProtocol
 
 from zope.interface import implementer
 
@@ -67,7 +67,7 @@ class _ProtoWithFactory(TypingProtocol):
     def connectionLost(self, reason: Failure) -> None:
         ...
 
-    def makeConnection(self, transport: "ITransport") -> None:
+    def makeConnection(self, transport: ITransport) -> None:
         ...
 
     def connectionMade(self) -> None:
@@ -83,7 +83,7 @@ class Factory(Generic[P]):
     self.protocol.
     """
 
-    protocol: "Optional[Callable[..., P]]" = None
+    protocol: Callable[..., P] | None = None
 
     numPorts = 0
     noisy = True
@@ -171,7 +171,7 @@ class Factory(Generic[P]):
         directly.
         """
 
-    def buildProtocol(self, addr: IAddress | None) -> "Optional[P]":
+    def buildProtocol(self, addr: IAddress | None) -> P | None:
         """
         Create an instance of a subclass of Protocol.
 
@@ -550,7 +550,7 @@ class BaseProtocol:
     """
 
     connected = 0
-    transport: Optional[ITransport] = None
+    transport: ITransport | None = None
 
     def makeConnection(self, transport):
         """
@@ -678,7 +678,7 @@ class ProcessProtocol(BaseProtocol):
     stdin, stdout, and stderr file descriptors.
     """
 
-    transport: Optional[interfaces.IProcessTransport] = None
+    transport: interfaces.IProcessTransport | None = None
 
     def childDataReceived(self, childFD: int, data: bytes) -> None:
         if childFD == 1:

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -11,7 +11,7 @@ import select
 import sys
 from errno import EBADF, EINTR
 from time import sleep
-from typing import Callable, Type, TypeVar
+from typing import Callable, TypeVar
 
 from zope.interface import implementer
 
@@ -48,7 +48,7 @@ else:
 try:
     from twisted.internet.win32eventreactor import _ThreadedWin32EventsMixin
 except ImportError:
-    _extraBase: Type[object] = object
+    _extraBase: type[object] = object
 else:
     _extraBase = _ThreadedWin32EventsMixin
 

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -6,23 +6,13 @@
 Scheduling utility methods and classes.
 """
 
+from __future__ import annotations
 
 import sys
 import time
 import warnings
-from typing import (
-    Callable,
-    Coroutine,
-    Iterable,
-    Iterator,
-    List,
-    NoReturn,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-)
+from collections.abc import Coroutine, Iterable, Iterator, Sequence
+from typing import Callable, NoReturn, TypeVar, cast
 
 from zope.interface import implementer
 
@@ -67,13 +57,13 @@ class LoopingCall:
         to L{LoopingCall.start}.
     """
 
-    call: Optional[IDelayedCall] = None
+    call: IDelayedCall | None = None
     running = False
-    _deferred: Optional[Deferred["LoopingCall"]] = None
-    interval: Optional[float] = None
+    _deferred: Deferred[LoopingCall] | None = None
+    interval: float | None = None
     _runAtStart = False
-    starttime: Optional[float] = None
-    _realLastTime: Optional[float] = None
+    starttime: float | None = None
+    _realLastTime: float | None = None
 
     def __init__(self, f: Callable[..., object], *a: object, **kw: object) -> None:
         self.f = f
@@ -84,7 +74,7 @@ class LoopingCall:
         self.clock = cast(IReactorTime, reactor)
 
     @property
-    def deferred(self) -> Optional[Deferred["LoopingCall"]]:
+    def deferred(self) -> Deferred[LoopingCall] | None:
         """
         DEPRECATED. L{Deferred} fired when loop stops or fails.
 
@@ -100,7 +90,7 @@ class LoopingCall:
         return self._deferred
 
     @classmethod
-    def withCount(cls, countCallable: Callable[[int], object]) -> "LoopingCall":
+    def withCount(cls, countCallable: Callable[[int], object]) -> LoopingCall:
         """
         An alternate constructor for L{LoopingCall} that makes available the
         number of calls which should have occurred since it was last invoked.
@@ -176,7 +166,7 @@ class LoopingCall:
         intervalNum = int(elapsedTime / self.interval)
         return intervalNum
 
-    def start(self, interval: float, now: bool = True) -> Deferred["LoopingCall"]:
+    def start(self, interval: float, now: bool = True) -> Deferred[LoopingCall]:
         """
         Start running function every interval seconds.
 
@@ -411,7 +401,7 @@ class CooperativeTask:
     """
 
     def __init__(
-        self, iterator: Iterator[_TaskResultT], cooperator: "Cooperator"
+        self, iterator: Iterator[_TaskResultT], cooperator: Cooperator
     ) -> None:
         """
         A private constructor: to create a new L{CooperativeTask}, see
@@ -419,10 +409,10 @@ class CooperativeTask:
         """
         self._iterator = iterator
         self._cooperator = cooperator
-        self._deferreds: List[Deferred[Iterator[_TaskResultT]]] = []
+        self._deferreds: list[Deferred[Iterator[_TaskResultT]]] = []
         self._pauseCount = 0
-        self._completionState: Optional[SchedulerError] = None
-        self._completionResult: Optional[Union[Iterator[_TaskResultT], Failure]] = None
+        self._completionState: SchedulerError | None = None
+        self._completionResult: Iterator[_TaskResultT] | Failure | None = None
         cooperator._addTask(self)
 
     def whenDone(self) -> Deferred[Iterator[_TaskResultT]]:
@@ -474,7 +464,7 @@ class CooperativeTask:
     def _completeWith(
         self,
         completionState: SchedulerError,
-        deferredResult: Union[Iterator[_TaskResultT], Failure],
+        deferredResult: Iterator[_TaskResultT] | Failure,
     ) -> None:
         """
         @param completionState: a L{SchedulerError} exception or a subclass
@@ -594,18 +584,18 @@ class Cooperator:
         stepped as soon as they are added, or if they will be queued up until
         L{Cooperator.start} is called.
         """
-        self._tasks: List[CooperativeTask] = []
+        self._tasks: list[CooperativeTask] = []
         self._metarator: Iterator[CooperativeTask] = iter(())
         self._terminationPredicateFactory = terminationPredicateFactory
         self._scheduler = scheduler
-        self._delayedCall: Optional[IDelayedCall] = None
+        self._delayedCall: IDelayedCall | None = None
         self._stopped = False
         self._started = started
 
     def coiterate(
         self,
         iterator: Iterator[_TaskResultT],
-        doneDeferred: Optional[Deferred[Iterator[_TaskResultT]]] = None,
+        doneDeferred: Deferred[Iterator[_TaskResultT]] | None = None,
     ) -> Deferred[Iterator[_TaskResultT]]:
         """
         Add an iterator to the list of iterators this L{Cooperator} is
@@ -771,7 +761,7 @@ class Clock:
     rightNow = 0.0
 
     def __init__(self) -> None:
-        self.calls: List[DelayedCall] = []
+        self.calls: list[DelayedCall] = []
 
     def seconds(self) -> float:
         """
@@ -841,7 +831,7 @@ class Clock:
 def deferLater(
     clock: IReactorTime,
     delay: float,
-    callable: Optional[Callable[..., _T]] = None,
+    callable: Callable[..., _T] | None = None,
     *args: object,
     **kw: object,
 ) -> Deferred[_T]:
@@ -880,10 +870,10 @@ def deferLater(
 def react(
     main: Callable[
         ...,
-        Union[Deferred[_T], Coroutine["Deferred[_T]", object, _T]],
+        Deferred[_T] | Coroutine[Deferred[_T], object, _T],
     ],
     argv: Iterable[object] = (),
-    _reactor: Optional[IReactorCore] = None,
+    _reactor: IReactorCore | None = None,
 ) -> NoReturn:
     """
     Call C{main} and run the reactor until the L{Deferred} it returns fires or

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -15,7 +15,7 @@ import socket
 import struct
 import sys
 import typing
-from typing import Any, Callable, ClassVar, List, Optional, Union
+from typing import Any, Callable, ClassVar
 
 from zope.interface import Interface, implementer
 
@@ -796,9 +796,9 @@ class Server(_TLSServerMixin, Connection):
 
     _base = Connection
 
-    _addressType: Union[
-        type[address.IPv4Address], type[address.IPv6Address]
-    ] = address.IPv4Address
+    _addressType: (
+        type[address.IPv4Address] | type[address.IPv6Address]
+    ) = address.IPv4Address
 
     def __init__(
         self,
@@ -981,7 +981,7 @@ class _FileDescriptorReservation:
     _log: ClassVar[Logger] = Logger()
 
     _fileFactory: Callable[[], _HasClose]
-    _fileDescriptor: Optional[_HasClose] = attr.ib(init=False, default=None)
+    _fileDescriptor: _HasClose | None = attr.ib(init=False, default=None)
 
     def available(self):
         """
@@ -1133,7 +1133,7 @@ class _BuffersLogs:
 
     _namespace: str
     _observer: ILogObserver
-    _logs: List[LogEvent] = attr.ib(default=attr.Factory(list))
+    _logs: list[LogEvent] = attr.ib(default=attr.Factory(list))
 
     def __enter__(self):
         """
@@ -1278,7 +1278,7 @@ class Port(base.BasePort, _SocketCloser):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
 
     # An externally initialized socket that we will use, rather than creating
     # our own.

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -8,21 +8,12 @@ Assorted functionality which is commonly useful when writing unit tests.
 from __future__ import annotations
 
 import typing
+from collections.abc import Coroutine, Generator, Iterator, Sequence
 from dataclasses import dataclass
 from io import BytesIO
 from socket import AF_INET, AF_INET6
 from time import time
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    Iterator,
-    Sequence,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, TypeVar, overload
 
 from zope.interface import implementedBy, implementer
 from zope.interface.verify import verifyClass
@@ -1095,11 +1086,11 @@ _T = TypeVar("_T")
 def _benchmarkWithReactor(
     test_target: Callable[
         [],
-        Union[
-            Coroutine[Deferred[Any], Any, _T],
-            Generator[Deferred[Any], Any, _T],
-            Deferred[_T],
-        ],
+        (
+            Coroutine[Deferred[Any], Any, _T]
+            | Generator[Deferred[Any], Any, _T]
+            | Deferred[_T]
+        ),
     ],
 ) -> Callable[[Any], None]:  # pragma: no cover
     """

--- a/src/twisted/internet/threads.py
+++ b/src/twisted/internet/threads.py
@@ -10,7 +10,7 @@ For basic support see reactor threading API docs.
 from __future__ import annotations
 
 import queue as Queue
-from typing import Callable, TypeVar, Union, cast
+from typing import Callable, TypeVar, cast
 
 from typing_extensions import ParamSpec
 
@@ -109,7 +109,7 @@ def callMultipleInThread(tupleList):
 
 def blockingCallFromThread(
     reactor: IReactorFromThreads,
-    f: Union[Callable[_P, _R], Callable[_P, defer.Deferred[_R]]],
+    f: Callable[_P, _R] | Callable[_P, defer.Deferred[_R]],
     *a: _P.args,
     **kw: _P.kwargs,
 ) -> _R:

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 # System Imports
 import socket
 import warnings
-from typing import Optional
 
 from zope.interface import implementer
 
@@ -87,7 +86,7 @@ class Port(base.BasePort):
     socketType: socket.SocketKind = socket.SOCK_DGRAM
     maxThroughput = 256 * 1024
 
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
     _preexistingSocket = None
 
     def __init__(self, port, proto, interface="", maxPacketSize=8192, reactor=None):

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -10,13 +10,13 @@ End users shouldn't use this module directly - use the reactor APIs instead.
 Maintainer: Itamar Shtull-Trauring
 """
 
+from __future__ import annotations
 
 import os
 import socket
 import stat
 import struct
 from errno import EAGAIN, ECONNREFUSED, EINTR, EMSGSIZE, ENOBUFS, EWOULDBLOCK
-from typing import Optional, Type
 
 from zope.interface import implementedBy, implementer, implementer_only
 
@@ -66,7 +66,7 @@ class _SendmsgMixin:
         registered producer, if there is one.
     """
 
-    _writeSomeDataBase: Optional[Type[FileDescriptor]] = None
+    _writeSomeDataBase: type[FileDescriptor] | None = None
     _fileDescriptorBufferSize = 64
 
     def __init__(self):


### PR DESCRIPTION
## Scope and purpose

Fixes #12531

The changes were automatically generated using `pyupgrade --py39-plus .\src\twisted\internet\*.py`.

To limit scope of changes, I am only starting with the internet module.

Notes:
* Forward references no longer need to be string literals in some cases ([PEP 563](https://peps.python.org/pep-0563/#forward-references)).
* `Union` is changed to `A | B` in annotations
* `Optional` is changed to `A | None` in annotations
* Type Aliases will continue to use `Union` and `Optional` until support for Python 3.9 is dropped.

Manual work done:
* Add `from __future__ import annotations` where appropriate
* Add `TypeAlias` annotation in a few places where appropriate, where previously no annotation was set.
* Remove unused imports from `typing` module such as `List`.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
