### PR TITLE
Enable Python 3.12 RC on GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
       # The matrix is designed to not expand into any job.
       # It is used to document the test environement variations.
       # The actual job enviroment are defined in the `include` section.
-      matrix:
+      :matrix
         # The Python version on which the job is executed.
         # We need at least one value here, so we go with latest Python version
         # that we support..
@@ -137,6 +137,9 @@ jobs:
 
           # Just Python 3.11 with default settings.
           - python-version: '3.11'
+
+          # Just Python 3.12 RC with default settings.
+          - python-version: '3.12-rc'
 
           # Just Python 3.13 with default settings.
           - python-version: '3.13'


### PR DESCRIPTION
## Scope and purpose
This PR enables testing against **Python 3.12 RC** in the GitHub Actions workflow.

## Details
- Adds `3.12-rc` to the test matrix.
- Ensures Twisted is tested against the upcoming Python release before it becomes stable.
- No functional code changes, only CI configuration.

## Motivation
Keeping the CI matrix updated helps Twisted detect compatibility issues early before official Python releases.