### PR TITLE
#12622 trial: update type annotations for Python 3.9+

### DIFF
--- a/src/twisted/trial/_asyncrunner.py
+++ b/src/twisted/trial/_asyncrunner.py
@@ -5,12 +5,12 @@
 """
 Infrastructure for test running and suites.
 """
-
+from __future__ import annotations
 
 import doctest
 import gc
 import unittest as pyunit
-from typing import Iterator, Union
+from collections.abc import Iterator
 
 from zope.interface import implementer
 
@@ -162,7 +162,7 @@ if _docTestCase:
 
 
 def _iterateTests(
-    testSuiteOrCase: Union[pyunit.TestCase, pyunit.TestSuite]
+    testSuiteOrCase: pyunit.TestCase | pyunit.TestSuite,
 ) -> Iterator[itrial.ITestCase]:
     """
     Iterate through all of the test cases in C{testSuiteOrCase}.

--- a/src/twisted/trial/_asynctest.py
+++ b/src/twisted/trial/_asynctest.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import Callable, List
+from typing import Callable
 
 from zope.interface import implementer
 
@@ -27,7 +27,7 @@ from twisted.trial._synctest import FailTest, SkipTest, SynchronousTestCase
 
 _P = ParamSpec("_P")
 
-_wait_is_running: List[None] = []
+_wait_is_running: list[None] = []
 
 
 @implementer(itrial.ITestCase)
@@ -127,7 +127,7 @@ class TestCase(SynchronousTestCase):
         )
         if inspect.isgeneratorfunction(func):
             exc = TypeError(
-                "{!r} is a generator function and therefore will never run".format(func)
+                f"{func!r} is a generator function and therefore will never run"
             )
             return defer.fail(exc)
         d = defer.maybeDeferred(

--- a/src/twisted/trial/_dist/distreporter.py
+++ b/src/twisted/trial/_dist/distreporter.py
@@ -10,17 +10,20 @@ test is over.
 
 @since: 12.3
 """
+from __future__ import annotations
 
 from types import TracebackType
-from typing import Optional, Tuple, Union
+from typing import Union
 
 from zope.interface import implementer
+
+from typing_extensions import TypeAlias
 
 from twisted.python.components import proxyForInterface
 from twisted.python.failure import Failure
 from ..itrial import IReporterWithDurations, ITestCase
 
-ReporterFailure = Union[Failure, Tuple[type, Exception, TracebackType]]
+ReporterFailure: TypeAlias = Union[Failure, tuple[type, Exception, TracebackType]]
 
 
 @implementer(IReporterWithDurations)
@@ -65,7 +68,7 @@ class DistReporter(proxyForInterface(IReporterWithDurations)):  # type: ignore[m
         self.running[test.id()].append((self.original.addUnexpectedSuccess, test, todo))
 
     def addExpectedFailure(
-        self, test: ITestCase, error: ReporterFailure, todo: Optional[str] = None
+        self, test: ITestCase, error: ReporterFailure, todo: str | None = None
     ) -> None:
         """
         Queue adding an expected failure.

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -8,23 +8,14 @@ responsible for coordinating all of trial's behavior at the highest level.
 
 @since: 12.3
 """
+from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Awaitable, Iterable, Sequence
 from functools import partial
 from os.path import isabs
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    TextIO,
-    Union,
-    cast,
-)
+from typing import Any, Callable, TextIO, cast
 from unittest import TestCase, TestSuite
 
 from attrs import define, field, frozen
@@ -119,8 +110,8 @@ class StartedWorkerPool:
     workingDirectory: FilePath[Any]
     testDirLock: FilesystemLock
     testLog: TextIO
-    workers: List[LocalWorker]
-    ampWorkers: List[LocalWorkerAMP]
+    workers: list[LocalWorker]
+    ampWorkers: list[LocalWorkerAMP]
 
     _logger = Logger()
 
@@ -168,7 +159,7 @@ class WorkerPool:
         protocols: Iterable[LocalWorkerAMP],
         workingDirectory: FilePath[Any],
         logFile: TextIO,
-    ) -> List[LocalWorker]:
+    ) -> list[LocalWorker]:
         """
         Create local worker protocol instances and return them.
 
@@ -310,7 +301,7 @@ class DistTrialRunner:
     # on the argument annotation
     _reporterFactory: Callable[..., IReporter]
     _maxWorkers: int
-    _workerArguments: List[str]
+    _workerArguments: list[str]
     _exitFirst: bool = False
     _reactor: IDistTrialReactor = field(
         # mypy doesn't understand the converter
@@ -377,7 +368,7 @@ class DistTrialRunner:
 
     async def runAsync(
         self,
-        suite: Union[TestCase, TestSuite],
+        suite: TestCase | TestSuite,
         untilFailure: bool = False,
     ) -> DistReporter:
         """
@@ -451,16 +442,16 @@ class DistTrialRunner:
             # Shut down the worker pool.
             await startedPool.join()
 
-    def _run(self, test: Union[TestCase, TestSuite], untilFailure: bool) -> IReporter:
-        result: Union[Failure, DistReporter, None] = None
+    def _run(self, test: TestCase | TestSuite, untilFailure: bool) -> IReporter:
+        result: Failure | DistReporter | None = None
         reactorStopping: bool = False
         testsInProgress: Deferred[object]
 
-        def capture(r: Union[Failure, DistReporter]) -> None:
+        def capture(r: Failure | DistReporter) -> None:
             nonlocal result
             result = r
 
-        def maybeStopTests() -> Optional[Deferred[object]]:
+        def maybeStopTests() -> Deferred[object] | None:
             nonlocal reactorStopping
             reactorStopping = True
             if result is None:
@@ -495,7 +486,7 @@ class DistTrialRunner:
         # object.  DistReporter isn't type annotated correctly so fix it here.
         return cast(IReporter, result.original)
 
-    def run(self, test: Union[TestCase, TestSuite]) -> IReporter:
+    def run(self, test: TestCase | TestSuite) -> IReporter:
         """
         Run a reactor and a test suite.
 
@@ -503,7 +494,7 @@ class DistTrialRunner:
         """
         return self._run(test, untilFailure=False)
 
-    def runUntilFailure(self, test: Union[TestCase, TestSuite]) -> IReporter:
+    def runUntilFailure(self, test: TestCase | TestSuite) -> IReporter:
         """
         Run the tests with local worker processes until they fail.
 

--- a/src/twisted/trial/_dist/functional.py
+++ b/src/twisted/trial/_dist/functional.py
@@ -4,9 +4,11 @@
 """
 General functional-style helpers for disttrial.
 """
+from __future__ import annotations
 
+from collections.abc import Awaitable, Iterable
 from functools import partial, wraps
-from typing import Awaitable, Callable, Iterable, Optional, TypeVar
+from typing import Callable, TypeVar
 
 from twisted.internet.defer import Deferred, succeed
 
@@ -15,7 +17,7 @@ _B = TypeVar("_B")
 _C = TypeVar("_C")
 
 
-def fromOptional(default: _A, optional: Optional[_A]) -> _A:
+def fromOptional(default: _A, optional: _A | None) -> _A:
     """
     Get a definite value from an optional value.
 

--- a/src/twisted/trial/_dist/stream.py
+++ b/src/twisted/trial/_dist/stream.py
@@ -2,8 +2,9 @@
 Buffer byte streams.
 """
 
+from collections.abc import Iterator
 from itertools import count
-from typing import Dict, Iterator, List, TypeVar
+from typing import TypeVar
 
 from attrs import Factory, define
 
@@ -38,7 +39,7 @@ class StreamReceiver:
     """
 
     _counter: Iterator[int] = count()
-    _streams: Dict[int, List[bytes]] = Factory(dict)
+    _streams: dict[int, list[bytes]] = Factory(dict)
 
     def open(self) -> int:
         """
@@ -56,7 +57,7 @@ class StreamReceiver:
         """
         self._streams[streamId].append(chunk)
 
-    def finish(self, streamId: int) -> List[bytes]:
+    def finish(self, streamId: int) -> list[bytes]:
         """
         Indicate an open stream may receive no further data and return all of
         its current contents.

--- a/src/twisted/trial/_dist/test/matchers.py
+++ b/src/twisted/trial/_dist/test/matchers.py
@@ -11,7 +11,8 @@ __all__ = [
     "IsSequenceOf",
 ]
 
-from typing import Any, List, Protocol, Sequence, Tuple, TypeVar
+from collections.abc import Sequence
+from typing import Any, Protocol, TypeVar
 
 from hamcrest import (
     contains_exactly,
@@ -167,7 +168,7 @@ def isFailure(**properties: Matcher[object]) -> Matcher[object]:
 
 def similarFrame(
     functionName: str, fileName: str
-) -> Matcher[Sequence[Tuple[str, str, int, List[object], List[object]]]]:
+) -> Matcher[Sequence[tuple[str, str, int, list[object], list[object]]]]:
     """
     Match a tuple representation of a frame like those used by
     L{twisted.python.failure.Failure}.

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -10,7 +10,7 @@ import sys
 from functools import partial
 from io import StringIO
 from os.path import sep
-from typing import Callable, List, Set
+from typing import Callable
 from unittest import TestCase as PyUnitTestCase
 
 from zope.interface import implementer, verify
@@ -68,7 +68,7 @@ class FakeTransport:
     A simple fake process transport.
     """
 
-    _closed: Set[int] = field(default=Factory(set))
+    _closed: set[int] = field(default=Factory(set))
 
     def writeToChild(self, fd, data):
         """
@@ -712,7 +712,7 @@ class FunctionalTests(TestCase):
         ``iterateWhile`` executes the actions from its factory until the predicate
         does not match an action result.
         """
-        actions: List[Deferred[int]] = [Deferred(), Deferred(), Deferred()]
+        actions: list[Deferred[int]] = [Deferred(), Deferred(), Deferred()]
 
         def predicate(value):
             return value != 42
@@ -822,7 +822,7 @@ class StartedLocalWorkerPool:
     """
 
     workingDirectory: FilePath[str]
-    workers: List[Worker]
+    workers: list[Worker]
     _stopped: Deferred[None]
 
     async def run(self, workerAction: WorkerAction[None]) -> None:
@@ -844,7 +844,7 @@ class LocalWorkerPool:
     """
 
     _config: WorkerPoolConfig
-    _started: List[StartedLocalWorkerPool] = field(default=Factory(list))
+    _started: list[StartedLocalWorkerPool] = field(default=Factory(list))
     _autostop: bool = False
     _workerFactory: Callable[[], Worker] = _LocalWorker
 

--- a/src/twisted/trial/_dist/test/test_matchers.py
+++ b/src/twisted/trial/_dist/test/test_matchers.py
@@ -2,7 +2,8 @@
 Tests for L{twisted.trial._dist.test.matchers}.
 """
 
-from typing import Callable, Sequence, Tuple, Type
+from collections.abc import Sequence
+from typing import Callable
 
 from hamcrest import anything, assert_that, contains, contains_string, equal_to, not_
 from hamcrest.core.matcher import Matcher
@@ -42,7 +43,7 @@ class HasSumTests(SynchronousTestCase):
     )
 
     @given(summables)
-    def test_matches(self, summable: Tuple[Sequence[S], Summer[S]]) -> None:
+    def test_matches(self, summable: tuple[Sequence[S], Summer[S]]) -> None:
         """
         L{HasSum} matches a sequence if the elements sum to a value matched by
         the parameterized matcher.
@@ -62,7 +63,7 @@ class HasSumTests(SynchronousTestCase):
     @given(summables)
     def test_mismatches(
         self,
-        summable: Tuple[
+        summable: tuple[
             Sequence[S],
             Summer[S],
         ],
@@ -142,7 +143,7 @@ class IsFailureTests(SynchronousTestCase):
     """
 
     @given(sampled_from([ValueError, ZeroDivisionError, RuntimeError]))
-    def test_matches(self, excType: Type[BaseException]) -> None:
+    def test_matches(self, excType: type[BaseException]) -> None:
         """
         L{isFailure} matches instances of L{Failure} with matching
         attributes.
@@ -155,7 +156,7 @@ class IsFailureTests(SynchronousTestCase):
         assert_that(matcher.matches(failure), equal_to(True))
 
     @given(sampled_from([ValueError, ZeroDivisionError, RuntimeError]))
-    def test_mismatches(self, excType: Type[BaseException]) -> None:
+    def test_mismatches(self, excType: type[BaseException]) -> None:
         """
         L{isFailure} does not match instances of L{Failure} with
         attributes that don't match.

--- a/src/twisted/trial/_dist/test/test_stream.py
+++ b/src/twisted/trial/_dist/test/test_stream.py
@@ -1,9 +1,11 @@
 """
 Tests for L{twisted.trial._dist.stream}.
 """
+from __future__ import annotations
 
+from collections.abc import Awaitable
 from random import Random
-from typing import Awaitable, Dict, List, TypeVar, Union
+from typing import TypeVar
 
 from hamcrest import (
     all_of,
@@ -37,7 +39,7 @@ class StreamReceiverTests(SynchronousTestCase):
     """
 
     @given(lists(lists(binary())), randoms())
-    def test_streamReceived(self, streams: List[List[bytes]], random: Random) -> None:
+    def test_streamReceived(self, streams: list[list[bytes]], random: Random) -> None:
         """
         All data passed to L{StreamReceiver.write} is returned by a call to
         L{StreamReceiver.finish} with a matching C{streamId}.
@@ -121,11 +123,11 @@ class AMPStreamReceiver(AMP):
         self.streams = streams
 
     @StreamOpen.responder
-    def streamOpen(self) -> Dict[str, object]:
+    def streamOpen(self) -> dict[str, object]:
         return {"streamId": self.streams.open()}
 
     @StreamWrite.responder
-    def streamWrite(self, streamId: int, data: bytes) -> Dict[str, object]:
+    def streamWrite(self, streamId: int, data: bytes) -> dict[str, object]:
         self.streams.write(streamId, data)
         return {}
 
@@ -135,12 +137,12 @@ def interact(server: IProtocol, client: IProtocol, interaction: Awaitable[T]) ->
     Let C{server} and C{client} exchange bytes while C{interaction} runs.
     """
     finished = False
-    result: Union[Failure, T]
+    result: Failure | T
 
     async def to_coroutine() -> T:
         return await interaction
 
-    def collect_result(r: Union[Failure, T]) -> None:
+    def collect_result(r: Failure | T) -> None:
         nonlocal result, finished
         finished = True
         result = r
@@ -195,7 +197,7 @@ class StreamTests(SynchronousTestCase):
     """
 
     @given(lists(binary()))
-    def test_stream(self, chunks: List[bytes]) -> None:
+    def test_stream(self, chunks: list[bytes]) -> None:
         """
         All of the chunks passed to L{stream} are sent in order over a
         stream using the given AMP connection.

--- a/src/twisted/trial/_dist/test/test_worker.py
+++ b/src/twisted/trial/_dist/test/test_worker.py
@@ -7,7 +7,6 @@ Test for distributed trial worker side.
 
 import os
 from io import BytesIO, StringIO
-from typing import Type
 from unittest import TestCase as PyUnitTestCase
 
 from zope.interface.verify import verifyObject
@@ -81,7 +80,7 @@ class WorkerProtocolErrorTests(TestCase):
     """
 
     def _runErrorTest(
-        self, brokenTestName: str, loggedExceptionType: Type[BaseException]
+        self, brokenTestName: str, loggedExceptionType: type[BaseException]
     ) -> None:
         worker, server, pump = connectedServerAndClient(
             LocalWorkerAMP, WorkerProtocol, greet=False
@@ -181,7 +180,7 @@ class LocalWorkerAMPTests(TestCase):
         self.flush = pump.flush
 
     def workerRunTest(
-        self, testCase: PyUnitTestCase, makeResult: Type[TestResult] = TestResult
+        self, testCase: PyUnitTestCase, makeResult: type[TestResult] = TestResult
     ) -> TestResult:
         result = makeResult()
         d = Deferred.fromCoroutine(self.managerAMP.run(testCase, result))
@@ -397,7 +396,7 @@ class LocalWorkerTests(TestCase):
         tempDir.makedirs()
         logPath = tempDir.child("test.log")
 
-        with open(logPath.path, "wt", encoding="utf-8") as logFile:
+        with open(logPath.path, "w", encoding="utf-8") as logFile:
             worker = LocalWorker(amp, tempDir, logFile)
             worker.makeConnection(FakeTransport())
             self.addCleanup(worker._outLog.close)

--- a/src/twisted/trial/_dist/test/test_workerreporter.py
+++ b/src/twisted/trial/_dist/test/test_workerreporter.py
@@ -6,7 +6,7 @@ Tests for L{twisted.trial._dist.workerreporter}.
 """
 from __future__ import annotations
 
-from typing import Sized
+from collections.abc import Sized
 from unittest import TestCase
 
 from hamcrest import assert_that, equal_to, has_length

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -8,19 +8,11 @@ This module implements the worker classes.
 
 @since: 12.3
 """
+from __future__ import annotations
 
 import os
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    TextIO,
-    TypeVar,
-)
+from collections.abc import Awaitable
+from typing import Any, Callable, Protocol, TextIO, TypeVar
 from unittest import TestCase
 
 from zope.interface import implementer
@@ -181,7 +173,7 @@ class LocalWorkerAMP(AMP):
         self,
         error: WorkerException,
         errorClass: str,
-        frames: List[str],
+        frames: list[str],
     ) -> Failure:
         """
         Helper to build a C{Failure} with some traceback.
@@ -211,7 +203,7 @@ class LocalWorkerAMP(AMP):
         errorClass: str,
         errorStreamId: int,
         framesStreamId: int,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """
         Add an error to the reporter.
 
@@ -241,7 +233,7 @@ class LocalWorkerAMP(AMP):
         failStreamId: int,
         failClass: str,
         framesStreamId: int,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """
         Add a failure to the reporter.
 
@@ -271,8 +263,8 @@ class LocalWorkerAMP(AMP):
 
     @managercommands.AddExpectedFailure.responder
     def addExpectedFailure(
-        self, testName: str, errorStreamId: int, todo: Optional[str]
-    ) -> Dict[str, bool]:
+        self, testName: str, errorStreamId: int, todo: str | None
+    ) -> dict[str, bool]:
         """
         Add an expected failure to the reporter.
 

--- a/src/twisted/trial/_dist/workerreporter.py
+++ b/src/twisted/trial/_dist/workerreporter.py
@@ -8,9 +8,11 @@ Test reporter forwarding test results over trial distributed AMP commands.
 
 @since: 12.3
 """
+from __future__ import annotations
 
+from collections.abc import Sequence
 from types import TracebackType
-from typing import Callable, List, Literal, Optional, Sequence, Type, TypeVar
+from typing import Callable, Literal, TypeVar
 from unittest import TestCase as PyUnitTestCase
 
 from attrs import Factory, define
@@ -28,7 +30,7 @@ T = TypeVar("T")
 
 
 async def addError(
-    amp: AMP, testName: str, errorClass: str, error: str, frames: List[str]
+    amp: AMP, testName: str, errorClass: str, error: str, frames: list[str]
 ) -> None:
     """
     Send an error to the worker manager over an AMP connection.
@@ -57,7 +59,7 @@ async def addError(
 
 
 async def addFailure(
-    amp: AMP, testName: str, fail: str, failClass: str, frames: List[str]
+    amp: AMP, testName: str, fail: str, failClass: str, frames: list[str]
 ) -> None:
     """
     Like L{addError} but for failures.
@@ -122,8 +124,8 @@ class ReportingResults:
         interface.
     """
 
-    _reporter: "WorkerReporter"
-    _results: List[Deferred[object]] = Factory(list)
+    _reporter: WorkerReporter
+    _results: list[Deferred[object]] = Factory(list)
 
     def __enter__(self) -> Sequence[Deferred[object]]:
         """
@@ -139,7 +141,7 @@ class ReportingResults:
 
     def __exit__(
         self,
-        excType: Type[BaseException],
+        excType: type[BaseException],
         excValue: BaseException,
         excTraceback: TracebackType,
     ) -> Literal[False]:
@@ -172,7 +174,7 @@ class WorkerReporter(TestResult):
     _DEFAULT_TODO = "Test expected to fail"
 
     ampProtocol: AMP
-    _reporting: Optional[ReportingResults] = None
+    _reporting: ReportingResults | None = None
 
     def __init__(self, ampProtocol):
         """
@@ -201,11 +203,11 @@ class WorkerReporter(TestResult):
             return Failure(error[1], error[0], error[2])
         return error
 
-    def _getFrames(self, failure: Failure) -> List[str]:
+    def _getFrames(self, failure: Failure) -> list[str]:
         """
         Extract frames from a C{Failure} instance.
         """
-        frames: List[str] = []
+        frames: list[str] = []
         for frame in failure.frames:
             # The code object's name, the code object's filename, and the line
             # number.

--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -7,7 +7,7 @@ Things likely to be used by writers of unit tests.
 
 Maintainer: Jonathan Lange
 """
-
+from __future__ import annotations
 
 import inspect
 import os
@@ -16,21 +16,9 @@ import tempfile
 import types
 import unittest as pyunit
 import warnings
+from collections.abc import Coroutine, Generator, Iterable
 from dis import findlinestarts as _findlinestarts
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    Iterable,
-    List,
-    NoReturn,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, NoReturn, TypeVar
 
 # Python 2.7 and higher has skip support built-in
 from unittest import SkipTest
@@ -78,7 +66,7 @@ class Todo:
     """
 
     reason: str
-    errors: Optional[Iterable[Type[BaseException]]] = None
+    errors: Iterable[type[BaseException]] | None = None
 
     def __repr__(self) -> str:
         return f"<Todo reason={self.reason!r} errors={self.errors!r}>"
@@ -98,9 +86,7 @@ class Todo:
 
 
 def makeTodo(
-    value: Union[
-        str, Tuple[Union[Type[BaseException], Iterable[Type[BaseException]]], str]
-    ]
+    value: (str | tuple[type[BaseException] | Iterable[type[BaseException]], str])
 ) -> Todo:
     """
     Return a L{Todo} object built from C{value}.
@@ -119,7 +105,7 @@ def makeTodo(
     if isinstance(value, tuple):
         errors, reason = value
         if isinstance(errors, type):
-            iterableErrors: Iterable[Type[BaseException]] = [errors]
+            iterableErrors: Iterable[type[BaseException]] = [errors]
         else:
             iterableErrors = errors
         return Todo(reason=reason, errors=iterableErrors)
@@ -371,7 +357,7 @@ class _Assertions(pyunit.TestCase):
     callbacks.
     """
 
-    def fail(self, msg: Optional[object] = None) -> NoReturn:
+    def fail(self, msg: object | None = None) -> NoReturn:
         """
         Absolutely fail the test.  Do not pass go, do not collect $200.
 
@@ -689,11 +675,11 @@ class _Assertions(pyunit.TestCase):
 
     def successResultOf(
         self,
-        deferred: Union[
-            Coroutine[Deferred[T], Any, T],
-            Generator[Deferred[T], Any, T],
-            Deferred[T],
-        ],
+        deferred: (
+            Coroutine[Deferred[T], Any, T]
+            | Generator[Deferred[T], Any, T]
+            | Deferred[T]
+        ),
     ) -> T:
         """
         Return the current success result of C{deferred} or raise
@@ -719,7 +705,7 @@ class _Assertions(pyunit.TestCase):
         @return: The result of C{deferred}.
         """
         deferred = ensureDeferred(deferred)
-        results: List[Union[T, failure.Failure]] = []
+        results: list[T | failure.Failure] = []
         deferred.addBoth(results.append)
 
         if not results:
@@ -995,7 +981,7 @@ class SynchronousTestCase(_Assertions):
             return self._testMethodName
         return desc
 
-    def getSkip(self) -> Tuple[bool, Optional[str]]:
+    def getSkip(self) -> tuple[bool, str | None]:
         """
         Return the skip reason set on this test, if any is set. Checks on the
         instance first, then the class, then the module, then packages. As
@@ -1263,7 +1249,7 @@ class SynchronousTestCase(_Assertions):
         }
         if message is not None:
             expectedWarning = expectedWarning + ": " + message
-        self.assert_(
+        self.assertTrue(
             observedWarning.startswith(expectedWarning),
             f"Expected {observedWarning!r} to start with {expectedWarning!r}",
         )

--- a/src/twisted/trial/reporter.py
+++ b/src/twisted/trial/reporter.py
@@ -16,7 +16,7 @@ import unittest as pyunit
 import warnings
 from collections import OrderedDict
 from types import TracebackType
-from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Union
 
 from zope.interface import implementer
 
@@ -36,12 +36,12 @@ try:
 except ImportError:
     TestProtocolClient = None
 
-ExcInfo: TypeAlias = Tuple[Type[BaseException], BaseException, TracebackType]
-XUnitFailure = Union[ExcInfo, Tuple[None, None, None]]
+ExcInfo: TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
+XUnitFailure = Union[ExcInfo, tuple[None, None, None]]
 TrialFailure = Union[XUnitFailure, Failure]
 
 
-def _makeTodo(value: str) -> "Todo":
+def _makeTodo(value: str) -> Todo:
     """
     Return a L{Todo} object built from C{value}.
 
@@ -100,13 +100,13 @@ class TestResult(pyunit.TestResult):
     errors: list[
         tuple[itrial.ITestCase | pyunit.TestCase, str | Failure]
     ]  # type:ignore[assignment]
-    skips: List[Tuple[itrial.ITestCase, str]]
-    expectedFailures: List[Tuple[itrial.ITestCase, str | Failure, "Todo"]]  # type: ignore[assignment]
-    unexpectedSuccesses: List[Tuple[itrial.ITestCase, str]]  # type: ignore[assignment]
+    skips: list[tuple[itrial.ITestCase, str]]
+    expectedFailures: list[tuple[itrial.ITestCase, str | Failure, Todo]]  # type: ignore[assignment]
+    unexpectedSuccesses: list[tuple[itrial.ITestCase, str]]  # type: ignore[assignment]
     successes: int
-    _testStarted: Optional[int]
+    _testStarted: int | None
     # The duration of the test. It is None until the test completes.
-    _lastTime: Optional[int]
+    _lastTime: int | None
 
     # Make pytest not think this is test class
     __test__ = False

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -7,7 +7,7 @@ A miscellany of code used to run Trial tests.
 
 Maintainer: Jonathan Lange
 """
-
+from __future__ import annotations
 
 __all__ = [
     "TestSuite",
@@ -35,9 +35,10 @@ import sys
 import types
 import unittest as pyunit
 import warnings
+from collections.abc import Generator
 from contextlib import contextmanager
 from importlib.machinery import SourceFileLoader
-from typing import Callable, Generator, List, Optional, Protocol, TextIO, Type, Union
+from typing import Callable, Protocol, TextIO, Union
 
 from zope.interface import implementer
 
@@ -275,7 +276,7 @@ _Loadable: TypeAlias = Union[
     modules.PythonAttribute,
     modules.PythonModule,
     pyunit.TestCase,
-    Type[pyunit.TestCase],
+    type[pyunit.TestCase],
 ]
 
 
@@ -301,7 +302,7 @@ def name(thing: _Loadable) -> str:
     raise TypeError(f"Cannot name {thing!r}")
 
 
-def isTestCase(obj: type) -> TypeGuard[Type[pyunit.TestCase]]:
+def isTestCase(obj: type) -> TypeGuard[type[pyunit.TestCase]]:
     """
     @return: C{True} if C{obj} is a class that contains test cases, C{False}
         otherwise. Used to find all the tests in a module.
@@ -413,7 +414,7 @@ class TestLoader:
     methodPrefix = "test"
     modulePrefix = "test_"
 
-    suiteFactory: Type[TestSuite] = TestSuite
+    suiteFactory: type[TestSuite] = TestSuite
     sorter: Callable[[_Loadable], object] = name
 
     def sort(self, xs):
@@ -714,7 +715,7 @@ class TestLoader:
 
     loadTestsFromName = loadByName
 
-    def loadByNames(self, names: List[str], recurse: bool = False) -> TestSuite:
+    def loadByNames(self, names: list[str], recurse: bool = False) -> TestSuite:
         """
         Load some tests by a list of names.
 
@@ -789,7 +790,7 @@ def _qualNameWalker(qualName):
 
 
 @contextmanager
-def _testDirectory(workingDirectory: str) -> Generator[None, None, None]:
+def _testDirectory(workingDirectory: str) -> Generator[None]:
     """
     A context manager which obtains a lock on a trial working directory
     and enters (L{os.chdir}) it and then reverses these things.
@@ -809,7 +810,7 @@ def _testDirectory(workingDirectory: str) -> Generator[None, None, None]:
 
 
 @contextmanager
-def _logFile(logfile: str) -> Generator[None, None, None]:
+def _logFile(logfile: str) -> Generator[None]:
     """
     A context manager which adds a log observer and then removes it.
 
@@ -834,11 +835,11 @@ def _logFile(logfile: str) -> Generator[None, None, None]:
 class _Runner(Protocol):
     stream: TextIO
 
-    def run(self, test: Union[pyunit.TestCase, pyunit.TestSuite]) -> itrial.IReporter:
+    def run(self, test: pyunit.TestCase | pyunit.TestSuite) -> itrial.IReporter:
         ...
 
     def runUntilFailure(
-        self, test: Union[pyunit.TestCase, pyunit.TestSuite]
+        self, test: pyunit.TestCase | pyunit.TestSuite
     ) -> itrial.IReporter:
         ...
 
@@ -889,7 +890,7 @@ class TrialRunner:
     DRY_RUN = "dry-run"
 
     reporterFactory: Callable[[TextIO, str, bool, log.LogPublisher], itrial.IReporter]
-    mode: Optional[str] = None
+    mode: str | None = None
     logfile: str = "test.log"
     stream: TextIO = sys.stdout
     profile: bool = False
@@ -898,7 +899,7 @@ class TrialRunner:
     uncleanWarnings: bool = False
     workingDirectory: str = "_trial_temp"
     _forceGarbageCollection: bool = False
-    debugger: Optional[_Debugger] = None
+    debugger: _Debugger | None = None
     _exitFirst: bool = False
 
     _log: log.LogPublisher = log  # type: ignore[assignment]
@@ -921,7 +922,7 @@ class TrialRunner:
     def rterrors(self) -> bool:
         return self._realTimeErrors
 
-    def run(self, test: Union[pyunit.TestCase, pyunit.TestSuite]) -> itrial.IReporter:
+    def run(self, test: pyunit.TestCase | pyunit.TestSuite) -> itrial.IReporter:
         """
         Run the test or suite and return a result object.
         """
@@ -934,7 +935,7 @@ class TrialRunner:
 
     def _runWithoutDecoration(
         self,
-        test: Union[pyunit.TestCase, pyunit.TestSuite],
+        test: pyunit.TestCase | pyunit.TestSuite,
         forceGarbageCollection: bool = False,
     ) -> itrial.IReporter:
         """
@@ -964,7 +965,7 @@ class TrialRunner:
         return result
 
     def runUntilFailure(
-        self, test: Union[pyunit.TestCase, pyunit.TestSuite]
+        self, test: pyunit.TestCase | pyunit.TestSuite
     ) -> itrial.IReporter:
         """
         Repeatedly run C{test} until it fails.

--- a/src/twisted/trial/test/test_loader.py
+++ b/src/twisted/trial/test/test_loader.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import os
 import sys
 import unittest as pyunit
+from collections.abc import Generator
 from hashlib import md5
 from operator import attrgetter
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Generator
+from typing import TYPE_CHECKING, Callable
 
 from hamcrest import assert_that, equal_to, has_properties
 from hamcrest.core.matcher import Matcher
@@ -565,7 +566,7 @@ class PackageOrderingTests(packages.SysPathManglingTest):
 
     def _trialSortAlgorithm(
         self, sorter: Callable[[PythonModule | PythonAttribute], SupportsRichComparison]
-    ) -> Generator[PythonModule | PythonAttribute, None, None]:
+    ) -> Generator[PythonModule | PythonAttribute]:
         """
         Right now, halfway by accident, trial sorts like this:
 

--- a/src/twisted/trial/test/test_reporter.py
+++ b/src/twisted/trial/test/test_reporter.py
@@ -13,7 +13,6 @@ import re
 import sys
 from inspect import getmro
 from io import BytesIO, StringIO
-from typing import Type
 from unittest import (
     TestCase as StdlibTestCase,
     TestSuite as PyUnitTestSuite,
@@ -977,7 +976,7 @@ class ReporterInterfaceTests(unittest.SynchronousTestCase):
         callable must take the same parameters as L{reporter.Reporter}.
     """
 
-    resultFactory: Type[itrial.IReporter] = reporter.Reporter
+    resultFactory: type[itrial.IReporter] = reporter.Reporter
 
     def setUp(self):
         self.test = sample.FooTest("test_foo")
@@ -1163,7 +1162,7 @@ class SubunitReporterTests(ReporterInterfaceTests):
     This just tests that the subunit reporter implements the basic interface.
     """
 
-    resultFactory: Type[itrial.IReporter] = reporter.SubunitReporter
+    resultFactory: type[itrial.IReporter] = reporter.SubunitReporter
 
     def setUp(self):
         if reporter.TestProtocolClient is None:
@@ -1376,7 +1375,7 @@ class SubunitReporterNotInstalledTests(unittest.SynchronousTestCase):
 
 
 class TimingReporterTests(ReporterTests):
-    resultFactory: Type[itrial.IReporter] = reporter.TimingTextReporter
+    resultFactory: type[itrial.IReporter] = reporter.TimingTextReporter
 
 
 class LoggingReporter(reporter.Reporter):

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -10,7 +10,6 @@ import pdb
 import sys
 import unittest as pyunit
 from io import StringIO
-from typing import List
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -580,7 +579,7 @@ class UntilFailureTests(unittest.SynchronousTestCase):
         A test case that fails when run 3 times in a row.
         """
 
-        count: List[None] = []
+        count: list[None] = []
 
         def test_foo(self):
             self.count.append(None)

--- a/src/twisted/trial/test/test_script.py
+++ b/src/twisted/trial/test/test_script.py
@@ -9,7 +9,7 @@ import sys
 import textwrap
 import types
 from io import StringIO
-from typing import Any, List
+from typing import Any
 from unittest import skipIf
 
 from hamcrest import assert_that, contains_string
@@ -51,7 +51,7 @@ def logSomething() -> None:
     Logger().info("something")
 
 
-def parseArguments(argv: List[str]) -> trial.Options:
+def parseArguments(argv: list[str]) -> trial.Options:
     """
     Parse an argument list using trial's argument parser.
     """

--- a/src/twisted/trial/test/test_util.py
+++ b/src/twisted/trial/test/test_util.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import locale
 import os
 import sys
+from collections.abc import Generator
 from io import StringIO
-from typing import Generator
 
 from zope.interface import implementer
 
@@ -598,7 +598,7 @@ class ListToPhraseTests(SynchronousTestCase):
         If things is a generator, a TypeError is raised.
         """
 
-        def sample() -> Generator[int, None, None]:
+        def sample() -> Generator[int]:
             yield from range(2)
 
         error = self.assertRaises(TypeError, util._listToPhrase, sample, "and")

--- a/src/twisted/trial/test/test_warning.py
+++ b/src/twisted/trial/test/test_warning.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import sys
 import warnings
+from collections.abc import Mapping, Sequence
 from io import StringIO
-from typing import Mapping, Sequence, TypeVar
+from typing import TypeVar
 from unittest import TestResult
 
 from twisted.python.filepath import FilePath


### PR DESCRIPTION
## Scope and purpose

Fixes #12622 

The changes were automatically generated using `pyupgrade --py39-plus`.

Manual work done:

* Add `from __future__ import annotations` where appropriate
* Remove unused imports from typing module such as `List`. (`pyupgrade` doesn't remove these)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
