### PR TITLE
#12612 internet: update type annotations for Python 3.9+ (3/3)

### DIFF
--- a/src/twisted/internet/_glibbase.py
+++ b/src/twisted/internet/_glibbase.py
@@ -13,7 +13,7 @@ or glib2reactor or gtk2reactor for applications using legacy static bindings.
 
 
 import sys
-from typing import Any, Callable, Dict, Set
+from typing import Any, Callable
 
 from zope.interface import implementer
 
@@ -135,9 +135,9 @@ class GlibReactorBase(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
 
     def __init__(self, glib_module: Any, gtk_module: Any, useGtk: bool = False) -> None:
         self._simtag = None
-        self._reads: Set[IReadDescriptor] = set()
-        self._writes: Set[IWriteDescriptor] = set()
-        self._sources: Dict[FileDescriptor, int] = {}
+        self._reads: set[IReadDescriptor] = set()
+        self._writes: set[IWriteDescriptor] = set()
+        self._sources: dict[FileDescriptor, int] = {}
         self._glib = glib_module
 
         self._POLL_DISCONNECTED = (

--- a/src/twisted/internet/_producer_helpers.py
+++ b/src/twisted/internet/_producer_helpers.py
@@ -6,8 +6,6 @@
 Helpers for working with producers.
 """
 
-from typing import List
-
 from zope.interface import implementer
 
 from twisted.internet.interfaces import IPushProducer
@@ -17,7 +15,7 @@ from twisted.logger import Logger
 _log = Logger()
 
 # This module exports nothing public, it's for internal Twisted use only.
-__all__: List[str] = []
+__all__: list[str] = []
 
 
 @implementer(IPushProducer)

--- a/src/twisted/internet/_resolver.py
+++ b/src/twisted/internet/_resolver.py
@@ -9,6 +9,7 @@ IPv6-aware hostname resolution.
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from socket import (
     AF_INET,
     AF_INET6,
@@ -20,7 +21,7 @@ from socket import (
     gaierror,
     getaddrinfo,
 )
-from typing import TYPE_CHECKING, Callable, NoReturn, Optional, Protocol, Sequence, Type
+from typing import TYPE_CHECKING, Callable, NoReturn, Protocol
 
 from zope.interface import implementer
 
@@ -120,7 +121,7 @@ class GAIResolver:
     def __init__(
         self,
         reactor: IReactorThreads,
-        getThreadPool: Optional[Callable[[], "ThreadPool"]] = None,
+        getThreadPool: Callable[[], ThreadPool] | None = None,
         getaddrinfo: _LikeGetAddrInfo = getaddrinfo,
     ):
         """
@@ -150,7 +151,7 @@ class GAIResolver:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -220,7 +221,7 @@ class SimpleResolverComplexifier:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -283,7 +284,7 @@ class FirstOneWins:
     An L{IResolutionReceiver} which fires a L{Deferred} with its first result.
     """
 
-    def __init__(self, deferred: "Deferred[str]"):
+    def __init__(self, deferred: Deferred[str]):
         """
         @param deferred: The L{Deferred} to fire when the first resolution
             result arrives.
@@ -336,7 +337,7 @@ class ComplexResolverSimplifier:
         """
         self._nameResolver = nameResolver
 
-    def getHostByName(self, name: str, timeouts: Sequence[int] = ()) -> "Deferred[str]":
+    def getHostByName(self, name: str, timeouts: Sequence[int] = ()) -> Deferred[str]:
         """
         See L{IResolverSimple.getHostByName}
 
@@ -346,6 +347,6 @@ class ComplexResolverSimplifier:
 
         @return: see L{IResolverSimple.getHostByName}
         """
-        result: "Deferred[str]" = Deferred()
+        result: Deferred[str] = Deferred()
         self._nameResolver.resolveHostName(FirstOneWins(result), name, 0, [IPv4Address])
         return result

--- a/src/twisted/internet/_signals.py
+++ b/src/twisted/internet/_signals.py
@@ -38,8 +38,9 @@ import errno
 import os
 import signal
 import socket
+from collections.abc import Sequence
 from types import FrameType
-from typing import Callable, Optional, Protocol, Sequence
+from typing import Callable, Optional, Protocol
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -213,7 +214,7 @@ class _ChildSignalHandling:
 
     _addInternalReader: Callable[[IReadDescriptor], object]
     _removeInternalReader: Callable[[IReadDescriptor], object]
-    _childWaker: Optional[_SIGCHLDWaker] = None
+    _childWaker: _SIGCHLDWaker | None = None
 
     def install(self) -> None:
         """

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -6,18 +6,10 @@ from __future__ import annotations
 
 import warnings
 from binascii import hexlify
+from collections.abc import Sequence
 from functools import lru_cache
 from hashlib import md5
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from zope.interface import Interface, implementer
 
@@ -178,7 +170,7 @@ _x509names = {
 }
 
 
-class DistinguishedName(Dict[str, bytes]):
+class DistinguishedName(dict[str, bytes]):
     """
     Identify and describe an entity.
 
@@ -1101,11 +1093,11 @@ def _verifyCB(
 
 def optionsForClientTLS(
     hostname: str,
-    trustRoot: Optional[Union[IOpenSSLTrustRoot, Certificate]] = None,
-    clientCertificate: Optional[PrivateCertificate] = None,
-    acceptableProtocols: Optional[Sequence[bytes]] = None,
+    trustRoot: IOpenSSLTrustRoot | Certificate | None = None,
+    clientCertificate: PrivateCertificate | None = None,
+    acceptableProtocols: Sequence[bytes] | None = None,
     *,
-    extraCertificateOptions: Optional[dict[str, Any]] = None,
+    extraCertificateOptions: dict[str, Any] | None = None,
     sendServerName: bool | None = None,
 ) -> IOpenSSLClientConnectionCreator:
     """

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -8,8 +8,8 @@ Support for generic select()able objects.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from socket import AF_INET, AF_INET6, inet_pton
-from typing import Iterable, List, Optional, Union
 
 from zope.interface import implementer
 
@@ -182,7 +182,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
 
     SEND_LIMIT = 128 * 1024
 
-    def __init__(self, reactor: Optional[interfaces.IReactorFDSet] = None):
+    def __init__(self, reactor: interfaces.IReactorFDSet | None = None):
         """
         @param reactor: An L{IReactorFDSet} provider which this descriptor will
             use to get readable and writeable event notifications.  If no value
@@ -194,7 +194,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             reactor = _reactor
         self.reactor = reactor
         # will be added to dataBuffer in doWrite
-        self._tempDataBuffer: List[bytes] = []
+        self._tempDataBuffer: list[bytes] = []
         self._tempDataLen = 0
 
     def connectionLost(self, reason):
@@ -215,7 +215,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.stopReading()
         self.stopWriting()
 
-    def writeSomeData(self, data: bytes) -> Union[int, BaseException]:
+    def writeSomeData(self, data: bytes) -> int | BaseException:
         """
         Write as much as possible of the given data, immediately.
 

--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -6,11 +6,11 @@
 asyncio-based reactor implementation.
 """
 
+from __future__ import annotations
 
 import errno
 import sys
 from asyncio import AbstractEventLoop, get_running_loop, new_event_loop, set_event_loop
-from typing import Dict, Optional, Type
 
 from zope.interface import implementer
 
@@ -45,7 +45,7 @@ class AsyncioSelectorReactor(PosixReactorBase):
     _asyncClosed = False
     _log = Logger()
 
-    def __init__(self, eventloop: Optional[AbstractEventLoop] = None):
+    def __init__(self, eventloop: AbstractEventLoop | None = None):
         if eventloop is None:
             try:
                 _eventloop: AbstractEventLoop = get_running_loop()
@@ -67,8 +67,8 @@ class AsyncioSelectorReactor(PosixReactorBase):
                 )
 
         self._asyncioEventloop: AbstractEventLoop = _eventloop
-        self._writers: Dict[Type[FileDescriptor], int] = {}
-        self._readers: Dict[Type[FileDescriptor], int] = {}
+        self._writers: dict[type[FileDescriptor], int] = {}
+        self._readers: dict[type[FileDescriptor], int] = {}
         self._continuousPolling = _ContinuousPolling(self)
 
         self._scheduledAt = None

--- a/src/twisted/internet/base.py
+++ b/src/twisted/internet/base.py
@@ -6,28 +6,17 @@
 Very basic functionality for a Reactor implementation.
 """
 
+from __future__ import annotations
 
 import builtins
 import socket  # needed only for sync-dns
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from heapq import heapify, heappop, heappush
 from traceback import format_stack
 from types import FrameType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    NewType,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, NewType, cast
 
 from zope.interface import classImplements, implementer
 
@@ -89,19 +78,19 @@ class DelayedCall:
     # enable .debug to record creator call stack, and it will be logged if
     # an exception occurs while the function is being run
     debug = False
-    _repr: Optional[str] = None
+    _repr: str | None = None
 
     # In debug mode, the call stack at the time of instantiation.
-    creator: Optional[Sequence[str]] = None
+    creator: Sequence[str] | None = None
 
     def __init__(
         self,
         time: float,
         func: Callable[..., Any],
         args: Sequence[object],
-        kw: Dict[str, object],
-        cancel: Callable[["DelayedCall"], None],
-        reset: Callable[["DelayedCall"], None],
+        kw: dict[str, object],
+        cancel: Callable[[DelayedCall], None],
+        reset: Callable[[DelayedCall], None],
         seconds: Callable[[], float] = runtimeSeconds,
     ) -> None:
         """
@@ -213,7 +202,7 @@ class DelayedCall:
         """
         return not (self.cancelled or self.called)
 
-    def __le__(self, other: "DelayedCall") -> bool:
+    def __le__(self, other: DelayedCall) -> bool:
         """
         Implement C{<=} operator between two L{DelayedCall} instances.
 
@@ -222,7 +211,7 @@ class DelayedCall:
         """
         return self.time <= other.time
 
-    def __lt__(self, other: "DelayedCall") -> bool:
+    def __lt__(self, other: DelayedCall) -> bool:
         """
         Implement C{<} operator between two L{DelayedCall} instances.
 
@@ -293,10 +282,10 @@ class ThreadedResolver:
         delivered.
     """
 
-    def __init__(self, reactor: "ReactorBase") -> None:
+    def __init__(self, reactor: ReactorBase) -> None:
         self.reactor = reactor
-        self._runningQueries: Dict[
-            Deferred[str], Tuple[Deferred[str], IDelayedCall]
+        self._runningQueries: dict[
+            Deferred[str], tuple[Deferred[str], IDelayedCall]
         ] = {}
 
     def _fail(self, name: str, err: str) -> Failure:
@@ -309,7 +298,7 @@ class ThreadedResolver:
         userDeferred.errback(self._fail(name, "timeout error"))
 
     def _checkTimeout(
-        self, result: Union[str, Failure], name: str, lookupDeferred: Deferred[str]
+        self, result: str | Failure, name: str, lookupDeferred: Deferred[str]
     ) -> None:
         try:
             userDeferred, cancelCall = self._runningQueries[lookupDeferred]
@@ -371,12 +360,12 @@ class BlockingResolver:
 
 
 _ThreePhaseEventTriggerCallable = Callable[..., Any]
-_ThreePhaseEventTrigger = Tuple[
-    _ThreePhaseEventTriggerCallable, Tuple[object, ...], Dict[str, object]
+_ThreePhaseEventTrigger = tuple[
+    _ThreePhaseEventTriggerCallable, tuple[object, ...], dict[str, object]
 ]
 _ThreePhaseEventTriggerHandle = NewType(
     "_ThreePhaseEventTriggerHandle",
-    Tuple[str, _ThreePhaseEventTriggerCallable, Tuple[object, ...], Dict[str, object]],
+    tuple[str, _ThreePhaseEventTriggerCallable, tuple[object, ...], dict[str, object]],
 )
 
 
@@ -411,9 +400,9 @@ class _ThreePhaseEvent:
     """
 
     def __init__(self) -> None:
-        self.before: List[_ThreePhaseEventTrigger] = []
-        self.during: List[_ThreePhaseEventTrigger] = []
-        self.after: List[_ThreePhaseEventTrigger] = []
+        self.before: list[_ThreePhaseEventTrigger] = []
+        self.during: list[_ThreePhaseEventTrigger] = []
+        self.after: list[_ThreePhaseEventTrigger] = []
         self.state = "BASE"
 
     def addTrigger(
@@ -494,7 +483,7 @@ class _ThreePhaseEvent:
         """
         self.state = "BEFORE"
         self.finishedBefore = []
-        beforeResults: List[Deferred[object]] = []
+        beforeResults: list[Deferred[object]] = []
         while self.before:
             callable, args, kwargs = self.before.pop(0)
             self.finishedBefore.append((callable, args, kwargs))
@@ -568,8 +557,8 @@ class PluggableResolverMixin:
         return self._nameResolver
 
 
-_SystemEventID = NewType("_SystemEventID", Tuple[str, _ThreePhaseEventTriggerHandle])
-_ThreadCall = Tuple[Callable[..., Any], Tuple[object, ...], Dict[str, object]]
+_SystemEventID = NewType("_SystemEventID", tuple[str, _ThreePhaseEventTriggerHandle])
+_ThreadCall = tuple[Callable[..., Any], tuple[object, ...], dict[str, object]]
 
 _DEFAULT_DELAYED_CALL_LOGGING_HANDLER = _log.failureHandler("while handling timed call")
 
@@ -622,10 +611,10 @@ class ReactorBase(PluggableResolverMixin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.threadCallQueue: List[_ThreadCall] = []
-        self._eventTriggers: Dict[str, _ThreePhaseEvent] = {}
-        self._pendingTimedCalls: List[DelayedCall] = []
-        self._newTimedCalls: List[DelayedCall] = []
+        self.threadCallQueue: list[_ThreadCall] = []
+        self._eventTriggers: dict[str, _ThreePhaseEvent] = {}
+        self._pendingTimedCalls: list[DelayedCall] = []
+        self._newTimedCalls: list[DelayedCall] = []
         self._cancellations = 0
         self.running = False
         self._started = False
@@ -633,7 +622,7 @@ class ReactorBase(PluggableResolverMixin):
         self._startedBefore = False
         # reactor internal readers, e.g. the waker.
         # Using Any as the type here… unable to find a suitable defined interface
-        self._internalReaders: Set[Any] = set()
+        self._internalReaders: set[Any] = set()
         self.waker: Any = None
 
         # Arrange for the running attribute to change to True at the right time
@@ -726,7 +715,7 @@ class ReactorBase(PluggableResolverMixin):
         # if the waker isn't installed, the reactor isn't running, and
         # therefore doesn't need to be woken up
 
-    def doIteration(self, delay: Optional[float]) -> None:
+    def doIteration(self, delay: float | None) -> None:
         """
         Do one iteration over the readers and writers which have been added.
         """
@@ -754,17 +743,17 @@ class ReactorBase(PluggableResolverMixin):
             reflect.qual(self.__class__) + " did not implement removeWriter"
         )
 
-    def removeAll(self) -> List[Union[IReadDescriptor, IWriteDescriptor]]:
+    def removeAll(self) -> list[IReadDescriptor | IWriteDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement removeAll"
         )
 
-    def getReaders(self) -> List[IReadDescriptor]:
+    def getReaders(self) -> list[IReadDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement getReaders"
         )
 
-    def getWriters(self) -> List[IWriteDescriptor]:
+    def getWriters(self) -> list[IWriteDescriptor]:
         raise NotImplementedError(
             reflect.qual(self.__class__) + " did not implement getWriters"
         )
@@ -804,7 +793,7 @@ class ReactorBase(PluggableResolverMixin):
         self.running = False
         self.addSystemEventTrigger("during", "startup", self._reallyStartRunning)
 
-    def sigInt(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigInt(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGINT interrupt.
 
@@ -815,7 +804,7 @@ class ReactorBase(PluggableResolverMixin):
         self.callFromThread(self.stop)
         self._exitSignal = number
 
-    def sigBreak(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigBreak(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGBREAK interrupt.
 
@@ -826,7 +815,7 @@ class ReactorBase(PluggableResolverMixin):
         self.callFromThread(self.stop)
         self._exitSignal = number
 
-    def sigTerm(self, number: int, frame: Optional[FrameType] = None) -> None:
+    def sigTerm(self, number: int, frame: FrameType | None = None) -> None:
         """
         Handle a SIGTERM interrupt.
 
@@ -892,7 +881,7 @@ class ReactorBase(PluggableResolverMixin):
 
     def callWhenRunning(
         self, callable: Callable[..., Any], *args: object, **kwargs: object
-    ) -> Optional[_SystemEventID]:
+    ) -> _SystemEventID | None:
         """
         See twisted.internet.interfaces.IReactorCore.callWhenRunning.
         """
@@ -1021,7 +1010,7 @@ class ReactorBase(PluggableResolverMixin):
                 heappush(self._pendingTimedCalls, call)
         self._newTimedCalls = []
 
-    def timeout(self) -> Optional[float]:
+    def timeout(self) -> float | None:
         """
         Determine the longest time the reactor may sleep (waiting on I/O
         notification, perhaps) before it must wake up to service a time-related
@@ -1251,7 +1240,7 @@ class BaseConnector(ABC):
             self.transport.loseConnection()
 
     @abstractmethod
-    def _makeTransport(self) -> "Client":
+    def _makeTransport(self) -> Client:
         pass
 
     def connect(self) -> None:
@@ -1263,7 +1252,7 @@ class BaseConnector(ABC):
         if not self.factoryStarted:
             self.factory.doStart()
             self.factoryStarted = 1
-        self.transport: Optional[Client] = self._makeTransport()
+        self.transport: Client | None = self._makeTransport()
         if self.timeout is not None:
             self.timeoutID = self.reactor.callLater(
                 self.timeout, self.transport.failIfNotConnected, error.TimeoutError()
@@ -1288,7 +1277,7 @@ class BaseConnector(ABC):
                 pass
             del self.timeoutID
 
-    def buildProtocol(self, addr: IAddress) -> Optional[IProtocol]:
+    def buildProtocol(self, addr: IAddress) -> IProtocol | None:
         self.state = "connected"
         self.cancelTimeout()
         return self.factory.buildProtocol(addr)
@@ -1340,9 +1329,9 @@ class BasePort(abstract.FileDescriptor):
         fdesc._setCloseOnExec(s.fileno())
         return s
 
-    def doWrite(self) -> Optional[Failure]:
+    def doWrite(self) -> Failure | None:
         """Raises a RuntimeError"""
         raise RuntimeError("doWrite called on a %s" % reflect.qual(self.__class__))
 
 
-__all__: List[str] = []
+__all__: list[str] = []

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -18,20 +18,8 @@ import os
 import re
 import socket
 import warnings
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Iterable,
-    List,
-    Optional,
-    Protocol as TypingProtocol,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from collections.abc import Iterable, Sequence
+from typing import Any, Callable, ClassVar, Protocol as TypingProtocol, TypeVar, Union
 from unicodedata import normalize
 
 from zope.interface import directlyProvides, implementer
@@ -753,15 +741,15 @@ class TCP6ClientEndpoint:
             return defer.fail()
 
 
-_gairesult = List[
-    Tuple[
+_gairesult = list[
+    tuple[
         socket.AddressFamily,
         socket.SocketKind,
         int,
         str,
         Union[
-            Tuple[str, int],
-            Tuple[str, int, int, int],
+            tuple[str, int],
+            tuple[str, int, int, int],
         ],
     ]
 ]
@@ -798,7 +786,7 @@ class _SimpleHostnameResolver:
         resolutionReceiver: IResolutionReceiver,
         hostName: str,
         portNumber: int = 0,
-        addressTypes: Optional[Sequence[Type[IAddress]]] = None,
+        addressTypes: Sequence[type[IAddress]] | None = None,
         transportSemantics: str = "TCP",
     ) -> IHostResolution:
         """
@@ -1641,8 +1629,8 @@ class _SystemdParser:
         self,
         reactor: IReactorSocket,
         domain: str,
-        index: Optional[str] = None,
-        name: Optional[str] = None,
+        index: str | None = None,
+        name: str | None = None,
     ) -> AdoptedStreamServerEndpoint:
         """
         Internal parser function for L{_parseServer} to convert the string

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import socket
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 from zope.interface import classImplements, implementer
 
@@ -370,7 +370,7 @@ class PosixReactorBase(_DisconnectSelectableMixin, ReactorBase):
         self,
         host: str,
         port: int,
-        factory: "ClientFactory[P]",
+        factory: ClientFactory[P],
         timeout: float = 30.0,
         bindAddress: tuple[str, int] | None = None,
     ) -> IConnector:

--- a/src/twisted/internet/process.py
+++ b/src/twisted/internet/process.py
@@ -20,7 +20,7 @@ import stat
 import sys
 import traceback
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 _PS_CLOSE: int
 _PS_DUP2: int
@@ -66,7 +66,7 @@ else:
 # here for backwards compatibility:
 ProcessExitedAlready = error.ProcessExitedAlready
 
-reapProcessHandlers: Dict[int, _BaseProcess] = {}
+reapProcessHandlers: dict[int, _BaseProcess] = {}
 
 
 def reapAllProcesses() -> None:
@@ -285,7 +285,7 @@ class _BaseProcess(BaseProcess):
     Base class for Process and PTYProcess.
     """
 
-    status: Optional[int] = None
+    status: int | None = None
     pid = None
 
     def reapProcess(self):
@@ -632,11 +632,11 @@ def _listOpenFDs():
 
 
 def _getFileActions(
-    fdState: List[Tuple[int, bool]],
-    childToParentFD: Dict[int, int],
+    fdState: list[tuple[int, bool]],
+    childToParentFD: dict[int, int],
     doClose: int,
     doDup2: int,
-) -> List[Tuple[int, ...]]:
+) -> list[tuple[int, ...]]:
     """
     Get the C{file_actions} parameter for C{posix_spawn} based on the
     parameters describing the current process state.
@@ -649,7 +649,7 @@ def _getFileActions(
     @param doDup2: the integer to use for the 'dup2' instruction
     """
     fdStateDict = dict(fdState)
-    parentToChildren: Dict[int, List[int]] = defaultdict(list)
+    parentToChildren: dict[int, list[int]] = defaultdict(list)
     for inChild, inParent in childToParentFD.items():
         parentToChildren[inParent].append(inChild)
     allocated = set(fdStateDict)
@@ -664,7 +664,7 @@ def _getFileActions(
         allocated.add(nextFD)
         return nextFD
 
-    result: List[Tuple[int, ...]] = []
+    result: list[tuple[int, ...]] = []
     relocations = {}
     for inChild, inParent in sorted(childToParentFD.items()):
         # The parent FD will later be reused by a child FD.

--- a/src/twisted/internet/protocol.py
+++ b/src/twisted/internet/protocol.py
@@ -11,7 +11,7 @@ Twisted.  The Protocol class contains some introductory material.
 from __future__ import annotations
 
 import random
-from typing import Any, Callable, Generic, Optional, Protocol as TypingProtocol
+from typing import Any, Callable, Generic, Protocol as TypingProtocol
 
 from zope.interface import implementer
 
@@ -67,7 +67,7 @@ class _ProtoWithFactory(TypingProtocol):
     def connectionLost(self, reason: Failure) -> None:
         ...
 
-    def makeConnection(self, transport: "ITransport") -> None:
+    def makeConnection(self, transport: ITransport) -> None:
         ...
 
     def connectionMade(self) -> None:
@@ -83,7 +83,7 @@ class Factory(Generic[P]):
     self.protocol.
     """
 
-    protocol: "Optional[Callable[..., P]]" = None
+    protocol: Callable[..., P] | None = None
 
     numPorts = 0
     noisy = True
@@ -171,7 +171,7 @@ class Factory(Generic[P]):
         directly.
         """
 
-    def buildProtocol(self, addr: IAddress | None) -> "Optional[P]":
+    def buildProtocol(self, addr: IAddress | None) -> P | None:
         """
         Create an instance of a subclass of Protocol.
 
@@ -550,7 +550,7 @@ class BaseProtocol:
     """
 
     connected = 0
-    transport: Optional[ITransport] = None
+    transport: ITransport | None = None
 
     def makeConnection(self, transport):
         """
@@ -678,7 +678,7 @@ class ProcessProtocol(BaseProtocol):
     stdin, stdout, and stderr file descriptors.
     """
 
-    transport: Optional[interfaces.IProcessTransport] = None
+    transport: interfaces.IProcessTransport | None = None
 
     def childDataReceived(self, childFD: int, data: bytes) -> None:
         if childFD == 1:

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -11,7 +11,7 @@ import select
 import sys
 from errno import EBADF, EINTR
 from time import sleep
-from typing import Callable, Type, TypeVar
+from typing import Callable, TypeVar
 
 from zope.interface import implementer
 
@@ -48,7 +48,7 @@ else:
 try:
     from twisted.internet.win32eventreactor import _ThreadedWin32EventsMixin
 except ImportError:
-    _extraBase: Type[object] = object
+    _extraBase: type[object] = object
 else:
     _extraBase = _ThreadedWin32EventsMixin
 

--- a/src/twisted/internet/task.py
+++ b/src/twisted/internet/task.py
@@ -10,21 +10,8 @@ from __future__ import annotations
 import sys
 import time
 import warnings
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    NoReturn,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-)
+from collections.abc import Coroutine, Iterable, Iterator, Sequence
+from typing import Any, Callable, Generic, NoReturn, TypeVar, cast
 
 from zope.interface import implementer
 
@@ -69,13 +56,13 @@ class LoopingCall:
         to L{LoopingCall.start}.
     """
 
-    call: Optional[IDelayedCall] = None
+    call: IDelayedCall | None = None
     running = False
-    _deferred: Optional[Deferred["LoopingCall"]] = None
-    interval: Optional[float] = None
+    _deferred: Deferred[LoopingCall] | None = None
+    interval: float | None = None
     _runAtStart = False
-    starttime: Optional[float] = None
-    _realLastTime: Optional[float] = None
+    starttime: float | None = None
+    _realLastTime: float | None = None
 
     def __init__(self, f: Callable[..., object], *a: object, **kw: object) -> None:
         self.f = f
@@ -86,7 +73,7 @@ class LoopingCall:
         self.clock = cast(IReactorTime, reactor)
 
     @property
-    def deferred(self) -> Optional[Deferred["LoopingCall"]]:
+    def deferred(self) -> Deferred[LoopingCall] | None:
         """
         DEPRECATED. L{Deferred} fired when loop stops or fails.
 
@@ -102,7 +89,7 @@ class LoopingCall:
         return self._deferred
 
     @classmethod
-    def withCount(cls, countCallable: Callable[[int], object]) -> "LoopingCall":
+    def withCount(cls, countCallable: Callable[[int], object]) -> LoopingCall:
         """
         An alternate constructor for L{LoopingCall} that makes available the
         number of calls which should have occurred since it was last invoked.
@@ -178,7 +165,7 @@ class LoopingCall:
         intervalNum = int(elapsedTime / self.interval)
         return intervalNum
 
-    def start(self, interval: float, now: bool = True) -> Deferred["LoopingCall"]:
+    def start(self, interval: float, now: bool = True) -> Deferred[LoopingCall]:
         """
         Start running function every interval seconds.
 
@@ -418,7 +405,7 @@ class CooperativeTask(Generic[_TaskIteratorT]):
     def __init__(
         self,
         iterator: _TaskIteratorT,
-        cooperator: "Cooperator",
+        cooperator: Cooperator,
     ) -> None:
         """
         A private constructor: to create a new L{CooperativeTask}, see
@@ -426,10 +413,10 @@ class CooperativeTask(Generic[_TaskIteratorT]):
         """
         self._iterator = iterator
         self._cooperator = cooperator
-        self._deferreds: List[Deferred[_TaskIteratorT]] = []
+        self._deferreds: list[Deferred[_TaskIteratorT]] = []
         self._pauseCount = 0
-        self._completionState: Optional[SchedulerError] = None
-        self._completionResult: Optional[Union[_TaskIteratorT, Failure]] = None
+        self._completionState: SchedulerError | None = None
+        self._completionResult: _TaskIteratorT | Failure | None = None
         cooperator._addTask(self)
 
     def whenDone(self) -> Deferred[_TaskIteratorT]:
@@ -481,7 +468,7 @@ class CooperativeTask(Generic[_TaskIteratorT]):
     def _completeWith(
         self,
         completionState: SchedulerError,
-        deferredResult: Union[_TaskIteratorT, Failure],
+        deferredResult: _TaskIteratorT | Failure,
     ) -> None:
         """
         @param completionState: a L{SchedulerError} exception or a subclass
@@ -601,18 +588,18 @@ class Cooperator:
         stepped as soon as they are added, or if they will be queued up until
         L{Cooperator.start} is called.
         """
-        self._tasks: List[CooperativeTask[Iterator[object]]] = []
+        self._tasks: list[CooperativeTask[Iterator[object]]] = []
         self._metarator: Iterator[CooperativeTask[Iterator[object]]] = iter(())
         self._terminationPredicateFactory = terminationPredicateFactory
         self._scheduler = scheduler
-        self._delayedCall: Optional[IDelayedCall] = None
+        self._delayedCall: IDelayedCall | None = None
         self._stopped = False
         self._started = started
 
     def coiterate(
         self,
         iterator: _TaskIteratorT,
-        doneDeferred: Optional[Deferred[_TaskIteratorT]] = None,
+        doneDeferred: Deferred[_TaskIteratorT] | None = None,
     ) -> Deferred[_TaskIteratorT]:
         """
         Add an iterator to the list of iterators this L{Cooperator} is
@@ -779,7 +766,7 @@ class Clock:
     rightNow = 0.0
 
     def __init__(self) -> None:
-        self.calls: List[DelayedCall] = []
+        self.calls: list[DelayedCall] = []
 
     def seconds(self) -> float:
         """
@@ -849,7 +836,7 @@ class Clock:
 def deferLater(
     clock: IReactorTime,
     delay: float,
-    callable: Optional[Callable[..., _T]] = None,
+    callable: Callable[..., _T] | None = None,
     *args: object,
     **kw: object,
 ) -> Deferred[_T]:
@@ -888,10 +875,10 @@ def deferLater(
 def react(
     main: Callable[
         ...,
-        Union[Deferred[_T], Coroutine["Deferred[_T]", object, _T]],
+        Deferred[_T] | Coroutine[Deferred[_T], object, _T],
     ],
     argv: Iterable[object] = (),
-    _reactor: Optional[IReactorCore] = None,
+    _reactor: IReactorCore | None = None,
 ) -> NoReturn:
     """
     Call C{main} and run the reactor until the L{Deferred} it returns fires or

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -14,8 +14,7 @@ import os
 import socket
 import struct
 import sys
-import typing
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol as TypingProtocol
 
 from zope.interface import Interface, implementer
 
@@ -799,9 +798,9 @@ class Server(_TLSServerMixin, Connection):
 
     _base = Connection
 
-    _addressType: Union[
-        type[address.IPv4Address], type[address.IPv6Address]
-    ] = address.IPv4Address
+    _addressType: (
+        type[address.IPv4Address] | type[address.IPv6Address]
+    ) = address.IPv4Address
 
     def __init__(
         self,
@@ -964,7 +963,7 @@ class _IFileDescriptorReservation(Interface):
         """
 
 
-class _HasClose(typing.Protocol):
+class _HasClose(TypingProtocol):
     def close(self) -> object:
         ...
 
@@ -984,7 +983,7 @@ class _FileDescriptorReservation:
     _log: ClassVar[Logger] = Logger()
 
     _fileFactory: Callable[[], _HasClose]
-    _fileDescriptor: Optional[_HasClose] = attr.ib(init=False, default=None)
+    _fileDescriptor: _HasClose | None = attr.ib(init=False, default=None)
 
     def available(self):
         """
@@ -1136,7 +1135,7 @@ class _BuffersLogs:
 
     _namespace: str
     _observer: ILogObserver
-    _logs: List[LogEvent] = attr.ib(default=attr.Factory(list))
+    _logs: list[LogEvent] = attr.ib(default=attr.Factory(list))
 
     def __enter__(self):
         """
@@ -1281,7 +1280,7 @@ class Port(base.BasePort, _SocketCloser):
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
 
     # An externally initialized socket that we will use, rather than creating
     # our own.

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -7,22 +7,12 @@ Assorted functionality which is commonly useful when writing unit tests.
 """
 from __future__ import annotations
 
-import typing
+from collections.abc import Coroutine, Generator, Iterator, Sequence
 from dataclasses import dataclass
 from io import BytesIO
 from socket import AF_INET, AF_INET6
 from time import time
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    Iterator,
-    Sequence,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Protocol, TypeVar, overload
 
 from zope.interface import implementedBy, implementer
 from zope.interface.verify import verifyClass
@@ -81,7 +71,7 @@ __all__ = [
 _P = ParamSpec("_P")
 
 
-class _ProtocolConnectionMadeHaver(typing.Protocol):
+class _ProtocolConnectionMadeHaver(Protocol):
     """
     Explicit stipulation of the implicit requirement of L{AccumulatingProtocol}'s factory.
     """
@@ -1095,11 +1085,11 @@ _T = TypeVar("_T")
 def _benchmarkWithReactor(
     test_target: Callable[
         [],
-        Union[
-            Coroutine[Deferred[Any], Any, _T],
-            Generator[Deferred[Any], Any, _T],
-            Deferred[_T],
-        ],
+        (
+            Coroutine[Deferred[Any], Any, _T]
+            | Generator[Deferred[Any], Any, _T]
+            | Deferred[_T]
+        ),
     ],
 ) -> Callable[[Any], None]:  # pragma: no cover
     """

--- a/src/twisted/internet/threads.py
+++ b/src/twisted/internet/threads.py
@@ -10,7 +10,7 @@ For basic support see reactor threading API docs.
 from __future__ import annotations
 
 import queue as Queue
-from typing import Callable, TypeVar, Union, cast
+from typing import Callable, TypeVar, cast
 
 from typing_extensions import ParamSpec
 
@@ -109,7 +109,7 @@ def callMultipleInThread(tupleList):
 
 def blockingCallFromThread(
     reactor: IReactorFromThreads,
-    f: Union[Callable[_P, _R], Callable[_P, defer.Deferred[_R]]],
+    f: Callable[_P, _R] | Callable[_P, defer.Deferred[_R]],
     *a: _P.args,
     **kw: _P.kwargs,
 ) -> _R:

--- a/src/twisted/internet/udp.py
+++ b/src/twisted/internet/udp.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 # System Imports
 import socket
 import warnings
-from typing import Optional
 
 from zope.interface import implementer
 
@@ -87,7 +86,7 @@ class Port(base.BasePort):
     socketType: socket.SocketKind = socket.SOCK_DGRAM
     maxThroughput = 256 * 1024
 
-    _realPortNumber: Optional[int] = None
+    _realPortNumber: int | None = None
     _preexistingSocket = None
 
     def __init__(self, port, proto, interface="", maxPacketSize=8192, reactor=None):

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -10,13 +10,13 @@ End users shouldn't use this module directly - use the reactor APIs instead.
 Maintainer: Itamar Shtull-Trauring
 """
 
+from __future__ import annotations
 
 import os
 import socket
 import stat
 import struct
 from errno import EAGAIN, ECONNREFUSED, EINTR, EMSGSIZE, ENOBUFS, EWOULDBLOCK
-from typing import Optional, Type
 
 from zope.interface import implementedBy, implementer, implementer_only
 
@@ -66,7 +66,7 @@ class _SendmsgMixin:
         registered producer, if there is one.
     """
 
-    _writeSomeDataBase: Optional[Type[FileDescriptor]] = None
+    _writeSomeDataBase: type[FileDescriptor] | None = None
     _fileDescriptorBufferSize = 64
 
     def __init__(self):


### PR DESCRIPTION
## Scope and purpose

Fixes #12612 

The changes were automatically generated using `pyupgrade --py39-plus`

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Run linting


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
