### PR TITLE
#12629 ci: use setup-python pip caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -230,21 +230,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
         check-latest: true
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "cache-dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-    - name: pip cache
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pip-cache.outputs.cache-dir }}
-        key:
-          ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
-          'setup.cfg', 'tox.ini') }}
-        restore-keys: |
-            ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.


### PR DESCRIPTION


## Scope and purpose

Fixes #12629 

Replace the custom pip cache lookup and actions/cache step with setup-python's built-in pip cache support. Keep the existing dependency files in the cache key so changes to packaging and tox configuration still invalidate the cache.

Removed `setup.py` file from invalidating the cache, since the file no longer exists in the repository

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
