### PR TITLE
#12640 Fix mypy and formatting on trunk

### DIFF
--- a/src/twisted/names/dns.py
+++ b/src/twisted/names/dns.py
@@ -16,7 +16,7 @@ import inspect
 import random
 import socket
 import struct
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from io import BytesIO
 from itertools import chain
@@ -506,13 +506,13 @@ class _DecodeContext:
 # guarantees the scope is restored correctly on exit -- and remains isolated
 # per-task should a future caller decode messages from multiple
 # L{asyncio}-style contexts concurrently.
-_decodeContextVar: contextvars.ContextVar[_DecodeContext | None] = (
-    contextvars.ContextVar("_dnsDecodeContext", default=None)
-)
+_decodeContextVar: contextvars.ContextVar[
+    _DecodeContext | None
+] = contextvars.ContextVar("_dnsDecodeContext", default=None)
 
 
 @contextmanager
-def _installDecodeContext(context: _DecodeContext):
+def _installDecodeContext(context: _DecodeContext) -> Generator[_DecodeContext]:
     """
     Install C{context} on L{_decodeContextVar} for the duration of the
     C{with} block and restore the previous value on exit.

--- a/src/twisted/names/test/test_dns.py
+++ b/src/twisted/names/test/test_dns.py
@@ -364,9 +364,7 @@ class NameTests(unittest.TestCase):
         payload = b"\xc0\x02\xc0\x04\xc0\x06\xc0\x08\x00"
         name = dns.Name()
         name.maxCompressionPointers = 3
-        self.assertRaises(
-            dns.DNSDecodeError, name.decode, BytesIO(payload)
-        )
+        self.assertRaises(dns.DNSDecodeError, name.decode, BytesIO(payload))
 
     def test_decodeRecoversAfterDNSDecodeError(self):
         """
@@ -818,9 +816,7 @@ class MessageTests(unittest.SynchronousTestCase):
         """
         chainLength = 100
         numRecords = 8000
-        header = struct.pack(
-            "!H2B4H", 0x1234, 0x80, 0x00, 0, numRecords, 0, 0
-        )
+        header = struct.pack("!H2B4H", 0x1234, 0x80, 0x00, 0, numRecords, 0, 0)
 
         # Long compression chain inside the RDATA of an unknown
         # record so that subsequent records can aim pointers at it.
@@ -831,11 +827,7 @@ class MessageTests(unittest.SynchronousTestCase):
             chain += struct.pack("!H", 0xC000 | (chainBase + 2 * (i + 1)))
         chain += b"\x04test\x00"
 
-        firstRecord = (
-            owner
-            + struct.pack("!HHIH", 999, 1, 0, len(chain))
-            + bytes(chain)
-        )
+        firstRecord = owner + struct.pack("!HHIH", 999, 1, 0, len(chain)) + bytes(chain)
         followupRecord = (
             struct.pack("!H", 0xC000 | chainBase)
             + struct.pack("!HHIH", 1, 1, 0, 4)


### PR DESCRIPTION
## Scope and purpose

Fixes #12640

This tries to fix the GHA jobs failing on trunk.

The last CVE PR was merged from a private security fork and GHA was not executed there.

I am not an expert on `mypy` ... if I run mypy on my my local env I get way more errors than the ones reported by GitHub Actions... but for this PR the plan is to fix trunk