### PR TITLE
#12560 logger: update type annotations for Python 3.9+ (1/1)

### DIFF
--- a/src/twisted/logger/_buffer.py
+++ b/src/twisted/logger/_buffer.py
@@ -6,8 +6,10 @@
 Log observer that maintains a buffer.
 """
 
+from __future__ import annotations
+
 from collections import deque
-from typing import Deque, Optional
+from typing import Deque
 
 from zope.interface import implementer
 
@@ -34,7 +36,7 @@ class LimitedHistoryLogObserver:
         >>>
     """
 
-    def __init__(self, size: Optional[int] = _DEFAULT_BUFFER_MAXIMUM) -> None:
+    def __init__(self, size: int | None = _DEFAULT_BUFFER_MAXIMUM) -> None:
         """
         @param size: The maximum number of events to buffer.  If L{None}, the
             buffer is unbounded.

--- a/src/twisted/logger/_capture.py
+++ b/src/twisted/logger/_capture.py
@@ -6,8 +6,9 @@
 Context manager for capturing logs.
 """
 
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from typing import Iterator, List, Sequence, cast
+from typing import cast
 
 from twisted.logger import globalLogPublisher
 from ._interfaces import ILogObserver, LogEvent
@@ -15,7 +16,7 @@ from ._interfaces import ILogObserver, LogEvent
 
 @contextmanager
 def capturedLogs() -> Iterator[Sequence[LogEvent]]:
-    events: List[LogEvent] = []
+    events: list[LogEvent] = []
     observer = cast(ILogObserver, events.append)
 
     globalLogPublisher.addObserver(observer)

--- a/src/twisted/logger/_file.py
+++ b/src/twisted/logger/_file.py
@@ -6,7 +6,9 @@
 File log observer.
 """
 
-from typing import IO, Any, Callable, Optional
+from __future__ import annotations
+
+from typing import IO, Any, Callable
 
 from zope.interface import implementer
 
@@ -22,7 +24,7 @@ class FileLogObserver:
     """
 
     def __init__(
-        self, outFile: IO[Any], formatEvent: Callable[[LogEvent], Optional[str]]
+        self, outFile: IO[Any], formatEvent: Callable[[LogEvent], str | None]
     ) -> None:
         """
         @param outFile: A file-like object.  Ideally one should be passed which
@@ -30,7 +32,7 @@ class FileLogObserver:
         @param formatEvent: A callable that formats an event.
         """
         if ioType(outFile) is not str:
-            self._encoding: Optional[str] = "utf-8"
+            self._encoding: str | None = "utf-8"
         else:
             self._encoding = None
 
@@ -54,7 +56,7 @@ class FileLogObserver:
 
 
 def textFileLogObserver(
-    outFile: IO[Any], timeFormat: Optional[str] = timeFormatRFC3339
+    outFile: IO[Any], timeFormat: str | None = timeFormatRFC3339
 ) -> FileLogObserver:
     """
     Create a L{FileLogObserver} that emits text to a specified (writable)
@@ -69,7 +71,7 @@ def textFileLogObserver(
     @return: A file log observer.
     """
 
-    def formatEvent(event: LogEvent) -> Optional[str]:
+    def formatEvent(event: LogEvent) -> str | None:
         return formatEventAsClassicLogText(
             event, formatTime=lambda e: formatTime(e, timeFormat)
         )

--- a/src/twisted/logger/_filter.py
+++ b/src/twisted/logger/_filter.py
@@ -6,8 +6,8 @@
 Filtering log observer.
 """
 
+from collections.abc import Iterable
 from functools import partial
-from typing import Dict, Iterable
 
 from zope.interface import Interface, implementer
 
@@ -138,7 +138,7 @@ class LogLevelFilterPredicate:
         """
         @param defaultLogLevel: The default minimum log level.
         """
-        self._logLevelsByNamespace: Dict[str, NamedConstant] = {}
+        self._logLevelsByNamespace: dict[str, NamedConstant] = {}
         self.defaultLogLevel = defaultLogLevel
         self.clearLogLevels()
 

--- a/src/twisted/logger/_flatten.py
+++ b/src/twisted/logger/_flatten.py
@@ -8,9 +8,11 @@ relevant fields from the format string and persisting them for later
 examination.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from string import Formatter
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ._interfaces import LogEvent
 
@@ -27,10 +29,10 @@ class KeyFlattener:
         """
         Initialize a L{KeyFlattener}.
         """
-        self.keys: Dict[str, int] = defaultdict(lambda: 0)
+        self.keys: dict[str, int] = defaultdict(int)
 
     def flatKey(
-        self, fieldName: str, formatSpec: Optional[str], conversion: Optional[str]
+        self, fieldName: str, formatSpec: str | None, conversion: str | None
     ) -> str:
         """
         Compute a string key for a given field/format/conversion.

--- a/src/twisted/logger/_format.py
+++ b/src/twisted/logger/_format.py
@@ -8,8 +8,9 @@ Tools for formatting logging events.
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from datetime import datetime as DateTime
-from typing import Any, Callable, Iterator, Mapping, Optional, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 from constantly import NamedConstant
 
@@ -79,8 +80,8 @@ def formatUnformattableEvent(event: LogEvent, error: BaseException) -> str:
 
 
 def formatTime(
-    when: Optional[float],
-    timeFormat: Optional[str] = timeFormatRFC3339,
+    when: float | None,
+    timeFormat: str | None = timeFormatRFC3339,
     default: str = "-",
 ) -> str:
     """
@@ -113,8 +114,8 @@ def formatTime(
 
 
 def formatEventAsClassicLogText(
-    event: LogEvent, formatTime: Callable[[Optional[float]], str] = formatTime
-) -> Optional[str]:
+    event: LogEvent, formatTime: Callable[[float | None], str] = formatTime
+) -> str | None:
     """
     Format an event as a line of human-readable text for, e.g. traditional log
     file output.
@@ -189,7 +190,7 @@ def keycall(key: str, getter: Callable[[str], Any]) -> PotentialCallWrapper:
     return PotentialCallWrapper(value)
 
 
-class PotentialCallWrapper(object):
+class PotentialCallWrapper:
     """
     Object wrapper that wraps C{getattr()} so as to process call-parentheses
     C{"()"} after a dotted attribute access.

--- a/src/twisted/logger/_global.py
+++ b/src/twisted/logger/_global.py
@@ -7,9 +7,12 @@ This module includes process-global state associated with the logging system,
 and implementation of logic for managing that global state.
 """
 
+from __future__ import annotations
+
 import sys
 import warnings
-from typing import IO, Any, Iterable, Optional, Type
+from collections.abc import Iterable
+from typing import IO, Any
 
 from twisted.python.compat import currentframe
 from twisted.python.reflect import qual
@@ -73,7 +76,7 @@ class LogBeginner:
         errorStream: IO[Any],
         stdio: object,
         warningsModule: Any,
-        initialBufferSize: Optional[int] = None,
+        initialBufferSize: int | None = None,
     ) -> None:
         """
         Initialize this L{LogBeginner}.
@@ -89,7 +92,7 @@ class LogBeginner:
         self._log = Logger(observer=publisher)
         self._stdio = stdio
         self._warningsModule = warningsModule
-        self._temporaryObserver: Optional[ILogObserver] = LogPublisher(
+        self._temporaryObserver: ILogObserver | None = LogPublisher(
             self._initialBuffer,
             FilteringLogObserver(
                 FileLogObserver(
@@ -185,11 +188,11 @@ class LogBeginner:
     def showwarning(
         self,
         message: str,
-        category: Type[Warning],
+        category: type[Warning],
         filename: str,
         lineno: int,
-        file: Optional[IO[Any]] = None,
-        line: Optional[str] = None,
+        file: IO[Any] | None = None,
+        line: str | None = None,
     ) -> None:
         """
         Twisted-enabled wrapper around L{warnings.showwarning}.

--- a/src/twisted/logger/_interfaces.py
+++ b/src/twisted/logger/_interfaces.py
@@ -9,12 +9,14 @@ from typing import TYPE_CHECKING, Any
 
 from zope.interface import Interface
 
+from typing_extensions import TypeAlias
+
 if TYPE_CHECKING:
     from ._logger import Logger
 
 
-LogEvent = dict[str, Any]
-LogTrace = list[tuple["Logger", "ILogObserver"]]
+LogEvent: TypeAlias = dict[str, Any]
+LogTrace: TypeAlias = list[tuple["Logger", "ILogObserver"]]
 
 
 class ILogObserver(Interface):

--- a/src/twisted/logger/_interfaces.py
+++ b/src/twisted/logger/_interfaces.py
@@ -5,7 +5,7 @@
 Logger interfaces.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any
 
 from zope.interface import Interface
 
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
     from ._logger import Logger
 
 
-LogEvent = Dict[str, Any]
-LogTrace = List[Tuple["Logger", "ILogObserver"]]
+LogEvent = dict[str, Any]
+LogTrace = list[tuple["Logger", "ILogObserver"]]
 
 
 class ILogObserver(Interface):

--- a/src/twisted/logger/_io.py
+++ b/src/twisted/logger/_io.py
@@ -6,8 +6,11 @@
 File-like object that logs.
 """
 
+from __future__ import annotations
+
 import sys
-from typing import AnyStr, Iterable, Optional
+from collections.abc import Iterable
+from typing import AnyStr
 
 from constantly import NamedConstant
 from incremental import Version
@@ -42,7 +45,7 @@ class LoggingFile:
         self,
         logger: Logger,
         level: NamedConstant = LogLevel.info,
-        encoding: Optional[str] = None,
+        encoding: str | None = None,
     ) -> None:
         """
         @param logger: the logger to log through.

--- a/src/twisted/logger/_json.py
+++ b/src/twisted/logger/_json.py
@@ -6,8 +6,11 @@
 Tools for saving and loading log events in a structured format.
 """
 
+from __future__ import annotations
+
+from collections.abc import Iterable
 from json import dumps, loads
-from typing import IO, Any, AnyStr, Dict, Iterable, Optional, Union, cast
+from typing import IO, Any, AnyStr, cast
 from uuid import UUID
 
 from constantly import NamedConstant
@@ -22,7 +25,7 @@ from ._logger import Logger
 log = Logger()
 
 
-JSONDict = Dict[str, Any]
+JSONDict = dict[str, Any]
 
 
 def failureAsJSON(failure: Failure) -> JSONDict:
@@ -133,7 +136,7 @@ def eventAsJSON(event: LogEvent) -> str:
         file.
     """
 
-    def default(unencodable: object) -> Union[JSONDict, str]:
+    def default(unencodable: object) -> JSONDict | str:
         """
         Serialize an object not otherwise serializable by L{dumps}.
 
@@ -189,7 +192,7 @@ def jsonFileLogObserver(
 
 def eventsFromJSONLogFile(
     inFile: IO[Any],
-    recordSeparator: Optional[str] = None,
+    recordSeparator: str | None = None,
     bufferSize: int = 4096,
 ) -> Iterable[LogEvent]:
     """
@@ -213,7 +216,7 @@ def eventsFromJSONLogFile(
         else:
             return s.encode("utf-8")
 
-    def eventFromBytearray(record: bytearray) -> Optional[LogEvent]:
+    def eventFromBytearray(record: bytearray) -> LogEvent | None:
         try:
             text = bytes(record).decode("utf-8")
         except UnicodeDecodeError:
@@ -251,7 +254,7 @@ def eventsFromJSONLogFile(
 
     else:
 
-        def eventFromRecord(record: bytearray) -> Optional[LogEvent]:
+        def eventFromRecord(record: bytearray) -> LogEvent | None:
             if record[-1] == ord("\n"):
                 return eventFromBytearray(record)
             else:

--- a/src/twisted/logger/_legacy.py
+++ b/src/twisted/logger/_legacy.py
@@ -6,7 +6,9 @@
 Integration with L{twisted.python.log}.
 """
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
 
 from zope.interface import implementer
 
@@ -29,7 +31,7 @@ class LegacyLogObserverWrapper:
     expect legacy events.
     """
 
-    def __init__(self, legacyObserver: "ILegacyLogObserver") -> None:
+    def __init__(self, legacyObserver: ILegacyLogObserver) -> None:
         """
         @param legacyObserver: a legacy observer to which this observer will
             forward events.
@@ -92,8 +94,8 @@ class LegacyLogObserverWrapper:
 
 def publishToNewObserver(
     observer: ILogObserver,
-    eventDict: Dict[str, Any],
-    textFromEventDict: Callable[[Dict[str, Any]], Optional[str]],
+    eventDict: dict[str, Any],
+    textFromEventDict: Callable[[dict[str, Any]], str | None],
 ) -> None:
     """
     Publish an old-style (L{twisted.python.log}) event to a new-style

--- a/src/twisted/logger/_logger.py
+++ b/src/twisted/logger/_logger.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from time import time
 from types import TracebackType
-from typing import Any, Callable, ContextManager, Optional, Protocol, cast
+from typing import Any, Callable, ContextManager, Protocol, cast
 
 from twisted.python.compat import currentframe
 from twisted.python.failure import Failure
@@ -124,9 +124,9 @@ class Logger:
 
     def __init__(
         self,
-        namespace: Optional[str] = None,
-        source: Optional[object] = None,
-        observer: Optional["ILogObserver"] = None,
+        namespace: str | None = None,
+        source: object | None = None,
+        observer: ILogObserver | None = None,
     ) -> None:
         """
         @param namespace: The namespace for this logger.  Uses a dotted
@@ -151,7 +151,7 @@ class Logger:
         else:
             self.observer = observer
 
-    def __get__(self, instance: object, owner: Optional[type] = None) -> "Logger":
+    def __get__(self, instance: object, owner: type | None = None) -> Logger:
         """
         When used as a descriptor, i.e.::
 
@@ -187,7 +187,7 @@ class Logger:
         return f"<{self.__class__.__name__} {self.namespace!r}>"
 
     def emit(
-        self, level: LogLevel, format: Optional[str] = None, **kwargs: object
+        self, level: LogLevel, format: str | None = None, **kwargs: object
     ) -> None:
         """
         Emit a log event to all log observers at the given level.
@@ -228,7 +228,7 @@ class Logger:
     def failure(
         self,
         format: str,
-        failure: Optional[Failure] = None,
+        failure: Failure | None = None,
         level: LogLevel = LogLevel.critical,
         **kwargs: object,
     ) -> None:
@@ -280,7 +280,7 @@ class Logger:
 
         self.emit(level, format, log_failure=failure, **kwargs)
 
-    def debug(self, format: Optional[str] = None, **kwargs: object) -> None:
+    def debug(self, format: str | None = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.debug}.
 
@@ -295,7 +295,7 @@ class Logger:
         """
         self.emit(LogLevel.debug, format, **kwargs)
 
-    def info(self, format: Optional[str] = None, **kwargs: object) -> None:
+    def info(self, format: str | None = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.info}.
 
@@ -310,7 +310,7 @@ class Logger:
         """
         self.emit(LogLevel.info, format, **kwargs)
 
-    def warn(self, format: Optional[str] = None, **kwargs: object) -> None:
+    def warn(self, format: str | None = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.warn}.
 
@@ -325,7 +325,7 @@ class Logger:
         """
         self.emit(LogLevel.warn, format, **kwargs)
 
-    def error(self, format: Optional[str] = None, **kwargs: object) -> None:
+    def error(self, format: str | None = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.error}.
 
@@ -340,7 +340,7 @@ class Logger:
         """
         self.emit(LogLevel.error, format, **kwargs)
 
-    def critical(self, format: Optional[str] = None, **kwargs: object) -> None:
+    def critical(self, format: str | None = None, **kwargs: object) -> None:
         """
         Emit a log event at log level L{LogLevel.critical}.
 

--- a/src/twisted/logger/_observer.py
+++ b/src/twisted/logger/_observer.py
@@ -6,7 +6,9 @@
 Basic log observers.
 """
 
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable
 
 from zope.interface import implementer
 
@@ -59,7 +61,7 @@ class LogPublisher:
         Forward events to contained observers.
         """
         if "log_trace" not in event:
-            trace: Optional[Callable[[ILogObserver], None]] = None
+            trace: Callable[[ILogObserver], None] | None = None
 
         else:
 

--- a/src/twisted/logger/_stdlib.py
+++ b/src/twisted/logger/_stdlib.py
@@ -7,7 +7,7 @@ Integration with Python standard library logging.
 """
 
 import logging as stdlibLogging
-from typing import Mapping, Tuple
+from collections.abc import Mapping
 
 from zope.interface import implementer
 
@@ -80,7 +80,7 @@ class STDLibLogObserver:
 
     def _findCaller(
         self, stackInfo: bool = False, stackLevel: int = 1
-    ) -> Tuple[str, int, str, None]:
+    ) -> tuple[str, int, str, None]:
         """
         Based on the stack depth passed to this L{STDLibLogObserver}, identify
         the calling function.

--- a/src/twisted/logger/_util.py
+++ b/src/twisted/logger/_util.py
@@ -6,8 +6,6 @@
 Logging utilities.
 """
 
-from typing import List
-
 from ._interfaces import LogTrace
 from ._logger import Logger
 
@@ -31,7 +29,7 @@ def formatTrace(trace: LogTrace) -> str:
             return f"{obj}"
 
     result = []
-    lineage: List[Logger] = []
+    lineage: list[Logger] = []
 
     for parent, child in trace:
         if not lineage or lineage[-1] is not parent:

--- a/src/twisted/logger/test/test_buffer.py
+++ b/src/twisted/logger/test/test_buffer.py
@@ -5,7 +5,7 @@
 Test cases for L{twisted.logger._buffer}.
 """
 
-from typing import List, cast
+from typing import cast
 
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
@@ -41,7 +41,7 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         for event in events:
             observer(event)
 
-        outEvents: List[LogEvent] = []
+        outEvents: list[LogEvent] = []
         observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events, outEvents)
 
@@ -57,6 +57,6 @@ class LimitedHistoryLogObserverTests(unittest.TestCase):
         for event in events:
             observer(event)
 
-        outEvents: List[LogEvent] = []
+        outEvents: list[LogEvent] = []
         observer.replayTo(cast(ILogObserver, outEvents.append))
         self.assertEqual(events[-size:], outEvents)

--- a/src/twisted/logger/test/test_file.py
+++ b/src/twisted/logger/test/test_file.py
@@ -5,9 +5,11 @@
 Test cases for L{twisted.logger._file}.
 """
 
+from __future__ import annotations
+
 from io import StringIO
 from types import TracebackType
-from typing import IO, Any, AnyStr, Optional, Type, cast
+from typing import IO, Any, AnyStr, cast
 
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
@@ -44,7 +46,7 @@ class FileLogObserverTests(TestCase):
             observer(event)
             self.assertEqual(fileHandle.getvalue(), str(event))
 
-    def _test_observeWrites(self, what: Optional[str], count: int) -> None:
+    def _test_observeWrites(self, what: str | None, count: int) -> None:
         """
         Verify that observer performs an expected number of writes when the
         formatter returns a given value.
@@ -172,13 +174,13 @@ class DummyFile:
         """
         self.flushes += 1
 
-    def __enter__(self) -> "DummyFile":
+    def __enter__(self) -> DummyFile:
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
         pass

--- a/src/twisted/logger/test/test_file.py
+++ b/src/twisted/logger/test/test_file.py
@@ -7,7 +7,7 @@ Test cases for L{twisted.logger._file}.
 
 from __future__ import annotations
 
-from io import StringIO
+from io import BytesIO, StringIO
 from types import TracebackType
 from typing import IO, Any, AnyStr, cast
 
@@ -35,6 +35,17 @@ class FileLogObserverTests(TestCase):
                 verifyObject(ILogObserver, observer)
             except BrokenMethodImplementation as e:
                 self.fail(e)
+
+    def test_observeWritesBytes(self) -> None:
+        """
+        L{FileLogObserver} encodes text as UTF-8 when the output file is binary.
+        """
+        with BytesIO() as fileHandle:
+            observer = FileLogObserver(fileHandle, lambda _: "Hello World")
+            self.assertEqual(observer._encoding, "utf-8")
+            event = dict(x=1)
+            observer(event)
+            self.assertEqual(fileHandle.getvalue(), "Hello World".encode("utf-8"))
 
     def test_observeWrites(self) -> None:
         """

--- a/src/twisted/logger/test/test_filter.py
+++ b/src/twisted/logger/test/test_filter.py
@@ -5,7 +5,10 @@
 Test cases for L{twisted.logger._filter}.
 """
 
-from typing import Iterable, List, Tuple, Union, cast
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import cast
 
 from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
@@ -42,7 +45,7 @@ class FilteringLogObserverTests(unittest.TestCase):
 
     def filterWith(
         self, filters: Iterable[str], other: bool = False
-    ) -> Union[List[int], Tuple[List[int], List[int]]]:
+    ) -> list[int] | tuple[list[int], list[int]]:
         """
         Apply a set of pre-defined filters on a known set of events and return
         the filtered list of event numbers.
@@ -60,7 +63,7 @@ class FilteringLogObserverTests(unittest.TestCase):
 
         @return: event numbers or 2-tuple of lists of event numbers.
         """
-        events: List[LogEvent] = [
+        events: list[LogEvent] = [
             dict(count=0),
             dict(count=1),
             dict(count=2),
@@ -133,8 +136,8 @@ class FilteringLogObserverTests(unittest.TestCase):
                 return None
 
         predicates = (getattr(Filters, f) for f in filters)
-        eventsSeen: List[LogEvent] = []
-        eventsNotSeen: List[LogEvent] = []
+        eventsSeen: list[LogEvent] = []
+        eventsNotSeen: list[LogEvent] = []
         trackingObserver = cast(ILogObserver, eventsSeen.append)
 
         if other:
@@ -206,8 +209,8 @@ class FilteringLogObserverTests(unittest.TestCase):
         """
         e: LogEvent = dict(obj=object())
 
-        def callWithPredicateResult(result: NamedConstant) -> List[LogEvent]:
-            seen: List[LogEvent] = []
+        def callWithPredicateResult(result: NamedConstant) -> list[LogEvent]:
+            seen: list[LogEvent] = []
             observer = FilteringLogObserver(
                 cast(ILogObserver, lambda e: seen.append(e)),
                 (cast(ILogFilterPredicate, lambda e: result),),

--- a/src/twisted/logger/test/test_flatten.py
+++ b/src/twisted/logger/test/test_flatten.py
@@ -5,9 +5,11 @@
 Test cases for L{twisted.logger._format}.
 """
 
+from __future__ import annotations
+
 import json
 from itertools import count
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 try:
     from time import tzset
@@ -180,7 +182,7 @@ class FlatFormattingTests(unittest.TestCase):
         )
 
     def _test_formatFlatEvent_fieldNamesSame(
-        self, event: Optional[LogEvent] = None
+        self, event: LogEvent | None = None
     ) -> LogEvent:
         """
         The same format field used twice in one event is rendered twice.

--- a/src/twisted/logger/test/test_format.py
+++ b/src/twisted/logger/test/test_format.py
@@ -5,7 +5,9 @@
 Test cases for L{twisted.logger._format}.
 """
 
-from typing import Any, AnyStr, Dict, Optional, cast
+from __future__ import annotations
+
+from typing import Any, AnyStr, cast
 
 try:
     from time import tzset
@@ -100,8 +102,8 @@ class FormattingTests(unittest.TestCase):
         L{formatEvent} will format subscripts of attributes per PEP 3101.
         """
 
-        class Example(object):
-            config: Dict[str, str] = dict(foo="bar", baz="qux")
+        class Example:
+            config: dict[str, str] = dict(foo="bar", baz="qux")
 
         self.assertEqual(
             "bar qux",
@@ -200,7 +202,7 @@ class TimeFormattingTests(unittest.TestCase):
             raise SkipTest("Platform cannot change timezone; unable to verify offsets.")
 
         def testForTimeZone(
-            name: str, expectedDST: Optional[str], expectedSTD: str
+            name: str, expectedDST: str | None, expectedSTD: str
         ) -> None:
             setTZ(name)
 
@@ -298,7 +300,7 @@ class ClassicLogFormattingTests(unittest.TestCase):
         argument.
         """
 
-        def formatTime(t: Optional[float]) -> str:
+        def formatTime(t: float | None) -> str:
             return f"__{t}__"
 
         event = dict(log_format="XYZZY", log_time=12345)

--- a/src/twisted/logger/test/test_global.py
+++ b/src/twisted/logger/test/test_global.py
@@ -5,8 +5,10 @@
 Test cases for L{twisted.logger._global}.
 """
 
+from __future__ import annotations
+
 import io
-from typing import IO, Any, List, Optional, TextIO, Tuple, Type, cast
+from typing import IO, Any, TextIO, cast
 
 from twisted.python.failure import Failure
 from twisted.trial import unittest
@@ -21,8 +23,8 @@ from ..test.test_stdlib import nextLine
 
 def compareEvents(
     test: unittest.TestCase,
-    actualEvents: List[LogEvent],
-    expectedEvents: List[LogEvent],
+    actualEvents: list[LogEvent],
+    expectedEvents: list[LogEvent],
 ) -> None:
     """
     Compare two sequences of log events, examining only the the keys which are
@@ -65,20 +67,18 @@ class LogBeginnerTests(unittest.TestCase):
 
         class NotWarnings:
             def __init__(self) -> None:
-                self.warnings: List[
-                    Tuple[
-                        str, Type[Warning], str, int, Optional[IO[Any]], Optional[int]
-                    ]
+                self.warnings: list[
+                    tuple[str, type[Warning], str, int, IO[Any] | None, int | None]
                 ] = []
 
             def showwarning(
                 self,
                 message: str,
-                category: Type[Warning],
+                category: type[Warning],
                 filename: str,
                 lineno: int,
-                file: Optional[IO[Any]] = None,
-                line: Optional[int] = None,
+                file: IO[Any] | None = None,
+                line: int | None = None,
             ) -> None:
                 """
                 Emulate warnings.showwarning.
@@ -110,8 +110,8 @@ class LogBeginnerTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1: List[LogEvent] = []
-        events2: List[LogEvent] = []
+        events1: list[LogEvent] = []
+        events2: list[LogEvent] = []
 
         o1 = cast(ILogObserver, lambda e: events1.append(e))
         o2 = cast(ILogObserver, lambda e: events2.append(e))
@@ -129,8 +129,8 @@ class LogBeginnerTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1: List[LogEvent] = []
-        events2: List[LogEvent] = []
+        events1: list[LogEvent] = []
+        events2: list[LogEvent] = []
 
         o1 = cast(ILogObserver, lambda e: events1.append(e))
         o2 = cast(ILogObserver, lambda e: events2.append(e))
@@ -155,7 +155,7 @@ class LogBeginnerTests(unittest.TestCase):
         """
         for count in range(limit + 1):
             self.publisher(dict(count=count))
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
         beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.assertEqual(
             list(range(1, limit + 1)),
@@ -191,8 +191,8 @@ class LogBeginnerTests(unittest.TestCase):
         message warning the user that they previously began logging, and add
         the new log observers.
         """
-        events1: List[LogEvent] = []
-        events2: List[LogEvent] = []
+        events1: list[LogEvent] = []
+        events2: list[LogEvent] = []
         fileHandle = io.StringIO()
         textObserver = textFileLogObserver(fileHandle)
         self.publisher(dict(event="prebuffer"))
@@ -253,7 +253,7 @@ class LogBeginnerTests(unittest.TestCase):
         error streams by setting the C{stdio} and C{stderr} attributes on its
         sys module object.
         """
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         print("Hello, world.", file=cast(TextIO, self.sysModule.stdout))
         compareEvents(
@@ -289,7 +289,7 @@ class LogBeginnerTests(unittest.TestCase):
         self.sysModule.stdout = weird
         self.sysModule.stderr = weirderr
 
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         stdout = cast(TextIO, self.sysModule.stdout)
         stderr = cast(TextIO, self.sysModule.stderr)
@@ -306,7 +306,7 @@ class LogBeginnerTests(unittest.TestCase):
         warnings module into the logging system.
         """
         self.warningsModule.showwarning("a message", DeprecationWarning, __file__, 1)
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
         self.beginner.beginLoggingTo([cast(ILogObserver, events.append)])
         self.warningsModule.showwarning(
             "another message", DeprecationWarning, __file__, 2

--- a/src/twisted/logger/test/test_io.py
+++ b/src/twisted/logger/test/test_io.py
@@ -5,8 +5,9 @@
 Test cases for L{twisted.logger._io}.
 """
 
+from __future__ import annotations
+
 import sys
-from typing import List, Optional
 
 from zope.interface import implementer
 
@@ -30,11 +31,11 @@ class TestLoggingFile(LoggingFile):
         self,
         logger: Logger,
         level: NamedConstant = LogLevel.info,
-        encoding: Optional[str] = None,
+        encoding: str | None = None,
     ) -> None:
         super().__init__(logger=logger, level=level, encoding=encoding)
-        self.events: List[LogEvent] = []
-        self.messages: List[str] = []
+        self.events: list[LogEvent] = []
+        self.messages: list[str] = []
 
     def __call__(self, event: LogEvent) -> None:
         self.events.append(event)
@@ -261,7 +262,7 @@ class LoggingFileTests(unittest.TestCase):
     def observedFile(
         self,
         level: NamedConstant = LogLevel.info,
-        encoding: Optional[str] = None,
+        encoding: str | None = None,
     ) -> TestLoggingFile:
         """
         Construct a L{LoggingFile} with a built-in observer.
@@ -277,7 +278,7 @@ class LoggingFileTests(unittest.TestCase):
         # TestLoggingFile we will create, but that takes the Logger as an
         # argument, so we'll use an array to indirectly reference the
         # TestLoggingFile.
-        loggingFiles: List[TestLoggingFile] = []
+        loggingFiles: list[TestLoggingFile] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:

--- a/src/twisted/logger/test/test_json.py
+++ b/src/twisted/logger/test/test_json.py
@@ -5,8 +5,11 @@
 Tests for L{twisted.logger._json}.
 """
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 from io import BytesIO, StringIO
-from typing import IO, Any, List, Optional, Sequence, cast
+from typing import IO, Any, cast
 
 from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
@@ -158,7 +161,7 @@ class SaveLoadTests(TestCase):
         Round-tripping a failure through L{eventAsJSON} preserves its class and
         structure.
         """
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
         log = Logger(observer=cast(ILogObserver, events.append))
         try:
             1 / 0
@@ -247,7 +250,7 @@ class FileLogObserverTests(TestCase):
         """
         io = StringIO()
         publisher = LogPublisher()
-        logged: List[LogEvent] = []
+        logged: list[LogEvent] = []
         publisher.addObserver(cast(ILogObserver, logged.append))
         publisher.addObserver(jsonFileLogObserver(io))
         logger = Logger(observer=publisher)
@@ -280,7 +283,7 @@ class LogFileReaderTests(TestCase):
     """
 
     def setUp(self) -> None:
-        self.errorEvents: List[LogEvent] = []
+        self.errorEvents: list[LogEvent] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:
@@ -297,7 +300,7 @@ class LogFileReaderTests(TestCase):
     def _readEvents(
         self,
         inFile: IO[Any],
-        recordSeparator: Optional[str] = None,
+        recordSeparator: str | None = None,
         bufferSize: int = 4096,
     ) -> None:
         """

--- a/src/twisted/logger/test/test_legacy.py
+++ b/src/twisted/logger/test/test_legacy.py
@@ -5,9 +5,11 @@
 Test cases for L{twisted.logger._legacy}.
 """
 
+from __future__ import annotations
+
 import logging as py_logging
 from time import time
-from typing import List, cast
+from typing import cast
 
 from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
@@ -64,7 +66,7 @@ class LegacyLogObserverWrapperTests(unittest.TestCase):
 
         @return: the event as observed by the legacy wrapper
         """
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
 
         legacyObserver = cast(legacyLog.ILogObserver, lambda e: events.append(e))
         observer = LegacyLogObserverWrapper(legacyObserver)
@@ -280,7 +282,7 @@ class PublishToNewObserverTests(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.events: List[LogEvent] = []
+        self.events: list[LogEvent] = []
         self.observer = cast(ILogObserver, self.events.append)
 
     def legacyEvent(self, *message: str, **values: object) -> legacyLog.EventDict:

--- a/src/twisted/logger/test/test_logger.py
+++ b/src/twisted/logger/test/test_logger.py
@@ -5,7 +5,9 @@
 Test cases for L{twisted.logger._logger}.
 """
 
-from typing import List, Optional, Type, cast
+from __future__ import annotations
+
+from typing import cast
 
 from zope.interface import implementer
 
@@ -27,7 +29,7 @@ class TestLogger(Logger):
     """
 
     def emit(
-        self, level: NamedConstant, format: Optional[str] = None, **kwargs: object
+        self, level: NamedConstant, format: str | None = None, **kwargs: object
     ) -> None:
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:
@@ -53,7 +55,7 @@ class LogComposedObject:
 
     log = TestLogger()
 
-    def __init__(self, state: Optional[str] = None) -> None:
+    def __init__(self, state: str | None = None) -> None:
         self.state = state
 
     def __str__(self) -> str:
@@ -86,7 +88,7 @@ class LoggerTests(unittest.TestCase):
         context in which is can't be determined automatically and no namespace
         was specified.
         """
-        result: List[Logger] = []
+        result: list[Logger] = []
         exec(
             "result.append(Logger())",
             dict(Logger=Logger),
@@ -108,10 +110,10 @@ class LoggerTests(unittest.TestCase):
 
         self.assertEqual(cast(TestLogger, obj.log).namespace, expectedNamespace)
         self.assertEqual(
-            cast(Type[TestLogger], LogComposedObject.log).namespace, expectedNamespace
+            cast(type[TestLogger], LogComposedObject.log).namespace, expectedNamespace
         )
         self.assertIs(
-            cast(Type[TestLogger], LogComposedObject.log).source, LogComposedObject
+            cast(type[TestLogger], LogComposedObject.log).source, LogComposedObject
         )
         self.assertIs(cast(TestLogger, obj.log).source, obj)
         self.assertIsNone(Logger().source)
@@ -120,7 +122,7 @@ class LoggerTests(unittest.TestCase):
         """
         When used as a descriptor, the observer is propagated.
         """
-        observed: List[LogEvent] = []
+        observed: list[LogEvent] = []
 
         class MyObject:
             log = Logger(observer=cast(ILogObserver, observed.append))

--- a/src/twisted/logger/test/test_observer.py
+++ b/src/twisted/logger/test/test_observer.py
@@ -5,7 +5,9 @@
 Test cases for L{twisted.logger._observer}.
 """
 
-from typing import Dict, List, Tuple, cast
+from __future__ import annotations
+
+from typing import cast
 
 from zope.interface import implementer
 from zope.interface.exceptions import BrokenMethodImplementation
@@ -93,9 +95,9 @@ class LogPublisherTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2)
 
-        events1: List[LogEvent] = []
-        events2: List[LogEvent] = []
-        events3: List[LogEvent] = []
+        events1: list[LogEvent] = []
+        events2: list[LogEvent] = []
+        events3: list[LogEvent] = []
 
         o1 = cast(ILogObserver, events1.append)
         o2 = cast(ILogObserver, events2.append)
@@ -115,7 +117,7 @@ class LogPublisherTests(unittest.TestCase):
         event = dict(foo=1, bar=2)
         exception = RuntimeError("ARGH! EVIL DEATH!")
 
-        events: List[LogEvent] = []
+        events: list[LogEvent] = []
 
         @implementer(ILogObserver)
         def observer(event: LogEvent) -> None:
@@ -124,7 +126,7 @@ class LogPublisherTests(unittest.TestCase):
             if shouldRaise:
                 raise exception
 
-        collector: List[LogEvent] = []
+        collector: list[LogEvent] = []
 
         publisher = LogPublisher(observer, cast(ILogObserver, collector.append))
         publisher(event)
@@ -168,7 +170,7 @@ class LogPublisherTests(unittest.TestCase):
         """
         event = dict(foo=1, bar=2, log_trace=[])
 
-        traces: Dict[int, Tuple[Tuple[Logger, ILogObserver]]] = {}
+        traces: dict[int, tuple[tuple[Logger, ILogObserver]]] = {}
 
         # Copy trace to a tuple; otherwise, both observers will store the same
         # mutable list, and we won't be able to see o1's view distinctly.
@@ -176,13 +178,13 @@ class LogPublisherTests(unittest.TestCase):
         @implementer(ILogObserver)
         def o1(e: LogEvent) -> None:
             traces.setdefault(
-                1, cast(Tuple[Tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
+                1, cast(tuple[tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
             )
 
         @implementer(ILogObserver)
         def o2(e: LogEvent) -> None:
             traces.setdefault(
-                2, cast(Tuple[Tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
+                2, cast(tuple[tuple[Logger, ILogObserver]], tuple(e["log_trace"]))
             )
 
         publisher = LogPublisher(o1, o2)

--- a/src/twisted/logger/test/test_stdlib.py
+++ b/src/twisted/logger/test/test_stdlib.py
@@ -11,7 +11,6 @@ import sys
 from inspect import getsourcefile
 from io import BytesIO, TextIOWrapper
 from logging import Formatter, LogRecord, StreamHandler, getLogger
-from typing import List, Optional, Tuple
 
 from zope.interface.exceptions import BrokenMethodImplementation
 from zope.interface.verify import verifyObject
@@ -24,7 +23,7 @@ from .._levels import LogLevel
 from .._stdlib import STDLibLogObserver
 
 
-def nextLine() -> Tuple[Optional[str], int]:
+def nextLine() -> tuple[str | None, int]:
     """
     Retrive the file name and line number immediately after where this function
     is called.
@@ -99,7 +98,7 @@ class STDLibLogObserverTests(unittest.TestCase):
         self.addCleanup(logger.close)
         return logger
 
-    def logEvent(self, *events: LogEvent) -> Tuple[List[LogRecord], str]:
+    def logEvent(self, *events: LogEvent) -> tuple[list[LogRecord], str]:
         """
         Send one or more events to Python's logging module, and capture the
         emitted L{LogRecord}s and output stream as a string.
@@ -284,7 +283,7 @@ class BufferedHandler(py_logging.Handler):
         Initialize this L{BufferedHandler}.
         """
         py_logging.Handler.__init__(self)
-        self.records: List[LogRecord] = []
+        self.records: list[LogRecord] = []
 
     def emit(self, record: LogRecord) -> None:
         """


### PR DESCRIPTION
## Scope and purpose

Fixes #12560 

The changes were automatically generated using:

* `pyupgrade --py39-plus .\src\twisted\logger\*.py`
* `pyupgrade --py39-plus .\src\twisted\logger\test\*.py`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as List. (`pyupgrade` doesn't remove these)
* Fix a flake8 issue by using `TypeAlias` explicitly https://github.com/twisted/twisted/pull/12561/commits/1efbdf3d71b53417d69a55ffe99dbbbb6816f40f
* Add a new test to fix a code coverage warning: https://github.com/twisted/twisted/pull/12561/commits/ed49afdb96524761c9bb631c814cc57f79136b79

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
