### PR TITLE
#12592 protocols: update type annotations for Python 3.9+ (1/1)

### DIFF
--- a/src/twisted/protocols/_sni.py
+++ b/src/twisted/protocols/_sni.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property, partial
-from typing import Callable, Dict, List, Tuple
+from typing import Callable
 
 from zope.interface import implementer
 
@@ -57,7 +57,7 @@ def lookupWithWildcard(
 
 @implementer(IOpenSSLServerConnectionCreator)
 @dataclass
-class SNIConnectionCreator(object):
+class SNIConnectionCreator:
     """
     (Private) L{IOpenSSLServerConnectionCreator} implementation that creates an
     OpenSSL connection with a context that will switch to the appropriate one.
@@ -114,7 +114,7 @@ class SNIConnectionCreator(object):
 
 
 @implementer(IStreamServerEndpoint)
-class TLSServerEndpoint(object):
+class TLSServerEndpoint:
     """
     A wrapper L{IStreamServerEndpoint} that can run TLS over an arbitrary other
     L{IStreamServerEndpoint} (most commonly, TCP).
@@ -149,7 +149,7 @@ class TLSServerEndpoint(object):
         )
 
 
-def _getSubjectAltNames(c: Certificate) -> List[str]:
+def _getSubjectAltNames(c: Certificate) -> list[str]:
     """
     Get all the DNSName SANs for a given certificate.
     """
@@ -217,12 +217,12 @@ class PEMObjects:
     A collection of objects loaded from a collection of PEM-encoded files.
     """
 
-    _certificates: List[tuple[FilePath[str], Certificate]]
+    _certificates: list[tuple[FilePath[str], Certificate]]
     """
     A list of pairs of (FilePath, Certificate) that indicates what files
     contain what certificates.
     """
-    _keyPairs: List[tuple[FilePath[str], KeyPair]]
+    _keyPairs: list[tuple[FilePath[str], KeyPair]]
     """
     A list of pairs of (FilePath, KeyPair) that indicates what pairs contain
     what certificates.
@@ -254,8 +254,8 @@ class PEMObjects:
         @param fp: A L{FilePath} pointing at a file on the filesystem whose
             contents should be PEM data.
         """
-        certBlobs: List[bytes] = []
-        keyBlobs: List[bytes] = []
+        certBlobs: list[bytes] = []
+        keyBlobs: list[bytes] = []
         blobs = [b""]
         with fp.open() as pemlines:
             for line in pemlines:
@@ -272,19 +272,17 @@ class PEMObjects:
             ],
         )
 
-    def inferDomainMapping(self) -> Dict[str, CertificateOptions]:
+    def inferDomainMapping(self) -> dict[str, CertificateOptions]:
         """
         Return a mapping of DNS name to L{CertificateOptions}.
         """
 
         privateCerts = []
 
-        certificatesByFingerprint = dict(
-            [
-                (certificate.getPublicKey().keyHash(), certificate)
-                for (_, certificate) in self._certificates
-            ]
-        )
+        certificatesByFingerprint = {
+            certificate.getPublicKey().keyHash(): certificate
+            for (_, certificate) in self._certificates
+        }
 
         for pairPath, keyPair in self._keyPairs:
             keyHash = keyPair.keyHash()
@@ -308,12 +306,10 @@ class PEMObjects:
 
         noPrivateKeys = [
             Certificate.load(dumped)
-            for dumped in set(
-                each.dump() for each in certificatesByFingerprint.values()
-            )
+            for dumped in {each.dump() for each in certificatesByFingerprint.values()}
         ]
 
-        def hashDN(dn: DN) -> Tuple[Tuple[str, bytes], ...]:
+        def hashDN(dn: DN) -> tuple[tuple[str, bytes], ...]:
             return tuple(sorted(dn.items()))
 
         bySubject = {

--- a/src/twisted/protocols/amp.py
+++ b/src/twisted/protocols/amp.py
@@ -196,18 +196,7 @@ from io import BytesIO
 from itertools import count
 from struct import pack
 from types import MethodType
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, ClassVar, TypeVar
 
 from zope.interface import Interface, implementer
 
@@ -616,7 +605,7 @@ class IncompatibleVersions(AmpError):
 PROTOCOL_ERRORS = {UNHANDLED_ERROR_CODE: UnhandledCommand}
 
 
-class AmpBox(Dict[bytes, bytes]):
+class AmpBox(dict[bytes, bytes]):
     """
     I am a packet in the AMP protocol, much like a
     regular bytes:bytes dictionary.
@@ -624,7 +613,7 @@ class AmpBox(Dict[bytes, bytes]):
 
     # be like a regular dictionary don't magically
     # acquire a __dict__...
-    __slots__: List[str] = []
+    __slots__: list[str] = []
 
     def __init__(self, *args, **kw):
         """
@@ -720,7 +709,7 @@ class QuitBox(AmpBox):
     I am an AmpBox that, upon being sent, terminates the connection.
     """
 
-    __slots__: List[str] = []
+    __slots__: list[str] = []
 
     def __repr__(self) -> str:
         return f"QuitBox(**{super().__repr__()})"
@@ -1091,7 +1080,7 @@ class _CommandLocatorMeta(type):
     metaclass.
     """
 
-    _currentClassCommands: "list[tuple[type[Command], Callable[..., Any]]]" = []
+    _currentClassCommands: list[tuple[type[Command], Callable[..., Any]]] = []
 
     def __new__(cls, name, bases, attrs):
         commands = cls._currentClassCommands[:]
@@ -1704,12 +1693,12 @@ class _CommandMeta(type):
 
     def __new__(
         cls: type[_Self], name: str, bases: tuple[type], attrs: dict[str, object]
-    ) -> Type[Command]:
+    ) -> type[Command]:
         reverseErrors = attrs["reverseErrors"] = {}
         er = attrs["allErrors"] = {}
         if "commandName" not in attrs:
             attrs["commandName"] = name.encode("ascii")
-        newtype: Type[Command] = type.__new__(cls, name, bases, attrs)  # type:ignore
+        newtype: type[Command] = type.__new__(cls, name, bases, attrs)  # type:ignore
 
         if not isinstance(newtype.commandName, bytes):
             raise TypeError(
@@ -1724,8 +1713,8 @@ class _CommandMeta(type):
             if not isinstance(bname, bytes):
                 raise TypeError(f"Response names must be byte strings, got: {bname!r}")
 
-        errors: Dict[Type[Exception], bytes] = {}
-        fatalErrors: Dict[Type[Exception], bytes] = {}
+        errors: dict[type[Exception], bytes] = {}
+        fatalErrors: dict[type[Exception], bytes] = {}
         accumulateClassDict(newtype, "errors", errors)
         accumulateClassDict(newtype, "fatalErrors", fatalErrors)
 
@@ -1797,14 +1786,14 @@ class Command(metaclass=_CommandMeta):
     """
 
     commandName: ClassVar[bytes]
-    arguments: ClassVar[List[Tuple[bytes, Argument]]] = []
-    response: ClassVar[List[Tuple[bytes, Argument]]] = []
-    extra: ClassVar[List[Any]] = []
-    errors: ClassVar[Dict[Type[Exception], bytes]] = {}
-    fatalErrors: ClassVar[Dict[Type[Exception], bytes]] = {}
+    arguments: ClassVar[list[tuple[bytes, Argument]]] = []
+    response: ClassVar[list[tuple[bytes, Argument]]] = []
+    extra: ClassVar[list[Any]] = []
+    errors: ClassVar[dict[type[Exception], bytes]] = {}
+    fatalErrors: ClassVar[dict[type[Exception], bytes]] = {}
 
-    commandType: "ClassVar[Union[Type[Command], Type[Box]]]" = Box
-    responseType: ClassVar[Type[AmpBox]] = Box
+    commandType: ClassVar[type[Command] | type[Box]] = Box
+    responseType: ClassVar[type[AmpBox]] = Box
 
     requiresAnswer = True
 
@@ -2038,7 +2027,7 @@ class _TLSBox(AmpBox):
     I am an AmpBox that, upon being sent, initiates a TLS connection.
     """
 
-    __slots__: List[str] = []
+    __slots__: list[str] = []
 
     def __init__(self):
         if ssl is None:
@@ -2302,7 +2291,7 @@ class BinaryBoxProtocol(
 
     hostCertificate = None
     noPeerCertificate = False  # for tests
-    innerProtocol: Optional[Protocol] = None
+    innerProtocol: Protocol | None = None
     innerProtocolClientFactory = None
 
     def __init__(self, boxReceiver):

--- a/src/twisted/protocols/haproxy/_exceptions.py
+++ b/src/twisted/protocols/haproxy/_exceptions.py
@@ -7,7 +7,8 @@ HAProxy specific exceptions.
 """
 
 import contextlib
-from typing import Callable, Generator, Type
+from collections.abc import Generator
+from typing import Callable
 
 
 class InvalidProxyHeader(Exception):
@@ -30,7 +31,7 @@ class MissingAddressData(InvalidProxyHeader):
 
 @contextlib.contextmanager
 def convertError(
-    sourceType: Type[BaseException], targetType: Callable[[], BaseException]
+    sourceType: type[BaseException], targetType: Callable[[], BaseException]
 ) -> Generator[None, None, None]:
     """
     Convert an error into a different error type.

--- a/src/twisted/protocols/haproxy/_interfaces.py
+++ b/src/twisted/protocols/haproxy/_interfaces.py
@@ -5,7 +5,7 @@
 """
 Interfaces used by the PROXY protocol modules.
 """
-from typing import Tuple, Union
+from __future__ import annotations
 
 import zope.interface
 
@@ -33,7 +33,7 @@ class IProxyParser(zope.interface.Interface):
     Streaming parser that handles PROXY protocol headers.
     """
 
-    def feed(data: bytes) -> Union[Tuple[IProxyInfo, bytes], Tuple[None, None]]:
+    def feed(data: bytes) -> tuple[IProxyInfo, bytes] | tuple[None, None]:
         """
         Consume a chunk of data and attempt to parse it.
 

--- a/src/twisted/protocols/haproxy/_parser.py
+++ b/src/twisted/protocols/haproxy/_parser.py
@@ -5,7 +5,7 @@
 """
 Parser for 'haproxy:' string endpoint.
 """
-from typing import Mapping, Tuple
+from collections.abc import Mapping
 
 from zope.interface import implementer
 
@@ -20,7 +20,7 @@ from twisted.plugin import IPlugin
 from . import proxyEndpoint
 
 
-def unparseEndpoint(args: Tuple[object, ...], kwargs: Mapping[str, object]) -> str:
+def unparseEndpoint(args: tuple[object, ...], kwargs: Mapping[str, object]) -> str:
     """
     Un-parse the already-parsed args and kwargs back into endpoint syntax.
 

--- a/src/twisted/protocols/haproxy/_v1parser.py
+++ b/src/twisted/protocols/haproxy/_v1parser.py
@@ -6,7 +6,7 @@
 """
 IProxyParser implementation for version one of the PROXY protocol.
 """
-from typing import Tuple, Union
+from __future__ import annotations
 
 from zope.interface import implementer
 
@@ -44,9 +44,7 @@ class V1Parser:
     def __init__(self) -> None:
         self.buffer = b""
 
-    def feed(
-        self, data: bytes
-    ) -> Union[Tuple[_info.ProxyInfo, bytes], Tuple[None, None]]:
+    def feed(self, data: bytes) -> tuple[_info.ProxyInfo, bytes] | tuple[None, None]:
         """
         Consume a chunk of data and attempt to parse it.
 

--- a/src/twisted/protocols/haproxy/_v2parser.py
+++ b/src/twisted/protocols/haproxy/_v2parser.py
@@ -6,10 +6,11 @@
 """
 IProxyParser implementation for version two of the PROXY protocol.
 """
+from __future__ import annotations
 
 import binascii
 import struct
-from typing import Callable, Literal, Tuple, Type, Union
+from typing import Callable, Literal
 
 from zope.interface import implementer
 
@@ -79,9 +80,7 @@ class V2Parser:
     def __init__(self) -> None:
         self.buffer = b""
 
-    def feed(
-        self, data: bytes
-    ) -> Union[Tuple[_info.ProxyInfo, bytes], Tuple[None, None]]:
+    def feed(self, data: bytes) -> tuple[_info.ProxyInfo, bytes] | tuple[None, None]:
         """
         Consume a chunk of data and attempt to parse it.
 
@@ -194,12 +193,12 @@ class V2Parser:
                 address.UNIXAddress(dest.rstrip(b"\x00")),
             )
 
-        addrType: Union[Literal["TCP"], Literal["UDP"]] = "TCP"
+        addrType: Literal["TCP"] | Literal["UDP"] = "TCP"
         if netproto is NetProtocol.DGRAM:
             addrType = "UDP"
-        addrCls: Union[
-            Type[address.IPv4Address], Type[address.IPv6Address]
-        ] = address.IPv4Address
+        addrCls: (
+            type[address.IPv4Address] | type[address.IPv6Address]
+        ) = address.IPv4Address
         addrParser: Callable[[bytes], bytes] = cls._bytesToIPv4
         if family is NetFamily.INET6:
             addrCls = address.IPv6Address

--- a/src/twisted/protocols/haproxy/test/test_parser.py
+++ b/src/twisted/protocols/haproxy/test/test_parser.py
@@ -4,7 +4,7 @@
 """
 Tests for L{twisted.protocols.haproxy._parser}.
 """
-from typing import Type, Union
+from __future__ import annotations
 
 from twisted.internet.endpoints import (
     TCP4ServerEndpoint,
@@ -83,11 +83,11 @@ class HAProxyServerParserTests(TestCase):
     def onePrefix(
         self,
         description: str,
-        expectedClass: Union[
-            Type[TCP4ServerEndpoint],
-            Type[TCP6ServerEndpoint],
-            Type[UNIXServerEndpoint],
-        ],
+        expectedClass: (
+            type[TCP4ServerEndpoint]
+            | type[TCP6ServerEndpoint]
+            | type[UNIXServerEndpoint]
+        ),
     ) -> _WrapperServerEndpoint:
         """
         Test the C{haproxy} enpdoint prefix against one sub-endpoint type.

--- a/src/twisted/protocols/policies.py
+++ b/src/twisted/protocols/policies.py
@@ -7,12 +7,11 @@ Resource limiting policies.
 
 @seealso: See also L{twisted.protocols.htb} for rate limiting.
 """
-
 from __future__ import annotations
 
 # system imports
 import sys
-from typing import Callable, Optional, Type
+from typing import Callable
 
 from zope.interface import directlyProvides, providedBy
 
@@ -52,7 +51,7 @@ class ProtocolWrapper(Protocol):
     disconnecting = 0
 
     def __init__(
-        self, factory: "WrappingFactory[Self]", wrappedProtocol: interfaces.IProtocol
+        self, factory: WrappingFactory[Self], wrappedProtocol: interfaces.IProtocol
     ):
         self.wrappedProtocol = wrappedProtocol
         self.factory = factory
@@ -399,7 +398,7 @@ class LimitTotalConnectionsFactory(ServerFactory):
 
     connectionCount = 0
     connectionLimit = None
-    overflowProtocol: Optional[Type[Protocol]] = None
+    overflowProtocol: type[Protocol] | None = None
 
     def buildProtocol(self, addr):
         if self.connectionLimit is None or self.connectionCount < self.connectionLimit:
@@ -632,7 +631,7 @@ class TimeoutMixin:
     @cvar timeOut: The number of seconds after which to timeout the connection.
     """
 
-    timeOut: Optional[int] = None
+    timeOut: int | None = None
 
     __timeoutCall = None
 

--- a/src/twisted/protocols/sip.py
+++ b/src/twisted/protocols/sip.py
@@ -13,7 +13,6 @@ import socket
 import time
 import warnings
 from collections import OrderedDict
-from typing import Dict, List
 
 from zope.interface import Interface, implementer
 
@@ -340,7 +339,7 @@ class URL:
             self.headers = headers
 
     def toString(self) -> str:
-        l: List[str] = []
+        l: list[str] = []
         w = l.append
         w("sip:")
         if self.username != None:
@@ -1057,7 +1056,7 @@ class RegisterProxy(Proxy):
 
     registry = None  # Should implement IRegistry
 
-    authorizers: Dict[str, IAuthorizer] = {}
+    authorizers: dict[str, IAuthorizer] = {}
 
     def __init__(self, *args, **kw):
         Proxy.__init__(self, *args, **kw)

--- a/src/twisted/protocols/test/test_basic.py
+++ b/src/twisted/protocols/test/test_basic.py
@@ -4,12 +4,11 @@
 """
 Test cases for L{twisted.protocols.basic}.
 """
-
+from __future__ import annotations
 
 import struct
 import sys
 from io import BytesIO
-from typing import List, Optional, Type
 
 from zope.interface.verify import verifyObject
 
@@ -555,8 +554,8 @@ class TestNetstring(TestMixin, basic.NetstringReceiver):
 
 
 class LPTestCaseMixin:
-    illegalStrings: Optional[List[bytes]] = []
-    protocol: "Optional[Type[protocol.Protocol]]" = None
+    illegalStrings: list[bytes] | None = []
+    protocol: type[protocol.Protocol] | None = None
 
     def getProtocol(self):
         """
@@ -800,10 +799,10 @@ class IntNTestCaseMixin(LPTestCaseMixin):
     TestCase mixin for int-prefixed protocols.
     """
 
-    protocol: "Optional[Type[protocol.Protocol]]" = None
-    strings: Optional[List[bytes]] = None
-    illegalStrings: Optional[List[bytes]] = None
-    partialStrings: Optional[List[bytes]] = None
+    protocol: type[protocol.Protocol] | None = None
+    strings: list[bytes] | None = None
+    illegalStrings: list[bytes] | None = None
+    partialStrings: list[bytes] | None = None
 
     def test_receive(self):
         """

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -8,7 +8,7 @@ Tests for L{twisted.protocols.tls}.
 from __future__ import annotations
 
 import gc
-from typing import Any, Union
+from typing import Any
 
 from zope.interface import Interface, directlyProvides, implementer
 from zope.interface.verify import verifyObject
@@ -1931,7 +1931,7 @@ class _AggregateSmallWritesTests(SynchronousTestCase):
             max_size=1_000,
         )
     )
-    def test_writes_get_aggregated(self, writes: list[Union[bytes, None]]) -> None:
+    def test_writes_get_aggregated(self, writes: list[bytes | None]) -> None:
         """
         A L{_AggregateSmallWrites} correctly aggregates data for the given
         sequence of writes (indicated by bytes) and increments in the clock

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -38,7 +38,8 @@ transports, such as UNIX sockets and stdio.
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, Optional, cast
+from collections.abc import Iterable
+from typing import Callable, cast
 
 from zope.interface import directlyProvides, implementer, providedBy
 
@@ -629,7 +630,7 @@ class _AggregateSmallWrites:
         self._clock = clock
         self._buffer: list[bytes] = []
         self._bufferLeft = self.MAX_BUFFER_SIZE
-        self._scheduled: Optional[IDelayedCall] = None
+        self._scheduled: IDelayedCall | None = None
 
     def write(self, data: bytes) -> None:
         """
@@ -738,7 +739,7 @@ class TLSMemoryBIOFactory(WrappingFactory[TLSMemoryBIOProtocol]):
         contextFactory: SomeConnectionCreator,
         isClient: bool,
         wrappedFactory: IProtocolFactory,
-        clock: Optional[IReactorTime] = None,
+        clock: IReactorTime | None = None,
     ) -> None:
         """
         Create a L{TLSMemoryBIOFactory}.


### PR DESCRIPTION
## Scope and purpose

Fixes #12592 

The changes were automatically generated using `pyupgrade --py39-plus`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Run linting


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
