### PR TITLE
#12586 runner: update type annotations for Python 3.9+ (1/1)

### DIFF
--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -7,7 +7,7 @@ Support for starting, monitoring, and restarting child process.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import attr
 import incremental
@@ -48,11 +48,11 @@ class _Process:
     @type cwd: C{str}
     """
 
-    args: List[str]
-    uid: Optional[int] = None
-    gid: Optional[int] = None
-    env: Dict[str, str] = attr.ib(default=attr.Factory(dict))
-    cwd: Optional[str] = None
+    args: list[str]
+    uid: int | None = None
+    gid: int | None = None
+    env: dict[str, str] = attr.ib(default=attr.Factory(dict))
+    cwd: str | None = None
 
     @deprecate.deprecated(incremental.Version("Twisted", 18, 7, 0))
     def toTuple(self) -> tuple[list[str], int | None, int | None, dict[str, str]]:

--- a/src/twisted/runner/procmon.py
+++ b/src/twisted/runner/procmon.py
@@ -32,20 +32,15 @@ class _Process:
     The parameters of a process to be restarted.
 
     @ivar args: command-line arguments (including name of command as first one)
-    @type args: C{list}
 
     @ivar uid: user-id to run process as, or None (which means inherit uid)
-    @type uid: C{int}
 
     @ivar gid: group-id to run process as, or None (which means inherit gid)
-    @type gid: C{int}
 
     @ivar env: environment for process
-    @type env: C{dict}
 
     @ivar cwd: initial working directory for process or None
                (which means inherit cwd)
-    @type cwd: C{str}
     """
 
     args: list[str]

--- a/src/twisted/runner/procmontap.py
+++ b/src/twisted/runner/procmontap.py
@@ -6,7 +6,7 @@
 Support for creating a service which runs a process monitor.
 """
 
-from typing import List, Sequence
+from collections.abc import Sequence
 
 from twisted.python import usage
 from twisted.runner.procmon import ProcessMonitor
@@ -57,7 +57,7 @@ class Options(usage.Options):
         ],
     ]
 
-    optFlags: List[Sequence[str]] = []
+    optFlags: list[Sequence[str]] = []
 
     longdesc = """\
 procmon runs processes, monitors their progress, and restarts them when they

--- a/src/twisted/runner/test/test_procmon.py
+++ b/src/twisted/runner/test/test_procmon.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import errno
 import os
 import pickle
-from typing import AnyStr, Mapping, Optional, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import AnyStr
 
 from zope.interface import implementer
 
@@ -118,14 +119,14 @@ class DummyProcessReactor(MemoryReactor, Clock):
     def spawnProcess(
         self,
         processProtocol: IProcessProtocol,
-        executable: Union[bytes, str],
-        args: Sequence[Union[bytes, str]],
-        env: Optional[Mapping[AnyStr, AnyStr]] = None,
-        path: Union[None, bytes, str] = None,
-        uid: Optional[int] = None,
-        gid: Optional[int] = None,
+        executable: bytes | str,
+        args: Sequence[bytes | str],
+        env: Mapping[AnyStr, AnyStr] | None = None,
+        path: None | bytes | str = None,
+        uid: int | None = None,
+        gid: int | None = None,
         usePTY: bool = False,
-        childFDs: Optional[Mapping[int, Union[int, str]]] = None,
+        childFDs: Mapping[int, int | str] | None = None,
     ) -> IProcessTransport:
         """
         Fake L{reactor.spawnProcess}, that logs all the process


### PR DESCRIPTION
## Scope and purpose

Fixes #12586 

The changes were automatically generated using:

* `pyupgrade --py39-plus .\src\twisted\runner\*.py`
* `pyupgrade --py39-plus .\src\twisted\runner\*\*.py`

Manual work done:

* Remove unused imports from typing module such as List. (`pyupgrade` doesn't remove these)


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
