### PR TITLE
#12562 python: update type annotations for Python 3.9+ (1/1) 

### DIFF
--- a/src/twisted/python/_release.py
+++ b/src/twisted/python/_release.py
@@ -14,7 +14,6 @@ which must run on multiple platforms (eg the setup.py script).
 
 import os
 from subprocess import STDOUT, CalledProcessError, check_output
-from typing import Dict
 
 from zope.interface import Interface, implementer
 
@@ -198,7 +197,7 @@ class Project:
         @return: A L{incremental.Version} specifying the version number of the
             project based on live python modules.
         """
-        namespace: Dict[str, object] = {}
+        namespace: dict[str, object] = {}
         directory = self.directory
         while not namespace:
             if directory.path == "/":

--- a/src/twisted/python/_shellcomp.py
+++ b/src/twisted/python/_shellcomp.py
@@ -30,7 +30,6 @@ import getopt
 import inspect
 import itertools
 from types import MethodType
-from typing import Dict, List, Set
 
 from twisted.python import reflect, usage, util
 from twisted.python.compat import ioType
@@ -305,8 +304,8 @@ class ZshArgumentsGenerator:
 
         aCL = reflect.accumulateClassList
 
-        optFlags: List[List[object]] = []
-        optParams: List[List[object]] = []
+        optFlags: list[list[object]] = []
+        optParams: list[list[object]] = []
 
         aCL(options.__class__, "optFlags", optFlags)
         aCL(options.__class__, "optParameters", optParams)
@@ -468,7 +467,7 @@ class ZshArgumentsGenerator:
         strings.sort()  # need deterministic order for reliable unit-tests
         return "(%s)" % " ".join(strings)
 
-    def makeExcludesDict(self) -> Dict[str, Set[str]]:
+    def makeExcludesDict(self) -> dict[str, set[str]]:
         """
         @return: A C{dict} that maps each option name appearing in
             self.mutuallyExclusive to a set of those option names that is it
@@ -481,7 +480,7 @@ class ZshArgumentsGenerator:
             if optList[1] != None:
                 longToShort[optList[0]] = optList[1]
 
-        excludes: Dict[str, Set[str]] = {}
+        excludes: dict[str, set[str]] = {}
         for lst in self.mutuallyExclusive:
             for i, longname in enumerate(lst):
                 tmp = set(lst[:i] + lst[i + 1 :])
@@ -624,7 +623,7 @@ class ZshArgumentsGenerator:
         These will be defined by 'opt_foo' methods of the Options subclass
         @return: L{None}
         """
-        methodsDict: Dict[str, MethodType] = {}
+        methodsDict: dict[str, MethodType] = {}
         reflect.accumulateMethods(self.options, methodsDict, "opt_")
         methodToShort = {}
         for name in methodsDict.copy():

--- a/src/twisted/python/_textattributes.py
+++ b/src/twisted/python/_textattributes.py
@@ -21,7 +21,8 @@ Serializing a formatting structure is done with L{flatten}.
 """
 
 
-from typing import ClassVar, List, Sequence
+from collections.abc import Sequence
+from typing import ClassVar
 
 from twisted.python.util import FancyEqMixin
 
@@ -296,7 +297,7 @@ def flatten(output, attrs, attributeRenderer="toVT102"):
     @return: A string expressing the text and display attributes specified by
         L{output}.
     """
-    flattened: List[str] = []
+    flattened: list[str] = []
     output.serialize(flattened.append, attrs, attributeRenderer)
     return "".join(flattened)
 

--- a/src/twisted/python/_tzhelper.py
+++ b/src/twisted/python/_tzhelper.py
@@ -6,13 +6,14 @@
 Time zone utilities.
 """
 
+from __future__ import annotations
+
 from datetime import (
     datetime as DateTime,
     timedelta as TimeDelta,
     timezone,
     tzinfo as TZInfo,
 )
-from typing import Optional
 
 __all__ = [
     "FixedOffsetTimeZone",
@@ -31,7 +32,7 @@ class FixedOffsetTimeZone(TZInfo):
         offset.
     """
 
-    def __init__(self, offset: TimeDelta, name: Optional[str] = None) -> None:
+    def __init__(self, offset: TimeDelta, name: str | None = None) -> None:
         """
         Construct a L{FixedOffsetTimeZone} with a fixed offset.
 
@@ -44,7 +45,7 @@ class FixedOffsetTimeZone(TZInfo):
     @classmethod
     def fromSignHoursMinutes(
         cls, sign: str, hours: int, minutes: int
-    ) -> "FixedOffsetTimeZone":
+    ) -> FixedOffsetTimeZone:
         """
         Construct a L{FixedOffsetTimeZone} from an offset described by sign
         ('+' or '-'), hours, and minutes.
@@ -68,7 +69,7 @@ class FixedOffsetTimeZone(TZInfo):
         return cls(TimeDelta(hours=hours, minutes=minutes), name)
 
     @classmethod
-    def fromLocalTimeStamp(cls, timeStamp: float) -> "FixedOffsetTimeZone":
+    def fromLocalTimeStamp(cls, timeStamp: float) -> FixedOffsetTimeZone:
         """
         Create a time zone with a fixed offset corresponding to a time stamp in
         the system's locally configured time zone.
@@ -78,20 +79,20 @@ class FixedOffsetTimeZone(TZInfo):
         ).replace(tzinfo=None)
         return cls(offset)
 
-    def utcoffset(self, dt: Optional[DateTime]) -> TimeDelta:
+    def utcoffset(self, dt: DateTime | None) -> TimeDelta:
         """
         Return the given timezone's offset from UTC.
         """
         return self.offset
 
-    def dst(self, dt: Optional[DateTime]) -> TimeDelta:
+    def dst(self, dt: DateTime | None) -> TimeDelta:
         """
         Return a zero L{TimeDelta} for the daylight saving time
         offset, since there is never one.
         """
         return TimeDelta(0)
 
-    def tzname(self, dt: Optional[DateTime]) -> str:
+    def tzname(self, dt: DateTime | None) -> str:
         """
         Return a string describing this timezone.
         """

--- a/src/twisted/python/components.py
+++ b/src/twisted/python/components.py
@@ -31,7 +31,6 @@ interface.
 
 
 from io import StringIO
-from typing import Dict
 
 # zope3 imports
 from zope.interface import declarations, interface
@@ -332,7 +331,7 @@ def proxyForInterface(iface, originalAttribute="original"):
     def __init__(self, original):
         setattr(self, originalAttribute, original)
 
-    contents: Dict[str, object] = {"__init__": __init__}
+    contents: dict[str, object] = {"__init__": __init__}
     for name in iface:
         contents[name] = _ProxyDescriptor(name, originalAttribute)
     proxy = type(f"(Proxy for {reflect.qual(iface)})", (object,), contents)

--- a/src/twisted/python/context.py
+++ b/src/twisted/python/context.py
@@ -14,9 +14,8 @@ This is thread-safe.
 
 
 from threading import local
-from typing import Dict, Type
 
-defaultContextDict: Dict[Type[object], Dict[str, str]] = {}
+defaultContextDict: dict[type[object], dict[str, str]] = {}
 
 setDefault = defaultContextDict.__setitem__
 

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -94,10 +94,11 @@ __all__ = [
 
 import inspect
 import sys
+from collections.abc import Sequence
 from dis import findlinestarts
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Optional, Sequence, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 from warnings import warn, warn_explicit
 
 from incremental import Version, getVersionString
@@ -728,7 +729,7 @@ _Tc = TypeVar("_Tc", bound=Callable[..., Any])
 
 
 def deprecatedKeywordParameter(
-    version: Version, name: str, replacement: Optional[str] = None
+    version: Version, name: str, replacement: str | None = None
 ) -> Callable[[_Tc], _Tc]:
     """
     Return a decorator that marks a keyword parameter of a callable

--- a/src/twisted/python/fakepwd.py
+++ b/src/twisted/python/fakepwd.py
@@ -6,7 +6,7 @@
 L{twisted.python.fakepwd} provides a fake implementation of the L{pwd} API.
 """
 
-from typing import List, Optional
+from __future__ import annotations
 
 __all__ = ["UserDatabase", "ShadowDatabase"]
 
@@ -60,7 +60,7 @@ class UserDatabase:
         added to this database.
     """
 
-    _users: List[_UserRecord]
+    _users: list[_UserRecord]
     _lastUID: int = 10101
     _lastGID: int = 20202
 
@@ -71,8 +71,8 @@ class UserDatabase:
         self,
         username: str,
         password: str = "password",
-        uid: Optional[int] = None,
-        gid: Optional[int] = None,
+        uid: int | None = None,
+        gid: int | None = None,
         gecos: str = "",
         home: str = "",
         shell: str = "/bin/sh",
@@ -130,7 +130,7 @@ class UserDatabase:
                 return entry
         raise KeyError()
 
-    def getpwall(self) -> List[_UserRecord]:
+    def getpwall(self) -> list[_UserRecord]:
         """
         Return a list of all user records.
         """
@@ -194,7 +194,7 @@ class ShadowDatabase:
     @since: 12.0
     """
 
-    _users: List[_ShadowRecord]
+    _users: list[_ShadowRecord]
 
     def __init__(self) -> None:
         self._users = []

--- a/src/twisted/python/filepath.py
+++ b/src/twisted/python/filepath.py
@@ -12,6 +12,7 @@ import base64
 import errno
 import os
 import sys
+from collections.abc import Iterable, Sequence
 from os import listdir, stat, utime
 from os.path import (
     abspath,
@@ -46,16 +47,9 @@ from typing import (
     Any,
     AnyStr,
     Callable,
-    Dict,
     Generic,
-    Iterable,
-    List,
     Literal,
-    Optional,
-    Sequence,
-    Tuple,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -207,7 +201,7 @@ class IFilePath(Interface):
         @raise Exception: if the file at this file path is not a directory.
         """
 
-    def basename() -> Union[str, bytes]:
+    def basename() -> str | bytes:
         """
         Retrieve the final component of the file path's path (everything after
         the final path separator).
@@ -351,7 +345,7 @@ class AbstractFilePath(Generic[AnyStr]):
         """
         raise NotImplementedError()
 
-    def listdir(self) -> List[AnyStr]:
+    def listdir(self) -> list[AnyStr]:
         """
         Subclasses must implement this.
         """
@@ -404,7 +398,7 @@ class AbstractFilePath(Generic[AnyStr]):
         @return: an iterable of all currently-existing children of this object.
         """
         try:
-            subnames: List[AnyStr] = self.listdir()
+            subnames: list[AnyStr] = self.listdir()
         except OSError as ose:
             # Under Python 3.3 and higher on Windows, WindowsError is an
             # alias for OSError.  OSError has a winerror attribute and an
@@ -440,7 +434,7 @@ class AbstractFilePath(Generic[AnyStr]):
 
     def walk(
         self: _Self,
-        descend: Optional[Callable[[_Self], bool]] = None,
+        descend: Callable[[_Self], bool] | None = None,
     ) -> Iterable[_Self]:
         """
         Yield myself, then each of my children, and each of those children's
@@ -512,7 +506,7 @@ class AbstractFilePath(Generic[AnyStr]):
             path = path.child(name)
         return path
 
-    def segmentsFrom(self: _Self, ancestor: _Self) -> List[AnyStr]:
+    def segmentsFrom(self: _Self, ancestor: _Self) -> list[AnyStr]:
         """
         Return a list of segments between a child and its ancestor.
 
@@ -533,7 +527,7 @@ class AbstractFilePath(Generic[AnyStr]):
         # obvious fast implemenation does the right thing too
         f = self
         p: _Self = f.parent()  # type:ignore[assignment]
-        segments: List[AnyStr] = []
+        segments: list[AnyStr] = []
         while f != ancestor and p != f:
             segments[0:0] = [f.basename()]
             f = p
@@ -663,7 +657,7 @@ class Permissions(FancyEqMixin):
         return "".join([x.shorthand() for x in (self.user, self.group, self.other)])
 
 
-def _asFilesystemBytes(path: Union[bytes, str], encoding: Optional[str] = "") -> bytes:
+def _asFilesystemBytes(path: bytes | str, encoding: str | None = "") -> bytes:
     """
     Return C{path} as a string of L{bytes} suitable for use on this system's
     filesystem.
@@ -683,7 +677,7 @@ def _asFilesystemBytes(path: Union[bytes, str], encoding: Optional[str] = "") ->
         return path.encode(encoding, errors="surrogateescape")
 
 
-def _asFilesystemText(path: Union[bytes, str], encoding: Optional[str] = None) -> str:
+def _asFilesystemText(path: bytes | str, encoding: str | None = None) -> str:
     """
     Return C{path} as a string of L{unicode} suitable for use on this system's
     filesystem.
@@ -705,7 +699,7 @@ def _asFilesystemText(path: Union[bytes, str], encoding: Optional[str] = None) -
 
 
 def _coerceToFilesystemEncoding(
-    path: AnyStr, newpath: Union[bytes, str], encoding: Optional[str] = None
+    path: AnyStr, newpath: bytes | str, encoding: str | None = None
 ) -> AnyStr:
     """
     Return a C{newpath} that is suitable for joining to C{path}.
@@ -806,7 +800,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return FilePath(path)
 
-    def __getstate__(self) -> Dict[str, object]:
+    def __getstate__(self) -> dict[str, object]:
         """
         Support serialization by discarding cached L{os.stat} results and
         returning everything else.
@@ -826,7 +820,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return _coerceToFilesystemEncoding(self.path, os.sep)
 
-    def _asBytesPath(self, encoding: Optional[str] = None) -> bytes:
+    def _asBytesPath(self, encoding: str | None = None) -> bytes:
         """
         Return the path of this L{FilePath} as bytes.
 
@@ -837,7 +831,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return _asFilesystemBytes(self.path, encoding=encoding)
 
-    def _asTextPath(self, encoding: Optional[str] = None) -> str:
+    def _asTextPath(self, encoding: str | None = None) -> str:
         """
         Return the path of this L{FilePath} as text.
 
@@ -848,7 +842,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return _asFilesystemText(self.path, encoding=encoding)
 
-    def asBytesMode(self, encoding: Optional[str] = None) -> FilePath[bytes]:
+    def asBytesMode(self, encoding: str | None = None) -> FilePath[bytes]:
         """
         Return this L{FilePath} in L{bytes}-mode.
 
@@ -861,7 +855,7 @@ class FilePath(AbstractFilePath[AnyStr]):
             return self.clonePath(self._asBytesPath(encoding=encoding))
         return self
 
-    def asTextMode(self, encoding: Optional[str] = None) -> FilePath[str]:
+    def asTextMode(self, encoding: str | None = None) -> FilePath[str]:
         """
         Return this L{FilePath} in L{unicode}-mode.
 
@@ -937,9 +931,7 @@ class FilePath(AbstractFilePath[AnyStr]):
             raise InsecurePath(f"{newpath!r} is not a child of {ourPath!r}")
         return self.clonePath(newpath)
 
-    def childSearchPreauth(
-        self, *paths: OtherAnyStr
-    ) -> Optional[FilePath[OtherAnyStr]]:
+    def childSearchPreauth(self, *paths: OtherAnyStr) -> FilePath[OtherAnyStr] | None:
         """
         Return my first existing child with a name in C{paths}.
 
@@ -961,7 +953,7 @@ class FilePath(AbstractFilePath[AnyStr]):
 
     def siblingExtensionSearch(
         self, *exts: OtherAnyStr
-    ) -> Optional[FilePath[OtherAnyStr]]:
+    ) -> FilePath[OtherAnyStr] | None:
         """
         Attempt to return a path with my name, given multiple possible
         extensions.
@@ -1396,7 +1388,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return isabs(self.path)
 
-    def listdir(self) -> List[AnyStr]:
+    def listdir(self) -> list[AnyStr]:
         """
         List the base names of the direct children of this L{FilePath}.
 
@@ -1410,7 +1402,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return listdir(self.path)
 
-    def splitext(self) -> Tuple[AnyStr, AnyStr]:
+    def splitext(self) -> tuple[AnyStr, AnyStr]:
         """
         Split the file path into a pair C{(root, ext)} such that
         C{root + ext == path}.
@@ -1472,7 +1464,7 @@ class FilePath(AbstractFilePath[AnyStr]):
             ):
                 raise
 
-    def globChildren(self, pattern: OtherAnyStr) -> List[FilePath[OtherAnyStr]]:
+    def globChildren(self, pattern: OtherAnyStr) -> list[FilePath[OtherAnyStr]]:
         """
         Assuming I am representing a directory, return a list of FilePaths
         representing my children that match the given pattern.
@@ -1523,7 +1515,7 @@ class FilePath(AbstractFilePath[AnyStr]):
         """
         return self.clonePath(self.dirname())
 
-    def setContent(self, content: bytes, ext: Union[str, bytes] = ".new") -> None:
+    def setContent(self, content: bytes, ext: str | bytes = ".new") -> None:
         """
         Replace the file at this path with a new file that contains the given
         bytes, trying to avoid data-loss in the meanwhile.
@@ -1621,13 +1613,11 @@ class FilePath(AbstractFilePath[AnyStr]):
         ...
 
     @overload
-    def temporarySibling(
-        self, extension: Optional[OtherAnyStr]
-    ) -> FilePath[OtherAnyStr]:
+    def temporarySibling(self, extension: OtherAnyStr | None) -> FilePath[OtherAnyStr]:
         ...
 
     def temporarySibling(
-        self, extension: Optional[OtherAnyStr] = None
+        self, extension: OtherAnyStr | None = None
     ) -> FilePath[OtherAnyStr]:
         """
         Construct a path referring to a sibling of this path.

--- a/src/twisted/python/formmethod.py
+++ b/src/twisted/python/formmethod.py
@@ -10,8 +10,10 @@ This module contains support for descriptive method signatures that can be used
 to format methods.
 """
 
+from __future__ import annotations
+
 import calendar
-from typing import Any, Optional, Tuple
+from typing import Any
 
 
 class FormException(Exception):
@@ -136,7 +138,7 @@ class Hidden(String):
 class Integer(Argument):
     """A single integer."""
 
-    defaultDefault: Optional[int] = None
+    defaultDefault: int | None = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None
@@ -203,7 +205,7 @@ class IntegerRange(Integer):
 
 
 class Float(Argument):
-    defaultDefault: Optional[float] = None
+    defaultDefault: float | None = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None
@@ -343,7 +345,7 @@ def positiveInt(x):
 class Date(Argument):
     """A date -- (year, month, day) tuple."""
 
-    defaultDefault: Optional[Tuple[int, int, int]] = None
+    defaultDefault: tuple[int, int, int] | None = None
 
     def __init__(
         self, name, allowNone=1, default=None, shortDesc=None, longDesc=None, hints=None

--- a/src/twisted/python/htmlizer.py
+++ b/src/twisted/python/htmlizer.py
@@ -9,7 +9,6 @@ HTML rendering of Python source.
 import keyword
 import tokenize
 from html import escape
-from typing import List
 
 from . import reflect
 
@@ -74,11 +73,11 @@ class HTMLWriter:
     tokens as HTML spans.
     """
 
-    noSpan: List[str] = []
+    noSpan: list[str] = []
 
     def __init__(self, writer):
         self.writer = writer
-        noSpan: List[str] = []
+        noSpan: list[str] = []
         reflect.accumulateClassList(self.__class__, "noSpan", noSpan)
         self.noSpan = noSpan
 

--- a/src/twisted/python/log.py
+++ b/src/twisted/python/log.py
@@ -6,13 +6,14 @@
 Logging and metrics infrastructure.
 """
 
+from __future__ import annotations
 
 import sys
 import time
 import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Any, BinaryIO, Dict, Optional, cast
+from typing import Any, BinaryIO, cast
 
 from zope.interface import Interface
 
@@ -31,7 +32,7 @@ from twisted.logger._legacy import publishToNewObserver as _publishNew
 from twisted.python import context, failure, reflect, util
 from twisted.python.threadable import synchronize
 
-EventDict = Dict[str, Any]
+EventDict = dict[str, Any]
 
 
 class ILogContext:
@@ -353,7 +354,7 @@ if "theLogPublisher" not in globals():
         """
 
 
-def _safeFormat(fmtString: str, fmtDict: Dict[str, Any]) -> str:
+def _safeFormat(fmtString: str, fmtDict: dict[str, Any]) -> str:
     """
     Try to format a string, swallowing all errors to always return a string.
 
@@ -397,7 +398,7 @@ def _safeFormat(fmtString: str, fmtDict: Dict[str, Any]) -> str:
     return text
 
 
-def textFromEventDict(eventDict: EventDict) -> Optional[str]:
+def textFromEventDict(eventDict: EventDict) -> str | None:
     """
     Extract text from an event dict passed to a log observer. If it cannot
     handle the dict, it returns None.
@@ -472,7 +473,7 @@ class FileLogObserver(_GlobalStartStopObserver):
     @ivar timeFormat: If not L{None}, the format string passed to strftime().
     """
 
-    timeFormat: Optional[str] = None
+    timeFormat: str | None = None
 
     def __init__(self, f):
         # Compatibility

--- a/src/twisted/python/logfile.py
+++ b/src/twisted/python/logfile.py
@@ -7,13 +7,14 @@
 A rotating, browsable log file.
 """
 
+from __future__ import annotations
 
 # System Imports
 import glob
 import os
 import stat
 import time
-from typing import BinaryIO, Optional, cast
+from typing import BinaryIO, cast
 
 from twisted.python import threadable
 
@@ -26,7 +27,7 @@ class BaseLogFile:
     synchronized = ["write", "rotate"]
 
     def __init__(
-        self, name: str, directory: str, defaultMode: Optional[int] = None
+        self, name: str, directory: str, defaultMode: int | None = None
     ) -> None:
         """
         Create a log file.
@@ -40,7 +41,7 @@ class BaseLogFile:
         self.name = name
         self.path = os.path.join(directory, name)
         if defaultMode is None and os.path.exists(self.path):
-            self.defaultMode: Optional[int] = stat.S_IMODE(
+            self.defaultMode: int | None = stat.S_IMODE(
                 os.stat(self.path)[stat.ST_MODE]
             )
         else:

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -15,7 +15,6 @@ import time
 import types
 from importlib import reload
 from types import ModuleType
-from typing import Dict
 
 # Sibling Imports
 from twisted.python import log, reflect
@@ -60,7 +59,7 @@ class Sensitive:
             return anObject
 
 
-_modDictIDMap: Dict[int, ModuleType] = {}
+_modDictIDMap: dict[int, ModuleType] = {}
 
 
 def latestFunction(oldFunc):

--- a/src/twisted/python/reflect.py
+++ b/src/twisted/python/reflect.py
@@ -7,6 +7,7 @@ Standardized versions of various cool and/or strange things that you can do
 with Python's reflection capabilities.
 """
 
+from __future__ import annotations
 
 import os
 import pickle
@@ -17,7 +18,6 @@ import types
 import weakref
 from collections import deque
 from io import IOBase, StringIO
-from typing import Type, Union
 
 from twisted.python.compat import nativeString
 from twisted.python.deprecate import _fullyQualifiedName as fullyQualifiedName
@@ -348,7 +348,7 @@ def filenameToModuleName(fn):
     return modName
 
 
-def qual(clazz: Type[object]) -> str:
+def qual(clazz: type[object]) -> str:
     """
     Return full import path of a class.
     """
@@ -373,7 +373,7 @@ def _determineClassName(x):
             return "<BROKEN CLASS AT 0x%x>" % id(c)
 
 
-def _safeFormat(formatter: Union[types.FunctionType, Type[str]], o: object) -> str:
+def _safeFormat(formatter: types.FunctionType | type[str], o: object) -> str:
     """
     Helper function for L{safe_repr} and L{safe_str}.
 

--- a/src/twisted/python/runtime.py
+++ b/src/twisted/python/runtime.py
@@ -2,6 +2,8 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
+from __future__ import annotations
+
 __all__ = [
     "seconds",
     "shortPythonVersion",
@@ -13,7 +15,6 @@ import os
 import sys
 import warnings
 from time import time as seconds
-from typing import Optional
 
 
 def shortPythonVersion() -> str:
@@ -37,13 +38,11 @@ class Platform:
     Gives us information about the platform we're running on.
     """
 
-    type: Optional[str] = knownPlatforms.get(os.name)
+    type: str | None = knownPlatforms.get(os.name)
     seconds = staticmethod(seconds)
     _platform = sys.platform
 
-    def __init__(
-        self, name: Optional[str] = None, platform: Optional[str] = None
-    ) -> None:
+    def __init__(self, name: str | None = None, platform: str | None = None) -> None:
         if name is not None:
             self.type = knownPlatforms.get(name)
         if platform is not None:
@@ -57,7 +56,7 @@ class Platform:
         """
         return self.type != None
 
-    def getType(self) -> Optional[str]:
+    def getType(self) -> str | None:
         """
         Get platform type.
 

--- a/src/twisted/python/sendmsg.py
+++ b/src/twisted/python/sendmsg.py
@@ -9,7 +9,6 @@ sendmsg(2) and recvmsg(2) support for Python.
 
 from collections import namedtuple
 from socket import CMSG_SPACE, SCM_RIGHTS, socket as Socket
-from typing import List, Tuple
 
 __all__ = ["sendmsg", "recvmsg", "getSocketFamily", "SCM_RIGHTS"]
 
@@ -20,7 +19,7 @@ ReceivedMessage = namedtuple("ReceivedMessage", ["data", "ancillary", "flags"])
 def sendmsg(
     socket: Socket,
     data: bytes,
-    ancillary: List[Tuple[int, int, bytes]] = [],
+    ancillary: list[tuple[int, int, bytes]] = [],
     flags: int = 0,
 ) -> int:
     """

--- a/src/twisted/python/systemd.py
+++ b/src/twisted/python/systemd.py
@@ -9,11 +9,12 @@ Currently only the minimum APIs necessary for using systemd's socket activation
 feature are supported.
 """
 
+from __future__ import annotations
 
 __all__ = ["ListenFDs"]
 
+from collections.abc import Mapping, Sequence
 from os import getpid
-from typing import Dict, List, Mapping, Optional, Sequence
 
 from attrs import Factory, define
 
@@ -46,9 +47,9 @@ class ListenFDs:
     @classmethod
     def fromEnvironment(
         cls,
-        environ: Optional[Mapping[str, str]] = None,
-        start: Optional[int] = None,
-    ) -> "ListenFDs":
+        environ: Mapping[str, str] | None = None,
+        start: int | None = None,
+    ) -> ListenFDs:
         """
         @param environ: A dictionary-like object to inspect to discover
             inherited descriptors.  By default, L{None}, indicating that the
@@ -71,7 +72,7 @@ class ListenFDs:
             start = cls._START
 
         if str(getpid()) == environ.get("LISTEN_PID"):
-            descriptors: List[int] = _parseDescriptors(start, environ)
+            descriptors: list[int] = _parseDescriptors(start, environ)
             names: Sequence[str] = _parseNames(environ)
         else:
             descriptors = []
@@ -89,13 +90,13 @@ class ListenFDs:
 
         return cls(descriptors, names)
 
-    def inheritedDescriptors(self) -> List[int]:
+    def inheritedDescriptors(self) -> list[int]:
         """
         @return: The configured descriptors.
         """
         return list(self._descriptors)
 
-    def inheritedNamedDescriptors(self) -> Dict[str, int]:
+    def inheritedNamedDescriptors(self) -> dict[str, int]:
         """
         @return: A mapping from the names of configured descriptors to
             their integer values.
@@ -103,7 +104,7 @@ class ListenFDs:
         return dict(zip(self._names, self._descriptors))
 
 
-def _parseDescriptors(start: int, environ: Mapping[str, str]) -> List[int]:
+def _parseDescriptors(start: int, environ: Mapping[str, str]) -> list[int]:
     """
     Parse the I{LISTEN_FDS} environment variable supplied by systemd.
 

--- a/src/twisted/python/test/modules_helpers.py
+++ b/src/twisted/python/test/modules_helpers.py
@@ -7,8 +7,8 @@ to load code.
 """
 
 import sys
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Iterable, List, Tuple
 
 from twisted.python.filepath import FilePath
 
@@ -19,7 +19,7 @@ class TwistedModulesMixin:
     methods for manipulating Python's module system.
     """
 
-    def replaceSysPath(self, sysPath: List[str]) -> None:
+    def replaceSysPath(self, sysPath: list[str]) -> None:
         """
         Replace sys.path, for the duration of the test, with the given value.
         """
@@ -31,7 +31,7 @@ class TwistedModulesMixin:
         self.addCleanup(cleanUpSysPath)  # type: ignore[attr-defined]
         sys.path[:] = sysPath
 
-    def replaceSysModules(self, sysModules: Iterable[Tuple[str, ModuleType]]) -> None:
+    def replaceSysModules(self, sysModules: Iterable[tuple[str, ModuleType]]) -> None:
         """
         Replace sys.modules, for the duration of the test, with the given value.
         """

--- a/src/twisted/python/test/pullpipe.py
+++ b/src/twisted/python/test/pullpipe.py
@@ -6,12 +6,11 @@ import os
 import socket
 import sys
 from struct import unpack
-from typing import Tuple
 
 from twisted.python.sendmsg import recvmsg
 
 
-def recvfd(socketfd: int) -> Tuple[int, bytes]:
+def recvfd(socketfd: int) -> tuple[int, bytes]:
     """
     Receive a file descriptor from a L{sendmsg} message on the given C{AF_UNIX}
     socket.

--- a/src/twisted/python/test/test_sendmsg.py
+++ b/src/twisted/python/test/test_sendmsg.py
@@ -7,6 +7,7 @@ Tests for L{twisted.python.sendmsg}.
 
 import errno
 import os
+import runpy
 import sys
 import warnings
 from os import close, pathsep, pipe, read
@@ -295,6 +296,78 @@ class SendmsgTests(TestCase):
         yield sspp.stopped
         self.assertEqual(read(pipeOut.fileno(), 1024), b"Test fixture data: blonk.\n")
         # Make sure that the pipe is actually closed now.
+        self.assertEqual(read(pipeOut.fileno(), 1024), b"")
+
+
+@skipIf(nonUNIXSkip, "Platform does not support AF_UNIX sockets")
+@skipIf(doImportSkip, importSkipReason)
+class PullPipeTests(TestCase):
+    """
+    Tests for L{twisted.python.test.pullpipe}.
+    """
+
+    def setUp(self):
+        """
+        Create a pair of UNIX sockets.
+        """
+        self.input, self.output = socketpair(AF_UNIX)
+
+    def tearDown(self):
+        """
+        Close the sockets opened by setUp.
+        """
+        self.input.close()
+        self.output.close()
+
+    def test_recvfd(self):
+        """
+        L{pullpipe.recvfd} returns a received FD and payload bytes.
+        """
+        from twisted.python.test import pullpipe
+
+        pipeOut, pipeIn = _makePipe()
+        self.addCleanup(pipeOut.close)
+        self.addCleanup(pipeIn.close)
+
+        with pipeIn:
+            sendmsg(
+                self.input,
+                b"blonk",
+                [(SOL_SOCKET, SCM_RIGHTS, pack("i", pipeIn.fileno()))],
+            )
+
+        receivedFD, description = pullpipe.recvfd(self.output.fileno())
+        self.addCleanup(close, receivedFD)
+        self.assertEqual(description, b"blonk")
+
+        os.write(receivedFD, b"from recvfd")
+        self.assertEqual(read(pipeOut.fileno(), 1024), b"from recvfd")
+
+    def test_main(self):
+        """
+        Running C{pullpipe.py} as C{__main__} writes fixture data and closes the
+        passed FD.
+        """
+        pullpipePath = FilePath(__file__).sibling("pullpipe.py").asTextMode().path
+        pipeOut, pipeIn = _makePipe()
+        self.addCleanup(pipeOut.close)
+        self.addCleanup(pipeIn.close)
+
+        with pipeIn:
+            sendmsg(
+                self.input,
+                b"blonk",
+                [(SOL_SOCKET, SCM_RIGHTS, pack("i", pipeIn.fileno()))],
+            )
+
+        self.patch(
+            sys,
+            "argv",
+            [pullpipePath, str(self.output.fileno())],
+        )
+        runpy.run_path(pullpipePath, run_name="__main__")
+
+        self.assertEqual(read(pipeOut.fileno(), 1024), b"Test fixture data: blonk.\n")
         self.assertEqual(read(pipeOut.fileno(), 1024), b"")
 
 

--- a/src/twisted/python/test/test_shellcomp.py
+++ b/src/twisted/python/test/test_shellcomp.py
@@ -5,10 +5,10 @@
 Test cases for twisted.python._shellcomp
 """
 
+from __future__ import annotations
 
 import sys
 from io import BytesIO
-from typing import List, Optional
 
 from twisted.python import _shellcomp, reflect, usage
 from twisted.python.usage import CompleteFiles, CompleteList, Completer, Completions
@@ -458,7 +458,7 @@ class FighterAceOptions(usage.Options):
     Command-line options for an imaginary `Fighter Ace` game
     """
 
-    optFlags: List[List[Optional[str]]] = [
+    optFlags: list[list[str | None]] = [
         ["fokker", "f", "Select the Fokker Dr.I as your dogfighter aircraft"],
         ["albatros", "a", "Select the Albatros D-III as your dogfighter aircraft"],
         ["spad", "s", "Select the SPAD S.VII as your dogfighter aircraft"],
@@ -468,7 +468,7 @@ class FighterAceOptions(usage.Options):
         ["verbose", "v", "Verbose logging (may be specified more than once)"],
     ]
 
-    optParameters: List[List[Optional[str]]] = [
+    optParameters: list[list[str | None]] = [
         ["pilot-name", None, "What's your name, Ace?", "Manfred von Richthofen"],
         ["detail", "d", "Select the level of rendering detail (1-5)", "3"],
     ]

--- a/src/twisted/python/test/test_systemd.py
+++ b/src/twisted/python/test/test_systemd.py
@@ -7,7 +7,7 @@ Tests for L{twisted.python.systemd}.
 
 
 import os
-from typing import Dict, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from hamcrest import assert_that, equal_to, not_
 from hypothesis import given
@@ -18,7 +18,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from .strategies import systemdDescriptorNames
 
 
-def buildEnvironment(count: int, pid: object) -> Dict[str, str]:
+def buildEnvironment(count: int, pid: object) -> dict[str, str]:
     """
     @param count: The number of file descriptors to indicate as inherited.
 

--- a/src/twisted/python/test/test_url.py
+++ b/src/twisted/python/test/test_url.py
@@ -7,7 +7,8 @@ Tests for L{twisted.python.url}.
 """
 from __future__ import annotations
 
-from typing import Iterable, Protocol
+from collections.abc import Iterable
+from typing import Protocol
 
 from twisted.trial.unittest import SynchronousTestCase
 from ..url import URL

--- a/src/twisted/python/test/test_util.py
+++ b/src/twisted/python/test/test_util.py
@@ -12,7 +12,7 @@ import os.path
 import shutil
 import sys
 import warnings
-from typing import Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from unittest import skipIf
 
 try:

--- a/src/twisted/python/test/test_zippath.py
+++ b/src/twisted/python/test/test_zippath.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import zipfile
-from typing import Union
 
 from twisted.python.filepath import _coerceToFilesystemEncoding
 from twisted.python.zippath import ZipArchive, ZipPath
@@ -62,7 +61,7 @@ class ZipFilePathTests(AbstractFilePathTests):
         Make sure that invoking ZipPath's repr prints the correct class name
         and an absolute path to the zip file.
         """
-        child: Union[ZipPath[str, bytes], ZipPath[str, str]] = self.path.child("foo")
+        child: ZipPath[str, bytes] | ZipPath[str, str] = self.path.child("foo")
         pathRepr = "ZipPath({!r})".format(
             os.path.abspath(self.nativecmn + ".zip" + os.sep + "foo"),
         )

--- a/src/twisted/python/threadpool.py
+++ b/src/twisted/python/threadpool.py
@@ -12,7 +12,7 @@ instead of creating a thread pool directly.
 from __future__ import annotations
 
 from threading import Thread, current_thread
-from typing import Any, Callable, List, Optional, Protocol, TypeVar
+from typing import Any, Callable, Protocol, TypeVar
 
 from typing_extensions import ParamSpec, TypedDict
 
@@ -72,7 +72,7 @@ class ThreadPool:
     _pool = staticmethod(_pool)
 
     def __init__(
-        self, minthreads: int = 5, maxthreads: int = 20, name: Optional[str] = None
+        self, minthreads: int = 5, maxthreads: int = 20, name: str | None = None
     ):
         """
         Create a new threadpool.
@@ -91,7 +91,7 @@ class ThreadPool:
         self.min = minthreads
         self.max = maxthreads
         self.name = name
-        self.threads: List[Thread] = []
+        self.threads: list[Thread] = []
 
         def trackingThreadFactory(*a: Any, **kw: Any) -> Thread:
             thread = self.threadFactory(  # type: ignore[misc]
@@ -226,7 +226,7 @@ class ThreadPool:
 
     def callInThreadWithCallback(
         self,
-        onResult: Optional[Callable[[bool, _R], object]],
+        onResult: Callable[[bool, _R], object] | None,
         func: Callable[_P, _R],
         *args: _P.args,
         **kw: _P.kwargs,
@@ -300,7 +300,7 @@ class ThreadPool:
             thread.join()
 
     def adjustPoolsize(
-        self, minthreads: Optional[int] = None, maxthreads: Optional[int] = None
+        self, minthreads: int | None = None, maxthreads: int | None = None
     ) -> None:
         """
         Adjust the number of available threads by setting C{min} and C{max} to

--- a/src/twisted/python/usage.py
+++ b/src/twisted/python/usage.py
@@ -21,7 +21,7 @@ import os
 import sys
 import textwrap
 from os import path
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 # Sibling Imports
 from twisted.python import reflect, util
@@ -63,7 +63,7 @@ class CoerceParameter:
         self.options.opts[parameterName] = value
 
 
-class Options(Dict[str, Any]):
+class Options(dict[str, Any]):
     """
     An option list parser class
 
@@ -150,9 +150,9 @@ class Options(Dict[str, Any]):
     or doc/core/howto/options.xhtml in your Twisted directory.
     """
 
-    subCommand: Optional[str] = None
-    defaultSubCommand: Optional[str] = None
-    parent: "Optional[Options]" = None
+    subCommand: str | None = None
+    defaultSubCommand: str | None = None
+    parent: Options | None = None
     completionData = None
     _shellCompFile = sys.stdout  # file to use if shell completion is requested
 
@@ -477,7 +477,7 @@ class Options(Dict[str, Any]):
             )
         return synopsis
 
-    def getUsage(self, width: Optional[int] = None) -> str:
+    def getUsage(self, width: int | None = None) -> str:
         # If subOptions exists by now, then there was probably an error while
         # parsing its options.
         if hasattr(self, "subOptions"):
@@ -569,7 +569,7 @@ class Completer:
     subclasses for specific completion functionality.
     """
 
-    _descr: Optional[str] = None
+    _descr: str | None = None
 
     def __init__(self, descr=None, repeat=False):
         """

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -30,17 +30,8 @@ else:
 
 # For backwards compatibility, some things import this, so just link it
 from collections import OrderedDict
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Mapping,
-    MutableMapping,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, Callable, ClassVar, TypeVar
 
 from incremental import Version
 
@@ -615,7 +606,7 @@ class FancyStrMixin:
 
     # Override in subclasses:
     showAttributes: Sequence[
-        Union[str, Tuple[str, str, str], Tuple[str, Callable[[Any], str]]]
+        str | tuple[str, str, str] | tuple[str, Callable[[Any], str]]
     ] = ()
 
     def __str__(self) -> str:

--- a/src/twisted/python/zippath.py
+++ b/src/twisted/python/zippath.py
@@ -12,20 +12,8 @@ from __future__ import annotations
 import errno
 import os
 import time
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    Literal,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Iterable
+from typing import IO, TYPE_CHECKING, Any, AnyStr, Generic, Literal, TypeVar
 from zipfile import ZipFile
 
 from zope.interface import implementer
@@ -81,7 +69,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
         archiveFilename: _ZipStr = _coerceToFilesystemEncoding(
             pathInArchive, archive._zipfileFilename
         )
-        segments: List[_ZipStr] = self.pathInArchive.split(sep)
+        segments: list[_ZipStr] = self.pathInArchive.split(sep)
         fakePath: _ZipStr = os.path.join(archiveFilename, *segments)
         self.path: _ZipStr = fakePath
 
@@ -93,7 +81,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
         )
 
     def __repr__(self) -> str:
-        parts: List[_ZipStr]
+        parts: list[_ZipStr]
         parts = [
             _coerceToFilesystemEncoding(self.sep, os.path.abspath(self.archive.path))
         ]
@@ -113,7 +101,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
 
     def _nativeParent(
         self,
-    ) -> Union[ZipPath[_ZipStr, _ArchiveStr], ZipArchive[_ArchiveStr]]:
+    ) -> ZipPath[_ZipStr, _ArchiveStr] | ZipArchive[_ArchiveStr]:
         """
         Return parent, discarding our own encoding in favor of whatever the
         archive's is.
@@ -123,7 +111,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
             return self.archive
         return ZipPath(self.archive, self.sep.join(splitup[:-1]))
 
-    def parent(self) -> Union[ZipPath[_ZipStr, _ArchiveStr], ZipArchive[_ZipStr]]:
+    def parent(self) -> ZipPath[_ZipStr, _ArchiveStr] | ZipArchive[_ZipStr]:
         parent = self._nativeParent()
         if isinstance(parent, ZipArchive):
             return ZipArchive(
@@ -135,7 +123,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
 
         def parents(
             self,
-        ) -> Iterable[Union[ZipPath[_ZipStr, _ArchiveStr], ZipArchive[_ZipStr]]]:
+        ) -> Iterable[ZipPath[_ZipStr, _ArchiveStr] | ZipArchive[_ZipStr]]:
             ...
 
     def child(self, path: OtherAnyStr) -> ZipPath[OtherAnyStr, _ArchiveStr]:
@@ -155,8 +143,8 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
         return ZipPath(self.archive, joiner.join([pathInArchive, path]))
 
     def sibling(self, path: OtherAnyStr) -> ZipPath[OtherAnyStr, _ArchiveStr]:
-        parent: Union[ZipPath[_ZipStr, _ArchiveStr], ZipArchive[_ZipStr]]
-        rightTypedParent: Union[ZipPath[_ZipStr, _ArchiveStr], ZipArchive[_ArchiveStr]]
+        parent: ZipPath[_ZipStr, _ArchiveStr] | ZipArchive[_ZipStr]
+        rightTypedParent: ZipPath[_ZipStr, _ArchiveStr] | ZipArchive[_ArchiveStr]
 
         parent = self.parent()
         rightTypedParent = self.archive if isinstance(parent, ZipArchive) else parent
@@ -175,7 +163,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
     def islink(self) -> bool:
         return False
 
-    def listdir(self) -> List[_ZipStr]:
+    def listdir(self) -> list[_ZipStr]:
         if self.exists():
             if self.isdir():
                 parentArchivePath: _ArchiveStr = _coerceToFilesystemEncoding(
@@ -192,7 +180,7 @@ class ZipPath(Generic[_ZipStr, _ArchiveStr], AbstractFilePath[_ZipStr]):
                 OSError(errno.ENOENT, "Non-existent zip entry listed")
             )
 
-    def splitext(self) -> Tuple[_ZipStr, _ZipStr]:
+    def splitext(self) -> tuple[_ZipStr, _ZipStr]:
         """
         Return a value similar to that returned by C{os.path.splitext}.
         """
@@ -296,7 +284,7 @@ class ZipArchive(ZipPath[AnyStr, AnyStr]):
         self.pathInArchive = _coerceToFilesystemEncoding(archivePathname, "")
         # zipfile is already wasting O(N) memory on cached ZipInfo instances,
         # so there's no sense in trying to do this lazily or intelligently
-        self.childmap: Dict[AnyStr, Dict[AnyStr, int]] = {}
+        self.childmap: dict[AnyStr, dict[AnyStr, int]] = {}
 
         for name in self.zipfile.namelist():
             splitName = _coerceToFilesystemEncoding(self.path, name).split(self.sep)


### PR DESCRIPTION
## Scope and purpose

Fixes #12562

The changes were automatically generated using:

* `pyupgrade --py39-plus .\src\twisted\python\*.py`
* `pyupgrade --py39-plus .\src\twisted\python\test\*.py`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as List. (`pyupgrade` doesn't remove these)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
