### PR TITLE
#12564 Remove `_passedArgSpec` method in `deprecate.py`

### DIFF
--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -97,7 +97,7 @@ import sys
 from dis import findlinestarts
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, cast
+from typing import Any, Callable, Optional, Sequence, TypeVar, cast
 from warnings import warn, warn_explicit
 
 from incremental import Version, getVersionString
@@ -626,48 +626,6 @@ def warnAboutFunction(offender, warningString):
         registry=offender.__globals__.setdefault("__warningregistry__", {}),
         module_globals=None,
     )
-
-
-def _passedArgSpec(argspec, positional, keyword):
-    """
-    Take an I{inspect.ArgSpec}, a tuple of positional arguments, and a dict of
-    keyword arguments, and return a mapping of arguments that were actually
-    passed to their passed values.
-
-    @param argspec: The argument specification for the function to inspect.
-    @type argspec: I{inspect.ArgSpec}
-
-    @param positional: The positional arguments that were passed.
-    @type positional: L{tuple}
-
-    @param keyword: The keyword arguments that were passed.
-    @type keyword: L{dict}
-
-    @return: A dictionary mapping argument names (those declared in C{argspec})
-        to values that were passed explicitly by the user.
-    @rtype: L{dict} mapping L{str} to L{object}
-    """
-    result: Dict[str, object] = {}
-    unpassed = len(argspec.args) - len(positional)
-    if argspec.keywords is not None:
-        kwargs = result[argspec.keywords] = {}
-    if unpassed < 0:
-        if argspec.varargs is None:
-            raise TypeError("Too many arguments.")
-        else:
-            result[argspec.varargs] = positional[len(argspec.args) :]
-    for name, value in zip(argspec.args, positional):
-        result[name] = value
-    for name, value in keyword.items():
-        if name in argspec.args:
-            if name in result:
-                raise TypeError("Already passed.")
-            result[name] = value
-        elif argspec.keywords is not None:
-            kwargs[name] = value
-        else:
-            raise TypeError("no such param")
-    return result
 
 
 def _passedSignature(signature, positional, keyword):

--- a/src/twisted/python/deprecate.py
+++ b/src/twisted/python/deprecate.py
@@ -628,33 +628,32 @@ def warnAboutFunction(offender, warningString):
     )
 
 
-def _passedSignature(signature, positional, keyword):
+def _passedSignature(
+    signature: inspect.Signature,
+    positional: tuple[object, ...],
+    keyword: dict[str, object],
+) -> dict[str, object]:
     """
     Take an L{inspect.Signature}, a tuple of positional arguments, and a dict of
     keyword arguments, and return a mapping of arguments that were actually
     passed to their passed values.
 
     @param signature: The signature of the function to inspect.
-    @type signature: L{inspect.Signature}
-
     @param positional: The positional arguments that were passed.
-    @type positional: L{tuple}
-
     @param keyword: The keyword arguments that were passed.
-    @type keyword: L{dict}
 
     @return: A dictionary mapping argument names (those declared in
         C{signature}) to values that were passed explicitly by the user.
-    @rtype: L{dict} mapping L{str} to L{object}
     """
-    result = {}
-    kwargs = None
-    numPositional = 0
+    result: dict[str, object] = {}
+    kwargs: dict[str, object] | None = None
+    numPositional: int = 0
     for n, (name, param) in enumerate(signature.parameters.items()):
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
             # Varargs, for example: *args
-            result[name] = positional[n:]
-            numPositional = len(result[name]) + 1
+            varargs: tuple[object, ...] = positional[n:]
+            result[name] = varargs
+            numPositional = len(varargs) + 1
         elif param.kind == inspect.Parameter.VAR_KEYWORD:
             # Variable keyword args, for example: **my_kwargs
             kwargs = result[name] = {}

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -45,6 +45,24 @@ from twisted.trial.unittest import SynchronousTestCase
 # #5203.
 
 
+def checkPassed(func, *args, **kw):
+    """
+    Test an invocation of L{passed} with the given function, arguments, and
+    keyword arguments.
+
+    @param func: A function whose argspec to pass to L{_passed}.
+    @type func: A callable.
+
+    @param args: The arguments which could be passed to L{func}.
+
+    @param kw: The keyword arguments which could be passed to L{func}.
+
+    @return: L{_passed}'s return value
+    @rtype: L{dict}
+    """
+    return _passedSignature(inspect.signature(func), args, kw)
+
+
 class _MockDeprecatedAttribute:
     """
     Mock of L{twisted.python.deprecate._DeprecatedAttribute}.
@@ -1002,23 +1020,6 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
     Tests for L{mutuallyExclusiveArguments}.
     """
 
-    def checkPassed(self, func, *args, **kw):
-        """
-        Test an invocation of L{passed} with the given function, arguments, and
-        keyword arguments.
-
-        @param func: A function whose argspec will be inspected.
-        @type func: A callable.
-
-        @param args: The arguments which could be passed to C{func}.
-
-        @param kw: The keyword arguments which could be passed to C{func}.
-
-        @return: L{_passedSignature}'s return value
-        @rtype: L{dict}
-        """
-        return _passedSignature(inspect.signature(func), args, kw)
-
     def test_passed_simplePositional(self):
         """
         L{passed} identifies the arguments passed by a simple
@@ -1028,7 +1029,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a, b):
             pass
 
-        self.assertEqual(self.checkPassed(func, 1, 2), dict(a=1, b=2))
+        self.assertEqual(checkPassed(func, 1, 2), dict(a=1, b=2))
 
     def test_passed_tooManyArgs(self):
         """
@@ -1039,7 +1040,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a, b):
             pass
 
-        self.assertRaises(TypeError, self.checkPassed, func, 1, 2, 3)
+        self.assertRaises(TypeError, checkPassed, func, 1, 2, 3)
 
     def test_passed_doublePassKeyword(self):
         """
@@ -1050,7 +1051,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a):
             pass
 
-        self.assertRaises(TypeError, self.checkPassed, func, 1, a=2)
+        self.assertRaises(TypeError, checkPassed, func, 1, a=2)
 
     def test_passed_unspecifiedKeyword(self):
         """
@@ -1061,7 +1062,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a):
             pass
 
-        self.assertRaises(TypeError, self.checkPassed, func, 1, z=2)
+        self.assertRaises(TypeError, checkPassed, func, 1, z=2)
 
     def test_passed_star(self):
         """
@@ -1072,7 +1073,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a, *b):
             pass
 
-        self.assertEqual(self.checkPassed(func, 1, 2, 3), dict(a=1, b=(2, 3)))
+        self.assertEqual(checkPassed(func, 1, 2, 3), dict(a=1, b=(2, 3)))
 
     def test_passed_starStar(self):
         """
@@ -1084,7 +1085,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
             pass
 
         self.assertEqual(
-            self.checkPassed(func, 1, x=2, y=3, z=4), dict(a=1, b=dict(x=2, y=3, z=4))
+            checkPassed(func, 1, x=2, y=3, z=4), dict(a=1, b=dict(x=2, y=3, z=4))
         )
 
     def test_passed_noDefaultValues(self):
@@ -1096,7 +1097,7 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
         def func(a, b, c=1, d=2, e=3):
             pass
 
-        self.assertEqual(self.checkPassed(func, 1, 2, e=7), dict(a=1, b=2, e=7))
+        self.assertEqual(checkPassed(func, 1, 2, e=7), dict(a=1, b=2, e=7))
 
     def test_mutualExclusionPrimeDirective(self):
         """
@@ -1157,23 +1158,6 @@ class KeywordOnlyTests(SynchronousTestCase):
     Keyword only arguments (PEP 3102).
     """
 
-    def checkPassed(self, func, *args, **kw):
-        """
-        Test an invocation of L{passed} with the given function, arguments, and
-        keyword arguments.
-
-        @param func: A function whose argspec to pass to L{_passed}.
-        @type func: A callable.
-
-        @param args: The arguments which could be passed to L{func}.
-
-        @param kw: The keyword arguments which could be passed to L{func}.
-
-        @return: L{_passed}'s return value
-        @rtype: L{dict}
-        """
-        return _passedSignature(inspect.signature(func), args, kw)
-
     def test_passedKeywordOnly(self):
         """
         Keyword only arguments follow varargs.
@@ -1191,12 +1175,12 @@ class KeywordOnlyTests(SynchronousTestCase):
             b has a default value.
             """
 
-        self.assertEqual(self.checkPassed(func1, 1, 2, 3), dict(a=(1, 2, 3), b=True))
+        self.assertEqual(checkPassed(func1, 1, 2, 3), dict(a=(1, 2, 3), b=True))
         self.assertEqual(
-            self.checkPassed(func1, 1, 2, 3, b=False), dict(a=(1, 2, 3), b=False)
+            checkPassed(func1, 1, 2, 3, b=False), dict(a=(1, 2, 3), b=False)
         )
         self.assertEqual(
-            self.checkPassed(func2, 1, 2, b=False, c=1, d=2, e=3),
+            checkPassed(func2, 1, 2, b=False, c=1, d=2, e=3),
             dict(a=(1, 2), b=False, c=1, d=2, e=3),
         )
-        self.assertRaises(TypeError, self.checkPassed, func2, 1, 2, b=False, c=1, d=2)
+        self.assertRaises(TypeError, checkPassed, func2, 1, 2, b=False, c=1, d=2)

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -28,7 +28,6 @@ from twisted.python.deprecate import (
     _getDeprecationDocstring,
     _getDeprecationWarningString,
     _mutuallyExclusiveArguments,
-    _passedArgSpec,
     _passedSignature,
     deprecated,
     deprecatedKeywordParameter,
@@ -1015,15 +1014,10 @@ class MutualArgumentExclusionTests(SynchronousTestCase):
 
         @param kw: The keyword arguments which could be passed to C{func}.
 
-        @return: L{_passedSignature} or L{_passedArgSpec}'s return value
+        @return: L{_passedSignature}'s return value
         @rtype: L{dict}
         """
-        if getattr(inspect, "signature", None):
-            # Python 3
-            return _passedSignature(inspect.signature(func), args, kw)
-        else:
-            # Python 2
-            return _passedArgSpec(inspect.getargspec(func), args, kw)
+        return _passedSignature(inspect.signature(func), args, kw)
 
     def test_passed_simplePositional(self):
         """

--- a/src/twisted/python/test/test_deprecate.py
+++ b/src/twisted/python/test/test_deprecate.py
@@ -4,13 +4,14 @@
 """
 Tests for Twisted's deprecation framework, L{twisted.python.deprecate}.
 """
-
+from __future__ import annotations
 
 import inspect
 import sys
 import types
 import warnings
 from os.path import normcase
+from typing import Callable
 from warnings import catch_warnings, simplefilter
 
 try:
@@ -19,6 +20,7 @@ except ImportError:
     invalidate_caches = None  # type: ignore[assignment]
 
 from incremental import Version
+from typing_extensions import ParamSpec
 
 from twisted.python import deprecate
 from twisted.python.deprecate import (
@@ -40,27 +42,27 @@ from twisted.python.test import deprecatedattributes
 from twisted.python.test.modules_helpers import TwistedModulesMixin
 from twisted.trial.unittest import SynchronousTestCase
 
+_P = ParamSpec("_P")
+
 # Note that various tests in this module require manual encoding of paths to
 # utf-8. This can be fixed once FilePath supports Unicode; see #2366, #4736,
 # #5203.
 
 
-def checkPassed(func, *args, **kw):
+def checkPassed(
+    func: Callable[_P, object], *args: _P.args, **kwargs: _P.kwargs
+) -> dict[str, object]:
     """
     Test an invocation of L{passed} with the given function, arguments, and
     keyword arguments.
 
     @param func: A function whose argspec to pass to L{_passed}.
-    @type func: A callable.
-
     @param args: The arguments which could be passed to L{func}.
-
-    @param kw: The keyword arguments which could be passed to L{func}.
+    @param kwargs: The keyword arguments which could be passed to L{func}.
 
     @return: L{_passed}'s return value
-    @rtype: L{dict}
     """
-    return _passedSignature(inspect.signature(func), args, kw)
+    return _passedSignature(inspect.signature(func), args, kwargs)
 
 
 class _MockDeprecatedAttribute:

--- a/src/twisted/web/test/test_static.py
+++ b/src/twisted/web/test/test_static.py
@@ -1795,13 +1795,8 @@ class LoadMimeTypesTests(TestCase):
         # Checking mimetypes.inited doesn't always work, because
         # something, somewhere, calls mimetypes.init. Yay global
         # mutable state :)
-        if getattr(inspect, "signature", None):
-            signature = inspect.signature(static.loadMimeTypes)
-            self.assertIs(signature.parameters["init"].default, mimetypes.init)
-        else:
-            args, _, _, defaults = inspect.getargspec(static.loadMimeTypes)
-            defaultInit = defaults[args.index("init")]
-            self.assertIs(defaultInit, mimetypes.init)
+        signature = inspect.signature(static.loadMimeTypes)
+        self.assertIs(signature.parameters["init"].default, mimetypes.init)
 
 
 class StaticDeprecationTests(TestCase):


### PR DESCRIPTION
## Scope and purpose

Fixes #12564

I used an empty newsfragment since the removed code is a private function so my understanding is it doesn't need to be explicitly stated in release notes.

I also squeezed in a little cleanup for `test_usesGlobalInitFunction` function in `web/test/test_static.py`. 

`getattr(inspect, "signature", None)` is always `True` on Python 3.3+

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
