### PR TITLE
#12547  internet: update type annotations for Python 3.9+ (2/3)

### DIFF
--- a/src/twisted/internet/iocpreactor/reactor.py
+++ b/src/twisted/internet/iocpreactor/reactor.py
@@ -10,7 +10,6 @@ Reactor that uses IO completion ports
 import socket
 import sys
 import warnings
-from typing import Tuple, Type
 
 from zope.interface import implementer
 
@@ -27,7 +26,7 @@ except ImportError:
     TLSMemoryBIOFactory = None
     # Either pyOpenSSL isn't installed, or it is too old for this code to work.
     # The reactor won't provide IReactorSSL.
-    _extraInterfaces: Tuple[Type[interfaces.IReactorSSL], ...] = ()
+    _extraInterfaces: tuple[type[interfaces.IReactorSSL], ...] = ()
     warnings.warn(
         "pyOpenSSL 0.10 or newer is required for SSL support in iocpreactor. "
         "It is missing, so the reactor will not support SSL APIs."

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import errno
 import socket
 import struct
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from zope.interface import classImplements, implementer
 
@@ -356,8 +356,8 @@ class Server(Connection):
         self,
         sock: socket.socket,
         protocol: IProtocol,
-        clientAddr: Union[IPv4Address, IPv6Address],
-        serverAddr: Union[IPv4Address, IPv6Address],
+        clientAddr: IPv4Address | IPv6Address,
+        serverAddr: IPv4Address | IPv6Address,
         sessionno: int,
         reactor: IOCPReactor,
     ):
@@ -422,7 +422,7 @@ class Port(_SocketCloser, _LogOwner):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
 
     # A string describing the connections which will be created by this port.
     # Normally this is C{"TCP"}, since this is a TCP port, but when the TLS

--- a/src/twisted/internet/iocpreactor/udp.py
+++ b/src/twisted/internet/iocpreactor/udp.py
@@ -11,7 +11,7 @@ import errno
 import socket
 import struct
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from zope.interface import implementer
 
@@ -53,7 +53,7 @@ class Port(abstract.FileHandle):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
 
     def __init__(
         self,

--- a/src/twisted/internet/test/_posixifaces.py
+++ b/src/twisted/internet/test/_posixifaces.py
@@ -24,19 +24,19 @@ from ctypes import (
 )
 from ctypes.util import find_library
 from socket import AF_INET, AF_INET6, inet_ntop
-from typing import Any, List, Tuple
+from typing import Any
 
 from twisted.python.compat import nativeString
 
 libc = CDLL(find_library("c") or "")
 
 if sys.platform.startswith("freebsd") or sys.platform == "darwin":
-    _sockaddrCommon: List[Tuple[str, Any]] = [
+    _sockaddrCommon: list[tuple[str, Any]] = [
         ("sin_len", c_uint8),
         ("sin_family", c_uint8),
     ]
 else:
-    _sockaddrCommon: List[Tuple[str, Any]] = [
+    _sockaddrCommon: list[tuple[str, Any]] = [
         ("sin_family", c_ushort),
     ]
 

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -6,10 +6,10 @@
 Various helpers for tests for connection-oriented transports.
 """
 
+from __future__ import annotations
 
 import socket
 from gc import collect
-from typing import Optional
 from weakref import ref
 
 from zope.interface.verify import verifyObject
@@ -276,7 +276,7 @@ class ConnectionTestsMixin:
     implementations.
     """
 
-    endpoints: Optional[EndpointCreator] = None
+    endpoints: EndpointCreator | None = None
 
     def test_logPrefix(self):
         """

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -12,13 +12,15 @@ available.  Additionally, the tests will automatically be applied to all
 available reactor implementations.
 """
 
+from __future__ import annotations
 
 __all__ = ["TestTimeoutError", "ReactorBuilder", "needsRunningReactor"]
 
 import os
 import signal
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Type, Union, cast
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Callable, cast
 
 from zope.interface import Interface
 
@@ -175,11 +177,11 @@ class ReactorBuilder:
                     ]
                 )
 
-    reactorFactory: Optional[Callable[[], object]] = None
+    reactorFactory: Callable[[], object] | None = None
 
     originalHandler = None
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = None
-    skippedReactors: Dict[str, str] = {}
+    requiredInterfaces: Sequence[type[Interface]] | None = None
+    skippedReactors: dict[str, str] = {}
 
     def setUp(self):
         """
@@ -355,15 +357,13 @@ class ReactorBuilder:
 
     @classmethod
     def makeTestCaseClasses(
-        cls: Type["ReactorBuilder"],
-    ) -> Dict[str, Union[Type["ReactorBuilder"], Type[SynchronousTestCase]]]:
+        cls: type[ReactorBuilder],
+    ) -> dict[str, type[ReactorBuilder] | type[SynchronousTestCase]]:
         """
         Create a L{SynchronousTestCase} subclass which mixes in C{cls} for each
         known reactor and return a dict mapping their names to them.
         """
-        classes: Dict[
-            str, Union[Type["ReactorBuilder"], Type[SynchronousTestCase]]
-        ] = {}
+        classes: dict[str, type[ReactorBuilder] | type[SynchronousTestCase]] = {}
         for reactor in cls._reactors:
             shortReactorName = reactor.split(".")[-1]
             name = (cls.__name__ + "." + shortReactorName + "Tests").replace(".", "_")
@@ -383,7 +383,7 @@ class ReactorBuilder:
         return classes
 
 
-def asyncioSelectorReactor(self: object) -> "asyncioreactor.AsyncioSelectorReactor":
+def asyncioSelectorReactor(self: object) -> asyncioreactor.AsyncioSelectorReactor:
     """
     Make a new asyncio reactor associated with a new event loop.
 

--- a/src/twisted/internet/test/test_abstract.py
+++ b/src/twisted/internet/test/test_abstract.py
@@ -7,8 +7,6 @@ reactors.
 """
 from __future__ import annotations
 
-from typing import Union
-
 from hypothesis import example, given, strategies as st
 
 from twisted.internet.abstract import FileDescriptor, isIPv6Address
@@ -81,7 +79,7 @@ class TrackingFileDescriptor(FileDescriptor):
     _writeDisconnected = False
 
     def __init__(
-        self, operations: list[Union[int, bytes]], written: list[bytes], send_limit: int
+        self, operations: list[int | bytes], written: list[bytes], send_limit: int
     ):
         self.operations = operations
         self.written = written
@@ -113,7 +111,7 @@ class WriteBufferingTests(SynchronousTestCase):
     )
     # This catches a bug that was introduced by a performance refactoring:
     @example(operations=[b"abcdef", 0, b"g"])
-    def test_writeBuffering(self, operations: list[Union[bytes, int]]) -> None:
+    def test_writeBuffering(self, operations: list[bytes | int]) -> None:
         """
         A sequence of C{write()} and C{doWrite()} will eventually write all the
         data correctly and in order.

--- a/src/twisted/internet/test/test_cfreactor.py
+++ b/src/twisted/internet/test/test_cfreactor.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from twisted.trial.unittest import SynchronousTestCase
 from .reactormixins import ReactorBuilder
@@ -67,7 +67,7 @@ class CoreFoundationSpecificTests(ReactorBuilder, fakeBase):
         allow us to enumerate all active timers or sources.
         """
         r = self.buildReactor()
-        x: List[int] = []
+        x: list[int] = []
         r.callLater(0, x.append, 1)
         delayed = r.callLater(100, noop)
         r.iterate()

--- a/src/twisted/internet/test/test_core.py
+++ b/src/twisted/internet/test/test_core.py
@@ -5,11 +5,12 @@
 Tests for implementations of L{IReactorCore}.
 """
 
+from __future__ import annotations
 
 import signal
 import time
 from types import FrameType
-from typing import Callable, List, Optional, Tuple, Union, cast
+from typing import Callable, cast
 
 from twisted.internet.abstract import FileDescriptor
 from twisted.internet.defer import Deferred
@@ -49,7 +50,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         L{reactor.callWhenRunning}.
         """
         reactor = self.buildReactor()
-        events: List[str] = []
+        events: list[str] = []
         reactor.callWhenRunning(events.append, "first")
         reactor.callWhenRunning(events.append, "second")
         reactor.callWhenRunning(reactor.stop)
@@ -90,7 +91,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         C{"startup"}.
         """
         reactor = self.buildReactor()
-        phase: Optional[str] = None
+        phase: str | None = None
 
         def beforeStartup() -> None:
             nonlocal phase
@@ -147,7 +148,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         L{reactor.stop}.
         """
         reactor = self.buildReactor()
-        events: List[str] = []
+        events: list[str] = []
         reactor.addSystemEventTrigger(
             "before", "shutdown", events.append, "before shutdown"
         )
@@ -200,7 +201,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         C{reactor.run()} raises L{ReactorAlreadyRunning} when called when
         the reactor is already running.
         """
-        events: List[str] = []
+        events: list[str] = []
 
         testCase = cast(SynchronousTestCase, self)
 
@@ -275,7 +276,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         C{reactor.run()} restarts the reactor after it has been stopped by
         C{reactor.crash()}.
         """
-        events: List[Union[str, Tuple[str, bool]]] = []
+        events: list[str | tuple[str, bool]] = []
 
         def crash() -> None:
             events.append("crash")
@@ -298,7 +299,7 @@ class SystemEventTestsBuilder(ReactorBuilder):
         C{reactor.run()} raises L{ReactorNotRestartable} when called when
         the reactor is being run after getting stopped priorly.
         """
-        events: List[str] = []
+        events: list[str] = []
 
         testCase = cast(SynchronousTestCase, self)
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -9,11 +9,12 @@ L{twisted.internet.endpoints}.
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 from errno import EPERM
 from socket import AF_INET, AF_INET6, IPPROTO_TCP, SOCK_STREAM, AddressFamily, gaierror
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 from unicodedata import normalize
 from unittest import skipIf
 

--- a/src/twisted/internet/test/test_inlinecb.py
+++ b/src/twisted/internet/test/test_inlinecb.py
@@ -6,11 +6,14 @@
 Tests for L{twisted.internet.inlineCallbacks}.
 """
 
+from __future__ import annotations
+
 import traceback
 import unittest as pyunit
 import weakref
+from collections.abc import Generator
 from enum import Enum
-from typing import Any, Generator, List, Set, Union
+from typing import Any
 
 from twisted.internet import reactor, task
 from twisted.internet.defer import (
@@ -36,7 +39,7 @@ async def getValueViaCoro(value):
     return await getValueViaDeferred(value)
 
 
-def getDivisionFailure(msg: Union[str, None] = None) -> Failure:
+def getDivisionFailure(msg: str | None = None) -> Failure:
     """
     Make a L{Failure} of a divide-by-zero error.
     """
@@ -47,7 +50,7 @@ def getDivisionFailure(msg: Union[str, None] = None) -> Failure:
     return f
 
 
-async def getDivisionFailureCoro(msg: Union[str, None] = None) -> None:
+async def getDivisionFailureCoro(msg: str | None = None) -> None:
     """
     Make a coroutine that throws a divide-by-zero error.
     """
@@ -397,7 +400,7 @@ class BasicTests(TestCase):
         """
 
         # Create an object and weak reference to track if its gotten freed.
-        obj: Set[Any] = set()
+        obj: set[Any] = set()
         objWeakRef = weakref.ref(obj)
 
         @inlineCallbacks
@@ -1638,8 +1641,8 @@ class CancellationTests(SynchronousTestCase):
             3. Cancelling the deferred again cancels any deferred the function
                is waiting on, and the exception is raised.
         """
-        canceller1Calls: List[Deferred[object]] = []
-        canceller2Calls: List[Deferred[object]] = []
+        canceller1Calls: list[Deferred[object]] = []
+        canceller2Calls: list[Deferred[object]] = []
         d1: Deferred[object] = Deferred(canceller1Calls.append)
         d2: Deferred[object] = Deferred(canceller2Calls.append)
 

--- a/src/twisted/internet/test/test_posixprocess.py
+++ b/src/twisted/internet/test/test_posixprocess.py
@@ -5,13 +5,13 @@
 Tests for POSIX-based L{IReactorProcess} implementations.
 """
 
+from __future__ import annotations
 
 import errno
 import os
 import sys
-from typing import Optional
 
-platformSkip: Optional[str]
+platformSkip: str | None
 try:
     import fcntl
 except ImportError:

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -825,7 +825,7 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
         path to it.
         """
         script = _asFilesystemBytes(self.mktemp())
-        with open(script, "wt") as scriptFile:
+        with open(script, "w") as scriptFile:
             scriptFile.write(os.linesep.join(sourceLines) + os.linesep)
         return os.path.abspath(script)
 
@@ -842,7 +842,7 @@ class ProcessTestsBuilder(ProcessTestsBuilderBase):
         executable = getattr(sys, "_base_executable", pyExe.decode("ascii"))
         scriptFile = self.makeSourceFile(
             [
-                "#!{}".format(executable),
+                f"#!{executable}",
                 "import sys",
                 "sys.stdout.write('{}')".format(shebangOutput.decode("ascii")),
                 "sys.stdout.flush()",

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -13,10 +13,11 @@ import gc
 import io
 import os
 import socket
+from collections.abc import Mapping, Sequence
 from functools import wraps
 from io import BytesIO
 from types import ModuleType
-from typing import Any, Callable, ClassVar, List, Mapping, Optional, Sequence, Type
+from typing import Any, Callable, ClassVar
 from unittest import skipIf
 
 from zope.interface import Interface, implementer
@@ -474,7 +475,7 @@ class FakeResolver:
     def __init__(self, names: Mapping[str, str]):
         self.names = names
 
-    def getHostByName(self, name: str, timeout: Sequence[int] = ()) -> "Deferred[str]":
+    def getHostByName(self, name: str, timeout: Sequence[int] = ()) -> Deferred[str]:
         """
         Return the address mapped to C{name} if it exists, or raise a
         C{DNSLookupError}.
@@ -1037,7 +1038,7 @@ class _ExhaustsFileDescriptors:
         default=lambda: os.dup(0), repr=False
     )
     _close: Callable[[int], None] = attr.ib(default=os.close, repr=False)
-    _fileDescriptors: List[int] = attr.ib(
+    _fileDescriptors: list[int] = attr.ib(
         default=attr.Factory(list), init=False, repr=False
     )
     _sourceCache: SourceCacheForCoverage | None = None
@@ -1559,7 +1560,7 @@ class TCPPortTestsMixin:
     Tests for L{IReactorTCP.listenTCP}
     """
 
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorTCP,)
+    requiredInterfaces: Sequence[type[Interface]] | None = (IReactorTCP,)
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """
@@ -2121,7 +2122,7 @@ class WriteSequenceTestsMixin:
     Test for L{twisted.internet.abstract.FileDescriptor.writeSequence}.
     """
 
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorTCP,)
+    requiredInterfaces: Sequence[type[Interface]] | None = (IReactorTCP,)
 
     def setWriteBufferSize(self, transport, value):
         """
@@ -2791,7 +2792,7 @@ class AbortConnectionMixin:
     """
 
     # Override in subclasses, should be an EndpointCreator instance:
-    endpoints: Optional[EndpointCreator] = None
+    endpoints: EndpointCreator | None = None
 
     def runAbortTest(self, clientClass, serverClass, clientConnectionLostReason=None):
         """

--- a/src/twisted/internet/test/test_tls.py
+++ b/src/twisted/internet/test/test_tls.py
@@ -5,8 +5,9 @@
 Tests for implementations of L{ITLSTransport}.
 """
 
+from __future__ import annotations
 
-from typing import Optional, Sequence, Type
+from collections.abc import Sequence
 
 from zope.interface import Interface, implementer
 
@@ -48,7 +49,7 @@ else:
 
 
 class TLSMixin:
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = [IReactorSSL]
+    requiredInterfaces: Sequence[type[Interface]] | None = [IReactorSSL]
 
     if platform.isWindows():
         msg = (

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -5,7 +5,9 @@
 Tests for implementations of L{IReactorUNIX}.
 """
 
+from __future__ import annotations
 
+from collections.abc import Sequence
 from hashlib import md5
 from os import close, fstat, stat, unlink, urandom
 from pprint import pformat
@@ -13,7 +15,7 @@ from socket import AF_INET, SOCK_STREAM, SOL_SOCKET, socket
 from stat import S_IMODE
 from struct import pack
 from tempfile import mkstemp, mktemp
-from typing import Any, Callable, Optional, Sequence, Type
+from typing import Any, Callable
 from unittest import skipIf
 
 try:
@@ -103,7 +105,7 @@ class UNIXCreator(EndpointCreator):
     Create UNIX socket end points.
     """
 
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (interfaces.IReactorUNIX,)
+    requiredInterfaces: Sequence[type[Interface]] | None = (interfaces.IReactorUNIX,)
 
     def server(self, reactor):
         """
@@ -729,7 +731,7 @@ class SocketUNIXMixin:
     UNIX ports.
     """
 
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (
+    requiredInterfaces: Sequence[type[Interface]] | None = (
         IReactorUNIX,
         IReactorSocket,
     )
@@ -801,7 +803,7 @@ class ListenUNIXMixin:
 
 
 class UNIXPortTestsMixin:
-    requiredInterfaces: Optional[Sequence[Type[Interface]]] = (IReactorUNIX,)
+    requiredInterfaces: Sequence[type[Interface]] | None = (IReactorUNIX,)
 
     def getExpectedStartListeningLogMessage(self, port, factory):
         """


### PR DESCRIPTION
## Scope and purpose

Fixes #12547 

The changes were automatically generated using:
* `pyupgrade --py39-plus .\src\twisted\internet\test\*.py`
* `pyupgrade --py39-plus .\src\twisted\internet\iocpreactor\*.py`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`.

----

I separated https://github.com/twisted/twisted/commit/2dcceb1930894882f23218371a655f47a3104e84 into its own commit as it deserves a review on its own. Its the only changes made by `pyupgrade` which isn't relevant for annotations.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
