### PR TITLE
#12566 Revert the removal of assertEquals and assertNotEquals.

### DIFF
--- a/src/twisted/trial/_synctest.py
+++ b/src/twisted/trial/_synctest.py
@@ -433,9 +433,10 @@ class _Assertions(pyunit.TestCase):
         super().assertEqual(first, second, msg)
         return first
 
+    # We keep all these aliases for backward compatibility.
+    assertEquals = assertEqual
     failUnlessEqual = assertEqual
     failUnlessEquals = assertEqual
-    assertEqual = assertEqual
 
     def assertIs(self, first, second, msg=None):
         """
@@ -480,7 +481,8 @@ class _Assertions(pyunit.TestCase):
             raise self.failureException(msg or f"{first!r} == {second!r}")
         return first
 
-    assertNotEqual = assertNotEqual
+    # We keep all these aliases for backward compatibility.
+    assertNotEquals = assertNotEqual
     failIfEquals = assertNotEqual
     failIfEqual = assertNotEqual
 

--- a/src/twisted/trial/test/test_assertions.py
+++ b/src/twisted/trial/test/test_assertions.py
@@ -315,6 +315,19 @@ class SynchronousAssertionsTests(unittest.SynchronousTestCase):
         self._testUnequalPair(x, y)
         self._testUnequalPair(y, z)
 
+    def test_assertEqual_plural_form(self):
+        """
+        The plural forms are still avaialble for backward compatibility.
+        """
+        self.assertIs(
+            unittest.SynchronousTestCase.assertEqual,
+            unittest.SynchronousTestCase.assertEquals,
+        )
+        self.assertIs(
+            unittest.SynchronousTestCase.assertNotEqual,
+            unittest.SynchronousTestCase.assertNotEquals,
+        )
+
     def test_assertEqualMessage(self):
         """
         When a message is passed to L{assertEqual} it is included in the error


### PR DESCRIPTION
## Scope and purpose

Fixes #12566

This is just a `.misc` since this bug was not yet released

This reverted the changes from https://github.com/twisted/twisted/pull/12450/changes#diff-54b664956d68a20ebbdbdfad8fd9e742893c165bedca99b0f92c340edc0811da
and adds comment and a test...

I hope that this will make it less unlikely to repeat this error.

For now we will keep all these aliases... as there are many others and I think that for now it's more trouble to deprecate them. 
