### PR TITLE
#12616 test: update type annotations for Python 3.9+

### DIFF
--- a/src/twisted/test/_ca_with_intermediate.py
+++ b/src/twisted/test/_ca_with_intermediate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Tuple
 
 from cryptography.hazmat.primitives.asymmetric.rsa import (
     RSAPrivateKey,
@@ -33,7 +32,7 @@ def buildNew(validAround: datetime) -> CertificateBuilder:
     )
 
 
-def boilerplate(cn: str, ca: bool) -> Tuple[Name, RSAPrivateKey, CertificateBuilder]:
+def boilerplate(cn: str, ca: bool) -> tuple[Name, RSAPrivateKey, CertificateBuilder]:
     """
     Common boilerplate for any certificate.
     """
@@ -51,7 +50,7 @@ def boilerplate(cn: str, ca: bool) -> Tuple[Name, RSAPrivateKey, CertificateBuil
     )
 
 
-def createCA(caName: str) -> Tuple[RSAPrivateKey, Certificate]:
+def createCA(caName: str) -> tuple[RSAPrivateKey, Certificate]:
     """
     Create a CA certificate.
     """
@@ -61,7 +60,7 @@ def createCA(caName: str) -> Tuple[RSAPrivateKey, Certificate]:
 
 def createIntermediate(
     intermediateName: str, caCert: Certificate, caKey: RSAPrivateKey
-) -> Tuple[RSAPrivateKey, Certificate]:
+) -> tuple[RSAPrivateKey, Certificate]:
     """
     Create an intermediate CA certificate.
     """
@@ -73,7 +72,7 @@ def createIntermediate(
 
 def createLeaf(
     host: str, caCert: Certificate, caKey: RSAPrivateKey
-) -> Tuple[RSAPrivateKey, Certificate]:
+) -> tuple[RSAPrivateKey, Certificate]:
     """
     Create a leaf certificate for use by a server.
     """

--- a/src/twisted/test/test_adbapi.py
+++ b/src/twisted/test/test_adbapi.py
@@ -4,10 +4,10 @@
 """
 Tests for twisted.enterprise.adbapi.
 """
+from __future__ import annotations
 
 import os
 import stat
-from typing import Dict, Optional
 
 from twisted.enterprise.adbapi import (
     Connection,
@@ -32,7 +32,7 @@ class ADBAPITestBase:
     Test the asynchronous DB-API code.
     """
 
-    openfun_called: Dict[object, bool] = {}
+    openfun_called: dict[object, bool] = {}
 
     if interfaces.IReactorThreads(reactor, None) is None:
         skip = "ADB-API requires threads, no way to test without them"
@@ -338,7 +338,7 @@ class DBTestConnector:
     """
 
     # used for creating new test cases
-    TEST_PREFIX: Optional[str] = None
+    TEST_PREFIX: str | None = None
 
     DB_NAME = "twisted_test"
     DB_USER = "twisted_test"
@@ -351,7 +351,7 @@ class DBTestConnector:
     can_rollback = True  # rollback supported
     test_failures = True  # test bad sql?
     escape_slashes = True  # escape \ in sql?
-    good_sql: Optional[str] = ConnectionPool.good_sql
+    good_sql: str | None = ConnectionPool.good_sql
     early_reconnect = True  # cursor() will fail on closed connection
     can_clear = True  # can try to clear out tables when starting
 

--- a/src/twisted/test/test_amp.py
+++ b/src/twisted/test/test_amp.py
@@ -9,7 +9,7 @@ Tests for L{twisted.protocols.amp}.
 
 import datetime
 import decimal
-from typing import ClassVar, Dict, Type, TypeVar
+from typing import ClassVar, TypeVar
 from unittest import skipIf
 
 from zope.interface import implementer
@@ -136,9 +136,9 @@ class Hello(amp.Command):
 
     response = [(b"hello", amp.String()), (b"print", amp.Unicode(optional=True))]
 
-    errors: ClassVar[Dict[Type[Exception], bytes]] = {UnfriendlyGreeting: b"UNFRIENDLY"}
+    errors: ClassVar[dict[type[Exception], bytes]] = {UnfriendlyGreeting: b"UNFRIENDLY"}
 
-    fatalErrors: ClassVar[Dict[Type[Exception], bytes]] = {DeathThreat: b"DEAD"}
+    fatalErrors: ClassVar[dict[type[Exception], bytes]] = {DeathThreat: b"DEAD"}
 
 
 class NoAnswerHello(Hello):
@@ -2136,7 +2136,7 @@ class BaseCommand(amp.Command):
     This provides a command that will be subclassed.
     """
 
-    errors: ClassVar[Dict[Type[Exception], bytes]] = {
+    errors: ClassVar[dict[type[Exception], bytes]] = {
         InheritedError: b"INHERITED_ERROR"
     }
 
@@ -2155,7 +2155,7 @@ class AddErrorsCommand(BaseCommand):
     """
 
     arguments = [(b"other", amp.Boolean())]
-    errors: ClassVar[Dict[Type[Exception], bytes]] = {
+    errors: ClassVar[dict[type[Exception], bytes]] = {
         OtherInheritedError: b"OTHER_INHERITED_ERROR"
     }
 
@@ -2529,7 +2529,7 @@ _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
 
-class MyBox(Dict[_KT, _VT]):
+class MyBox(dict[_KT, _VT]):
     """
     A unique dict subclass.
     """

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -22,29 +22,13 @@ from asyncio import (
     Future,
     new_event_loop as _new_event_loop,
 )
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Dict,
-    Generator,
-    List,
-    Literal,
-    Mapping,
-    NoReturn,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from collections.abc import Coroutine, Generator, Mapping
+from typing import Any, Callable, Literal, NoReturn, TypeVar, Union, cast
 
 from hamcrest import assert_that, empty, equal_to
 from hypothesis import given
 from hypothesis.strategies import integers
-from typing_extensions import assert_type
+from typing_extensions import TypeAlias, assert_type
 
 from twisted.internet import defer, reactor
 from twisted.internet.defer import (
@@ -102,7 +86,7 @@ class ImmediateFailureMixin:
     """
 
     def assertImmediateFailure(
-        self, deferred: Deferred[Any], exception: Type[_ExceptionT]
+        self, deferred: Deferred[Any], exception: type[_ExceptionT]
     ) -> _ExceptionT:
         """
         Assert that the given Deferred current result is a Failure with the
@@ -111,7 +95,7 @@ class ImmediateFailureMixin:
         @return: The exception instance in the Deferred.
         """
         testCase = cast(unittest.TestCase, self)
-        failures: List[Failure] = []
+        failures: list[Failure] = []
         deferred.addErrback(failures.append)
         testCase.assertEqual(len(failures), 1)
         testCase.assertTrue(failures[0].check(exception))
@@ -149,7 +133,7 @@ class UtilTests(unittest.TestCase):
         """
         output = []
 
-        def emit(eventDict: Dict[str, Any]) -> None:
+        def emit(eventDict: dict[str, Any]) -> None:
             text = log.textFromEventDict(eventDict)
             assert text is not None
             output.append(text)
@@ -165,15 +149,15 @@ class UtilTests(unittest.TestCase):
 
 class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
     def setUp(self) -> None:
-        self.callbackResults: Optional[
-            Tuple[Tuple[object, ...], Dict[str, object]]
-        ] = None
-        self.callback2Results: Optional[
-            Tuple[Tuple[object, ...], Dict[str, object]]
-        ] = None
-        self.errbackResults: Optional[
-            Tuple[Tuple[Failure, ...], Dict[str, object]]
-        ] = None
+        self.callbackResults: None | (
+            tuple[tuple[object, ...], dict[str, object]]
+        ) = None
+        self.callback2Results: None | (
+            tuple[tuple[object, ...], dict[str, object]]
+        ) = None
+        self.errbackResults: None | (
+            tuple[tuple[Failure, ...], dict[str, object]]
+        ) = None
 
         # Restore the debug flag to its original state when done.
         self.addCleanup(defer.setDebugging, defer.getDebugging())
@@ -253,7 +237,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         deferred.addCallbacks(
             self._callback,
             self._errback,
-            cast(Tuple[object], None),
+            cast(tuple[object], None),
             cast(Mapping[str, object], None),
             (),
             {},
@@ -273,7 +257,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             self._errback,
             (),
             {},
-            cast(Tuple[object], None),
+            cast(tuple[object], None),
             cast(Mapping[str, object], None),
         )
         deferred.errback(error)
@@ -285,7 +269,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.assertEqual(self.errbackResults[1], {})
 
     def testDeferredList(self) -> None:
-        ResultList = List[Tuple[bool, Union[str, Failure]]]
+        ResultList: TypeAlias = list[tuple[bool, Union[str, Failure]]]
 
         defr1: Deferred[str] = Deferred()
         defr2: Deferred[str] = Deferred()
@@ -321,11 +305,11 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         )
 
     def testEmptyDeferredList(self) -> None:
-        result: List[_DeferredListResultListT[None]] = []
+        result: list[_DeferredListResultListT[None]] = []
 
         def cb(
             resultList: _DeferredListResultListT[None],
-            result: List[_DeferredListResultListT[None]] = result,
+            result: list[_DeferredListResultListT[None]] = result,
         ) -> None:
             result.append(resultList)
 
@@ -345,7 +329,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         defr2: Deferred[str] = Deferred()
         defr3: Deferred[str] = Deferred()
         dl = DeferredList([defr1, defr2, defr3], fireOnOneErrback=True)
-        result: List[Failure] = []
+        result: list[Failure] = []
         dl.addErrback(result.append)
 
         # consume errors after they pass through the DeferredList (to avoid
@@ -385,10 +369,10 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         d1: Deferred[None] = Deferred()
         dl = DeferredList([d1])
 
-        errorTrap: List[Failure] = []
+        errorTrap: list[Failure] = []
         d1.addErrback(errorTrap.append)
 
-        resultLists: List[_DeferredListResultListT[None]] = []
+        resultLists: list[_DeferredListResultListT[None]] = []
         dl.addCallback(resultLists.append)
 
         d1.errback(GenericError("Bang"))
@@ -402,10 +386,10 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         d1: Deferred[None] = Deferred()
         dl = DeferredList([d1], consumeErrors=True)
 
-        errorTrap: List[Failure] = []
+        errorTrap: list[Failure] = []
         d1.addErrback(errorTrap.append)
 
-        resultLists: List[_DeferredListResultListT[None]] = []
+        resultLists: list[_DeferredListResultListT[None]] = []
         dl.addCallback(resultLists.append)
 
         d1.errback(GenericError("Bang"))
@@ -423,7 +407,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
 
         # *Then* build the DeferredList, with fireOnOneErrback=True
         dl = DeferredList([d1, d2], fireOnOneErrback=True)
-        result: List[Failure] = []
+        result: list[Failure] = []
         dl.addErrback(result.append)
         self.assertEqual(1, len(result))
 
@@ -439,7 +423,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         # *Then* build the DeferredList
         dl = DeferredList([d1, d2])
 
-        result: List[List[Tuple[bool, int]]] = []
+        result: list[list[tuple[bool, int]]] = []
         dl.addCallback(result.append)
 
         self.assertEqual(1, len(result))
@@ -603,7 +587,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.failureResultOf(deferredList, defer.FirstError)
 
     def testImmediateSuccess(self) -> None:
-        l: List[str] = []
+        l: list[str] = []
         d: Deferred[str] = defer.succeed("success")
         d.addCallback(l.append)
         self.assertEqual(l, ["success"])
@@ -618,13 +602,13 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.assertEqual(d.__dict__, d2.__dict__)
 
     def testImmediateFailure(self) -> None:
-        l: List[Failure] = []
+        l: list[Failure] = []
         d: Deferred[None] = defer.fail(GenericError("fail"))
         d.addErrback(l.append)
         self.assertEqual(str(l[0].value), "fail")
 
     def testPausedFailure(self) -> None:
-        l: List[Failure] = []
+        l: list[Failure] = []
         d = defer.fail(GenericError("fail"))
         d.pause()
         d.addErrback(l.append)
@@ -633,7 +617,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         self.assertEqual(str(l[0].value), "fail")
 
     def testCallbackErrors(self) -> None:
-        l: List[Failure] = []
+        l: list[Failure] = []
         d: Deferred[int] = Deferred()
         d.addCallback(lambda _: 1 // 0).addErrback(l.append)
         d.callback(1)
@@ -686,7 +670,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         shouldFail = False
         rte = RuntimeError()
 
-        def maybeFail(result: int) -> Union[int, Failure]:
+        def maybeFail(result: int) -> int | Failure:
             # testing the Union return annotation here
             if shouldFail:
                 return Failure(rte)
@@ -719,7 +703,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         def asyncErrback(result: Failure) -> Deferred[str]:
             return d2
 
-        def syncCallback(result: Union[str, int]) -> None:
+        def syncCallback(result: str | int) -> None:
             resultValues.append(result)
 
         d.addErrback(asyncErrback).addCallback(syncCallback)
@@ -743,7 +727,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         chained.addCallback(lambda ignored: paused)
         chained.callback(None)
 
-        result: List[object] = []
+        result: list[object] = []
         chained.addCallback(result.append)
         self.assertEqual(result, [])
         paused.unpause()
@@ -761,19 +745,19 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         first.callback(None)
         first.pause()
         second.callback(None)
-        result: List[None] = []
+        result: list[None] = []
         second.addCallback(result.append)
         self.assertEqual(result, [None])
 
     def test_gatherResults(self) -> None:
         # test successful list of deferreds
-        results: List[List[int]] = []
+        results: list[list[int]] = []
         defer.gatherResults([defer.succeed(1), defer.succeed(2)]).addCallback(
             results.append
         )
         self.assertEqual(results, [[1, 2]])
         # test failing list of deferreds
-        errors: List[Failure] = []
+        errors: list[Failure] = []
         dl = [defer.succeed(1), defer.fail(ValueError())]
         defer.gatherResults(dl).addErrback(errors.append)
         self.assertEqual(len(errors), 1)
@@ -791,9 +775,9 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         dgood = defer.succeed(1)
         dbad = defer.fail(RuntimeError("oh noes"))
         d = defer.gatherResults([dgood, dbad], consumeErrors=True)
-        unconsumedErrors: List[Failure] = []
+        unconsumedErrors: list[Failure] = []
         dbad.addErrback(unconsumedErrors.append)
-        gatheredErrors: List[Failure] = []
+        gatheredErrors: list[Failure] = []
         d.addErrback(gatheredErrors.append)
 
         self.assertEqual((len(unconsumedErrors), len(gatheredErrors)), (0, 1))
@@ -837,8 +821,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         function and pass it to its resulting L{Deferred}.
         """
         result = object()
-        results: List[object] = []
-        errors: List[Failure] = []
+        results: list[object] = []
+        errors: list[Failure] = []
         d = defer.maybeDeferred(lambda: result)
         d.addCallbacks(results.append, errors.append)
         self.assertEqual(errors, [])
@@ -853,8 +837,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         def plusFive(x: int) -> int:
             return x + 5
 
-        results: List[int] = []
-        errors: List[Failure] = []
+        results: list[int] = []
+        errors: list[Failure] = []
         d = defer.maybeDeferred(plusFive, 10)
         assert_type(d, Deferred[int])
         d.addCallbacks(results.append, errors.append)
@@ -871,8 +855,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         def raisesException() -> NoReturn:
             raise expected
 
-        results: List[int] = []
-        errors: List[Failure] = []
+        results: list[int] = []
+        errors: list[Failure] = []
         defer.maybeDeferred(raisesException).addCallbacks(results.append, errors.append)
         self.assertEqual(results, [])
         self.assertEqual(len(errors), 1)
@@ -888,8 +872,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         except TypeError:
             expected = Failure()
 
-        results: List[int] = []
-        errors: List[Failure] = []
+        results: list[int] = []
+        errors: list[Failure] = []
         d = defer.maybeDeferred(lambda: expected)
         d.addCallbacks(results.append, errors.append)
         self.assertEqual(results, [])
@@ -904,7 +888,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         d1: Deferred[str] = Deferred()
         d2 = defer.maybeDeferred(lambda: d1)
         d1.callback("Success")
-        result: List[str] = []
+        result: list[str] = []
         d2.addCallback(result.append)
         self.assertEqual(result, ["Success"])
 
@@ -988,8 +972,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         callbacks are executed after the third L{Deferred} fires and before the
         first receives a result.
         """
-        results: List[Union[Tuple[str, str], str]] = []
-        failures: List[Failure] = []
+        results: list[tuple[str, str] | str] = []
+        failures: list[Failure] = []
         inner: Deferred[str] = Deferred()
 
         def cb(result: str) -> Deferred[str]:
@@ -1032,19 +1016,19 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         checking that we search for that callback among the whole list of
         callbacks.
         """
-        results: List[Tuple[str, Union[str, List[str], None]]] = []
-        failures: List[Failure] = []
+        results: list[tuple[str, str | list[str] | None]] = []
+        failures: list[Failure] = []
         a: Deferred[str] = Deferred()
 
         def cb(result: str) -> Deferred[None]:
             results.append(("cb", result))
             d: Deferred[None] = Deferred()
 
-            def firstCallback(result: None) -> Deferred[List[str]]:
+            def firstCallback(result: None) -> Deferred[list[str]]:
                 results.append(("firstCallback", result))
                 return defer.gatherResults([a])
 
-            def secondCallback(result: List[str]) -> None:
+            def secondCallback(result: list[str]) -> None:
                 results.append(("secondCallback", result))
 
             returner = (
@@ -1070,19 +1054,19 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         another L{Deferred} as a result is run after the callbacks of the other
         L{Deferred} are run.
         """
-        results: List[Tuple[str, Union[str, List[str], None]]] = []
-        failures: List[Failure] = []
+        results: list[tuple[str, str | list[str] | None]] = []
+        failures: list[Failure] = []
         a: Deferred[str] = Deferred()
 
         def cb(result: str) -> Deferred[None]:
             results.append(("cb", result))
             d: Deferred[None] = Deferred()
 
-            def firstCallback(result: None) -> Deferred[List[str]]:
+            def firstCallback(result: None) -> Deferred[list[str]]:
                 results.append(("firstCallback", result))
                 return defer.gatherResults([a])
 
-            def secondCallback(result: List[str]) -> None:
+            def secondCallback(result: list[str]) -> None:
                 results.append(("secondCallback", result))
 
             returner = (
@@ -1187,7 +1171,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second.addCallback(lambda ign: first)
         second.callback(None)
 
-        results: List[Optional[object]] = []
+        results: list[object | None] = []
         first.addCallback(results.append)
         self.assertIsNone(results[0])
         second.addCallback(results.append)
@@ -1205,9 +1189,9 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second.addCallback(lambda ign: first)
         second.callback(None)
 
-        firstResult: List[object] = []
+        firstResult: list[object] = []
         first.addCallback(firstResult.append)
-        secondResult: List[object] = []
+        secondResult: list[object] = []
         second.addCallback(secondResult.append)
 
         self.assertEqual(firstResult, [])
@@ -1234,7 +1218,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second: Deferred[None] = Deferred()
         second.addCallback(cb)
         second.callback(None)
-        firstResult: List[None] = []
+        firstResult: list[None] = []
         first.addCallback(firstResult.append)
         self.assertIsNone(firstResult[0])
         self.assertImmediateFailure(second, RuntimeError)
@@ -1252,12 +1236,12 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second: Deferred[None] = Deferred()
         second.addCallback(lambda ign: first)
         second.callback(None)
-        secondError: List[Failure] = []
+        secondError: list[Failure] = []
         second.addErrback(secondError.append)
 
-        firstResult: List[None] = []
+        firstResult: list[None] = []
         first.addCallback(firstResult.append)
-        secondResult: List[None] = []
+        secondResult: list[None] = []
         second.addCallback(secondResult.append)
 
         self.assertEqual(firstResult, [])
@@ -1282,7 +1266,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         third: Deferred[object] = Deferred()
         third.addCallback(lambda ign: second)
 
-        thirdResult: List[object] = []
+        thirdResult: list[object] = []
         third.addCallback(thirdResult.append)
 
         result = object()
@@ -1305,8 +1289,8 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         When these "inner" L{Deferred}s fire (even asynchronously), the
         callback chain continues.
         """
-        results: List[Union[Tuple[str, str], str]] = []
-        failures: List[Failure] = []
+        results: list[tuple[str, str] | str] = []
+        failures: list[Failure] = []
 
         # A Deferred returned in the inner callback.
         inner: Deferred[str] = Deferred()
@@ -1368,30 +1352,30 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         L{Deferred}s fire (even asynchronously), the outer callback chain
         continues.
         """
-        results: List[Any] = []
-        failures: List[Failure] = []
+        results: list[Any] = []
+        failures: list[Failure] = []
 
         # A Deferred returned in the inner callback after a callback is
         # added explicitly and directly to it.
         inner: Deferred[str] = Deferred()
 
-        def cb(result: str) -> Deferred[Optional[List[str]]]:
+        def cb(result: str) -> Deferred[list[str] | None]:
             results.append(("start-of-cb", result))
             d = defer.succeed("inner")
 
-            def firstCallback(result: str) -> Deferred[List[str]]:
+            def firstCallback(result: str) -> Deferred[list[str]]:
                 results.append(("firstCallback", result))
                 # Return a Deferred that definitely has not fired yet with a
                 # result-transforming callback so we can fire the Deferreds
                 # out of order and see how the callback affects the ultimate
                 # results.
 
-                def transform(result: str) -> List[str]:
+                def transform(result: str) -> list[str]:
                     return [result]
 
                 return inner.addCallback(transform)
 
-            def secondCallback(result: List[str]) -> List[str]:
+            def secondCallback(result: list[str]) -> list[str]:
                 results.append(("secondCallback", result))
                 return result * 2
 
@@ -1559,7 +1543,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
                 stack.append(len(traceback.extract_stack()))
 
             top: Deferred[None] = Deferred()
-            innerDeferreds: List[Deferred[None]] = [
+            innerDeferreds: list[Deferred[None]] = [
                 Deferred() for ignored in range(howMany)
             ]
             originalInners = innerDeferreds[:]
@@ -1624,7 +1608,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second.callback(None)
         first.callback(None)
         third.callback(None)
-        results: List[None] = []
+        results: list[None] = []
         second.addCallback(results.append)
         self.assertEqual(results, [None])
 
@@ -1636,7 +1620,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         """
         defer.setDebugging(False)
         d: Deferred[None] = Deferred()
-        l: List[Failure] = []
+        l: list[Failure] = []
         exc = GenericError("Bang")
         try:
             raise exc
@@ -1657,7 +1641,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         """
         defer.setDebugging(True)
         d: Deferred[None] = Deferred()
-        l: List[Failure] = []
+        l: list[Failure] = []
         exc = GenericError("Bang")
         try:
             raise exc
@@ -1683,7 +1667,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             raise GenericError("Bang")
 
         d.addCallback(raiseError)
-        l: List[Failure] = []
+        l: list[Failure] = []
         d.addErrback(l.append)
         fail = l[0]
         localz, globalz = fail.frames[0][-2:]
@@ -1703,7 +1687,7 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             raise GenericError("Bang")
 
         d.addCallback(raiseError)
-        l: List[Failure] = []
+        l: list[Failure] = []
         d.addErrback(l.append)
         fail = l[0]
         localz, globalz = fail.frames[0][-2:]
@@ -1858,7 +1842,7 @@ class DummyCanceller:
     to support GC related tests.
     """
 
-    deferred: Optional[Deferred[Any]] = None
+    deferred: Deferred[Any] | None = None
 
     def __call__(self, deferred: Deferred[Any]) -> None:  # pragma: no cover
         """
@@ -2126,7 +2110,7 @@ class AlreadyCalledTests(unittest.SynchronousTestCase):
         self._err_1(d)
         self.assertRaises(defer.AlreadyCalledError, self._call_2, d)
 
-    def _count(self, linetype: str, func: str, lines: List[str], expected: int) -> None:
+    def _count(self, linetype: str, func: str, lines: list[str], expected: int) -> None:
         count = 0
         for line in lines:
             if line.startswith(" %s:" % linetype) and line.endswith(" %s" % func):
@@ -2221,9 +2205,9 @@ class AlreadyCalledTests(unittest.SynchronousTestCase):
 
 class DeferredCancellerTests(unittest.SynchronousTestCase):
     def setUp(self) -> None:
-        self.callbackResults: Optional[str] = None
-        self.errbackResults: Optional[Failure] = None
-        self.callback2Results: Optional[str] = None
+        self.callbackResults: str | None = None
+        self.errbackResults: Failure | None = None
+        self.callback2Results: str | None = None
         self.cancellerCallCount = 0
 
     def tearDown(self) -> None:
@@ -2494,7 +2478,7 @@ class LogTests(unittest.SynchronousTestCase):
         """
         Add a custom observer to observer logging.
         """
-        self.c: List[Dict[str, Any]] = []
+        self.c: list[dict[str, Any]] = []
         log.addObserver(self.c.append)
 
     def tearDown(self) -> None:
@@ -2503,7 +2487,7 @@ class LogTests(unittest.SynchronousTestCase):
         """
         log.removeObserver(self.c.append)
 
-    def _loggedErrors(self) -> List[Dict[str, Any]]:
+    def _loggedErrors(self) -> list[dict[str, Any]]:
         return [e for e in self.c if e["isError"]]
 
     def _check(self) -> None:
@@ -2616,8 +2600,8 @@ class LogTests(unittest.SynchronousTestCase):
 
         # Sanity check - this isn't too interesting, but we do want the original
         # Deferred to have gotten the failure.
-        results: List[None] = []
-        errors: List[Failure] = []
+        results: list[None] = []
+        errors: list[Failure] = []
         d.addCallbacks(results.append, errors.append)
         self.assertEqual(results, [])
         self.assertEqual(len(errors), 1)
@@ -2639,8 +2623,8 @@ class LogTests(unittest.SynchronousTestCase):
         not logged.
         """
         # Start off with a Deferred with a failure for a result
-        bad: Optional[Deferred[None]] = defer.fail(Exception("oh no"))
-        good: Optional[Deferred[None]] = Deferred()
+        bad: Deferred[None] | None = defer.fail(Exception("oh no"))
+        good: Deferred[None] | None = Deferred()
         # Give it a callback that chains it to another Deferred
         assert bad is not None
         bad.addErrback(lambda ignored: good)
@@ -2660,7 +2644,7 @@ class DeferredListEmptyTests(unittest.SynchronousTestCase):
         dl: Deferred[_DeferredListResultListT[object]] = DeferredList([])
         dl.addCallback(self.cb_empty)
 
-    def cb_empty(self, res: List[Tuple[bool, object]]) -> None:
+    def cb_empty(self, res: list[tuple[bool, object]]) -> None:
         self.callbackRan = 1
         self.assertEqual([], res)
 
@@ -2700,7 +2684,7 @@ class OtherPrimitivesTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
 
         controlDeferred: Deferred[object] = Deferred()
 
-        result: Optional[object] = None
+        result: object | None = None
 
         def helper(resultValue: object, returnValue: object = None) -> object:
             nonlocal result
@@ -2780,7 +2764,7 @@ class OtherPrimitivesTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             helperArg = arg
             return controlDeferred
 
-        results: List[object] = []
+        results: list[object] = []
         uniqueObject = object()
         resultDeferred = sem.run(helper, arg=uniqueObject)
         resultDeferred.addCallback(results.append)
@@ -2856,7 +2840,7 @@ class OtherPrimitivesTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         N, M = 2, 2
         queue: DeferredQueue[int] = DeferredQueue(N, M)
 
-        gotten: List[int] = []
+        gotten: list[int] = []
 
         for i in range(M):
             queue.get().addCallback(gotten.append)
@@ -2923,7 +2907,7 @@ class OtherPrimitivesTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
             return queue.get().addCallback(self.assertIs, None)
 
         d.addCallback(cb)
-        done: List[None] = []
+        done: list[None] = []
         d.addCallback(done.append)
         self.assertEqual(len(done), 1)
 
@@ -3090,7 +3074,7 @@ class DeferredAddTimeoutTests(unittest.SynchronousTestCase):
         # addTimeout is added first so that if d is timed out, d would be
         # canceled before innerDeferred gets returned from an callback on d
         innerDeferred: Deferred[None] = Deferred()
-        dCallbacked: Optional[str] = None
+        dCallbacked: str | None = None
 
         def onCallback(results: str) -> Deferred[None]:
             nonlocal dCallbacked
@@ -3124,7 +3108,7 @@ class DeferredAddTimeoutTests(unittest.SynchronousTestCase):
         # addTimeout is added first so that if d is timed out, d would be
         # canceled before innerDeferred gets returned from an callback on d
         innerDeferred: Deferred[None] = Deferred()
-        dCallbacked: Optional[str] = None
+        dCallbacked: str | None = None
 
         def onCallback(results: str) -> Deferred[None]:
             nonlocal dCallbacked
@@ -3157,7 +3141,7 @@ class DeferredAddTimeoutTests(unittest.SynchronousTestCase):
         # addTimeout is added first so that if d is timed out, d would be
         # canceled before innerDeferred gets returned from an errback on d
         innerDeferred: Deferred[None] = Deferred()
-        dErrbacked: Optional[Failure] = None
+        dErrbacked: Failure | None = None
         error = ValueError("fail")
 
         def onErrback(f: Failure) -> Deferred[None]:
@@ -3193,7 +3177,7 @@ class DeferredAddTimeoutTests(unittest.SynchronousTestCase):
         # addTimeout is added first so that if d is timed out, d would be
         # canceled before innerDeferred gets returned from an errback on d
         innerDeferred: Deferred[None] = Deferred()
-        dErrbacked: Optional[Failure] = None
+        dErrbacked: Failure | None = None
         error = ValueError("fail")
 
         def onErrback(f: Failure) -> Deferred[None]:
@@ -4030,7 +4014,7 @@ class InlineCallbackTests(unittest.SynchronousTestCase):
         """
 
         # Create an object and weak reference to track if its gotten freed.
-        obj: Set[Any] = set()
+        obj: set[Any] = set()
         objWeakRef = weakref.ref(obj)
 
         async def func(a: Any) -> Any:

--- a/src/twisted/test/test_error.py
+++ b/src/twisted/test/test_error.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import errno
 import socket
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 from twisted.internet import error
 from twisted.trial import unittest

--- a/src/twisted/test/test_failure.py
+++ b/src/twisted/test/test_failure.py
@@ -12,11 +12,12 @@ import pickle
 import re
 import sys
 import traceback
+from collections.abc import Generator
 from dis import distb
 from io import StringIO
 from traceback import FrameSummary
 from types import TracebackType
-from typing import Any, Generator, cast
+from typing import Any, cast
 from unittest import skipIf
 
 from cython_test_exception_raiser import raiser
@@ -938,7 +939,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
         """
         stuff = []
 
-        def generator() -> Generator[None, None, None]:
+        def generator() -> Generator[None]:
             try:
                 yield
             except BaseException:
@@ -969,7 +970,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
 
         newFailures = []
 
-        def generator() -> Generator[None, None, None]:
+        def generator() -> Generator[None]:
             try:
                 yield
             except BaseException:
@@ -999,7 +1000,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
         original one.
         """
 
-        def generator() -> Generator[None, None, None]:
+        def generator() -> Generator[None]:
             try:
                 try:
                     yield
@@ -1020,7 +1021,7 @@ class ExtendedGeneratorTests(SynchronousTestCase):
         original one.
         """
 
-        def generator() -> Generator[None, None, None]:
+        def generator() -> Generator[None]:
             try:
                 yield
             except BaseException:

--- a/src/twisted/test/test_formmethod.py
+++ b/src/twisted/test/test_formmethod.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 Test cases for formmethod module.
 """
 
-from typing import Callable, Iterable
+from collections.abc import Iterable
+from typing import Callable
 
 from typing_extensions import Concatenate, ParamSpec
 

--- a/src/twisted/test/test_iutils.py
+++ b/src/twisted/test/test_iutils.py
@@ -39,7 +39,7 @@ class ProcessUtilsTests(TestCase):
         path to it.
         """
         script = self.mktemp()
-        with open(script, "wt") as scriptFile:
+        with open(script, "w") as scriptFile:
             scriptFile.write(os.linesep.join(sourceLines) + os.linesep)
         return os.path.abspath(script)
 

--- a/src/twisted/test/test_log.py
+++ b/src/twisted/test/test_log.py
@@ -13,7 +13,7 @@ import sys
 import time
 import warnings
 from io import IOBase, StringIO
-from typing import Callable, List, Protocol
+from typing import Callable, Protocol
 
 from zope.interface import implementer
 
@@ -293,7 +293,7 @@ class LogTests(unittest.SynchronousTestCase):
         self.assertIsInstance(errors[0], RuntimeError)
 
 
-class FakeFile(List[bytes]):
+class FakeFile(list[bytes]):
     def write(self, bytes: bytes) -> None:
         self.append(bytes)
 

--- a/src/twisted/test/test_modules.py
+++ b/src/twisted/test/test_modules.py
@@ -11,9 +11,10 @@ import compileall
 import itertools
 import sys
 import zipfile
+from collections.abc import Generator
 from importlib.abc import PathEntryFinder
 from types import ModuleType
-from typing import Any, Generator, Protocol
+from typing import Any, Protocol
 
 import twisted
 from twisted.python import modules
@@ -26,9 +27,7 @@ from twisted.trial.unittest import TestCase
 
 
 class _SupportsWalkModules(Protocol):
-    def walkModules(
-        self, importPackages: bool
-    ) -> Generator[modules.PythonModule, None, None]:
+    def walkModules(self, importPackages: bool) -> Generator[modules.PythonModule]:
         ...
 
 

--- a/src/twisted/test/test_paths.py
+++ b/src/twisted/test/test_paths.py
@@ -16,18 +16,7 @@ import sys
 import time
 from functools import total_ordering
 from pprint import pformat
-from typing import (
-    IO,
-    AnyStr,
-    Callable,
-    Dict,
-    List,
-    NoReturn,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import IO, AnyStr, Callable, NoReturn, TypeVar
 from unittest import skipIf
 
 from zope.interface.verify import verifyObject
@@ -210,7 +199,7 @@ class AbstractFilePathTests(BytesTestCase):
         with their string counterparts.
         """
         f1 = self.path.child(b"file1")
-        dictoid: Dict[Union[filepath.FilePath[bytes], bytes], str] = {f1: "hello"}
+        dictoid: dict[filepath.FilePath[bytes] | bytes, str] = {f1: "hello"}
         dictoid[f1.path] = "goodbye"
         self.assertEqual(len(dictoid), 2)
 
@@ -256,7 +245,7 @@ class FakeWindowsPath(filepath.FilePath[AnyStr]):
     A test version of FilePath which overrides listdir to raise L{WindowsError}.
     """
 
-    def listdir(self) -> List[AnyStr]:
+    def listdir(self) -> list[AnyStr]:
         """
         @raise WindowsError: always.
         """
@@ -379,17 +368,16 @@ class TrackingFilePath(filepath.FilePath[AnyStr]):
         self,
         path: AnyStr,
         alwaysCreate: bool = False,
-        trackingList: Optional[
-            List[Union[TrackingFilePath[str], TrackingFilePath[bytes]]]
-        ] = None,
+        trackingList: None
+        | (list[TrackingFilePath[str] | TrackingFilePath[bytes]]) = None,
     ) -> None:
         filepath.FilePath.__init__(self, path, alwaysCreate)
         if trackingList is None:
             trackingList = []
-        self.trackingList: List[
-            Union[TrackingFilePath[str], TrackingFilePath[bytes]]
+        self.trackingList: list[
+            TrackingFilePath[str] | TrackingFilePath[bytes]
         ] = trackingList
-        self.openedFiles: List[IO[bytes]] = []
+        self.openedFiles: list[IO[bytes]] = []
 
     def open(self, mode: FileMode = "r") -> IO[bytes]:
         """
@@ -401,7 +389,7 @@ class TrackingFilePath(filepath.FilePath[AnyStr]):
 
     def openedPaths(
         self,
-    ) -> List[Union[TrackingFilePath[str], TrackingFilePath[bytes]]]:
+    ) -> list[TrackingFilePath[str] | TrackingFilePath[bytes]]:
         """
         Return a list of all L{TrackingFilePath}s associated with this
         L{TrackingFilePath} that have had their C{open()} method called.
@@ -434,9 +422,8 @@ class ExplodingFilePath(filepath.FilePath[AnyStr]):
     def __init__(
         self,
         pathName: AnyStr,
-        originalExploder: Optional[
-            Union[ExplodingFilePath[str], ExplodingFilePath[bytes]]
-        ] = None,
+        originalExploder: None
+        | (ExplodingFilePath[str] | ExplodingFilePath[bytes]) = None,
     ) -> None:
         """
         Initialize an L{ExplodingFilePath} with a name and a reference to the
@@ -478,9 +465,7 @@ class PermissionsTests(BytesTestCase):
     Test Permissions and RWX classes
     """
 
-    def assertNotUnequal(
-        self, first: T, second: object, msg: Optional[str] = None
-    ) -> T:
+    def assertNotUnequal(self, first: T, second: object, msg: str | None = None) -> T:
         """
         Tests that C{first} != C{second} is false.  This method tests the
         __ne__ method, as opposed to L{assertEqual} (C{first} == C{second}),
@@ -707,7 +692,7 @@ class FilePathTests(AbstractFilePathTests):
             self.path.child(b"sub1").child(b"sub1.loopylink").path,
         )
 
-        def iterateOverPath() -> List[bytes]:
+        def iterateOverPath() -> list[bytes]:
             return [foo.path for foo in self.path.walk()]
 
         self.assertRaises(filepath.LinkError, iterateOverPath)
@@ -729,7 +714,7 @@ class FilePathTests(AbstractFilePathTests):
         def noSymLinks(path: filepath.FilePath[bytes]) -> bool:
             return not path.islink()
 
-        def iterateOverPath() -> List[bytes]:
+        def iterateOverPath() -> list[bytes]:
             return [foo.path for foo in self.path.walk(descend=noSymLinks)]
 
         self.assertTrue(iterateOverPath())
@@ -1151,7 +1136,7 @@ class FilePathTests(AbstractFilePathTests):
             (OSError, IOError), self.path.moveTo, self.path.child(b"file1")
         )
 
-    def setUpFaultyRename(self) -> List[Tuple[str, str]]:
+    def setUpFaultyRename(self) -> list[tuple[str, str]]:
         """
         Set up a C{os.rename} that will fail with L{errno.EXDEV} on first call.
         This is used to simulate a cross-device rename failure.

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -8,7 +8,9 @@ import io
 import pickle
 import sys
 import textwrap
-from typing import Any, Callable, List, NoReturn, Tuple
+from typing import Any, Callable, NoReturn
+
+from typing_extensions import TypeAlias
 
 # Twisted Imports
 from twisted.persisted import aot, crefutil, styles
@@ -337,7 +339,7 @@ class NonDictState:
         self.state = state
 
 
-_CircularTupleType = List[Tuple["_CircularTupleType", int]]
+_CircularTupleType: TypeAlias = list[tuple["_CircularTupleType", int]]
 
 
 class AOTTests(TestCase):

--- a/src/twisted/test/test_postfix.py
+++ b/src/twisted/test/test_postfix.py
@@ -5,8 +5,6 @@
 Test cases for twisted.protocols.postfix module.
 """
 
-from typing import Dict, List, Tuple
-
 from twisted.internet.testing import StringTransport
 from twisted.protocols import postfix
 from twisted.trial import unittest
@@ -41,11 +39,11 @@ class PostfixTCPMapQuoteTests(unittest.TestCase):
 
 
 class PostfixTCPMapServerTestCase:
-    data: Dict[bytes, bytes] = {
+    data: dict[bytes, bytes] = {
         # 'key': 'value',
     }
 
-    chat: List[Tuple[bytes, bytes]] = [
+    chat: list[tuple[bytes, bytes]] = [
         # (input, expected_output),
     ]
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -12,8 +12,8 @@ import datetime
 import gc
 import itertools
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 from weakref import ref
 
 from zope.interface import implementer

--- a/src/twisted/test/test_udp.py
+++ b/src/twisted/test/test_udp.py
@@ -889,7 +889,7 @@ class MulticastTestsIPv6(MulticastTests):
     clientAddress: str = "::1"
     multicastGroup: str = "ff03::1"
     alternateInterface: str | int = next(
-        (idxnm[0] for idxnm in if_nameindex() if idxnm[1].startswith("lo"))
+        idxnm[0] for idxnm in if_nameindex() if idxnm[1].startswith("lo")
     )
     interfaceSynonym: str | int = alternateInterface
     invalidGroup: str = "::1"


### PR DESCRIPTION
## Scope and purpose

Fixes #12616

The changes were automatically generated using `pyupgrade --py39-plus`.

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)
* Added `TypeAlias` annotation where appropriate.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
