### PR TITLE
#12539 Fix `SyntaxWarning` on Python 3.14 in `test_posixbase`

### DIFF
--- a/src/twisted/internet/test/test_posixbase.py
+++ b/src/twisted/internet/test/test_posixbase.py
@@ -29,15 +29,20 @@ class WarningCheckerTestCase(TestCase):
     A test case that will make sure that no warnings are left unchecked at the end of a test run.
     """
 
+    @staticmethod
+    def _skipWarningCheck():
+        # FIXME:
+        # https://github.com/twisted/twisted/issues/10332
+        # For now don't raise errors on Windows as the existing tests are dirty and we don't have the dev resources to fix this.
+        # If you care about Twisted on Windows, enable this check and hunt for the test that is generating the warnings.
+        # Note that even with this check disabled, you can still see flaky tests on Windows, as due to stray delayed calls
+        # the warnings can be generated while another test is running.
+        return os.environ.get("CI", "").lower() == "true" and platform.isWindows()
+
     def setUp(self):
         super().setUp()
-        # FIXME:
-        # https://twistedmatrix.com/trac/ticket/10332
-        # For now, try to start each test without previous warnings
-        # on Windows CI environment.
-        # We still want to see failures on local Windows development environment to make it easier to fix them,
-        # rather than ignoring the errors.
-        if os.environ.get("CI", "").lower() == "true" and platform.isWindows():
+
+        if self._skipWarningCheck():
             self.flushWarnings()
 
     def tearDown(self):
@@ -45,17 +50,12 @@ class WarningCheckerTestCase(TestCase):
             super().tearDown()
         finally:
             warnings = self.flushWarnings()
-            if os.environ.get("CI", "").lower() == "true" and platform.isWindows():
-                # FIXME:
-                # https://twistedmatrix.com/trac/ticket/10332
-                # For now don't raise errors on Windows as the existing tests are dirty and we don't have the dev resources to fix this.
-                # If you care about Twisted on Windows, enable this check and hunt for the test that is generating the warnings.
-                # Note that even with this check disabled, you can still see flaky tests on Windows, as due to stray delayed calls
-                # the warnings can be generated while another test is running.
-                return
-            self.assertEqual(
-                len(warnings), 0, f"Warnings found at the end of the test:\n{warnings}"
-            )
+            if not self._skipWarningCheck():
+                self.assertEqual(
+                    len(warnings),
+                    0,
+                    f"Warnings found at the end of the test:\n{warnings}",
+                )
 
 
 class TrivialReactor(PosixReactorBase):


### PR DESCRIPTION
## Scope and purpose

Fixes #12539

A small step to help support Python 3.14, feedback is very much appreciated.

1. Instead of using a `return`, I put the assertion under an if condition.
2. I pulled the condition into a static method so the condition is not duplicated. That way there is also just one FIXME comment, instead of two.
3. I updated the link in the FIXME comment to point to Github 


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
