### PR TITLE
internet: update type annotations for Python 3.9+ (1/3)

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -14,6 +14,7 @@ import traceback
 import warnings
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop, Future, iscoroutine
+from collections.abc import Awaitable, Coroutine, Generator, Iterable, Mapping, Sequence
 from contextvars import Context as _Context, copy_context as _copy_context
 from enum import Enum
 from functools import wraps
@@ -22,20 +23,10 @@ from types import CoroutineType, GeneratorType, MappingProxyType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
-    Coroutine,
-    Generator,
     Generic,
-    Iterable,
-    List,
     Literal,
-    Mapping,
     NoReturn,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -44,7 +35,7 @@ from typing import (
 
 import attr
 from incremental import Version
-from typing_extensions import Concatenate, ParamSpec, Self
+from typing_extensions import Concatenate, ParamSpec, Self, TypeAlias
 
 from twisted.internet.interfaces import IDelayedCall, IReactorTime
 from twisted.logger import Logger
@@ -99,7 +90,7 @@ def logError(err: Failure) -> Failure:
     return err
 
 
-def succeed(result: _T) -> "Deferred[_T]":
+def succeed(result: _T) -> Deferred[_T]:
     """
     Return a L{Deferred} that has already had C{.callback(result)} called.
 
@@ -123,7 +114,7 @@ def succeed(result: _T) -> "Deferred[_T]":
     return d
 
 
-def fail(result: Optional[Union[Failure, BaseException]] = None) -> "Deferred[Any]":
+def fail(result: Failure | BaseException | None = None) -> Deferred[Any]:
     """
     Return a L{Deferred} that has already had C{.errback(result)} called.
 
@@ -141,7 +132,7 @@ def fail(result: Optional[Union[Failure, BaseException]] = None) -> "Deferred[An
 
 def execute(
     callable: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     """
     Create a L{Deferred} from a callable and arguments.
 
@@ -160,7 +151,7 @@ def execute(
 @overload
 def maybeDeferred(
     f: Callable[_P, Deferred[_T]], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
@@ -169,22 +160,22 @@ def maybeDeferred(
     f: Callable[_P, Coroutine[Deferred[Any], Any, _T]],
     *args: _P.args,
     **kwargs: _P.kwargs,
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
 @overload
 def maybeDeferred(
     f: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     ...
 
 
 def maybeDeferred(
-    f: Callable[_P, Union[Deferred[_T], Coroutine[Deferred[Any], Any, _T], _T]],
+    f: Callable[_P, Deferred[_T] | Coroutine[Deferred[Any], Any, _T] | _T],
     *args: _P.args,
     **kwargs: _P.kwargs,
-) -> "Deferred[_T]":
+) -> Deferred[_T]:
     """
     Invoke a function that may or may not return a L{Deferred} or coroutine.
 
@@ -247,7 +238,7 @@ def maybeDeferred(
     Version("Twisted", 17, 1, 0),
     replacement="twisted.internet.defer.Deferred.addTimeout",
 )
-def timeout(deferred: "Deferred[object]") -> None:
+def timeout(deferred: Deferred[object]) -> None:
     deferred.errback(Failure(TimeoutError("Callback timed out")))
 
 
@@ -324,15 +315,15 @@ DeferredCallback = Callable[..., object]
 #     Callable[[Failure], object] is next best, but disallows valid callback signatures
 DeferredErrback = Callable[..., object]
 
-_CallbackOrderedArguments = Tuple[object, ...]
-_CallbackKeywordArguments = Mapping[str, object]
-_CallbackChain = Tuple[
-    Tuple[
+_CallbackOrderedArguments: TypeAlias = tuple[object, ...]
+_CallbackKeywordArguments: TypeAlias = Mapping[str, object]
+_CallbackChain: TypeAlias = tuple[
+    tuple[
         Union[DeferredCallback, Literal[_Sentinel._CONTINUE]],
         _CallbackOrderedArguments,
         _CallbackKeywordArguments,
     ],
-    Tuple[
+    tuple[
         Union[DeferredErrback, DeferredCallback, Literal[_Sentinel._CONTINUE]],
         _CallbackOrderedArguments,
         _CallbackKeywordArguments,
@@ -351,9 +342,9 @@ class DebugInfo:
     Deferred debug helper.
     """
 
-    failResult: Optional[Failure] = None
-    creator: Optional[List[str]] = None
-    invoker: Optional[List[str]] = None
+    failResult: Failure | None = None
+    creator: list[str] | None = None
+    invoker: list[str] | None = None
 
     def _getDebugTracebacks(self) -> str:
         info = ""
@@ -427,7 +418,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
     called = False
     paused = 0
-    _debugInfo: Optional[DebugInfo] = None
+    _debugInfo: DebugInfo | None = None
     _suppressAlreadyCalled = False
 
     # Are we currently running a user-installed callback?  Meant to prevent
@@ -439,10 +430,10 @@ class Deferred(Awaitable[_SelfResultT]):
     # sets it directly.
     debug = False
 
-    _chainedTo: "Optional[Deferred[Any]]" = None
+    _chainedTo: Deferred[Any] | None = None
 
     def __init__(
-        self, canceller: Optional[Callable[["Deferred[Any]"], None]] = None
+        self, canceller: Callable[[Deferred[Any]], None] | None = None
     ) -> None:
         """
         Initialize a L{Deferred}.
@@ -467,42 +458,42 @@ class Deferred(Awaitable[_SelfResultT]):
         @type canceller: a 1-argument callable which takes a L{Deferred}. The
             return result is ignored.
         """
-        self._callbacks: List[_CallbackChain] = []
+        self._callbacks: list[_CallbackChain] = []
         self._canceller = canceller
         if self.debug:
             self._debugInfo = DebugInfo()
             self._debugInfo.creator = traceback.format_stack()[:-1]
 
     @deprecatedProperty(Version("Twisted", 25, 5, 0))
-    def callbacks(self) -> List[_CallbackChain]:
+    def callbacks(self) -> list[_CallbackChain]:
         return self._callbacks
 
     def addCallbacks(
         self,
-        callback: Union[
-            Callable[..., _NextResultT],
-            Callable[..., Deferred[_NextResultT]],
-            Callable[..., Failure],
-            Callable[
+        callback: (
+            Callable[..., _NextResultT]
+            | Callable[..., Deferred[_NextResultT]]
+            | Callable[..., Failure]
+            | Callable[
                 ...,
-                Union[_NextResultT, Deferred[_NextResultT], Failure],
-            ],
-        ],
-        errback: Union[
-            Callable[..., _NextResultT],
-            Callable[..., Deferred[_NextResultT]],
-            Callable[..., Failure],
-            Callable[
+                _NextResultT | Deferred[_NextResultT] | Failure,
+            ]
+        ),
+        errback: (
+            Callable[..., _NextResultT]
+            | Callable[..., Deferred[_NextResultT]]
+            | Callable[..., Failure]
+            | Callable[
                 ...,
-                Union[_NextResultT, Deferred[_NextResultT], Failure],
-            ],
-            None,
-        ] = None,
-        callbackArgs: Tuple[Any, ...] = (),
+                _NextResultT | Deferred[_NextResultT] | Failure,
+            ]
+            | None
+        ) = None,
+        callbackArgs: tuple[Any, ...] = (),
         callbackKeywords: Mapping[str, Any] = _NONE_KWARGS,
         errbackArgs: _CallbackOrderedArguments = (),
         errbackKeywords: _CallbackKeywordArguments = _NONE_KWARGS,
-    ) -> "Deferred[_NextResultT]":
+    ) -> Deferred[_NextResultT]:
         """
         Add a pair of callbacks (success and error) to this L{Deferred}.
 
@@ -570,7 +561,7 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         callback: Callable[
             Concatenate[_SelfResultT, _P],
-            Union[Failure, Deferred[_NextResultT]],
+            Failure | Deferred[_NextResultT],
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -580,7 +571,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addCallback(
         self,
-        callback: Callable[Concatenate[_SelfResultT, _P], Union[Failure, _NextResultT]],
+        callback: Callable[Concatenate[_SelfResultT, _P], Failure | _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -600,7 +591,7 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         callback: Callable[
             Concatenate[_SelfResultT, _P],
-            Union[Deferred[_NextResultT], _NextResultT],
+            Deferred[_NextResultT] | _NextResultT,
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -616,7 +607,7 @@ class Deferred(Awaitable[_SelfResultT]):
     ) -> Deferred[_NextResultT]:
         ...
 
-    def addCallback(self, callback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addCallback(self, callback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding just a callback.
 
@@ -637,7 +628,7 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], Deferred[_NextResultT]],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         ...
 
     @overload
@@ -646,7 +637,7 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], Failure],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT]]":
+    ) -> Deferred[_SelfResultT]:
         ...
 
     @overload
@@ -655,10 +646,10 @@ class Deferred(Awaitable[_SelfResultT]):
         errback: Callable[Concatenate[Failure, _P], _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         ...
 
-    def addErrback(self, errback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addErrback(self, errback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding just an errback.
 
@@ -676,7 +667,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addBoth(
         self,
-        callback: Callable[Concatenate[Union[_SelfResultT, Failure], _P], Failure],
+        callback: Callable[Concatenate[_SelfResultT | Failure, _P], Failure],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -686,8 +677,8 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P],
-            Union[Failure, Deferred[_NextResultT]],
+            Concatenate[_SelfResultT | Failure, _P],
+            Failure | Deferred[_NextResultT],
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -698,7 +689,7 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P], Union[Failure, _NextResultT]
+            Concatenate[_SelfResultT | Failure, _P], Failure | _NextResultT
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -709,7 +700,7 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P], Deferred[_NextResultT]
+            Concatenate[_SelfResultT | Failure, _P], Deferred[_NextResultT]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -720,8 +711,8 @@ class Deferred(Awaitable[_SelfResultT]):
     def addBoth(
         self,
         callback: Callable[
-            Concatenate[Union[_SelfResultT, Failure], _P],
-            Union[Deferred[_NextResultT], _NextResultT],
+            Concatenate[_SelfResultT | Failure, _P],
+            Deferred[_NextResultT] | _NextResultT,
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -731,7 +722,7 @@ class Deferred(Awaitable[_SelfResultT]):
     @overload
     def addBoth(
         self,
-        callback: Callable[Concatenate[Union[_SelfResultT, Failure], _P], _NextResultT],
+        callback: Callable[Concatenate[_SelfResultT | Failure, _P], _NextResultT],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_NextResultT]:
@@ -746,7 +737,7 @@ class Deferred(Awaitable[_SelfResultT]):
     ) -> Deferred[_SelfResultT]:
         ...
 
-    def addBoth(self, callback: Any, *args: Any, **kwargs: Any) -> "Deferred[Any]":
+    def addBoth(self, callback: Any, *args: Any, **kwargs: Any) -> Deferred[Any]:
         """
         Convenience method for adding a single callable as both a callback
         and an errback.
@@ -769,13 +760,14 @@ class Deferred(Awaitable[_SelfResultT]):
         self,
         timeout: float,
         clock: IReactorTime,
-        onTimeoutCancel: Optional[
+        onTimeoutCancel: None
+        | (
             Callable[
-                [Union[_SelfResultT, Failure], float],
-                Union[_NextResultT, Failure],
+                [_SelfResultT | Failure, float],
+                _NextResultT | Failure,
             ]
-        ] = None,
-    ) -> "Deferred[Union[_SelfResultT, _NextResultT]]":
+        ) = None,
+    ) -> Deferred[_SelfResultT | _NextResultT]:
         """
         Time out this L{Deferred} by scheduling it to be cancelled after
         C{timeout} seconds.
@@ -813,8 +805,8 @@ class Deferred(Awaitable[_SelfResultT]):
         delayedCall = clock.callLater(timeout, timeItOut)
 
         def convertCancelled(
-            result: Union[_SelfResultT, Failure],
-        ) -> Union[_SelfResultT, _NextResultT, Failure]:
+            result: _SelfResultT | Failure,
+        ) -> _SelfResultT | _NextResultT | Failure:
             # if C{deferred} was timed out, call the translation function,
             # if provided, otherwise just use L{cancelledToTimedOutError}
             if timedOut[0]:
@@ -831,12 +823,12 @@ class Deferred(Awaitable[_SelfResultT]):
         # Note: Mypy cannot infer this type, apparently thanks to the ambiguity
         # of _SelfResultT / _NextResultT both being unbound.  Explicitly
         # annotating it seems to do the trick though.
-        converted: Deferred[Union[_SelfResultT, _NextResultT]] = self.addBoth(
+        converted: Deferred[_SelfResultT | _NextResultT] = self.addBoth(
             convertCancelled
         )
         return converted.addBoth(cancelTimeout)
 
-    def chainDeferred(self, d: "Deferred[_SelfResultT]") -> "Deferred[None]":
+    def chainDeferred(self, d: Deferred[_SelfResultT]) -> Deferred[None]:
         """
         Chain another L{Deferred} to this L{Deferred}.
 
@@ -863,7 +855,7 @@ class Deferred(Awaitable[_SelfResultT]):
         d._chainedTo = self
         return self.addCallbacks(d.callback, d.errback)
 
-    def callback(self, result: Union[_SelfResultT, Failure]) -> None:
+    def callback(self, result: _SelfResultT | Failure) -> None:
         """
         Run all success callbacks that have been added to this L{Deferred}.
 
@@ -888,7 +880,7 @@ class Deferred(Awaitable[_SelfResultT]):
         """
         self._startRunCallbacks(result)
 
-    def errback(self, fail: Optional[Union[Failure, BaseException]] = None) -> None:
+    def errback(self, fail: Failure | BaseException | None = None) -> None:
         """
         Run all error callbacks that have been added to this L{Deferred}.
 
@@ -1037,7 +1029,7 @@ class Deferred(Awaitable[_SelfResultT]):
         # added its _continuation() to the callbacks list of a second Deferred
         # and then that second Deferred being fired.  ie, if ever had _chainedTo
         # set to something other than None, you might end up on this stack.
-        chain: List[Deferred[Any]] = [self]
+        chain: list[Deferred[Any]] = [self]
 
         while chain:
             current = chain[-1]
@@ -1196,7 +1188,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
     __await__ = __iter__
 
-    def asFuture(self, loop: AbstractEventLoop) -> "Future[_SelfResultT]":
+    def asFuture(self, loop: AbstractEventLoop) -> Future[_SelfResultT]:
         """
         Adapt this L{Deferred} into a L{Future} which is bound to C{loop}.
 
@@ -1213,7 +1205,7 @@ class Deferred(Awaitable[_SelfResultT]):
         """
         future = loop.create_future()
 
-        def checkCancel(futureAgain: "Future[_SelfResultT]") -> None:
+        def checkCancel(futureAgain: Future[_SelfResultT]) -> None:
             if futureAgain.cancelled():
                 self.cancel()
 
@@ -1231,7 +1223,7 @@ class Deferred(Awaitable[_SelfResultT]):
         return future
 
     @classmethod
-    def fromFuture(cls, future: "Future[_SelfResultT]") -> "Deferred[_SelfResultT]":
+    def fromFuture(cls, future: Future[_SelfResultT]) -> Deferred[_SelfResultT]:
         """
         Adapt a L{Future} to a L{Deferred}.
 
@@ -1268,7 +1260,7 @@ class Deferred(Awaitable[_SelfResultT]):
 
         def uncancel(
             result: _SelfResultT,
-        ) -> Union[_SelfResultT, Deferred[_SelfResultT]]:
+        ) -> _SelfResultT | Deferred[_SelfResultT]:
             if result is futureCancel:
                 nonlocal actual
                 actual = Deferred()
@@ -1283,11 +1275,8 @@ class Deferred(Awaitable[_SelfResultT]):
     @classmethod
     def fromCoroutine(
         cls,
-        coro: Union[
-            Coroutine[Deferred[Any], Any, _T],
-            Generator[Deferred[Any], Any, _T],
-        ],
-    ) -> "Deferred[_T]":
+        coro: (Coroutine[Deferred[Any], Any, _T] | Generator[Deferred[Any], Any, _T]),
+    ) -> Deferred[_T]:
         """
         Schedule the execution of a coroutine that awaits on L{Deferred}s,
         wrapping it in a L{Deferred} that will fire on success/failure of the
@@ -1330,7 +1319,7 @@ class Deferred(Awaitable[_SelfResultT]):
             return _cancellableInlineCallbacks(coro)
         raise NotACoroutineError(f"{coro!r} is not a coroutine")
 
-    def __init_subclass__(cls: Type[Deferred[Any]], **kwargs: Any):
+    def __init_subclass__(cls: type[Deferred[Any]], **kwargs: Any):
         # Whenever a subclass is created, record it in L{_DEFERRED_SUBCLASSES}
         # so we can emulate C{isinstance()} more efficiently.
         _DEFERRED_SUBCLASSES.append(cls)
@@ -1340,11 +1329,11 @@ _DEFERRED_SUBCLASSES = [Deferred]
 
 
 def ensureDeferred(
-    coro: Union[
-        Coroutine[Deferred[Any], Any, _T],
-        Generator[Deferred[Any], Any, _T],
-        Deferred[_T],
-    ],
+    coro: (
+        Coroutine[Deferred[Any], Any, _T]
+        | Generator[Deferred[Any], Any, _T]
+        | Deferred[_T]
+    ),
 ) -> Deferred[_T]:
     """
     Schedule the execution of a coroutine that awaits/yields from L{Deferred}s,
@@ -1411,9 +1400,9 @@ class FirstError(Exception):
         return -1
 
 
-_DeferredListSingleResultT = Tuple[_SelfResultT, int]
-_DeferredListResultItemT = Tuple[bool, _SelfResultT]
-_DeferredListResultListT = List[_DeferredListResultItemT[_SelfResultT]]
+_DeferredListSingleResultT = tuple[_SelfResultT, int]
+_DeferredListResultItemT = tuple[bool, _SelfResultT]
+_DeferredListResultListT = list[_DeferredListResultItemT[_SelfResultT]]
 
 if TYPE_CHECKING:
     # The result type is different depending on whether fireOnOneCallback
@@ -1444,10 +1433,10 @@ if TYPE_CHECKING:
         fireOnOneCallback: bool = False,
         fireOnOneErrback: bool = False,
         consumeErrors: bool = False,
-    ) -> Union[
-        Deferred[_DeferredListSingleResultT[_SelfResultT]],
-        Deferred[_DeferredListResultListT[_SelfResultT]],
-    ]:
+    ) -> (
+        Deferred[_DeferredListSingleResultT[_SelfResultT]]
+        | Deferred[_DeferredListResultListT[_SelfResultT]]
+    ):
         ...
 
     DeferredList = _DeferredList
@@ -1519,7 +1508,7 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
         # Note this contains optional result values as the DeferredList is
         # processing its results, even though the callback result will not,
         # which is why we aren't using _DeferredListResultListT here.
-        self.resultList: List[Optional[_DeferredListResultItemT[Any]]] = [None] * len(
+        self.resultList: list[_DeferredListResultItemT[Any] | None] = [None] * len(
             self._deferredList
         )
         """
@@ -1553,7 +1542,7 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
 
     def _cbDeferred(
         self, result: _SelfResultT, index: int, succeeded: bool
-    ) -> Optional[_SelfResultT]:
+    ) -> _SelfResultT | None:
         """
         (internal) Callback for when one of my deferreds fires.
         """
@@ -1598,8 +1587,8 @@ class DeferredList(  # type: ignore[no-redef] # noqa:F811
 
 
 def _parseDeferredListResult(
-    resultList: List[_DeferredListResultItemT[_T]], fireOnOneErrback: bool = False, /
-) -> List[_T]:
+    resultList: list[_DeferredListResultItemT[_T]], fireOnOneErrback: bool = False, /
+) -> list[_T]:
     if __debug__:
         for result in resultList:
             assert result is not None
@@ -1610,7 +1599,7 @@ def _parseDeferredListResult(
 
 def gatherResults(
     deferredList: Iterable[Deferred[_T]], consumeErrors: bool = False
-) -> Deferred[List[_T]]:
+) -> Deferred[list[_T]]:
     """
     Returns, via a L{Deferred}, a list with the results of the given
     L{Deferred}s - in effect, a "join" of multiple deferred operations.
@@ -1643,7 +1632,7 @@ class FailureGroup(Exception):
     """
 
     def __init__(self, failures: Sequence[Failure]) -> None:
-        super(FailureGroup, self).__init__()
+        super().__init__()
         self.failures = failures
 
 
@@ -1662,7 +1651,7 @@ def race(ds: Sequence[Deferred[_T]]) -> Deferred[tuple[int, _T]]:
     # shouldn't be.  Even though it "completed" it isn't really done - the
     # caller will still be using it for something.  If we cancelled it,
     # cancellation could propagate down to them.
-    winner: Optional[Deferred[_T]] = None
+    winner: Deferred[_T] | None = None
 
     # The cancellation function for the Deferred this function returns.
     def cancel(result: Deferred[_T]) -> None:
@@ -1771,16 +1760,13 @@ class _CancellationStatus(Generic[_SelfResultT]):
     """
 
     deferred: Deferred[_SelfResultT]
-    waitingOn: Optional[Deferred[_SelfResultT]] = None
+    waitingOn: Deferred[_SelfResultT] | None = None
 
 
 def _gotResultInlineCallbacks(
     r: object,
-    waiting: List[Any],
-    gen: Union[
-        Generator[Deferred[Any], Any, _T],
-        Coroutine[Deferred[Any], Any, _T],
-    ],
+    waiting: list[Any],
+    gen: (Generator[Deferred[Any], Any, _T] | Coroutine[Deferred[Any], Any, _T]),
     status: _CancellationStatus[_T],
     context: _Context,
 ) -> None:
@@ -1804,10 +1790,7 @@ def _gotResultInlineCallbacks(
 @_extraneous
 def _inlineCallbacks(
     result: object,
-    gen: Union[
-        Generator[Deferred[Any], Any, _T],
-        Coroutine[Deferred[Any], Any, _T],
-    ],
+    gen: (Generator[Deferred[Any], Any, _T] | Coroutine[Deferred[Any], Any, _T]),
     status: _CancellationStatus[_T],
     context: _Context,
 ) -> None:
@@ -1837,7 +1820,7 @@ def _inlineCallbacks(
     # recursion.
 
     # waiting for result?  # result
-    waiting: List[Any] = [True, None]
+    waiting: list[Any] = [True, None]
 
     stopIteration: bool = False
     callbackValue: Any = None
@@ -2015,10 +1998,7 @@ def _handleCancelInlineCallbacks(
 
 
 def _cancellableInlineCallbacks(
-    gen: Union[
-        Generator[Deferred[Any], object, _T],
-        Coroutine[Deferred[Any], object, _T],
-    ],
+    gen: (Generator[Deferred[Any], object, _T] | Coroutine[Deferred[Any], object, _T]),
 ) -> Deferred[_T]:
     """
     Make an C{@}L{inlineCallbacks} cancellable.
@@ -2132,7 +2112,7 @@ def inlineCallbacks(
 
 class _ConcurrencyPrimitive(ABC):
     def __init__(self: Self) -> None:
-        self.waiting: List[Deferred[Self]] = []
+        self.waiting: list[Deferred[Self]] = []
 
     def _releaseAndReturn(self, r: _T) -> _T:
         self.release()
@@ -2167,7 +2147,7 @@ class _ConcurrencyPrimitive(ABC):
     def run(
         self: Self,
         /,
-        f: Callable[_P, Union[Deferred[_T], Coroutine[Deferred[Any], Any, _T], _T]],
+        f: Callable[_P, Deferred[_T] | Coroutine[Deferred[Any], Any, _T] | _T],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> Deferred[_T]:
@@ -2202,9 +2182,9 @@ class _ConcurrencyPrimitive(ABC):
 
     def __aexit__(
         self,
-        __exc_type: Optional[Type[BaseException]],
-        __exc_value: Optional[BaseException],
-        __traceback: Optional[TracebackType],
+        __exc_type: type[BaseException] | None,
+        __exc_value: BaseException | None,
+        __traceback: TracebackType | None,
     ) -> Deferred[Literal[False]]:
         self.release()
         # We return False to indicate that we have not consumed the
@@ -2377,11 +2357,9 @@ class DeferredQueue(Generic[_T]):
         for no limit.
     """
 
-    def __init__(
-        self, size: Optional[int] = None, backlog: Optional[int] = None
-    ) -> None:
-        self.waiting: List[Deferred[_T]] = []
-        self.pending: List[_T] = []
+    def __init__(self, size: int | None = None, backlog: int | None = None) -> None:
+        self.waiting: list[Deferred[_T]] = []
+        self.pending: list[_T] = []
         self.size = size
         self.backlog = backlog
 
@@ -2455,10 +2433,10 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
     """
 
     _interval = 1
-    _tryLockCall: Optional[IDelayedCall] = None
-    _timeoutCall: Optional[IDelayedCall] = None
+    _tryLockCall: IDelayedCall | None = None
+    _timeoutCall: IDelayedCall | None = None
 
-    def __init__(self, name: str, scheduler: Optional[IReactorTime] = None) -> None:
+    def __init__(self, name: str, scheduler: IReactorTime | None = None) -> None:
         """
         @param name: The name of the lock to acquire
         @param scheduler: An object which provides L{IReactorTime}
@@ -2472,7 +2450,7 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
 
         self._scheduler = scheduler
 
-    def deferUntilLocked(self, timeout: Optional[float] = None) -> Deferred[None]:
+    def deferUntilLocked(self, timeout: float | None = None) -> Deferred[None]:
         """
         Wait until we acquire this lock.  This method is not safe for
         concurrent use.
@@ -2492,7 +2470,7 @@ class DeferredFilesystemLock(lockfile.FilesystemLock):
                 )
             )
 
-        def _cancelLock(reason: Union[Failure, Exception]) -> None:
+        def _cancelLock(reason: Failure | Exception) -> None:
             """
             Cancel a L{DeferredFilesystemLock.deferUntilLocked} call.
 

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -8,20 +8,8 @@ Maintainer: Itamar Shtull-Trauring
 """
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Callable,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, AnyStr, Callable
 
 from zope.interface import Attribute, Interface
 
@@ -105,7 +93,7 @@ class IConnector(Interface):
 
 
 class IResolverSimple(Interface):
-    def getHostByName(name: str, timeout: Sequence[int] = ()) -> "Deferred[str]":
+    def getHostByName(name: str, timeout: Sequence[int] = ()) -> Deferred[str]:
         """
         Resolve the domain name C{name} into an IP address.
 
@@ -193,7 +181,7 @@ class IHostnameResolver(Interface):
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -223,8 +211,8 @@ class IHostnameResolver(Interface):
 
 class IResolver(IResolverSimple):
     def query(
-        query: "Query", timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+        query: Query, timeout: Sequence[int]
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Dispatch C{query} to the method which can handle its type.
 
@@ -244,7 +232,7 @@ class IResolver(IResolverSimple):
 
     def lookupAddress(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an A record lookup.
 
@@ -263,7 +251,7 @@ class IResolver(IResolverSimple):
 
     def lookupAddress6(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an A6 record lookup.
 
@@ -282,7 +270,7 @@ class IResolver(IResolverSimple):
 
     def lookupIPV6Address(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AAAA record lookup.
 
@@ -301,7 +289,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailExchange(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MX record lookup.
 
@@ -320,7 +308,7 @@ class IResolver(IResolverSimple):
 
     def lookupNameservers(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an NS record lookup.
 
@@ -339,7 +327,7 @@ class IResolver(IResolverSimple):
 
     def lookupCanonicalName(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a CNAME record lookup.
 
@@ -358,7 +346,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailBox(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MB record lookup.
 
@@ -377,7 +365,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailGroup(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MG record lookup.
 
@@ -396,7 +384,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailRename(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MR record lookup.
 
@@ -415,7 +403,7 @@ class IResolver(IResolverSimple):
 
     def lookupPointer(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a PTR record lookup.
 
@@ -434,7 +422,7 @@ class IResolver(IResolverSimple):
 
     def lookupAuthority(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an SOA record lookup.
 
@@ -453,7 +441,7 @@ class IResolver(IResolverSimple):
 
     def lookupNull(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a NULL record lookup.
 
@@ -472,7 +460,7 @@ class IResolver(IResolverSimple):
 
     def lookupWellKnownServices(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a WKS record lookup.
 
@@ -491,7 +479,7 @@ class IResolver(IResolverSimple):
 
     def lookupHostInfo(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a HINFO record lookup.
 
@@ -510,7 +498,7 @@ class IResolver(IResolverSimple):
 
     def lookupMailboxInfo(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an MINFO record lookup.
 
@@ -529,7 +517,7 @@ class IResolver(IResolverSimple):
 
     def lookupText(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a TXT record lookup.
 
@@ -548,7 +536,7 @@ class IResolver(IResolverSimple):
 
     def lookupResponsibility(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an RP record lookup.
 
@@ -567,7 +555,7 @@ class IResolver(IResolverSimple):
 
     def lookupAFSDatabase(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AFSDB record lookup.
 
@@ -586,7 +574,7 @@ class IResolver(IResolverSimple):
 
     def lookupService(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an SRV record lookup.
 
@@ -605,7 +593,7 @@ class IResolver(IResolverSimple):
 
     def lookupAllRecords(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an ALL_RECORD lookup.
 
@@ -624,7 +612,7 @@ class IResolver(IResolverSimple):
 
     def lookupSenderPolicy(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a SPF record lookup.
 
@@ -643,7 +631,7 @@ class IResolver(IResolverSimple):
 
     def lookupNamingAuthorityPointer(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform a NAPTR record lookup.
 
@@ -662,7 +650,7 @@ class IResolver(IResolverSimple):
 
     def lookupZone(
         name: str, timeout: Sequence[int]
-    ) -> "Deferred[Tuple[RRHeader, RRHeader, RRHeader]]":
+    ) -> Deferred[tuple[RRHeader, RRHeader, RRHeader]]:
         """
         Perform an AXFR record lookup.
 
@@ -690,10 +678,10 @@ class IResolver(IResolverSimple):
 class IReactorTCP(Interface):
     def listenTCP(
         port: int,
-        factory: "ServerFactory",
+        factory: ServerFactory,
         backlog: int = 50,
         interface: str = "",
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
 
@@ -715,9 +703,9 @@ class IReactorTCP(Interface):
     def connectTCP(
         host: str,
         port: int,
-        factory: "ClientFactory[P]",
+        factory: ClientFactory[P],
         timeout: float = 30.0,
-        bindAddress: Optional[Tuple[str, int]] = None,
+        bindAddress: tuple[str, int] | None = None,
     ) -> IConnector:
         """
         Connect a TCP client.
@@ -742,10 +730,10 @@ class IReactorSSL(Interface):
     def connectSSL(
         host: str,
         port: int,
-        factory: "ClientFactory[P]",
-        contextFactory: "ClientContextFactory",
+        factory: ClientFactory[P],
+        contextFactory: ClientContextFactory,
         timeout: float,
-        bindAddress: Optional[Tuple[str, int]],
+        bindAddress: tuple[str, int] | None,
     ) -> IConnector:
         """
         Connect a client Protocol to a remote SSL socket.
@@ -764,11 +752,11 @@ class IReactorSSL(Interface):
 
     def listenSSL(
         port: int,
-        factory: "ServerFactory[P]",
-        contextFactory: "IOpenSSLContextFactory",
+        factory: ServerFactory[P],
+        contextFactory: IOpenSSLContextFactory,
         backlog: int = 50,
         interface: str = "",
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Connects a given protocol factory to the given numeric TCP/IP port.
         The connection is a SSL one, using contexts created by the context
@@ -789,7 +777,7 @@ class IReactorUNIX(Interface):
 
     def connectUNIX(
         address: str,
-        factory: "ClientFactory",
+        factory: ClientFactory,
         timeout: float = 30,
         checkPID: bool = False,
     ) -> IConnector:
@@ -809,11 +797,11 @@ class IReactorUNIX(Interface):
 
     def listenUNIX(
         address: str,
-        factory: "Factory",
+        factory: Factory,
         backlog: int = 50,
         mode: int = 0o666,
         wantPID: bool = False,
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Listen on a UNIX socket.
 
@@ -837,10 +825,10 @@ class IReactorUNIXDatagram(Interface):
 
     def connectUNIXDatagram(
         address: str,
-        protocol: "ConnectedDatagramProtocol",
+        protocol: ConnectedDatagramProtocol,
         maxPacketSize: int,
         mode: int,
-        bindAddress: Optional[Tuple[str, int]],
+        bindAddress: tuple[str, int] | None,
     ) -> IConnector:
         """
         Connect a client protocol to a datagram UNIX socket.
@@ -858,8 +846,8 @@ class IReactorUNIXDatagram(Interface):
         """
 
     def listenUNIXDatagram(
-        address: str, protocol: "DatagramProtocol", maxPacketSize: int, mode: int
-    ) -> "IListeningPort":
+        address: str, protocol: DatagramProtocol, maxPacketSize: int, mode: int
+    ) -> IListeningPort:
         """
         Listen on a datagram UNIX socket.
 
@@ -881,7 +869,7 @@ class IReactorWin32Events(Interface):
     @since: 10.2
     """
 
-    def addEvent(event: object, fd: "FileDescriptor", action: str) -> None:
+    def addEvent(event: object, fd: FileDescriptor, action: str) -> None:
         """
         Add a new win32 event to the event loop.
 
@@ -907,8 +895,8 @@ class IReactorUDP(Interface):
     """
 
     def listenUDP(
-        port: int, protocol: "DatagramProtocol", interface: str, maxPacketSize: int
-    ) -> "IListeningPort":
+        port: int, protocol: DatagramProtocol, interface: str, maxPacketSize: int
+    ) -> IListeningPort:
         """
         Connects a given L{DatagramProtocol} to the given numeric UDP port.
 
@@ -933,7 +921,7 @@ class IReactorMulticast(Interface):
 
     def listenMulticast(
         port: int,
-        protocol: "DatagramProtocol",
+        protocol: DatagramProtocol,
         interface: str = "",
         maxPacketSize: int = 8192,
         listenMultiple: bool = False,
@@ -1003,8 +991,8 @@ class IReactorSocket(Interface):
     """
 
     def adoptStreamPort(
-        fileDescriptor: int, addressFamily: "AddressFamily", factory: "ServerFactory"
-    ) -> "IListeningPort":
+        fileDescriptor: int, addressFamily: AddressFamily, factory: ServerFactory
+    ) -> IListeningPort:
         """
         Add an existing listening I{SOCK_STREAM} socket to the reactor to
         monitor for new connections to accept and handle.
@@ -1031,7 +1019,7 @@ class IReactorSocket(Interface):
         """
 
     def adoptStreamConnection(
-        fileDescriptor: int, addressFamily: "AddressFamily", factory: "ServerFactory"
+        fileDescriptor: int, addressFamily: AddressFamily, factory: ServerFactory
     ) -> None:
         """
         Add an existing connected I{SOCK_STREAM} socket to the reactor to
@@ -1061,10 +1049,10 @@ class IReactorSocket(Interface):
 
     def adoptDatagramPort(
         fileDescriptor: int,
-        addressFamily: "AddressFamily",
-        protocol: "DatagramProtocol",
+        addressFamily: AddressFamily,
+        protocol: DatagramProtocol,
         maxPacketSize: int,
-    ) -> "IListeningPort":
+    ) -> IListeningPort:
         """
         Add an existing listening I{SOCK_DGRAM} socket to the reactor to
         monitor for read and write readiness.
@@ -1093,16 +1081,16 @@ class IReactorSocket(Interface):
 
 class IReactorProcess(Interface):
     def spawnProcess(
-        processProtocol: "IProcessProtocol",
-        executable: Union[bytes, str],
-        args: Sequence[Union[bytes, str]],
-        env: Optional[Mapping[AnyStr, AnyStr]] = None,
-        path: Union[None, bytes, str] = None,
-        uid: Optional[int] = None,
-        gid: Optional[int] = None,
+        processProtocol: IProcessProtocol,
+        executable: bytes | str,
+        args: Sequence[bytes | str],
+        env: Mapping[AnyStr, AnyStr] | None = None,
+        path: None | bytes | str = None,
+        uid: int | None = None,
+        gid: int | None = None,
         usePTY: bool = False,
-        childFDs: Optional[Mapping[int, Union[int, str]]] = None,
-    ) -> "IProcessTransport":
+        childFDs: Mapping[int, int | str] | None = None,
+    ) -> IProcessTransport:
         """
         Spawn a process, with a process protocol.
 
@@ -1203,7 +1191,7 @@ class IReactorTime(Interface):
 
     def callLater(
         delay: float, callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> "IDelayedCall":
+    ) -> IDelayedCall:
         """
         Call a function later.
 
@@ -1218,7 +1206,7 @@ class IReactorTime(Interface):
                  C{reset()} methods.
         """
 
-    def getDelayedCalls() -> Sequence["IDelayedCall"]:
+    def getDelayedCalls() -> Sequence[IDelayedCall]:
         """
         See L{twisted.internet.interfaces.IReactorTime.getDelayedCalls}
         """
@@ -1332,7 +1320,7 @@ class IReactorThreads(IReactorFromThreads, IReactorInThreads):
     Internally, this should use a thread pool and dispatch methods to them.
     """
 
-    def getThreadPool() -> "ThreadPool":
+    def getThreadPool() -> ThreadPool:
         """
         Return the threadpool used by L{IReactorInThreads.callInThread}.
         Create it first if necessary.
@@ -1355,7 +1343,7 @@ class IReactorCore(Interface):
         "I{during shutdown} and C{False} the rest of the time."
     )
 
-    def resolve(name: str, timeout: Sequence[int] = (1, 3, 11, 45)) -> "Deferred[str]":
+    def resolve(name: str, timeout: Sequence[int] = (1, 3, 11, 45)) -> Deferred[str]:
         """
         Asynchronously resolve a hostname to a single IPv4 address.
 
@@ -1475,7 +1463,7 @@ class IReactorCore(Interface):
 
     def callWhenRunning(
         callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> Optional[Any]:
+    ) -> Any | None:
         """
         Call a function when the reactor is running.
 
@@ -1567,7 +1555,7 @@ class IReactorFDSet(Interface):
     (or at least similarly opaque IDs returned from a .fileno() method)
     """
 
-    def addReader(reader: "IReadDescriptor") -> None:
+    def addReader(reader: IReadDescriptor) -> None:
         """
         I add reader to the set of file descriptors to get read events for.
 
@@ -1576,7 +1564,7 @@ class IReactorFDSet(Interface):
                        L{removeReader}.
         """
 
-    def addWriter(writer: "IWriteDescriptor") -> None:
+    def addWriter(writer: IWriteDescriptor) -> None:
         """
         I add writer to the set of file descriptors to get write events for.
 
@@ -1585,17 +1573,17 @@ class IReactorFDSet(Interface):
                        L{removeWriter}.
         """
 
-    def removeReader(reader: "IReadDescriptor") -> None:
+    def removeReader(reader: IReadDescriptor) -> None:
         """
         Removes an object previously added with L{addReader}.
         """
 
-    def removeWriter(writer: "IWriteDescriptor") -> None:
+    def removeWriter(writer: IWriteDescriptor) -> None:
         """
         Removes an object previously added with L{addWriter}.
         """
 
-    def removeAll() -> List[Union["IReadDescriptor", "IWriteDescriptor"]]:
+    def removeAll() -> list[IReadDescriptor | IWriteDescriptor]:
         """
         Remove all readers and writers.
 
@@ -1605,7 +1593,7 @@ class IReactorFDSet(Interface):
                  which were removed.
         """
 
-    def getReaders() -> List["IReadDescriptor"]:
+    def getReaders() -> list[IReadDescriptor]:
         """
         Return the list of file descriptors currently monitored for input
         events by the reactor.
@@ -1613,7 +1601,7 @@ class IReactorFDSet(Interface):
         @return: the list of file descriptors monitored for input events.
         """
 
-    def getWriters() -> List["IWriteDescriptor"]:
+    def getWriters() -> list[IWriteDescriptor]:
         """
         Return the list file descriptors currently monitored for output events
         by the reactor.
@@ -1636,7 +1624,7 @@ class IListeningPort(Interface):
                                   port number).
         """
 
-    def stopListening() -> Optional["Deferred[None]"]:
+    def stopListening() -> Deferred[None] | None:
         """
         Stop listening on this port.
 
@@ -1704,7 +1692,7 @@ class IReadDescriptor(IFileDescriptor):
     This interface is generally used in conjunction with L{IReactorFDSet}.
     """
 
-    def doRead() -> Optional[Failure]:
+    def doRead() -> Failure | None:
         """
         Some data is available for reading on your descriptor.
 
@@ -1721,7 +1709,7 @@ class IWriteDescriptor(IFileDescriptor):
     This interface is generally used in conjunction with L{IReactorFDSet}.
     """
 
-    def doWrite() -> Optional[Failure]:
+    def doWrite() -> Failure | None:
         """
         Some data can be written to your descriptor.
 
@@ -1776,7 +1764,7 @@ class IConsumer(Interface):
     A consumer consumes data from a producer.
     """
 
-    def registerProducer(producer: "IProducer", streaming: bool) -> None:
+    def registerProducer(producer: IProducer, streaming: bool) -> None:
         """
         Register to receive data from a producer.
 
@@ -1906,7 +1894,7 @@ class IProtocol(Interface):
         of one of those).
         """
 
-    def makeConnection(transport: "ITransport") -> None:
+    def makeConnection(transport: ITransport) -> None:
         """
         Make a connection to a transport and a server.
         """
@@ -1929,7 +1917,7 @@ class IProcessProtocol(Interface):
     Interface for process-related event handlers.
     """
 
-    def makeConnection(process: "IProcessTransport") -> None:
+    def makeConnection(process: IProcessTransport) -> None:
         """
         Called when the process has been created.
 
@@ -2061,7 +2049,7 @@ class IProtocolFactory(Interface):
     Interface for protocol factories.
     """
 
-    def buildProtocol(addr: IAddress) -> Optional[IProtocol]:
+    def buildProtocol(addr: IAddress) -> IProtocol | None:
         """
         Called when a connection has been established to addr.
 
@@ -2204,12 +2192,12 @@ class ITCPTransport(ITransport):
         to allow detection of lost peers in a non-infinite amount of time.
         """
 
-    def getHost() -> Union["IPv4Address", "IPv6Address"]:
+    def getHost() -> IPv4Address | IPv6Address:
         """
         Returns L{IPv4Address} or L{IPv6Address}.
         """
 
-    def getPeer() -> Union["IPv4Address", "IPv6Address"]:
+    def getPeer() -> IPv4Address | IPv6Address:
         """
         Returns L{IPv4Address} or L{IPv6Address}.
         """
@@ -2256,8 +2244,8 @@ class IOpenSSLServerConnectionCreator(Interface):
     """
 
     def serverConnectionForTLS(
-        tlsProtocol: "TLSMemoryBIOProtocol",
-    ) -> "OpenSSLConnection":
+        tlsProtocol: TLSMemoryBIOProtocol,
+    ) -> OpenSSLConnection:
         """
         Create a connection for the given server protocol.
 
@@ -2280,8 +2268,8 @@ class IOpenSSLClientConnectionCreator(Interface):
     """
 
     def clientConnectionForTLS(
-        tlsProtocol: "TLSMemoryBIOProtocol",
-    ) -> "OpenSSLConnection":
+        tlsProtocol: TLSMemoryBIOProtocol,
+    ) -> OpenSSLConnection:
         """
         Create a connection for the given client protocol.
 
@@ -2302,7 +2290,7 @@ class IProtocolNegotiationFactory(Interface):
     @see: L{twisted.internet.ssl}
     """
 
-    def acceptableProtocols() -> List[bytes]:
+    def acceptableProtocols() -> list[bytes]:
         """
         Returns a list of protocols that can be spoken by the connection
         factory in the form of ALPN tokens, as laid out in the IANA registry
@@ -2322,7 +2310,7 @@ class IOpenSSLContextFactory(Interface):
     @see: L{twisted.internet.ssl}
     """
 
-    def getContext() -> "OpenSSLContext":
+    def getContext() -> OpenSSLContext:
         """
         Returns a TLS context object, suitable for securing a TLS connection.
         This context object will be appropriately customized for the connection
@@ -2340,9 +2328,9 @@ class ITLSTransport(ITCPTransport):
     """
 
     def startTLS(
-        contextFactory: Union[
-            IOpenSSLClientConnectionCreator, IOpenSSLServerConnectionCreator
-        ],
+        contextFactory: (
+            IOpenSSLClientConnectionCreator | IOpenSSLServerConnectionCreator
+        ),
     ) -> None:
         """
         Initiate TLS negotiation.
@@ -2404,7 +2392,7 @@ class IAcceptableCiphers(Interface):
     A list of acceptable ciphers for a TLS context.
     """
 
-    def selectCiphers(availableCiphers: Tuple[ICipher]) -> Tuple[ICipher]:
+    def selectCiphers(availableCiphers: tuple[ICipher]) -> tuple[ICipher]:
         """
         Choose which ciphers to allow to be negotiated on a TLS connection.
 
@@ -2469,7 +2457,7 @@ class IProcessTransport(ITransport):
         Close stdin, stderr and stdout.
         """
 
-    def signalProcess(signalID: Union[str, int]) -> None:
+    def signalProcess(signalID: str | int) -> None:
         """
         Send a signal to the process.
 
@@ -2516,7 +2504,7 @@ class IUDPTransport(Interface):
     Transport for UDP DatagramProtocols.
     """
 
-    def write(packet: bytes, addr: Optional[Tuple[str, int]]) -> None:
+    def write(packet: bytes, addr: tuple[str, int] | None) -> None:
         """
         Write packet to given address.
 
@@ -2541,14 +2529,14 @@ class IUDPTransport(Interface):
         @param port: port to connect to.
         """
 
-    def getHost() -> Union["IPv4Address", "IPv6Address"]:
+    def getHost() -> IPv4Address | IPv6Address:
         """
         Get this port's host address.
 
         @return: an address describing the listening port.
         """
 
-    def stopListening() -> Optional["Deferred[None]"]:
+    def stopListening() -> Deferred[None] | None:
         """
         Stop listening on this port.
 
@@ -2581,7 +2569,7 @@ class IUNIXDatagramTransport(Interface):
         Write packet to given address.
         """
 
-    def getHost() -> "UNIXAddress":
+    def getHost() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
@@ -2597,12 +2585,12 @@ class IUNIXDatagramConnectedTransport(Interface):
         Write packet to address we are connected to.
         """
 
-    def getHost() -> "UNIXAddress":
+    def getHost() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
 
-    def getPeer() -> "UNIXAddress":
+    def getPeer() -> UNIXAddress:
         """
         Returns L{UNIXAddress}.
         """
@@ -2649,7 +2637,7 @@ class IMulticastTransport(IUDPTransport):
         Set time to live on multicast packets.
         """
 
-    def joinGroup(addr: str, interface: str = "") -> "Deferred[None]":
+    def joinGroup(addr: str, interface: str = "") -> Deferred[None]:
         """
         Join a multicast group. Returns L{Deferred} of success or failure.
 
@@ -2657,7 +2645,7 @@ class IMulticastTransport(IUDPTransport):
         L{error.MulticastJoinError}.
         """
 
-    def leaveGroup(addr: str, interface: str = "") -> "Deferred[None]":
+    def leaveGroup(addr: str, interface: str = "") -> Deferred[None]:
         """
         Leave multicast group, return L{Deferred} of success.
         """
@@ -2671,7 +2659,7 @@ class IStreamClientEndpoint(Interface):
     @since: 10.1
     """
 
-    def connect(protocolFactory: IProtocolFactory) -> "Deferred[IProtocol]":
+    def connect(protocolFactory: IProtocolFactory) -> Deferred[IProtocol]:
         """
         Connect the C{protocolFactory} to the location specified by this
         L{IStreamClientEndpoint} provider.
@@ -2692,7 +2680,7 @@ class IStreamServerEndpoint(Interface):
     @since: 10.1
     """
 
-    def listen(protocolFactory: IProtocolFactory) -> "Deferred[IListeningPort]":
+    def listen(protocolFactory: IProtocolFactory) -> Deferred[IListeningPort]:
         """
         Listen with C{protocolFactory} at the location specified by this
         L{IStreamServerEndpoint} provider.


### PR DESCRIPTION
## Scope and purpose

Fixes #12531 

The changes were automatically generated using `pyupgrade --py39-plus`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Run linting


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
