### PR TITLE
Pass usedforsecurity=False to md5() in twisted.spread.pb

### DIFF
--- a/src/twisted/spread/pb.py
+++ b/src/twisted/spread/pb.py
@@ -1257,10 +1257,10 @@ def respond(challenge, password):
     @param password: A password.
     @return: The password hashed twice.
     """
-    m = md5()
+    m = md5(usedforsecurity=False)
     m.update(password)
     hashedPassword = m.digest()
-    m = md5()
+    m = md5(usedforsecurity=False)
     m.update(hashedPassword)
     m.update(challenge)
     doubleHashedPassword = m.digest()
@@ -1273,7 +1273,7 @@ def challenge():
     @return: Some random data.
     """
     crap = bytes(random.randint(65, 90) for x in range(random.randrange(15, 25)))
-    crap = md5(crap).digest()
+    crap = md5(crap, usedforsecurity=False).digest()
     return crap
 
 
@@ -1620,7 +1620,7 @@ class _PortalAuthChallenger(Referenceable, _JellyableAvatarMixin):
         @param password: The password.
         @return: L{_PortalAuthChallenger.checkMD5Password}
         """
-        return self.checkMD5Password(md5(password).digest())
+        return self.checkMD5Password(md5(password, usedforsecurity=False).digest())
 
     def checkMD5Password(self, md5Password):
         """
@@ -1630,7 +1630,7 @@ class _PortalAuthChallenger(Referenceable, _JellyableAvatarMixin):
         @rtype: L{bool}
         @return: L{True} if password matches.
         """
-        md = md5()
+        md = md5(usedforsecurity=False)
         md.update(md5Password)
         md.update(self.challenge)
         correct = md.digest()


### PR DESCRIPTION
Fixes #12583

On FIPS-enabled systems (RHEL 8/9, CentOS Stream), OpenSSL blocks calls to `md5()` without `usedforsecurity=False`. This causes Perspective Broker connections to fail with:

```
ValueError: [digital envelope routines] unsupported
```

The PB challenge-response protocol uses MD5 for protocol-level password obfuscation, not as a cryptographic security boundary. Passing `usedforsecurity=False` allows OpenSSL's FIPS provider to permit these calls.

Changes:
- `respond()`: both `md5()` calls (double-hash of password + challenge)
- `challenge()`: `md5(crap)` for random challenge generation
- `_PortalAuthChallenger.verifyPassword()`: `md5(password)`
- `_PortalAuthChallenger.checkMD5Password()`: `md5()`

The `usedforsecurity` parameter has been available since Python 3.9, which is the minimum supported version for Twisted.