### PR TITLE
#12614 _thread/cred/pair/names: update type annotations for Python 3.9+

### DIFF
--- a/src/twisted/_threads/_pool.py
+++ b/src/twisted/_threads/_pool.py
@@ -7,10 +7,11 @@ Top level thread pool interface, used to implement
 L{twisted.python.threadpool}.
 """
 
+from __future__ import annotations
 
 from queue import Queue
 from threading import Lock, Thread, local as LocalStorage
-from typing import Callable, Optional, Protocol
+from typing import Callable, Protocol
 
 from twisted.python.log import err
 from ._ithreads import IWorker
@@ -57,7 +58,7 @@ def pool(
     def startThread(target: Callable[..., object]) -> None:
         return threadFactory(target=target).start()
 
-    def limitedWorkerCreator() -> Optional[IWorker]:
+    def limitedWorkerCreator() -> IWorker | None:
         stats = team.statistics()
         if stats.busyWorkerCount + stats.idleWorkerCount >= currentLimit():
             return None

--- a/src/twisted/_threads/_team.py
+++ b/src/twisted/_threads/_team.py
@@ -9,7 +9,7 @@ workers.
 from __future__ import annotations
 
 from collections import deque
-from typing import Callable, Optional, Set
+from typing import Callable
 
 from zope.interface import implementer
 
@@ -77,7 +77,7 @@ class Team:
     def __init__(
         self,
         coordinator: IExclusiveWorker,
-        createWorker: Callable[[], Optional[IWorker]],
+        createWorker: Callable[[], IWorker | None],
         logException: Callable[[], None],
     ):
         """
@@ -100,9 +100,9 @@ class Team:
         self._logException = logException
 
         # Don't touch these except from the coordinator.
-        self._idle: Set[IWorker] = set()
+        self._idle: set[IWorker] = set()
         self._busyCount = 0
-        self._pending: "deque[Callable[..., object]]" = deque()
+        self._pending: deque[Callable[..., object]] = deque()
         self._shouldQuitCoordinator = False
         self._toShrink = 0
 
@@ -131,7 +131,7 @@ class Team:
                     return
                 self._recycleWorker(worker)
 
-    def shrink(self, n: Optional[int] = None) -> None:
+    def shrink(self, n: int | None = None) -> None:
         """
         Decrease the number of idle workers by C{n}.
 
@@ -142,7 +142,7 @@ class Team:
         self._quit.check()
         self._coordinator.do(lambda: self._quitIdlers(n))
 
-    def _quitIdlers(self, n: Optional[int] = None) -> None:
+    def _quitIdlers(self, n: int | None = None) -> None:
         """
         The implmentation of C{shrink}, performed by the coordinator worker.
 

--- a/src/twisted/_threads/_threadworker.py
+++ b/src/twisted/_threads/_threadworker.py
@@ -7,8 +7,9 @@ Implementation of an L{IWorker} based on native threads and queues.
 """
 from __future__ import annotations
 
+from collections.abc import Iterator
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Callable, Iterator, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Callable, Literal, Protocol, TypeVar
 
 if TYPE_CHECKING:
     import threading

--- a/src/twisted/cred/checkers.py
+++ b/src/twisted/cred/checkers.py
@@ -7,10 +7,10 @@ Basic credential checkers
 
 @var ANONYMOUS: An empty tuple used to represent the anonymous avatar ID.
 """
-
+from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -35,7 +35,7 @@ from twisted.python import failure
 # username.  We do not want an instance of 'object', because that would
 # create potential problems with persistence.
 
-ANONYMOUS: Tuple[()] = ()
+ANONYMOUS: tuple[()] = ()
 
 
 class ICredentialsChecker(Interface):
@@ -48,7 +48,7 @@ class ICredentialsChecker(Interface):
         "may check."
     )
 
-    def requestAvatarId(credentials: Any) -> Deferred[Union[bytes, Tuple[()]]]:
+    def requestAvatarId(credentials: Any) -> Deferred[bytes | tuple[()]]:
         """
         Validate credentials and produce an avatar ID.
 
@@ -168,7 +168,7 @@ class FilePasswordDB:
     """
 
     cache = False
-    _credCache: Optional[Dict[bytes, bytes]] = None
+    _credCache: dict[bytes, bytes] | None = None
     _cacheTimestamp: float = 0
     _log = Logger()
 
@@ -277,7 +277,7 @@ class FilePasswordDB:
             self._log.error("Unable to load credentials db: {e!r}", e=e)
             raise error.UnauthorizedLogin()
 
-    def getUser(self, username: bytes) -> Tuple[bytes, bytes]:
+    def getUser(self, username: bytes) -> tuple[bytes, bytes]:
         """
         Look up the credentials for a username.
 
@@ -310,7 +310,7 @@ class FilePasswordDB:
 
     def requestAvatarId(
         self, credentials: IUsernamePassword
-    ) -> Deferred[Union[bytes, Tuple[()]]]:
+    ) -> Deferred[bytes | tuple[()]]:
         try:
             u, p = self.getUser(credentials.username)
         except KeyError:

--- a/src/twisted/cred/portal.py
+++ b/src/twisted/cred/portal.py
@@ -6,9 +6,10 @@
 """
 The point of integration of application and authentication.
 """
+from __future__ import annotations
 
-
-from typing import Callable, Dict, Iterable, List, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import Callable
 
 from zope.interface import Interface, providedBy
 
@@ -24,12 +25,12 @@ from twisted.python import failure, reflect
 # implementation of Interface itself (subclassing it actually instantiates it),
 # since mypy-zope treats Interface objects *as* types, this is how you have to
 # treat it.
-_InterfaceItself = Type[Interface]
+_InterfaceItself = type[Interface]
 
 # This is the result shape for both IRealm.requestAvatar and Portal.login,
 # although the former is optionally allowed to return synchronously and the
 # latter must be Deferred.
-_requestResult = Tuple[_InterfaceItself, object, Callable[[], None]]
+_requestResult = tuple[_InterfaceItself, object, Callable[[], None]]
 
 
 class IRealm(Interface):
@@ -39,8 +40,8 @@ class IRealm(Interface):
     """
 
     def requestAvatar(
-        avatarId: Union[bytes, Tuple[()]], mind: object, *interfaces: _InterfaceItself
-    ) -> Union[Deferred[_requestResult], _requestResult]:
+        avatarId: bytes | tuple[()], mind: object, *interfaces: _InterfaceItself
+    ) -> Deferred[_requestResult] | _requestResult:
         """
         Return avatar which provides one of the given interfaces.
 
@@ -75,7 +76,7 @@ class Portal:
     in the realm object and in the credentials checker objects.
     """
 
-    checkers: Dict[Type[Interface], ICredentialsChecker]
+    checkers: dict[type[Interface], ICredentialsChecker]
 
     def __init__(
         self, realm: IRealm, checkers: Iterable[ICredentialsChecker] = ()
@@ -88,14 +89,14 @@ class Portal:
         for checker in checkers:
             self.registerChecker(checker)
 
-    def listCredentialsInterfaces(self) -> List[Type[Interface]]:
+    def listCredentialsInterfaces(self) -> list[type[Interface]]:
         """
         Return list of credentials interfaces that can be used to login.
         """
         return list(self.checkers.keys())
 
     def registerChecker(
-        self, checker: ICredentialsChecker, *credentialInterfaces: Type[Interface]
+        self, checker: ICredentialsChecker, *credentialInterfaces: type[Interface]
     ) -> None:
         if not credentialInterfaces:
             credentialInterfaces = checker.credentialInterfaces
@@ -103,7 +104,7 @@ class Portal:
             self.checkers[credentialInterface] = checker
 
     def login(
-        self, credentials: ICredentials, mind: object, *interfaces: Type[Interface]
+        self, credentials: ICredentials, mind: object, *interfaces: type[Interface]
     ) -> Deferred[_requestResult]:
         """
         @param credentials: an implementor of

--- a/src/twisted/cred/strcred.py
+++ b/src/twisted/cred/strcred.py
@@ -13,10 +13,10 @@ Examples:
  - memory:admin:asdf:user:lkj
  - unix
 """
-
+from __future__ import annotations
 
 import sys
-from typing import Optional, Sequence, Type
+from collections.abc import Sequence
 
 from zope.interface import Attribute, Interface
 
@@ -142,7 +142,7 @@ class AuthOptionMixin:
         will send all help-related output. Default: L{sys.stdout}
     """
 
-    supportedInterfaces: Optional[Sequence[Type[Interface]]] = None
+    supportedInterfaces: Sequence[type[Interface]] | None = None
     authOutput = sys.stdout
 
     def supportsInterface(self, interface):

--- a/src/twisted/cred/test/test_strcred.py
+++ b/src/twisted/cred/test/test_strcred.py
@@ -7,8 +7,8 @@ L{twisted.cred.strcred}.
 
 
 import os
+from collections.abc import Sequence
 from io import StringIO
-from typing import Sequence, Type
 from unittest import skipIf
 
 from zope.interface import Interface
@@ -563,7 +563,7 @@ class OptionsSupportsAllInterfaces(usage.Options, strcred.AuthOptionMixin):
 
 
 class OptionsSupportsNoInterfaces(usage.Options, strcred.AuthOptionMixin):
-    supportedInterfaces: Sequence[Type[Interface]] = []
+    supportedInterfaces: Sequence[type[Interface]] = []
 
 
 class LimitingInterfacesTests(TestCase):

--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -15,9 +15,10 @@ import inspect
 import random
 import socket
 import struct
+from collections.abc import Sequence
 from io import BytesIO
 from itertools import chain
-from typing import Optional, Sequence, SupportsInt, Union, overload
+from typing import SupportsInt, overload
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -402,7 +403,7 @@ def _str2time(s: str) -> int:
 
 
 @overload
-def str2time(s: Union[str, bytes, int]) -> int:
+def str2time(s: str | bytes | int) -> int:
     ...
 
 
@@ -411,7 +412,7 @@ def str2time(s: None) -> None:
     ...
 
 
-def str2time(s: Union[str, bytes, int, None]) -> Union[int, None]:
+def str2time(s: str | bytes | int | None) -> int | None:
     """
     Parse a string description of an interval into an integer number of seconds.
 
@@ -660,7 +661,7 @@ class Query:
     @type cls: L{int}
     """
 
-    def __init__(self, name: Union[bytes, str] = b"", type: int = A, cls: int = IN):
+    def __init__(self, name: bytes | str = b"", type: int = A, cls: int = IN):
         """
         @type name: L{bytes} or L{str}
         @param name: See L{Query.name}
@@ -989,11 +990,11 @@ class RRHeader(tputil.FancyEqMixin):
 
     def __init__(
         self,
-        name: Union[bytes, str] = b"",
+        name: bytes | str = b"",
         type: int = A,
         cls: int = IN,
         ttl: SupportsInt = 0,
-        payload: Optional[IEncodableRecord] = None,
+        payload: IEncodableRecord | None = None,
         auth: bool = False,
     ):
         """
@@ -1093,7 +1094,7 @@ class SimpleRecord(tputil.FancyStrMixin, tputil.FancyEqMixin):
     showAttributes = (("name", "name", "%s"), "ttl")
     compareAttributes = ("name", "ttl")
 
-    TYPE: Optional[int] = None
+    TYPE: int | None = None
     name = None
 
     def __init__(self, name=b"", ttl=None):
@@ -1568,7 +1569,7 @@ class Record_A6(tputil.FancyStrMixin, tputil.FancyEqMixin):
         prefixLen: int = 0,
         suffix: bytes | str = "::",
         prefix: bytes | str = b"",
-        ttl: Union[str, bytes, int, None] = None,
+        ttl: str | bytes | int | None = None,
     ):
         """
         @param suffix: An IPv6 address suffix in in RFC 2373 format.
@@ -1943,7 +1944,7 @@ class Record_HINFO(tputil.FancyStrMixin, tputil.FancyEqMixin):
         self,
         cpu: bytes = b"",
         os: bytes = b"",
-        ttl: Union[str, bytes, int, None] = None,
+        ttl: str | bytes | int | None = None,
     ):
         self.cpu, self.os = cpu, os
         self.ttl = str2time(ttl)

--- a/src/twisted/pair/tuntap.py
+++ b/src/twisted/pair/tuntap.py
@@ -15,7 +15,6 @@ import platform
 import struct
 import warnings
 from collections import namedtuple
-from typing import Tuple
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -257,7 +256,7 @@ class TuntapPort(abstract.FileDescriptor):
         self.logstr = f"{logPrefix} ({self._mode.name})"
 
     def __repr__(self) -> str:
-        args: Tuple[str, ...] = (fullyQualifiedName(self.protocol.__class__),)
+        args: tuple[str, ...] = (fullyQualifiedName(self.protocol.__class__),)
         if self.connected:
             args = args + ("",)
         else:

--- a/src/twisted/plugin.py
+++ b/src/twisted/plugin.py
@@ -10,12 +10,14 @@ Plugin system for Twisted.
 @author: Glyph Lefkowitz
 """
 
+from __future__ import annotations
 
 import os
 import pickle
 import sys
 import types
-from typing import Iterable, Optional, Type, TypeVar
+from collections.abc import Iterable
+from typing import TypeVar
 
 from zope.interface import Interface, providedBy
 
@@ -196,7 +198,7 @@ _TInterface = TypeVar("_TInterface", bound=Interface)
 
 
 def getPlugins(
-    interface: Type[_TInterface], package: Optional[types.ModuleType] = None
+    interface: type[_TInterface], package: types.ModuleType | None = None
 ) -> Iterable[_TInterface]:
     """
     Retrieve all plugins implementing the given interface beneath the given module.


### PR DESCRIPTION
## Scope and purpose

Fixes #12614 

The changes were automatically generated using `pyupgrade --py39-plus`. Since the overall diff is small in each module, I've combined them in one PR.

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Run linting


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
