### PR TITLE
#12580 web: update type annotations for Python 3.9+ (1/1)

### DIFF
--- a/src/twisted/web/_element.py
+++ b/src/twisted/web/_element.py
@@ -2,17 +2,10 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
+from __future__ import annotations
+
 import itertools
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 
 from zope.interface import implementer
 
@@ -70,7 +63,7 @@ class Expose:
         @return: The first of C{funcObjs}.
         """
         for fObj in itertools.chain([f], funcObjs):
-            exposedThrough: List[Expose] = getattr(fObj, "exposedThrough", [])
+            exposedThrough: list[Expose] = getattr(fObj, "exposedThrough", [])
             exposedThrough.append(self)
             setattr(fObj, "exposedThrough", exposedThrough)
         return f
@@ -84,7 +77,7 @@ class Expose:
     @overload
     def get(
         self, instance: object, methodName: str, default: T
-    ) -> Union[Callable[..., Any], T]:
+    ) -> Callable[..., Any] | T:
         ...
 
     def get(
@@ -166,15 +159,15 @@ class Element:
         return from C{render}.
     """
 
-    loader: Optional[ITemplateLoader] = None
+    loader: ITemplateLoader | None = None
 
-    def __init__(self, loader: Optional[ITemplateLoader] = None):
+    def __init__(self, loader: ITemplateLoader | None = None):
         if loader is not None:
             self.loader = loader
 
     def lookupRenderMethod(
         self, name: str
-    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
+    ) -> Callable[[IRequest | None, Tag], Flattenable]:
         """
         Look up and return the named render method.
         """
@@ -183,7 +176,7 @@ class Element:
             raise MissingRenderMethod(self, name)
         return method
 
-    def render(self, request: Optional[IRequest]) -> "Flattenable":
+    def render(self, request: IRequest | None) -> Flattenable:
         """
         Implement L{IRenderable} to allow one L{Element} to be embedded in
         another's template or rendering output.

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -8,25 +8,13 @@ complex or arbitrarily nested, as strings.
 """
 from __future__ import annotations
 
+from collections.abc import Coroutine, Generator, Mapping, Sequence
 from inspect import iscoroutine
 from io import BytesIO
 from sys import exc_info
 from traceback import extract_tb
 from types import GeneratorType
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, TypeVar, Union, cast
 
 from twisted.internet.defer import Deferred, ensureDeferred
 from twisted.python.compat import nativeString
@@ -51,8 +39,8 @@ Flattenable = Union[
     CDATA,
     Comment,
     Tag,
-    Tuple[FlattenableRecursive, ...],
-    List[FlattenableRecursive],
+    tuple[FlattenableRecursive, ...],
+    list[FlattenableRecursive],
     Generator[FlattenableRecursive, None, None],
     CharRef,
     Deferred[FlattenableRecursive],
@@ -68,7 +56,7 @@ Type alias containing all types that can be flattened by L{flatten()}.
 BUFFER_SIZE = 2**16
 
 
-def escapeForContent(data: Union[bytes, str]) -> bytes:
+def escapeForContent(data: bytes | str) -> bytes:
     """
     Escape some character or UTF-8 byte data for inclusion in an HTML or XML
     document, by replacing metacharacters (C{&<>}) with their entity
@@ -87,7 +75,7 @@ def escapeForContent(data: Union[bytes, str]) -> bytes:
     return data
 
 
-def attributeEscapingDoneOutside(data: Union[bytes, str]) -> bytes:
+def attributeEscapingDoneOutside(data: bytes | str) -> bytes:
     """
     Escape some character or UTF-8 byte data for inclusion in the top level of
     an attribute.  L{attributeEscapingDoneOutside} actually passes the data
@@ -153,7 +141,7 @@ def writeWithAttributeEscaping(
     return _write
 
 
-def escapedCDATA(data: Union[bytes, str]) -> bytes:
+def escapedCDATA(data: bytes | str) -> bytes:
     """
     Escape CDATA for inclusion in a document.
 
@@ -167,7 +155,7 @@ def escapedCDATA(data: Union[bytes, str]) -> bytes:
     return data.replace(b"]]>", b"]]]]><![CDATA[>")
 
 
-def escapedComment(data: Union[bytes, str]) -> bytes:
+def escapedComment(data: bytes | str) -> bytes:
     """
     Within comments the sequence C{-->} can be mistaken as the end of the comment.
     To ensure consistent parsing and valid output the sequence is replaced with C{--&gt;}.
@@ -189,8 +177,8 @@ def escapedComment(data: Union[bytes, str]) -> bytes:
 
 def _getSlotValue(
     name: str,
-    slotData: Sequence[Optional[Mapping[str, Flattenable]]],
-    default: Optional[Flattenable] = None,
+    slotData: Sequence[Mapping[str, Flattenable] | None],
+    default: Flattenable | None = None,
 ) -> Flattenable:
     """
     Find the value of the named slot in the given stack of slot data.
@@ -224,16 +212,16 @@ def _fork(d: Deferred[T]) -> Deferred[T]:
 
 
 def _flattenElement(
-    request: Optional[IRequest],
+    request: IRequest | None,
     root: Flattenable,
     write: Callable[[bytes], object],
-    slotData: List[Optional[Mapping[str, Flattenable]]],
-    renderFactory: Optional[IRenderable],
-    dataEscaper: Callable[[Union[bytes, str]], bytes],
+    slotData: list[Mapping[str, Flattenable] | None],
+    renderFactory: IRenderable | None,
+    dataEscaper: Callable[[bytes | str], bytes],
     # This is annotated as Generator[T, None, None] instead of Iterator[T]
     # because mypy does not consider an Iterator to be an instance of
     # GeneratorType.
-) -> Generator[Union[Generator[Any, Any, Any], Deferred[Flattenable]], None, None]:
+) -> Generator[Generator[Any, Any, Any] | Deferred[Flattenable], None, None]:
     """
     Make C{root} slightly more flat by yielding all its immediate contents as
     strings, deferreds or generators that are recursive calls to itself.
@@ -272,10 +260,10 @@ def _flattenElement(
 
     def keepGoing(
         newRoot: Flattenable,
-        dataEscaper: Callable[[Union[bytes, str]], bytes] = dataEscaper,
-        renderFactory: Optional[IRenderable] = renderFactory,
+        dataEscaper: Callable[[bytes | str], bytes] = dataEscaper,
+        renderFactory: IRenderable | None = renderFactory,
         write: Callable[[bytes], object] = write,
-    ) -> Generator[Union[Flattenable, Deferred[Flattenable]], None, None]:
+    ) -> Generator[Flattenable | Deferred[Flattenable], None, None]:
         return _flattenElement(
             request, newRoot, write, slotData, renderFactory, dataEscaper
         )
@@ -369,7 +357,7 @@ def _flattenElement(
 
 
 async def _flattenTree(
-    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+    request: IRequest | None, root: Flattenable, write: Callable[[bytes], object]
 ) -> None:
     """
     Make C{root} into an iterable of L{bytes} and L{Deferred} by doing a depth
@@ -412,7 +400,7 @@ async def _flattenTree(
             del buf[:]
             bufSize = 0
 
-    stack: List[Generator[Any, Any, Any]] = [
+    stack: list[Generator[Any, Any, Any]] = [
         _flattenElement(request, root, bufferedWrite, [], None, escapeForContent)
     ]
 
@@ -441,7 +429,7 @@ async def _flattenTree(
 
 
 def flatten(
-    request: Optional[IRequest], root: Flattenable, write: Callable[[bytes], object]
+    request: IRequest | None, root: Flattenable, write: Callable[[bytes], object]
 ) -> Deferred[None]:
     """
     Incrementally write out a string representation of C{root} using C{write}.
@@ -468,7 +456,7 @@ def flatten(
     return ensureDeferred(_flattenTree(request, root, write))
 
 
-def flattenString(request: Optional[IRequest], root: Flattenable) -> Deferred[bytes]:
+def flattenString(request: IRequest | None, root: Flattenable) -> Deferred[bytes]:
     """
     Collate a string representation of C{root} into a single string.
 

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -16,7 +16,6 @@ it has stabilised, it'll be made public.
 
 import io
 from collections import deque
-from typing import List
 
 from zope.interface import implementer
 
@@ -45,7 +44,7 @@ from twisted.python.failure import Failure
 from twisted.web.error import ExcessiveBufferingError
 
 # This API is currently considered private.
-__all__: List[str] = []
+__all__: list[str] = []
 
 
 _END_STREAM_SENTINEL = object()

--- a/src/twisted/web/_newclient.py
+++ b/src/twisted/web/_newclient.py
@@ -29,7 +29,7 @@ Various other classes in this module support this usage:
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from zope.interface import implementer
 
@@ -606,7 +606,7 @@ def _ensureValidURI(uri):
     raise ValueError(f"Invalid URI {uri!r}")
 
 
-def _contentLength(connHeaders: Headers) -> Optional[int]:
+def _contentLength(connHeaders: Headers) -> int | None:
     """
     Parse the I{Content-Length} connection header.
 

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -21,9 +21,10 @@ cumbersome.
     output.
 """
 
+from __future__ import annotations
 
 from inspect import iscoroutine, isgenerator
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import attr
@@ -45,12 +46,12 @@ class slot:
     The key which must be used in L{Tag.fillSlots} to fill it.
     """
 
-    children: List["Tag"] = attr.ib(init=False, factory=list)
+    children: list[Tag] = attr.ib(init=False, factory=list)
     """
     The L{Tag} objects included in this L{slot}'s template.
     """
 
-    default: Optional["Flattenable"] = None
+    default: Flattenable | None = None
     """
     The default contents of this slot, if it is left unfilled.
 
@@ -58,14 +59,14 @@ class slot:
     L{None} actually being used.
     """
 
-    filename: Optional[str] = None
+    filename: str | None = None
     """
     The name of the XML file from which this tag was parsed.
 
     If it was not parsed from an XML file, L{None}.
     """
 
-    lineNumber: Optional[int] = None
+    lineNumber: int | None = None
     """
     The line number on which this tag was encountered in the XML file
     from which it was parsed.
@@ -73,7 +74,7 @@ class slot:
     If it was not parsed from an XML file, L{None}.
     """
 
-    columnNumber: Optional[int] = None
+    columnNumber: int | None = None
     """
     The column number at which this tag was encountered in the XML file
     from which it was parsed.
@@ -92,20 +93,20 @@ class Tag:
     using pure python syntax.
     """
 
-    tagName: Union[bytes, str]
+    tagName: bytes | str
     """
     The name of the represented element.
 
     For a tag like C{<div></div>}, this would be C{"div"}.
     """
 
-    attributes: Dict[Union[bytes, str], "Flattenable"] = attr.ib(factory=dict)
+    attributes: dict[bytes | str, Flattenable] = attr.ib(factory=dict)
     """The attributes of the element."""
 
-    children: List["Flattenable"] = attr.ib(factory=list)
+    children: list[Flattenable] = attr.ib(factory=list)
     """The contents of this C{Tag}."""
 
-    render: Optional[str] = None
+    render: str | None = None
     """
     The name of the render method to use for this L{Tag}.
 
@@ -115,14 +116,14 @@ class Tag:
     to determine which method to call.
     """
 
-    filename: Optional[str] = None
+    filename: str | None = None
     """
     The name of the XML file from which this tag was parsed.
 
     If it was not parsed from an XML file, L{None}.
     """
 
-    lineNumber: Optional[int] = None
+    lineNumber: int | None = None
     """
     The line number on which this tag was encountered in the XML file
     from which it was parsed.
@@ -130,7 +131,7 @@ class Tag:
     If it was not parsed from an XML file, L{None}.
     """
 
-    columnNumber: Optional[int] = None
+    columnNumber: int | None = None
     """
     The column number at which this tag was encountered in the XML file
     from which it was parsed.
@@ -138,7 +139,7 @@ class Tag:
     If it was not parsed from an XML file, L{None}.
     """
 
-    slotData: Optional[Dict[str, "Flattenable"]] = attr.ib(init=False, default=None)
+    slotData: dict[str, Flattenable] | None = attr.ib(init=False, default=None)
     """
     The data which can fill slots.
 
@@ -147,7 +148,7 @@ class Tag:
     the child of a L{Tag}: strings, lists, L{Tag}s, generators, etc.
     """
 
-    def fillSlots(self, **slots: "Flattenable") -> "Tag":
+    def fillSlots(self, **slots: Flattenable) -> Tag:
         """
         Remember the slots provided at this position in the DOM.
 
@@ -162,7 +163,7 @@ class Tag:
         self.slotData.update(slots)
         return self
 
-    def __call__(self, *children: "Flattenable", **kw: "Flattenable") -> "Tag":
+    def __call__(self, *children: Flattenable, **kw: Flattenable) -> Tag:
         """
         Add children and change attributes on this tag.
 
@@ -203,7 +204,7 @@ class Tag:
                 self.attributes[k] = v
         return self
 
-    def _clone(self, obj: "Flattenable", deep: bool) -> "Flattenable":
+    def _clone(self, obj: Flattenable, deep: bool) -> Flattenable:
         """
         Clone a C{Flattenable} object; used by L{Tag.clone}.
 
@@ -242,7 +243,7 @@ class Tag:
         else:
             return obj
 
-    def clone(self, deep: bool = True) -> "Tag":
+    def clone(self, deep: bool = True) -> Tag:
         """
         Return a clone of this tag. If deep is True, clone all of this tag's
         children. Otherwise, just shallow copy the children list without copying
@@ -275,7 +276,7 @@ class Tag:
 
         return newtag
 
-    def clear(self) -> "Tag":
+    def clear(self) -> Tag:
         """
         Clear any existing children from this tag.
         """

--- a/src/twisted/web/_template_util.py
+++ b/src/twisted/web/_template_util.py
@@ -5,24 +5,15 @@
 twisted.web.util and twisted.web.template merged to avoid cyclic deps
 """
 
+from __future__ import annotations
+
 import io
 import linecache
 import warnings
 from collections import OrderedDict
+from collections.abc import Mapping
 from html import escape
-from typing import (
-    IO,
-    Any,
-    AnyStr,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import IO, Any, AnyStr, Callable, Union, cast
 from xml.sax import handler, make_parser
 from xml.sax.xmlreader import AttributesNSImpl, Locator
 
@@ -321,18 +312,18 @@ class _NSContext:
     A mapping from XML namespaces onto their prefixes in the document.
     """
 
-    def __init__(self, parent: Optional["_NSContext"] = None):
+    def __init__(self, parent: _NSContext | None = None):
         """
         Pull out the parent's namespaces, if there's no parent then default to
         XML.
         """
         self.parent = parent
         if parent is not None:
-            self.nss: Dict[Optional[str], Optional[str]] = OrderedDict(parent.nss)
+            self.nss: dict[str | None, str | None] = OrderedDict(parent.nss)
         else:
             self.nss = {"http://www.w3.org/XML/1998/namespace": "xml"}
 
-    def get(self, k: Optional[str], d: Optional[str] = None) -> Optional[str]:
+    def get(self, k: str | None, d: str | None = None) -> str | None:
         """
         Get a prefix for a namespace.
 
@@ -340,13 +331,13 @@ class _NSContext:
         """
         return self.nss.get(k, d)
 
-    def __setitem__(self, k: Optional[str], v: Optional[str]) -> None:
+    def __setitem__(self, k: str | None, v: str | None) -> None:
         """
         Proxy through to setting the prefix for the namespace.
         """
         self.nss.__setitem__(k, v)
 
-    def __getitem__(self, k: Optional[str]) -> Optional[str]:
+    def __getitem__(self, k: str | None) -> str | None:
         """
         Proxy through to getting the prefix for the namespace.
         """
@@ -362,7 +353,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
     Document Object Model.
     """
 
-    def __init__(self, sourceFilename: Optional[str]):
+    def __init__(self, sourceFilename: str | None):
         """
         @param sourceFilename: the filename the XML was loaded out of.
         """
@@ -383,10 +374,10 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         # Depending on our active context, the element type can be Tag, slot
         # or str. Since mypy doesn't understand that context, it would be
         # a pain to not use Any here.
-        self.document: List[Any] = []
+        self.document: list[Any] = []
         self.current = self.document
-        self.stack: List[Any] = []
-        self.xmlnsAttrs: List[Tuple[str, str]] = []
+        self.stack: list[Any] = []
+        self.xmlnsAttrs: list[tuple[str, str]] = []
 
     def endDocument(self) -> None:
         """
@@ -398,7 +389,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         Processing instructions are ignored.
         """
 
-    def startPrefixMapping(self, prefix: Optional[str], uri: str) -> None:
+    def startPrefixMapping(self, prefix: str | None, uri: str) -> None:
         """
         Set up the prefix mapping, which maps fully qualified namespace URIs
         onto namespace prefixes.
@@ -420,7 +411,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         else:
             self.xmlnsAttrs.append(("xmlns:%s" % prefix, uri))
 
-    def endPrefixMapping(self, prefix: Optional[str]) -> None:
+    def endPrefixMapping(self, prefix: str | None) -> None:
         """
         "Pops the stack" on the prefix mapping.
 
@@ -432,8 +423,8 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
 
     def startElementNS(
         self,
-        namespaceAndName: Tuple[str, str],
-        qname: Optional[str],
+        namespaceAndName: tuple[str, str],
+        qname: str | None,
         attrs: AttributesNSImpl,
     ) -> None:
         """
@@ -455,7 +446,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
             if name == "transparent":
                 name = ""
             elif name == "slot":
-                default: Optional[str]
+                default: str | None
                 try:
                     # Try to get the default value for the slot
                     default = attrs[(None, "default")]
@@ -560,7 +551,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
             return
         self.current.append(ch)
 
-    def endElementNS(self, name: Tuple[str, str], qname: Optional[str]) -> None:
+    def endElementNS(self, name: tuple[str, str], qname: str | None) -> None:
         """
         A namespace tag is closed.  Pop the stack, if there's anything left in
         it, otherwise return to the document's namespace.
@@ -604,7 +595,7 @@ class _ToStan(handler.ContentHandler, handler.EntityResolver):
         self.current.append(Comment(content))
 
 
-def _flatsaxParse(fl: Union[IO[AnyStr], str]) -> List["Flattenable"]:
+def _flatsaxParse(fl: IO[AnyStr] | str) -> list[Flattenable]:
     """
     Perform a SAX parse of an XML document with the _ToStan class.
 
@@ -634,7 +625,7 @@ class XMLString:
     An L{ITemplateLoader} that loads and parses XML from a string.
     """
 
-    def __init__(self, s: Union[str, bytes]):
+    def __init__(self, s: str | bytes):
         """
         Run the parser on a L{io.StringIO} copy of the string.
 
@@ -644,10 +635,10 @@ class XMLString:
         if not isinstance(s, str):
             s = s.decode("utf8")
 
-        self._loadedTemplate: List["Flattenable"] = _flatsaxParse(io.StringIO(s))
+        self._loadedTemplate: list[Flattenable] = _flatsaxParse(io.StringIO(s))
         """The loaded document."""
 
-    def load(self) -> List["Flattenable"]:
+    def load(self) -> list[Flattenable]:
         """
         Return the document.
 
@@ -810,15 +801,15 @@ class TagLoader:
     An L{ITemplateLoader} that loads an existing flattenable object.
     """
 
-    def __init__(self, tag: "Flattenable"):
+    def __init__(self, tag: Flattenable):
         """
         @param tag: The object which will be loaded.
         """
 
-        self.tag: "Flattenable" = tag
+        self.tag: Flattenable = tag
         """The object which will be loaded."""
 
-    def load(self) -> List["Flattenable"]:
+    def load(self) -> list[Flattenable]:
         return [self.tag]
 
 
@@ -842,13 +833,13 @@ class XMLFile:
                 stacklevel=2,
             )
 
-        self._loadedTemplate: Optional[List["Flattenable"]] = None
+        self._loadedTemplate: list[Flattenable] | None = None
         """The loaded document, or L{None}, if not loaded."""
 
         self._path: FilePath[Any] = path
         """The file that is being loaded from."""
 
-    def _loadDoc(self) -> List["Flattenable"]:
+    def _loadDoc(self) -> list[Flattenable]:
         """
         Read and parse the XML.
 
@@ -863,7 +854,7 @@ class XMLFile:
     def __repr__(self) -> str:
         return f"<XMLFile of {self._path!r}>"
 
-    def load(self) -> List["Flattenable"]:
+    def load(self) -> list[Flattenable]:
         """
         Return the document, first loading it if necessary.
 
@@ -1032,8 +1023,8 @@ tags = _TagFactory()
 def renderElement(
     request: IRequest,
     element: IRenderable,
-    doctype: Optional[bytes] = b"<!DOCTYPE html>",
-    _failElement: Optional[Callable[[Failure], "Element"]] = None,
+    doctype: bytes | None = b"<!DOCTYPE html>",
+    _failElement: Callable[[Failure], Element] | None = None,
 ) -> object:
     """
     Render an element or other L{IRenderable}.
@@ -1058,7 +1049,7 @@ def renderElement(
 
     d = flatten(request, element, request.write)
 
-    def eb(failure: Failure) -> Optional[Deferred[None]]:
+    def eb(failure: Failure) -> Deferred[None] | None:
         _moduleLog.failure(
             "An error occurred while rendering the response.", failure=failure
         )

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -12,10 +12,11 @@ import collections
 import os
 import warnings
 import zlib
+from collections.abc import Hashable, Iterable
 from dataclasses import dataclass
 from functools import wraps
 from http.cookiejar import CookieJar
-from typing import TYPE_CHECKING, Hashable, Iterable, Optional
+from typing import TYPE_CHECKING
 from urllib.parse import urldefrag, urljoin, urlunparse as _urlunparse
 
 from zope.interface import implementer
@@ -1174,8 +1175,8 @@ class Agent(_AgentBase):
         self,
         method: bytes,
         uri: bytes,
-        headers: Optional[Headers] = None,
-        bodyProducer: Optional[IBodyProducer] = None,
+        headers: Headers | None = None,
+        bodyProducer: IBodyProducer | None = None,
     ) -> Deferred[IResponse]:
         """
         Issue a request to the server indicated by the given C{uri}.
@@ -1375,8 +1376,8 @@ class CookieAgent:
         self,
         method: bytes,
         uri: bytes,
-        headers: Optional[Headers] = None,
-        bodyProducer: Optional[IBodyProducer] = None,
+        headers: Headers | None = None,
+        bodyProducer: IBodyProducer | None = None,
     ) -> Deferred[IResponse]:
         """
         Issue a new request to the wrapped L{Agent}.

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -113,15 +113,7 @@ from email import message_from_bytes
 from email.message import EmailMessage, Message
 from io import BufferedIOBase, BytesIO, TextIOWrapper
 from time import gmtime, time
-from typing import (
-    AnyStr,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Protocol as TypingProtocol,
-    Tuple,
-)
+from typing import AnyStr, Callable, Protocol as TypingProtocol
 from urllib.parse import (
     ParseResultBytes,
     unquote_to_bytes as unquote,
@@ -526,7 +518,7 @@ def toChunk(data):
     return (networkString(f"{len(data):x}"), b"\r\n", data, b"\r\n")
 
 
-def fromChunk(data: bytes) -> Tuple[bytes, bytes]:
+def fromChunk(data: bytes) -> tuple[bytes, bytes]:
     """
     Convert chunk to string.
 
@@ -942,7 +934,7 @@ class Request:
             URL-encoded body uploads into C{request.args}. This can use large
             amounts of memory for large uploads.
         """
-        self.notifications: List[Deferred[None]] = []
+        self.notifications: list[Deferred[None]] = []
         self.channel = channel
 
         # Cache the client and server information, we'll need this
@@ -952,9 +944,9 @@ class Request:
         self.host = self.channel.getHost()
 
         self.requestHeaders: Headers = Headers()
-        self.received_cookies: Dict[bytes, bytes] = {}
+        self.received_cookies: dict[bytes, bytes] = {}
         self.responseHeaders: Headers = Headers()
-        self.cookies: List[bytes] = []  # outgoing cookies
+        self.cookies: list[bytes] = []  # outgoing cookies
         self.transport = self.channel.transport
 
         if queued is _QUEUED_SENTINEL:
@@ -1152,7 +1144,7 @@ class Request:
 
     # The following is the public interface that people should be
     # writing to.
-    def getHeader(self, key: AnyStr) -> Optional[AnyStr]:
+    def getHeader(self, key: AnyStr) -> AnyStr | None:
         """
         Get an HTTP request header.
 
@@ -1443,7 +1435,7 @@ class Request:
             cookie += b"; SameSite=" + sameSite
         self.cookies.append(cookie)
 
-    def setResponseCode(self, code: int, message: Optional[bytes] = None) -> None:
+    def setResponseCode(self, code: int, message: bytes | None = None) -> None:
         """
         Set the HTTP response code.
 
@@ -2000,7 +1992,7 @@ class _ChunkedTransferDecoder:
         self.finishCallback = finishCallback
         self._buffer = bytearray()
         self._start = 0
-        self._trailerHeaders: List[bytearray] = []
+        self._trailerHeaders: list[bytearray] = []
         self._maxTrailerHeadersSize = 2**16
         self._receivedTrailerHeadersSize = 0
 
@@ -2327,7 +2319,7 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
     totalHeadersSize = 16384
     abortTimeout = 15
 
-    length: Optional[int] = 0
+    length: int | None = 0
     persistent = 1
     __header = b""
     __first_line = 1

--- a/src/twisted/web/http_headers.py
+++ b/src/twisted/web/http_headers.py
@@ -7,20 +7,8 @@ An API for storing HTTP header names and values.
 """
 from __future__ import annotations
 
-from typing import (
-    AnyStr,
-    ClassVar,
-    Dict,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from collections.abc import Iterator, Mapping, Sequence
+from typing import AnyStr, ClassVar, TypeVar, overload
 
 from twisted.python.compat import cmp, comparable
 from twisted.web._abnf import _istoken
@@ -70,9 +58,9 @@ class Headers:
 
     def __init__(
         self,
-        rawHeaders: Optional[Mapping[AnyStr, Sequence[AnyStr]]] = None,
+        rawHeaders: Mapping[AnyStr, Sequence[AnyStr]] | None = None,
     ) -> None:
-        self._rawHeaders: Dict[bytes, List[bytes]] = {}
+        self._rawHeaders: dict[bytes, list[bytes]] = {}
         if rawHeaders is not None:
             for name, values in rawHeaders.items():
                 self.setRawHeaders(name, values)
@@ -127,9 +115,7 @@ class Headers:
         """
         self._rawHeaders.pop(_nameEncoder.encode(name), None)
 
-    def setRawHeaders(
-        self, name: Union[str, bytes], values: Sequence[Union[str, bytes]]
-    ) -> None:
+    def setRawHeaders(self, name: str | bytes, values: Sequence[str | bytes]) -> None:
         """
         Sets the raw representation of the given header.
 
@@ -144,7 +130,7 @@ class Headers:
         @return: L{None}
         """
         _name = _nameEncoder.encode(name)
-        encodedValues: List[bytes] = []
+        encodedValues: list[bytes] = []
         for v in values:
             if isinstance(v, str):
                 _v = v.encode("utf8")
@@ -154,7 +140,7 @@ class Headers:
 
         self._rawHeaders[_name] = encodedValues
 
-    def addRawHeader(self, name: Union[str, bytes], value: Union[str, bytes]) -> None:
+    def addRawHeader(self, name: str | bytes, value: str | bytes) -> None:
         """
         Add a new raw value for the given header.
 
@@ -169,16 +155,16 @@ class Headers:
         )
 
     @overload
-    def getRawHeaders(self, name: AnyStr) -> Optional[Sequence[AnyStr]]:
+    def getRawHeaders(self, name: AnyStr) -> Sequence[AnyStr] | None:
         ...
 
     @overload
-    def getRawHeaders(self, name: AnyStr, default: _T) -> Union[Sequence[AnyStr], _T]:
+    def getRawHeaders(self, name: AnyStr, default: _T) -> Sequence[AnyStr] | _T:
         ...
 
     def getRawHeaders(
-        self, name: AnyStr, default: Optional[_T] = None
-    ) -> Union[Sequence[AnyStr], Optional[_T]]:
+        self, name: AnyStr, default: _T | None = None
+    ) -> Sequence[AnyStr] | _T | None:
         """
         Returns a sequence of headers matching the given name as the raw string
         given.
@@ -200,7 +186,7 @@ class Headers:
             return [v.decode("utf8") for v in values]
         return values
 
-    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, Sequence[bytes]]]:
+    def getAllRawHeaders(self) -> Iterator[tuple[bytes, Sequence[bytes]]]:
         """
         Return an iterator of key, value pairs of all headers contained in this
         object, as L{bytes}.  The keys are capitalized in canonical
@@ -223,9 +209,9 @@ class _NameEncoder:
     """
 
     __slots__ = ("_canonicalHeaderCache",)
-    _canonicalHeaderCache: Dict[Union[bytes, str], bytes]
+    _canonicalHeaderCache: dict[bytes | str, bytes]
 
-    _caseMappings: ClassVar[Dict[bytes, bytes]] = {
+    _caseMappings: ClassVar[dict[bytes, bytes]] = {
         b"Content-Md5": b"Content-MD5",
         b"Dnt": b"DNT",
         b"Etag": b"ETag",
@@ -240,7 +226,7 @@ class _NameEncoder:
     def __init__(self):
         self._canonicalHeaderCache = {}
 
-    def encode(self, name: Union[str, bytes]) -> bytes:
+    def encode(self, name: str | bytes) -> bytes:
         """
         Encode the name of a header (eg 'Content-Type') to an ISO-8859-1
         bytestring if required. It will be canonicalized to Http-Header-Case.

--- a/src/twisted/web/iweb.py
+++ b/src/twisted/web/iweb.py
@@ -10,7 +10,9 @@ Interface definitions for L{twisted.web}.
     body is not known in advance.
 """
 
-from typing import TYPE_CHECKING, Callable, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
 
 from zope.interface import Attribute, Interface
 
@@ -514,7 +516,7 @@ class IRenderable(Interface):
 
     def lookupRenderMethod(
         name: str,
-    ) -> Callable[[Optional[IRequest], "Tag"], "Flattenable"]:
+    ) -> Callable[[IRequest | None, Tag], Flattenable]:
         """
         Look up and return the render method associated with the given name.
 
@@ -526,7 +528,7 @@ class IRenderable(Interface):
             was encountered.
         """
 
-    def render(request: Optional[IRequest]) -> "Flattenable":
+    def render(request: IRequest | None) -> Flattenable:
         """
         Get the document for this L{IRenderable}.
 
@@ -543,7 +545,7 @@ class ITemplateLoader(Interface):
     L{twisted.web.template.Element}'s C{loader} attribute.
     """
 
-    def load() -> List["Flattenable"]:
+    def load() -> list[Flattenable]:
         """
         Load a template suitable for rendering.
 
@@ -739,8 +741,8 @@ class IAgent(Interface):
     def request(
         method: bytes,
         uri: bytes,
-        headers: Optional[Headers] = None,
-        bodyProducer: Optional[IBodyProducer] = None,
+        headers: Headers | None = None,
+        bodyProducer: IBodyProducer | None = None,
     ) -> Deferred[IResponse]:
         """
         Request the resource at the given location.

--- a/src/twisted/web/resource.py
+++ b/src/twisted/web/resource.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 import warnings
-from typing import Sequence
+from collections.abc import Sequence
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -65,7 +65,7 @@ class IResource(Interface):
         @type request: L{twisted.web.server.Request}
         """
 
-    def putChild(path: bytes, child: "IResource") -> None:
+    def putChild(path: bytes, child: IResource) -> None:
         """
         Put a child L{IResource} implementor at the given path.
 

--- a/src/twisted/web/server.py
+++ b/src/twisted/web/server.py
@@ -13,13 +13,14 @@ This is a web server which integrates with the twisted.internet infrastructure.
     value.
 """
 
+from __future__ import annotations
+
 import copy
 import os
 import re
 import zlib
 from binascii import hexlify
 from html import escape
-from typing import List, Optional
 from urllib.parse import quote as _quote
 
 from zope.interface import implementer
@@ -87,11 +88,11 @@ class Request(Copyable, http.Request, components.Componentized):
         will be transmitted only over HTTPS.
     """
 
-    defaultContentType: Optional[bytes] = b"text/html"
+    defaultContentType: bytes | None = b"text/html"
     site = None
     appRootURL = None
-    prepath: Optional[List[bytes]] = None
-    postpath: Optional[List[bytes]] = None
+    prepath: list[bytes] | None = None
+    postpath: list[bytes] | None = None
     __pychecker__ = "unusednames=issuer"
     _inFakeHead = False
     _encoder = None

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -13,8 +13,9 @@ import mimetypes
 import os
 import time
 import warnings
+from collections.abc import Sequence
 from html import escape
-from typing import Any, Callable, Dict, Literal, Sequence
+from typing import Any, Callable, Literal
 from urllib.parse import quote, unquote
 
 from zope.interface import implementer
@@ -199,7 +200,7 @@ class File(resource.Resource, filepath.FilePath[str]):
 
     contentEncodings = {".gz": "gzip", ".bz2": "bzip2"}
 
-    processors: Dict[str, Callable[[str, Any], Data]] = {}
+    processors: dict[str, Callable[[str, Any], Data]] = {}
 
     indexNames = ["index", "index.html", "index.htm", "index.rpy"]
 

--- a/src/twisted/web/test/_util.py
+++ b/src/twisted/web/test/_util.py
@@ -6,8 +6,6 @@ General helpers for L{twisted.web} unit tests.
 """
 from __future__ import annotations
 
-from typing import Type
-
 from twisted.internet.defer import Deferred, succeed
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web import server
@@ -67,7 +65,7 @@ class FlattenTestCase(SynchronousTestCase):
         """
         return self.successResultOf(self.assertFlattensTo(root, target))
 
-    def assertFlatteningRaises(self, root: Flattenable, exn: Type[Exception]) -> None:
+    def assertFlatteningRaises(self, root: Flattenable, exn: type[Exception]) -> None:
         """
         Assert flattening a root element raises a particular exception.
         """

--- a/src/twisted/web/test/requesthelper.py
+++ b/src/twisted/web/test/requesthelper.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 __all__ = ["DummyChannel", "DummyRequest"]
 
 from io import BytesIO
-from typing import Dict, List, Optional
 
 from zope.interface import implementer, verify
 
@@ -210,12 +209,12 @@ class DummyRequest:
 
     uri = b"http://dummy/"
     method = b"GET"
-    client: Optional[IAddress] = None
-    sitepath: List[bytes]
-    written: List[bytes]
-    prepath: List[bytes]
-    args: Dict[bytes, List[bytes]]
-    _finishedDeferreds: List[Deferred[None]]
+    client: IAddress | None = None
+    sitepath: list[bytes]
+    written: list[bytes]
+    prepath: list[bytes]
+    args: dict[bytes, list[bytes]]
+    _finishedDeferreds: list[Deferred[None]]
 
     def registerProducer(self, prod, s):
         """
@@ -238,8 +237,8 @@ class DummyRequest:
     def __init__(
         self,
         postpath: list[bytes],
-        session: Optional[Session] = None,
-        client: Optional[IAddress] = None,
+        session: Session | None = None,
+        client: IAddress | None = None,
     ) -> None:
         self.sitepath = []
         self.written = []

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -8,9 +8,10 @@ Tests for L{twisted.web.client.Agent} and related new client APIs.
 from __future__ import annotations
 
 import zlib
+from collections.abc import Sequence
 from http.cookiejar import CookieJar
 from io import BytesIO
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING
 from unittest import SkipTest, skipIf
 
 from zope.interface.declarations import implementer
@@ -122,7 +123,7 @@ class StubHTTPProtocol(Protocol):
     """
 
     def __init__(self) -> None:
-        self.requests: List[Tuple[Request, Deferred[IResponse]]] = []
+        self.requests: list[tuple[Request, Deferred[IResponse]]] = []
         self.state = "QUIESCENT"
 
     def request(self, request):
@@ -2684,7 +2685,7 @@ class _RedirectAgentTestsMixin(testMixinClass):
         crossScheme: bool = False,
         crossDomain: bool = False,
         crossPort: bool = False,
-        requestHeaders: Optional[Headers] = None,
+        requestHeaders: Headers | None = None,
     ) -> Request:
         """
         When getting a redirect, L{client.RedirectAgent} follows the URL
@@ -2792,7 +2793,7 @@ class _RedirectAgentTestsMixin(testMixinClass):
         allHeaders = Headers({**sensitiveHeaderValues, **otherHeaderValues})
         redirected = self._testRedirectDefault(301, requestHeaders=allHeaders)
 
-        def normHeaders(headers: Headers) -> Dict[bytes, Sequence[bytes]]:
+        def normHeaders(headers: Headers) -> dict[bytes, Sequence[bytes]]:
             return {k.lower(): v for (k, v) in headers.getAllRawHeaders()}
 
         sameOriginHeaders = normHeaders(redirected.headers)

--- a/src/twisted/web/test/test_cgi.py
+++ b/src/twisted/web/test/test_cgi.py
@@ -114,7 +114,7 @@ class _StartServerAndTearDownMixin:
 
     def writeCGI(self, source):
         cgiFilename = os.path.abspath(self.mktemp())
-        with open(cgiFilename, "wt") as cgiFile:
+        with open(cgiFilename, "w") as cgiFile:
             cgiFile.write(source)
         return cgiFilename
 
@@ -264,7 +264,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
 
     def test_ReadEmptyInput(self):
         cgiFilename = os.path.abspath(self.mktemp())
-        with open(cgiFilename, "wt") as cgiFile:
+        with open(cgiFilename, "w") as cgiFile:
             cgiFile.write(READINPUT_CGI)
 
         portnum = self.startServer(cgiFilename)
@@ -285,7 +285,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
 
     def test_ReadInput(self):
         cgiFilename = os.path.abspath(self.mktemp())
-        with open(cgiFilename, "wt") as cgiFile:
+        with open(cgiFilename, "w") as cgiFile:
             cgiFile.write(READINPUT_CGI)
 
         portnum = self.startServer(cgiFilename)
@@ -310,7 +310,7 @@ class CGITests(_StartServerAndTearDownMixin, unittest.TestCase):
 
     def test_ReadAllInput(self):
         cgiFilename = os.path.abspath(self.mktemp())
-        with open(cgiFilename, "wt") as cgiFile:
+        with open(cgiFilename, "w") as cgiFile:
             cgiFile.write(READALLINPUT_CGI)
 
         portnum = self.startServer(cgiFilename)

--- a/src/twisted/web/test/test_flatten.py
+++ b/src/twisted/web/test/test_flatten.py
@@ -6,13 +6,15 @@ Tests for the flattening portion of L{twisted.web.template}, implemented in
 L{twisted.web._flatten}.
 """
 
+from __future__ import annotations
+
 import re
 import sys
 import traceback
 from collections import OrderedDict
 from textwrap import dedent
 from types import FunctionType
-from typing import Callable, Dict, List, NoReturn, Optional, Tuple, cast
+from typing import Callable, NoReturn, cast
 from xml.etree.ElementTree import XML
 
 from zope.interface import implementer
@@ -160,12 +162,12 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
 
         class WithRenderer(Element):
-            def __init__(self, value: str, loader: Optional[ITemplateLoader]) -> None:
+            def __init__(self, value: str, loader: ITemplateLoader | None) -> None:
                 self.value = value
                 super().__init__(loader)
 
             @renderer
-            def stuff(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
+            def stuff(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return self.value
 
         toss = []
@@ -191,12 +193,12 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
             def __init__(self, value: Flattenable) -> None:
                 self.value = value
 
-            def render(self, request: Optional[IRequest]) -> Flattenable:
+            def render(self, request: IRequest | None) -> Flattenable:
                 return self.value
 
             def lookupRenderMethod(
                 self, name: str
-            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
+            ) -> Callable[[IRequest | None, Tag], Flattenable]:
                 raise NotImplementedError("Unexpected call")
 
         self.checkAttributeSanitization(Arbitrary, passthru)
@@ -266,7 +268,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         self.assertFlattensImmediately(Comment("foo bar"), b"<!--foo bar-->")
 
-    def test_commentEscaping(self) -> Deferred[List[bytes]]:
+    def test_commentEscaping(self) -> Deferred[list[bytes]]:
         """
         The data in a L{Comment} is escaped and mangled in the flattened output
         so that the result can be safely included in an HTML document.
@@ -361,7 +363,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
         """
         from textwrap import dedent
 
-        namespace: Dict[str, FunctionType] = {}
+        namespace: dict[str, FunctionType] = {}
         exec(
             dedent(
                 """
@@ -413,7 +415,7 @@ class SerializationTests(FlattenTestCase, XMLAssertionMixin):
 
             def lookupRenderMethod(
                 ign, name: str
-            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
+            ) -> Callable[[IRequest | None, Tag], Flattenable]:
                 self.assertEqual(name, "test")
                 return lambda ign, node: node("world")
 
@@ -465,7 +467,7 @@ class FlattenChunkingTests(SynchronousTestCase):
         into the buffer it is all passed to a single call to the write
         function.
         """
-        output: List[bytes] = []
+        output: list[bytes] = []
         self.successResultOf(flatten(None, ["1", "2", "3"], output.append))
         assert_that(output, equal_to([b"123"]))
 
@@ -479,7 +481,7 @@ class FlattenChunkingTests(SynchronousTestCase):
         someMore = ["y"] * BUFFER_SIZE
         evenMore = ["z"] * BUFFER_SIZE
 
-        output: List[bytes] = []
+        output: list[bytes] = []
         self.successResultOf(flatten(None, [some, someMore, evenMore], output.append))
         assert_that(
             output,
@@ -489,7 +491,7 @@ class FlattenChunkingTests(SynchronousTestCase):
     def _chunksSeparatedByAsyncTest(
         self,
         start: Callable[
-            [Flattenable], Tuple[Deferred[Flattenable], Callable[[], object]]
+            [Flattenable], tuple[Deferred[Flattenable], Callable[[], object]]
         ],
     ) -> None:
         """
@@ -517,7 +519,7 @@ class FlattenChunkingTests(SynchronousTestCase):
             "more-chunks-",
             "already-available",
         ]
-        output: List[bytes] = []
+        output: list[bytes] = []
         d = flatten(None, value, output.append)
         first_finish()
         second_finish()
@@ -546,7 +548,7 @@ class FlattenChunkingTests(SynchronousTestCase):
 
         def sync_start(
             v: Flattenable,
-        ) -> Tuple[Deferred[Flattenable], Callable[[], None]]:
+        ) -> tuple[Deferred[Flattenable], Callable[[], None]]:
             return (succeed(v), lambda: None)
 
         self._chunksSeparatedByAsyncTest(sync_start)
@@ -561,7 +563,7 @@ class FlattenChunkingTests(SynchronousTestCase):
 
         def async_start(
             v: Flattenable,
-        ) -> Tuple[Deferred[Flattenable], Callable[[], None]]:
+        ) -> tuple[Deferred[Flattenable], Callable[[], None]]:
             d: Deferred[Flattenable] = Deferred()
             return (d, lambda: d.callback(v))
 
@@ -691,10 +693,10 @@ class FlattenerErrorTests(SynchronousTestCase):
 
             def lookupRenderMethod(  # type: ignore[empty-body]
                 self, name: str
-            ) -> Callable[[Optional[IRequest], Tag], Flattenable]:
+            ) -> Callable[[IRequest | None, Tag], Flattenable]:
                 ...
 
-            def render(self, request: Optional[IRequest]) -> Flattenable:
+            def render(self, request: IRequest | None) -> Flattenable:
                 return failing
 
         flattening = flattenString(None, [NotActuallyRenderable()])

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -5,13 +5,15 @@
 Test HTTP support.
 """
 
+from __future__ import annotations
+
 import base64
 import calendar
 import random
+from collections.abc import Sequence
 from functools import partial
 from io import BytesIO, TextIOWrapper
 from itertools import cycle
-from typing import Sequence, Union
 from unittest import skipIf
 from urllib.parse import clear_cache  # type: ignore[attr-defined]
 from urllib.parse import urlparse, urlunsplit
@@ -256,7 +258,7 @@ class HTTP1_0Tests(unittest.TestCase, ResponseTestMixin):
         b"\r\n"
     )
 
-    expected_response: Union[Sequence[Sequence[bytes]], bytes] = [
+    expected_response: Sequence[Sequence[bytes]] | bytes = [
         (
             b"HTTP/1.0 200 OK",
             b"Request: /",

--- a/src/twisted/web/test/test_http_headers.py
+++ b/src/twisted/web/test/test_http_headers.py
@@ -7,7 +7,7 @@ Tests for L{twisted.web.http_headers}.
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.web.http_headers import Headers, InvalidHeaderName, _nameEncoder

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -5,9 +5,10 @@
 Tests for L{twisted.web.template}
 """
 
+from __future__ import annotations
+
 import sys
 from io import StringIO
-from typing import List, Optional
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -146,7 +147,7 @@ class ElementTests(TestCase):
 
         class ElementWithRenderMethod(Element):
             @renderer
-            def foo(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
+            def foo(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return "bar"
 
         foo = ElementWithRenderMethod().lookupRenderMethod("foo")
@@ -160,7 +161,7 @@ class ElementTests(TestCase):
 
         @implementer(ITemplateLoader)
         class TemplateLoader:
-            def load(self) -> List[Flattenable]:
+            def load(self) -> list[Flattenable]:
                 return ["result"]
 
         class StubElement(Element):
@@ -481,9 +482,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def renderMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return succeed("Hello, world.")
 
         element = RenderfulElement(
@@ -518,9 +517,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def renderMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 renders.append((self, request))
                 return tag("Hello, world.")
 
@@ -542,9 +539,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def renderMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return "Hello, world."
 
         element = RenderfulElement(
@@ -567,9 +562,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def renderMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return tag(Element(loader=XMLString("<em>Hello, world.</em>")))
 
         element = RenderfulElement(
@@ -590,9 +583,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class RenderfulElement(Element):
             @renderer
-            def renderMethod(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def renderMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return tag.fillSlots(test2="world.")
 
         element = RenderfulElement(
@@ -615,7 +606,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class OuterElement(Element):
             @renderer
-            def outerMethod(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
+            def outerMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return tag(
                     InnerElement(
                         loader=XMLString(
@@ -630,7 +621,7 @@ class FlattenIntegrationTests(FlattenTestCase):
 
         class InnerElement(Element):
             @renderer
-            def innerMethod(self, request: Optional[IRequest], tag: Tag) -> Flattenable:
+            def innerMethod(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 return "Hello, world."
 
         element = OuterElement(
@@ -661,15 +652,13 @@ class FlattenIntegrationTests(FlattenTestCase):
             loader = sharedLoader
 
             @renderer
-            def classCounter(
-                self, request: Optional[IRequest], tag: Tag
-            ) -> Flattenable:
+            def classCounter(self, request: IRequest | None, tag: Tag) -> Flattenable:
                 DestructiveElement.count += 1
                 return tag(str(DestructiveElement.count))
 
             @renderer
             def instanceCounter(
-                self, request: Optional[IRequest], tag: Tag
+                self, request: IRequest | None, tag: Tag
             ) -> Flattenable:
                 self.instanceCount += 1
                 return tag(str(self.instanceCount))
@@ -743,7 +732,7 @@ class FailingElement(Element):
     An element that raises an exception when rendered.
     """
 
-    def render(self, request: Optional[IRequest]) -> "Flattenable":
+    def render(self, request: IRequest | None) -> Flattenable:
         a = 42
         b = 0
         return f"{a // b}"

--- a/src/twisted/web/test/test_web.py
+++ b/src/twisted/web/test/test_web.py
@@ -8,7 +8,6 @@ Tests for various parts of L{twisted.web}.
 import os
 import zlib
 from io import BytesIO
-from typing import List
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -1890,7 +1889,7 @@ class QueueResource(Resource):
 
     def __init__(self) -> None:
         super().__init__()
-        self.dispatchedRequests: List[Request] = []
+        self.dispatchedRequests: list[Request] = []
 
     def render_GET(self, request: Request) -> int:
         self.dispatchedRequests.append(request)

--- a/src/twisted/web/wsgi.py
+++ b/src/twisted/web/wsgi.py
@@ -6,9 +6,10 @@ An implementation of
 U{Python Web Server Gateway Interface v1.0.1<http://www.python.org/dev/peps/pep-3333/>}.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from sys import exc_info
-from typing import List, Union
 from warnings import warn
 
 from zope.interface import implementer
@@ -34,7 +35,7 @@ from twisted.web.server import NOT_DONE_YET
 #
 # The following pair of functions -- _wsgiString() and _wsgiStringToBytes() --
 # are used to make Twisted's WSGI support compliant with the standard.
-def _wsgiString(string: Union[str, bytes]) -> str:
+def _wsgiString(string: str | bytes) -> str:
     """
     Convert C{string} to a WSGI "bytes-as-unicode" string.
 
@@ -100,7 +101,7 @@ class _ErrorStream:
         # will overwrite this value if it is not properly formatted here.
         self._log.error(data, system="wsgi", isError=True, message=(data,))
 
-    def writelines(self, iovec: List[str]) -> None:
+    def writelines(self, iovec: list[str]) -> None:
         """
         Join the given lines and pass them to C{write} to be handled in the
         usual way.


### PR DESCRIPTION
## Scope and purpose

Fixes #12580

The changes were automatically generated using:

* `pyupgrade --py39-plus .\src\twisted\web\*.py`
* `pyupgrade --py39-plus .\src\twisted\web\*\*.py`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as List. (`pyupgrade` doesn't remove these)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
