### PR TITLE
epollreactor: Handle ENOENT from epoll_ctl gracefully

### DIFF
--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -143,9 +143,11 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
         old_selectable = self._selectables.get(fd)
         log.msg(
             f"epoll: ENOENT on modify(fd={fd}), "
-            f"old_selectable={old_selectable}, new_selectable={selectable}. "
+            f"old_selectable={old_selectable}, new_selectable={selectable}, "
             f"fd in _reads={fd in self._reads}, fd in _writes={fd in self._writes}. "
-            f"Cleaning up stale state."
+            f"This is either a bug in the reactor, the application, or the "
+            f"kernel. Please report this at https://github.com/twisted/twisted "
+            f"with reproduction steps if possible."
         )
         self._reads.discard(fd)
         self._writes.discard(fd)

--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -69,15 +69,20 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
     _POLL_IN = EPOLLIN
     _POLL_OUT = EPOLLOUT
 
-    def __init__(self):
+    def __init__(self, poller=None):
         """
         Initialize epoll object, file descriptor tracking dictionaries, and the
         base class.
+
+        @param poller: An epoll-like object to use for I/O event notification.
+            If C{None}, a new C{select.epoll} instance is created.
         """
         # Create the poller we're going to use.  The 1024 here is just a hint
         # to the kernel, it is not a hard maximum.  After Linux 2.6.8, the size
         # argument is completely ignored.
-        self._poller = epoll(1024)
+        if poller is None:
+            poller = epoll(1024)
+        self._poller = poller
         self._reads = set()
         self._writes = set()
         self._selectables = {}

--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -17,7 +17,7 @@ import select
 from zope.interface import implementer
 
 from twisted.internet import posixbase
-from twisted.internet.interfaces import IReactorFDSet
+from twisted.internet.interfaces import IFileDescriptor, IReactorFDSet
 from twisted.internet.main import CONNECTION_LOST
 from twisted.python import log
 
@@ -110,7 +110,7 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
             primary.add(fd)
             selectables[fd] = xer
 
-    def _handleENOENT(self, selectable):
+    def _handleENOENT(self, selectable: IFileDescriptor) -> None:
         """
         Handle ENOENT error from epoll_ctl(EPOLL_CTL_MOD).
 

--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -18,6 +18,7 @@ from zope.interface import implementer
 
 from twisted.internet import posixbase
 from twisted.internet.interfaces import IReactorFDSet
+from twisted.internet.main import CONNECTION_LOST
 from twisted.python import log
 
 try:
@@ -109,6 +110,52 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
             primary.add(fd)
             selectables[fd] = xer
 
+    def _handleENOENT(self, selectable):
+        """
+        Handle ENOENT error from epoll_ctl(EPOLL_CTL_MOD).
+
+        When C{_add()} sees a fd in the "other" set (e.g. fd is in C{_writes}
+        when C{addReader} is called), it uses C{modify()} rather than
+        C{register()}.  If the fd is not actually in the epoll interest list,
+        C{modify()} fails with ENOENT.
+
+        This has been observed in production but the exact cause of the
+        stale tracking state is not yet known.  The normal Twisted
+        connection lifecycle always calls C{stopReading}/C{stopWriting}
+        (which clean up C{_reads}/C{_writes}) before closing the socket fd,
+        so this should not happen.  Possible causes include a kernel epoll
+        bug or an as-yet-unidentified code path that closes a socket fd
+        without updating the reactor's tracking state.
+
+        As a defensive measure, clean up the stale tracking state and
+        schedule C{connectionLost} on the old selectable so the protocol
+        layer is notified.
+
+        @param selectable: The L{FileDescriptor} that triggered the ENOENT
+            when the reactor tried to modify its epoll registration.
+        """
+        fd = selectable.fileno()
+        old_selectable = self._selectables.get(fd)
+        log.msg(
+            f"epoll: ENOENT on modify(fd={fd}), "
+            f"old_selectable={old_selectable}, new_selectable={selectable}. "
+            f"fd in _reads={fd in self._reads}, fd in _writes={fd in self._writes}. "
+            f"Cleaning up stale state."
+        )
+        self._reads.discard(fd)
+        self._writes.discard(fd)
+        self._selectables.pop(fd, None)
+
+        # Notify the old selectable's protocol that the connection is gone.
+        if old_selectable is not None and old_selectable is not selectable:
+            self.callLater(
+                0,
+                log.callWithLogger,
+                old_selectable,
+                old_selectable.connectionLost,
+                CONNECTION_LOST,
+            )
+
     def addReader(self, reader):
         """
         Add a FileDescriptor for notification of data available to read.
@@ -123,6 +170,8 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
                 # e.g. filesystem files, so for those we just poll
                 # continuously:
                 self._continuousPolling.addReader(reader)
+            elif e.errno == errno.ENOENT:
+                self._handleENOENT(reader)
             else:
                 raise
 
@@ -140,6 +189,8 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
                 # e.g. filesystem files, so for those we just poll
                 # continuously:
                 self._continuousPolling.addWriter(writer)
+            elif e.errno == errno.ENOENT:
+                self._handleENOENT(writer)
             else:
                 raise
 

--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -128,7 +128,7 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
         without updating the reactor's tracking state.
 
         As a defensive measure, clean up the stale tracking state and
-        schedule C{connectionLost} on the old selectable so the protocol
+        call C{connectionLost} on the old selectable so the protocol
         layer is notified.
 
         @param selectable: The L{FileDescriptor} that triggered the ENOENT
@@ -148,9 +148,7 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
 
         # Notify the old selectable's protocol that the connection is gone.
         if old_selectable is not None and old_selectable is not selectable:
-            self.callLater(
-                0,
-                log.callWithLogger,
+            log.callWithLogger(
                 old_selectable,
                 old_selectable.connectionLost,
                 CONNECTION_LOST,

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -127,8 +127,7 @@ class EPollENOENTTests(TestCase):
         """
         Create an EPollReactor with a fake epoll that raises ENOENT on modify().
         """
-        self.patch(epollreactor, "epoll", FakeEpoll)
-        self.reactor = epollreactor.EPollReactor()
+        self.reactor = epollreactor.EPollReactor(poller=FakeEpoll())
 
     def test_addReader_ENOENT_handlesGracefully(self) -> None:
         """

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -136,15 +136,19 @@ class EPollENOENTTests(TestCase):
         connectionLost on the old selectable. Unexpected errors are re-raised.
         """
         fd = 42
-        descriptor = ENOENTDescriptor(fd)
+        old_descriptor = ENOENTDescriptor(fd)
+        new_descriptor = ENOENTDescriptor(fd)
 
-        # Pre-populate _writes to trigger the modify() code path in _add()
+        # Simulate stale state from an old connection: fd is in _writes
+        # and _selectables still maps to the old descriptor.
         self.reactor._writes.add(fd)
+        self.reactor._selectables[fd] = old_descriptor
 
-        # This should trigger ENOENT when _add() calls modify()
-        self.reactor.addReader(descriptor)
+        # New connection tries addReader on the same fd, triggering ENOENT
+        self.reactor.addReader(new_descriptor)
 
-        self.assertIn("lost", descriptor.events)
+        self.assertIn("lost", old_descriptor.events)
+        self.assertEqual(new_descriptor.events, [])
 
         # Verify unexpected errors are re-raised
         self.reactor._poller.modifyErrno = errno.EBADF
@@ -160,15 +164,19 @@ class EPollENOENTTests(TestCase):
         connectionLost on the old selectable. Unexpected errors are re-raised.
         """
         fd = 42
-        descriptor = ENOENTDescriptor(fd)
+        old_descriptor = ENOENTDescriptor(fd)
+        new_descriptor = ENOENTDescriptor(fd)
 
-        # Pre-populate _reads to trigger the modify() code path in _add()
+        # Simulate stale state from an old connection: fd is in _reads
+        # and _selectables still maps to the old descriptor.
         self.reactor._reads.add(fd)
+        self.reactor._selectables[fd] = old_descriptor
 
-        # This should trigger ENOENT when _add() calls modify()
-        self.reactor.addWriter(descriptor)
+        # New connection tries addWriter on the same fd, triggering ENOENT
+        self.reactor.addWriter(new_descriptor)
 
-        self.assertIn("lost", descriptor.events)
+        self.assertIn("lost", old_descriptor.events)
+        self.assertEqual(new_descriptor.events, [])
 
         # Verify unexpected errors are re-raised
         self.reactor._poller.modifyErrno = errno.EBADF

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -68,6 +68,27 @@ class FakeEpoll:
         pass
 
 
+class FakeEpollTests(TestCase):
+    """
+    Tests for L{FakeEpoll} to verify the test double behaves correctly.
+    """
+
+    def test_fakeEpoll(self) -> None:
+        """
+        L{FakeEpoll} tracks registered fds and raises ENOENT on modify.
+        """
+        fake = FakeEpoll()
+        fake.register(5, 0)
+        self.assertIn(5, fake._registered)
+        fake.unregister(5)
+        self.assertNotIn(5, fake._registered)
+        self.assertEqual(fake.poll(1.0, 10), [])
+        fake.close()
+        with self.assertRaises(OSError) as cm:
+            fake.modify(5, 0)
+        self.assertEqual(cm.exception.errno, errno.ENOENT)
+
+
 class ENOENTDescriptor:
     """
     A descriptor that tracks connectionLost calls for ENOENT testing.

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -45,9 +45,11 @@ class Descriptor:
 
 class FakeEpoll:
     """
-    A fake epoll object that raises ENOENT on modify() to simulate
-    fd reuse race conditions.
+    A fake epoll object that raises configurable errors on modify() to simulate
+    fd reuse race conditions and other error scenarios.
     """
+
+    modifyErrno: int = errno.ENOENT
 
     def __init__(self, size: int | None = None) -> None:
         self._registered: set[int] = set()
@@ -56,7 +58,7 @@ class FakeEpoll:
         self._registered.add(fd)
 
     def modify(self, fd: int, events: int) -> None:
-        raise OSError(errno.ENOENT, "No such file or directory")
+        raise OSError(self.modifyErrno, "Fake error")
 
     def unregister(self, fd: int) -> None:
         self._registered.discard(fd)
@@ -75,7 +77,7 @@ class FakeEpollTests(TestCase):
 
     def test_fakeEpoll(self) -> None:
         """
-        L{FakeEpoll} tracks registered fds and raises ENOENT on modify.
+        L{FakeEpoll} tracks registered fds and raises ENOENT on modify by default.
         """
         fake = FakeEpoll()
         fake.register(5, 0)
@@ -128,11 +130,11 @@ class EPollENOENTTests(TestCase):
         self.patch(epollreactor, "epoll", FakeEpoll)
         self.reactor = epollreactor.EPollReactor()
 
-    def test_addReader_addWriter_ENOENT_handlesGracefully(self):
+    def test_addReader_ENOENT_handlesGracefully(self) -> None:
         """
         When L{EPollReactor.addReader} encounters ENOENT from
         epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
-        connectionLost on the selectable.
+        connectionLost on the selectable. Unexpected errors are re-raised.
         """
         fd = 42
         descriptor = ENOENTDescriptor(fd)
@@ -149,11 +151,18 @@ class EPollENOENTTests(TestCase):
         # Verify connectionLost was called
         self.assertIn("lost", descriptor.events)
 
-    def test_addWriter_ENOENT_handlesGracefully(self):
+        # Verify unexpected errors are re-raised
+        self.reactor._poller.modifyErrno = errno.EBADF
+        self.reactor._writes.add(fd)
+        with self.assertRaises(OSError) as cm:
+            self.reactor.addReader(ENOENTDescriptor(fd))
+        self.assertEqual(cm.exception.errno, errno.EBADF)
+
+    def test_addWriter_ENOENT_handlesGracefully(self) -> None:
         """
         When L{EPollReactor.addWriter} encounters ENOENT from
         epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
-        connectionLost on the selectable.
+        connectionLost on the selectable. Unexpected errors are re-raised.
         """
         fd = 42
         descriptor = ENOENTDescriptor(fd)
@@ -169,6 +178,13 @@ class EPollENOENTTests(TestCase):
 
         # Verify connectionLost was called
         self.assertIn("lost", descriptor.events)
+
+        # Verify unexpected errors are re-raised
+        self.reactor._poller.modifyErrno = errno.EBADF
+        self.reactor._reads.add(fd)
+        with self.assertRaises(OSError) as cm:
+            self.reactor.addWriter(ENOENTDescriptor(fd))
+        self.assertEqual(cm.exception.errno, errno.EBADF)
 
 
 @skipIf(not epollreactor, "epoll not supported in this environment.")

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -133,8 +133,8 @@ class EPollENOENTTests(TestCase):
     def test_addReader_ENOENT_handlesGracefully(self) -> None:
         """
         When L{EPollReactor.addReader} encounters ENOENT from
-        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
-        connectionLost on the selectable. Unexpected errors are re-raised.
+        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and calls
+        connectionLost on the old selectable. Unexpected errors are re-raised.
         """
         fd = 42
         descriptor = ENOENTDescriptor(fd)
@@ -145,10 +145,6 @@ class EPollENOENTTests(TestCase):
         # This should trigger ENOENT when _add() calls modify()
         self.reactor.addReader(descriptor)
 
-        # Process the callLater(0, ...) to trigger connectionLost
-        self.reactor.runUntilCurrent()
-
-        # Verify connectionLost was called
         self.assertIn("lost", descriptor.events)
 
         # Verify unexpected errors are re-raised
@@ -161,8 +157,8 @@ class EPollENOENTTests(TestCase):
     def test_addWriter_ENOENT_handlesGracefully(self) -> None:
         """
         When L{EPollReactor.addWriter} encounters ENOENT from
-        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
-        connectionLost on the selectable. Unexpected errors are re-raised.
+        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and calls
+        connectionLost on the old selectable. Unexpected errors are re-raised.
         """
         fd = 42
         descriptor = ENOENTDescriptor(fd)
@@ -173,10 +169,6 @@ class EPollENOENTTests(TestCase):
         # This should trigger ENOENT when _add() calls modify()
         self.reactor.addWriter(descriptor)
 
-        # Process the callLater(0, ...) to trigger connectionLost
-        self.reactor.runUntilCurrent()
-
-        # Verify connectionLost was called
         self.assertIn("lost", descriptor.events)
 
         # Verify unexpected errors are re-raised

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -5,6 +5,8 @@
 Tests for L{twisted.internet.epollreactor}.
 """
 
+from __future__ import annotations
+
 import errno
 from unittest import skipIf
 
@@ -47,22 +49,22 @@ class FakeEpoll:
     fd reuse race conditions.
     """
 
-    def __init__(self, size=None):
-        self._registered = set()
+    def __init__(self, size: int | None = None) -> None:
+        self._registered: set[int] = set()
 
-    def register(self, fd, events):
+    def register(self, fd: int, events: int) -> None:
         self._registered.add(fd)
 
-    def modify(self, fd, events):
+    def modify(self, fd: int, events: int) -> None:
         raise OSError(errno.ENOENT, "No such file or directory")
 
-    def unregister(self, fd):
+    def unregister(self, fd: int) -> None:
         self._registered.discard(fd)
 
-    def poll(self, timeout, maxevents):
+    def poll(self, timeout: float, maxevents: int) -> list[tuple[int, int]]:
         return []
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 
@@ -71,17 +73,17 @@ class ENOENTDescriptor:
     A descriptor that tracks connectionLost calls for ENOENT testing.
     """
 
-    def __init__(self, fd):
+    def __init__(self, fd: int) -> None:
         self._fd = fd
-        self.events = []
+        self.events: list[str] = []
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self._fd
 
-    def logPrefix(self):
+    def logPrefix(self) -> str:
         return "ENOENTDescriptor"
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason: BaseException) -> None:
         from twisted.internet.error import ConnectionLost
 
         assert isinstance(reason, ConnectionLost)

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -5,6 +5,7 @@
 Tests for L{twisted.internet.epollreactor}.
 """
 
+import errno
 from unittest import skipIf
 
 from twisted.internet.error import ConnectionDone
@@ -38,6 +39,113 @@ class Descriptor:
     def connectionLost(self, reason):
         reason.trap(ConnectionDone)
         self.events.append("lost")
+
+
+class FakeEpoll:
+    """
+    A fake epoll object that raises ENOENT on modify() to simulate
+    fd reuse race conditions.
+    """
+
+    def __init__(self, size=None):
+        self._registered = set()
+
+    def register(self, fd, events):
+        self._registered.add(fd)
+
+    def modify(self, fd, events):
+        raise OSError(errno.ENOENT, "No such file or directory")
+
+    def unregister(self, fd):
+        self._registered.discard(fd)
+
+    def poll(self, timeout, maxevents):
+        return []
+
+    def close(self):
+        pass
+
+
+class ENOENTDescriptor:
+    """
+    A descriptor that tracks connectionLost calls for ENOENT testing.
+    """
+
+    def __init__(self, fd):
+        self._fd = fd
+        self.events = []
+
+    def fileno(self):
+        return self._fd
+
+    def logPrefix(self):
+        return "ENOENTDescriptor"
+
+    def connectionLost(self, reason):
+        from twisted.internet.error import ConnectionLost
+
+        assert isinstance(reason, ConnectionLost)
+        self.events.append("lost")
+
+
+@skipIf(not epollreactor, "epoll not supported in this environment.")
+class EPollENOENTTests(TestCase):
+    """
+    Tests for ENOENT handling in L{EPollReactor}.
+
+    These tests verify that the reactor gracefully handles ENOENT errors
+    from epoll_ctl(EPOLL_CTL_MOD), which can occur due to fd reuse race
+    conditions.
+    """
+
+    def setUp(self):
+        """
+        Create an EPollReactor with a fake epoll that raises ENOENT on modify().
+        """
+        self.patch(epollreactor, "epoll", FakeEpoll)
+        self.reactor = epollreactor.EPollReactor()
+
+    def test_addReader_addWriter_ENOENT_handlesGracefully(self):
+        """
+        When L{EPollReactor.addReader} encounters ENOENT from
+        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
+        connectionLost on the selectable.
+        """
+        fd = 42
+        descriptor = ENOENTDescriptor(fd)
+
+        # Pre-populate _writes to trigger the modify() code path in _add()
+        self.reactor._writes.add(fd)
+
+        # This should trigger ENOENT when _add() calls modify()
+        self.reactor.addReader(descriptor)
+
+        # Process the callLater(0, ...) to trigger connectionLost
+        self.reactor.runUntilCurrent()
+
+        # Verify connectionLost was called
+        self.assertIn("lost", descriptor.events)
+
+    def test_addWriter_ENOENT_handlesGracefully(self):
+        """
+        When L{EPollReactor.addWriter} encounters ENOENT from
+        epoll_ctl(EPOLL_CTL_MOD), it cleans up stale state and schedules
+        connectionLost on the selectable.
+        """
+        fd = 42
+        descriptor = ENOENTDescriptor(fd)
+
+        # Pre-populate _reads to trigger the modify() code path in _add()
+        self.reactor._reads.add(fd)
+
+        # This should trigger ENOENT when _add() calls modify()
+        self.reactor.addWriter(descriptor)
+
+        # Process the callLater(0, ...) to trigger connectionLost
+        self.reactor.runUntilCurrent()
+
+        # Verify connectionLost was called
+        self.assertIn("lost", descriptor.events)
 
 
 @skipIf(not epollreactor, "epoll not supported in this environment.")

--- a/src/twisted/newsfragments/12555.bugfix
+++ b/src/twisted/newsfragments/12555.bugfix
@@ -1,0 +1,1 @@
+EPollReactor now handles ENOENT errors from epoll_ctl(EPOLL_CTL_MOD) gracefully. This fixes a race condition where fd reuse could cause FileNotFoundError when registering new connections, commonly seen in high-traffic applications behind reverse proxies.


### PR DESCRIPTION
When epoll_ctl(EPOLL_CTL_MOD) is called on a file descriptor that is no longer registered with epoll, it returns ENOENT. This can happen due to fd reuse race conditions:

1. Old connection uses fd N, registered for writes in _writes set
2. Old connection closes, kernel removes fd N from epoll interest list
3. New connection accepted, kernel reuses fd N
4. startReading() -> addReader() -> _add() sees fd N still in _writes
5. Calls self._poller.modify(fd, flags) to add read events
6. modify() fails with ENOENT - fd N is not in epoll (old one was removed)

Stack trace from buildbot:
  tcp.py:1431: transport = self.transport(...)
  tcp.py:834:  self.startReading()
  abstract.py: self.reactor.addReader(self)
  epollreactor.py:117: self._add(...)
  epollreactor.py:103: self._poller.modify(fd, flags)
  FileNotFoundError: [Errno 2] No such file or directory

The epoll(7) manpage documents:
  ENOENT: op was EPOLL_CTL_MOD or EPOLL_CTL_DEL, and fd is not
          registered with this epoll instance.

Instead of raising an exception, clean up the internal tracking state and schedule connectionLost to properly notify the protocol layer.

Fixes race condition observed in buildbot.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
