### PR TITLE
#12618 persisted/positioning/and more: update type annotations for Python 3.9+ 

### DIFF
--- a/src/twisted/persisted/dirdbm.py
+++ b/src/twisted/persisted/dirdbm.py
@@ -22,7 +22,8 @@ import base64
 import glob
 import os
 import pickle
-from typing import AnyStr, Iterable, Mapping, TypeVar, overload
+from collections.abc import Iterable, Mapping
+from typing import AnyStr, TypeVar, overload
 
 from twisted.python.filepath import FilePath
 

--- a/src/twisted/persisted/styles.py
+++ b/src/twisted/persisted/styles.py
@@ -12,12 +12,11 @@ import inspect
 import pickle
 import types
 from io import StringIO as _cStringIO
-from typing import Dict
 
 from twisted.python import log, reflect
 from twisted.python.compat import _PYPY
 
-oldModules: Dict[str, types.ModuleType] = {}
+oldModules: dict[str, types.ModuleType] = {}
 
 
 _UniversalPicklingError = pickle.PicklingError
@@ -241,7 +240,7 @@ class Ephemeral:
         self.__class__ = Ephemeral
 
 
-versionedsToUpgrade: Dict[int, "Versioned"] = {}
+versionedsToUpgrade: dict[int, "Versioned"] = {}
 upgraded = {}
 
 

--- a/src/twisted/plugins/__init__.py
+++ b/src/twisted/plugins/__init__.py
@@ -14,9 +14,7 @@ the __path__ variable.
 @author: Glyph Lefkowitz
 """
 
-from typing import List
-
 from twisted.plugin import pluginPackagePaths
 
 __path__.extend(pluginPackagePaths(__name__))
-__all__: List[str] = []  # nothing to see here, move along, move along
+__all__: list[str] = []  # nothing to see here, move along, move along

--- a/src/twisted/positioning/_sentence.py
+++ b/src/twisted/positioning/_sentence.py
@@ -3,7 +3,6 @@
 """
 Generic sentence handling tools: hopefully reusable.
 """
-from typing import Set
 
 
 class _BaseSentence:
@@ -35,7 +34,7 @@ class _BaseSentence:
     @type ALLOWED_ATTRIBUTES: C{set} of C{str}
     """
 
-    ALLOWED_ATTRIBUTES: Set[str] = set()
+    ALLOWED_ATTRIBUTES: set[str] = set()
 
     def __init__(self, sentenceData):
         """

--- a/src/twisted/positioning/base.py
+++ b/src/twisted/positioning/base.py
@@ -8,9 +8,10 @@ Generic positioning base classes.
 """
 
 
+from collections.abc import Sequence
 from functools import partial
 from operator import attrgetter
-from typing import ClassVar, Sequence
+from typing import ClassVar
 
 from zope.interface import implementer
 

--- a/src/twisted/positioning/test/test_nmea.py
+++ b/src/twisted/positioning/test/test_nmea.py
@@ -6,8 +6,9 @@ Test cases for using NMEA sentences.
 from __future__ import annotations
 
 import datetime
+from collections.abc import Iterable
 from operator import attrgetter
-from typing import Callable, Iterable, Literal, Protocol, TypedDict
+from typing import Callable, Literal, Protocol, TypedDict
 
 from zope.interface import implementer
 

--- a/src/twisted/scripts/trial.py
+++ b/src/twisted/scripts/trial.py
@@ -2,6 +2,7 @@
 # Copyright (c) Twisted Matrix Laboratories.
 # See LICENSE for details.
 
+from __future__ import annotations
 
 import gc
 import inspect
@@ -12,7 +13,7 @@ import sys
 import time
 import trace
 import warnings
-from typing import Callable, NoReturn, Optional, Type
+from typing import Callable, NoReturn
 
 from twisted import plugin
 from twisted.application import app
@@ -57,7 +58,7 @@ def _autoJobs() -> int:
 
     @returns: A strictly positive integer.
     """
-    number: Optional[int]
+    number: int | None
     process_cpu_count: Callable[[], int | None] | None
     sched_getaffinity: Callable[[int], set[int]] | None
     if process_cpu_count := getattr(os, "process_cpu_count", None):
@@ -270,7 +271,7 @@ class _BasicOptions:
         ],
     )
 
-    tracer: Optional[trace.Trace] = None
+    tracer: trace.Trace | None = None
 
     def __init__(self):
         self["tests"] = []
@@ -627,7 +628,7 @@ def _makeRunner(config: Options) -> runner._Runner:
 
     @return: A trial runner instance.
     """
-    cls: Type[runner._Runner] = runner.TrialRunner
+    cls: type[runner._Runner] = runner.TrialRunner
     args = {
         "reporterFactory": config["reporter"],
         "tracebackFormat": config["tbformat"],

--- a/src/twisted/spread/test/test_pb.py
+++ b/src/twisted/spread/test/test_pb.py
@@ -19,7 +19,6 @@ import time
 import weakref
 from collections import deque
 from io import BytesIO as StringIO
-from typing import Dict
 
 from zope.interface import Interface, implementer
 
@@ -279,7 +278,7 @@ class SimpleFactoryCopy(pb.Copyable):
     @type allIDs: C{dict}
     """
 
-    allIDs: Dict[int, "SimpleFactoryCopy"] = {}
+    allIDs: dict[int, "SimpleFactoryCopy"] = {}
 
     def __init__(self, id):
         self.id = id

--- a/src/twisted/words/im/basesupport.py
+++ b/src/twisted/words/im/basesupport.py
@@ -7,8 +7,6 @@
 
 You will find these useful if you're adding a new protocol to IM.
 """
-from typing import Type
-
 from twisted.internet import error
 from twisted.internet.protocol import Protocol, connectionDone
 from twisted.persisted import styles
@@ -95,7 +93,7 @@ class AbstractClientMixin:
     @ivar _logonDeferred: Fired when I am done logging in.
     """
 
-    _protoBase: Type[Protocol] = None  # type: ignore[assignment]
+    _protoBase: type[Protocol] = None  # type: ignore[assignment]
 
     def __init__(self, account, chatui, logonDeferred):
         for base in self.__class__.__bases__:

--- a/src/twisted/words/tap.py
+++ b/src/twisted/words/tap.py
@@ -4,10 +4,11 @@
 """
 Shiny new words service maker
 """
+from __future__ import annotations
 
 import socket
 import sys
-from typing import List, Optional, Sequence
+from collections.abc import Sequence
 
 from twisted import plugin
 from twisted.application import strports
@@ -19,7 +20,7 @@ from twisted.words import iwords, service
 
 class Options(usage.Options, strcred.AuthOptionMixin):
     supportedInterfaces = [credentials.IUsernamePassword]
-    optParameters: List[Sequence[Optional[str]]] = [
+    optParameters: list[Sequence[str | None]] = [
         (
             "hostname",
             None,


### PR DESCRIPTION
## Scope and purpose

Fixes #12618 

The changes were automatically generated using `pyupgrade --py39-plus`.

The following folders are updated:

* persisted
* plugins
* positioning
* spread
* scripts
* words

Since the overall diff is very small, I've grouped these together in a single pull request.

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
