### PR TITLE
#12570 Convert WorkerProtocol.run from async def to sync def returning Deferred

### DIFF
--- a/src/twisted/newsfragments/12570.bugfix
+++ b/src/twisted/newsfragments/12570.bugfix
@@ -1,0 +1,1 @@
+twisted.trial._dist.worker.WorkerProtocol.run is now a synchronous function returning a Deferred instead of an async def, so that test suite execution in distributed trial workers does not run inside an _inlineCallbacks coroutine context.

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -97,7 +97,7 @@ class WorkerProtocol(AMP):
         self._forceGarbageCollection = forceGarbageCollection
 
     @workercommands.Run.responder
-    async def run(self, testCase: str) -> RunResult:
+    def run(self, testCase: str) -> Deferred[RunResult]:
         """
         Run a test case by name.
         """
@@ -106,8 +106,24 @@ class WorkerProtocol(AMP):
             suite = TrialSuite([case], self._forceGarbageCollection)
             suite.run(self._result)
 
+        d = DeferredList(results, consumeErrors=True)
+        d.addCallback(
+            lambda results: Deferred.fromCoroutine(
+                self._processRunResults(results, testCase)
+            )
+        )
+        return d  # type: ignore[return-value]
+
+    async def _processRunResults(
+        self,
+        results: list[tuple[bool, object]],
+        testCase: str,
+    ) -> RunResult:
+        """
+        Process the results of reporting test outcomes to the manager.
+        """
         allSucceeded = True
-        for success, result in await DeferredList(results, consumeErrors=True):
+        for success, result in results:
             if success:
                 # Nothing to do here, proceed to the next result.
                 continue


### PR DESCRIPTION
## Summary

- Convert `WorkerProtocol.run` from `async def` to a sync `def` returning `Deferred[RunResult]`, so that distributed trial worker test suite execution does not run inside an `_inlineCallbacks` coroutine context
- Extract post-test result processing into `async def _processRunResults`, called via `Deferred.fromCoroutine` in a callback (safe since tests are already complete)
- Preserves the improved error-handling behavior from PR #11644

## Motivation

PR #11644 (commit [`a5127a50`](https://github.com/twisted/twisted/commit/a5127a50b75ca0ad4703abe91c6ad30cf85878e1)) changed `WorkerProtocol.run` to `async def`. When AMP dispatches an `async def` responder, the call path goes through `maybeDeferred` → `Deferred.fromCoroutine` → `_cancellableInlineCallbacks` → `_inlineCallbacks`, which runs the generator inside a `copy_context()`. This means `suite.run()` — the entire test suite execution — runs inside `context.run(gen.send, result)`, inheriting that copied contextvars context.

This is a problem for PR #1263 (sniffio support), which sets `current_async_library_cvar` to `"twisted"` inside `_inlineCallbacks`. That context variable leaks into all tests run by the worker, including `SynchronousTestCase` tests, causing sniffio tests that assert `AsyncLibraryNotFoundError` to fail under `trial -j` (parallel mode).

Resolves #12570