### PR TITLE
#12594 mail: update type annotations for Python 3.9+ (1/1)

### DIFF
--- a/src/twisted/mail/_pop3client.py
+++ b/src/twisted/mail/_pop3client.py
@@ -13,7 +13,6 @@ Don't use this module directly.  Use twisted.mail.pop3 instead.
 
 import re
 from hashlib import md5
-from typing import List
 
 from twisted.internet import defer, error, interfaces
 from twisted.mail._except import (
@@ -1232,4 +1231,4 @@ class POP3Client(basic.LineOnlyReceiver, policies.TimeoutMixin):
         return self.sendShort(b"QUIT", None)
 
 
-__all__: List[str] = []
+__all__: list[str] = []

--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -14,6 +14,7 @@ To do::
   Clarify some API docs (Query, etc)
   Make APPEND recognize (again) non-existent mailboxes before accepting the literal
 """
+from __future__ import annotations
 
 import binascii
 import codecs
@@ -28,7 +29,7 @@ import uuid
 from base64 import decodebytes, encodebytes
 from io import BytesIO
 from itertools import chain
-from typing import Any, List, Optional, cast
+from typing import Any, cast
 
 from zope.interface import implementer
 
@@ -184,7 +185,7 @@ class MessageSet:
         that it will not be called out-of-order).
     """
 
-    _empty: List[Any] = []
+    _empty: list[Any] = []
     _infinity = float("inf")
 
     def __init__(self, start=_empty, end=_empty):
@@ -5691,7 +5692,7 @@ class _FetchParser:
         def __str__(self) -> str:
             return self.__bytes__().decode("ascii")
 
-        def getBytes(self, length: Optional[int] = None) -> bytes:
+        def getBytes(self, length: int | None = None) -> bytes:
             """
             Prepare the initial command response for a Fetch BODY request.
             Interpret the Fetch request from the client and return the

--- a/src/twisted/mail/pop3.py
+++ b/src/twisted/mail/pop3.py
@@ -16,7 +16,7 @@ import base64
 import binascii
 import warnings
 from hashlib import md5
-from typing import IO, Optional, overload
+from typing import IO, overload
 
 from zope.interface import implementer
 
@@ -432,7 +432,7 @@ class POP3(basic.LineOnlyReceiver, policies.TimeoutMixin):
     @ivar _auth: Authorization credentials.
     """
 
-    magic: Optional[bytes] = None
+    magic: bytes | None = None
     _userIs = None
     _onLogout = None
 

--- a/src/twisted/mail/pop3client.py
+++ b/src/twisted/mail/pop3client.py
@@ -4,7 +4,6 @@ Deprecated POP3 client protocol implementation.
 Don't use this module directly.  Use twisted.mail.pop3 instead.
 """
 import warnings
-from typing import List
 
 from twisted.mail._pop3client import ERR, OK, POP3Client
 
@@ -19,4 +18,4 @@ OK
 ERR
 POP3Client
 
-__all__: List[str] = []
+__all__: list[str] = []

--- a/src/twisted/mail/relaymanager.py
+++ b/src/twisted/mail/relaymanager.py
@@ -10,12 +10,12 @@ configurations.  Instead of sending mail directly to the recipient, a sender
 sends mail to a smart host.  The smart host finds the mail exchange server for
 the recipient and sends on the message.
 """
+from __future__ import annotations
 
 import email.utils
 import os
 import pickle
 import time
-from typing import Type
 
 from twisted.application import internet
 from twisted.internet import protocol
@@ -154,7 +154,7 @@ class SMTPManagedRelayerFactory(protocol.ClientFactory):
     @ivar pKwArgs: Keyword arguments for L{SMTPClient.__init__}
     """
 
-    protocol: "Type[protocol.Protocol]" = SMTPManagedRelayer
+    protocol: type[protocol.Protocol] = SMTPManagedRelayer
 
     def __init__(self, messages, manager, *args, **kw):
         """
@@ -674,7 +674,7 @@ class SmartHostSMTPRelayingManager:
         filenames of messages the managed relayer is responsible for.
     """
 
-    factory: Type[protocol.ClientFactory] = SMTPManagedRelayerFactory
+    factory: type[protocol.ClientFactory] = SMTPManagedRelayerFactory
 
     PORT = 25
 

--- a/src/twisted/mail/smtp.py
+++ b/src/twisted/mail/smtp.py
@@ -19,7 +19,6 @@ import time
 import warnings
 from email.utils import parseaddr
 from io import BytesIO
-from typing import Type
 
 from zope.interface import implementer
 
@@ -1862,7 +1861,7 @@ class SMTPSenderFactory(protocol.ClientFactory):
     """
 
     domain = DNSNAME
-    protocol: Type[SMTPClient] = SMTPSender
+    protocol: type[SMTPClient] = SMTPSender
 
     def __init__(self, fromEmail, toEmail, file, deferred, retries=5, timeout=None):
         """

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -17,7 +17,6 @@ import uuid
 from collections import OrderedDict
 from io import BytesIO
 from itertools import chain
-from typing import Optional, Type
 from unittest import skipIf
 
 from zope.interface import implementer
@@ -1880,8 +1879,8 @@ class SimpleClient(imap4.IMAP4Client):
 
 
 class IMAP4HelperMixin:
-    serverCTX: Optional[ServerTLSContext] = None
-    clientCTX: Optional[ClientTLSContext] = None
+    serverCTX: ServerTLSContext | None = None
+    clientCTX: ClientTLSContext | None = None
 
     def setUp(self):
         d = defer.Deferred()
@@ -4577,7 +4576,7 @@ class PreauthIMAP4ClientMixin:
         C{transport}.
     """
 
-    clientProtocol: Type[imap4.IMAP4Client] = imap4.IMAP4Client
+    clientProtocol: type[imap4.IMAP4Client] = imap4.IMAP4Client
 
     def setUp(self):
         """

--- a/src/twisted/mail/test/test_pop3client.py
+++ b/src/twisted/mail/test/test_pop3client.py
@@ -4,7 +4,6 @@
 
 import inspect
 import sys
-from typing import List
 from unittest import skipIf
 
 from zope.interface import directlyProvides
@@ -489,7 +488,7 @@ class POP3HelperMixin:
 class TLSServerFactory(protocol.ServerFactory):
     class protocol(basic.LineReceiver):
         context = None
-        output: List[bytes] = []
+        output: list[bytes] = []
 
         def connectionMade(self):
             self.factory.input = []

--- a/src/twisted/mail/test/test_smtp.py
+++ b/src/twisted/mail/test/test_smtp.py
@@ -4,13 +4,13 @@
 """
 Test cases for twisted.mail.smtp module.
 """
-
+from __future__ import annotations
 
 import base64
 import inspect
 import re
 from io import BytesIO
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any
 
 from zope.interface import directlyProvides, implementer
 
@@ -31,7 +31,7 @@ from twisted.protocols import basic, loopback
 from twisted.python.util import LineLog
 from twisted.trial.unittest import TestCase
 
-sslSkip: Optional[str]
+sslSkip: str | None
 try:
     from twisted.test.ssl_helpers import ClientTLSContext, ServerTLSContext
 except ImportError:
@@ -354,8 +354,8 @@ class DummyESMTP(DummyProto, smtp.ESMTP):
 
 
 class AnotherTestCase:
-    serverClass: Optional[Type[protocol.Protocol]] = None
-    clientClass: Optional[Type[smtp.SMTPClient]] = None
+    serverClass: type[protocol.Protocol] | None = None
+    clientClass: type[smtp.SMTPClient] | None = None
 
     messages = [
         (
@@ -401,7 +401,7 @@ To: foo
         ),
     ]
 
-    data: List[Tuple[bytes, bytes, Any, Any]] = [
+    data: list[tuple[bytes, bytes, Any, Any]] = [
         (b"", b"220.*\r\n$", None, None),
         (b"HELO foo.com\r\n", b"250.*\r\n$", None, None),
         (b"RSET\r\n", b"250.*\r\n$", None, None),


### PR DESCRIPTION
## Scope and purpose

Fixes #12594

The changes were automatically generated using `pyupgrade --py39-plus`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Run linting


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
