### PR TITLE
#12642 Remove 3.9 and promote 3.14 and 3.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -212,12 +212,12 @@ jobs:
           # Future Python 3.15 work in progress.
           # These tests might have various exceptions and
           # we will remove the exceptions as support is added.
-          - python-version: '3.15.0-beta'
+          - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-linux'
             runs-on: 'ubuntu-22.04'
 
-          - python-version: '3.15.0-beta'
+          - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-windows'
             job-name: 'nodeps-windows-select'
             runs-on: 'windows-2022'
@@ -225,7 +225,7 @@ jobs:
             # https://github.com/twisted/twisted/issues/12521
             trial-args: '--reactor=select'
 
-          - python-version: '3.15.0-beta'
+          - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-macos'
             runs-on: 'macos-14'
@@ -270,12 +270,11 @@ jobs:
         # https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.42.0/setup.py#L129-L134
         sudo apt-get update
         sudo apt-get install -y \
-          libgirepository1.0-dev \
+          libgirepository-2.0-dev \
           libglib2.0-dev \
           libcairo2-dev \
           libffi-dev \
           gir1.2-gtk-3.0 \
-          girepository-2.0 \
           xvfb
 
     - name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,9 +121,9 @@ jobs:
           # have IPv6 available.
           # Any supported Python version is OK for this job.
           # We go with latest micro release for the smallest minor release
-          # that we support.
+          # that is support by GitHub Actions for the target OS.
           # This is also used to run tests with minimum dependency versions.
-          - python-version: '3.10'
+          - python-version: '3.10.4'
             noipv6: '-noipv6'
             tox-env: 'mindeps-withcov-posix'
             job-name: 'minimum-deps-noipv6'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use.
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.10.0'
+          - python-version: '3.10.4'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,6 +209,26 @@ jobs:
             job-name: 'gtk-tests'
             trial-args: '--reactor=gi -j 4'
 
+          # Future Python 3.15 work in progress.
+          # These tests might have various exceptions and
+          # we will remove the exceptions as support is added.
+          - python-version: '3.15.0-beta'
+            tox-env: 'nodeps-withcov-posix'
+            job-name: 'nodeps-linux'
+            runs-on: 'ubuntu-22.04'
+
+          - python-version: '3.15.0-beta'
+            tox-env: 'nodeps-withcov-windows'
+            job-name: 'nodeps-windows-select'
+            runs-on: 'windows-2022'
+            # Should be removed once we can run distributed tests on Windows
+            # https://github.com/twisted/twisted/issues/12521
+            trial-args: '--reactor=select'
+
+          - python-version: '3.15.0-beta'
+            tox-env: 'nodeps-withcov-posix'
+            job-name: 'nodeps-macos'
+            runs-on: 'macos-14'
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,9 +121,9 @@ jobs:
           # have IPv6 available.
           # Any supported Python version is OK for this job.
           # We go with latest micro release for the smallest minor release
-          # that is support by GitHub Actions for the target OS.
+          # that is supported by GitHub Actions for the target OS.
           # This is also used to run tests with minimum dependency versions.
-          - python-version: '3.10.4'
+          - python-version: '3.10'
             noipv6: '-noipv6'
             tox-env: 'mindeps-withcov-posix'
             job-name: 'minimum-deps-noipv6'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,10 +113,9 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use.
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.10.20'
+          - python-version: '3.10.0'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
-            runs-on: 'ubuntu-24.04'
 
           # `noipv6` is created to make sure all is OK on an OS which doesn't
           # have IPv6 available.
@@ -203,7 +202,6 @@ jobs:
           # of Gtk packaged within our selected version of Linux above.
           # This is executed using the oldest Python that we support.
           - python-version: '3.10'
-            runs-on: 'ubuntu-24.04'
             tox-env: 'alldeps-gtk-withcov-posix'
             platform-deps: 'gtk-platform'
             tox-wrapper: 'xvfb-run -a'
@@ -216,7 +214,6 @@ jobs:
           - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-linux'
-            runs-on: 'ubuntu-24.04'
             # The arguments can be removed once trial tests are fixed.
             # https://github.com/twisted/twisted/issues/12645
             trial-target: '-- twisted.application twisted.conch twisted.cred twisted.enterprise twisted.internet twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.python twisted.runner twisted.scripts twisted.spread twisted.test twisted.web twisted.words'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           # by GitHub. The availability of the Python version
           # depends on the version of Ubuntu in use.
           # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - python-version: '3.9.12'
+          - python-version: '3.10.20'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
             runs-on: 'ubuntu-22.04'
@@ -124,13 +124,10 @@ jobs:
           # We go with latest micro release for the smallest minor release
           # that we support.
           # This is also used to run tests with minimum dependency versions.
-          - python-version: '3.9'
+          - python-version: '3.10'
             noipv6: '-noipv6'
             tox-env: 'mindeps-withcov-posix'
             job-name: 'minimum-deps-noipv6'
-
-          # Just Python 3.9 with default settings.
-          - python-version: '3.9'
 
           # Just Python 3.10 with default settings.
           - python-version: '3.10'
@@ -141,21 +138,24 @@ jobs:
           # Just Python 3.13 with default settings.
           - python-version: '3.13'
 
-          # Newest Intel macOS and oldest Python (major) supported versions.
-          # On 3.9 pyobjc-core build fails.
+          # Just Python 3.14 with default settings.
+          - python-version: '3.14'
+
+          # Oldest Intel macOS (available on GitHub)
+          # and oldest Python (major) supported versions.
           - python-version: '3.10'
             runs-on: 'macos-14'
             job-name: 'macos-14-default-tests'
             tox-env: 'macos-withcov-alldeps'
 
           # Newest ARM macOS and newest Python supported versions.
-          - python-version: '3.13'
+          - python-version: '3.14'
             runs-on: 'macos-15'
             job-name: 'macos-15-default-tests'
             tox-env: 'macos-withcov-alldeps'
 
           # Windows, minimum Python version with select reactor.
-          - python-version: '3.9'
+          - python-version: '3.10'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-select'
@@ -164,12 +164,22 @@ jobs:
             # select a reactor.
             trial-args: '--reactor=select'
 
+          # Windows, newest Python supported version with select reactor.
+          - python-version: '3.14'
+            tox-env: 'nodeps-withcov-windows'
+            job-name: 'nodeps-windows-select'
+            runs-on: 'windows-2022'
+            # Should be removed once we can run distributed tests on Windows
+            # https://github.com/twisted/twisted/issues/12521
+            trial-args: '--reactor=select'
+
           # Windows, newest Python supported version with iocp reactor.
-          - python-version: '3.13'
+          - python-version: '3.14'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'
             # Distributed trial is not yet suported on Windows.
+            # https://github.com/twisted/twisted/issues/12521
             trial-args: '--reactor=iocp'
 
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
@@ -191,30 +201,14 @@ jobs:
           # We run the full test suite with the GI reactor against an X virtual
           # framebuffer server.  This covers our integration with the version
           # of Gtk packaged within our selected version of Linux above.
-          - python-version: '3.9'
+          # This is executed using the oldest Python that we support.
+          - python-version: '3.10'
             tox-env: 'alldeps-gtk-withcov-posix'
             platform-deps: 'gtk-platform'
             tox-wrapper: 'xvfb-run -a'
             job-name: 'gtk-tests'
             trial-args: '--reactor=gi -j 4'
 
-          - python-version: '3.14'
-            tox-env: 'nodeps-withcov-posix'
-            job-name: 'nodeps-linux'
-            runs-on: 'ubuntu-22.04'
-
-          - python-version: '3.14'
-            tox-env: 'nodeps-withcov-windows'
-            job-name: 'nodeps-windows-select'
-            runs-on: 'windows-2022'
-            # Should be removed once we can run distributed tests on Windows
-            # https://github.com/twisted/twisted/issues/12521
-            trial-args: '--reactor=select'
-
-          - python-version: '3.14'
-            tox-env: 'nodeps-withcov-posix'
-            job-name: 'nodeps-macos'
-            runs-on: 'macos-14'
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
     # We can't use `env.*` in the job name, only in the steps.
     name: ${{ matrix.python-version }}-${{ matrix.job-name || 'default-tests' }}
     # We have Ubuntu as the base for running agains multiple Python versions.
-    runs-on: "${{ matrix.runs-on || 'ubuntu-22.04' }}"
+    runs-on: "${{ matrix.runs-on || 'ubuntu-24.04' }}"
     env:
       # By default we run all tests with all deps with coverage.
       TOXENV: "${{ matrix.tox-env || 'alldeps-withcov-posix' }}"
@@ -116,7 +116,7 @@ jobs:
           - python-version: '3.10.20'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-test'
-            runs-on: 'ubuntu-22.04'
+            runs-on: 'ubuntu-24.04'
 
           # `noipv6` is created to make sure all is OK on an OS which doesn't
           # have IPv6 available.
@@ -203,6 +203,7 @@ jobs:
           # of Gtk packaged within our selected version of Linux above.
           # This is executed using the oldest Python that we support.
           - python-version: '3.10'
+            runs-on: 'ubuntu-24.04'
             tox-env: 'alldeps-gtk-withcov-posix'
             platform-deps: 'gtk-platform'
             tox-wrapper: 'xvfb-run -a'
@@ -215,7 +216,7 @@ jobs:
           - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-linux'
-            runs-on: 'ubuntu-22.04'
+            runs-on: 'ubuntu-24.04'
 
           - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-windows'
@@ -319,7 +320,9 @@ jobs:
   coverage-report:
     name: Coverage report
     runs-on: ubuntu-latest
-    if: always()  # Always run the coverage report, even when the tests fail.
+    # Always run the coverage report, even when the tests fail.
+    # As long as the job is not cancelled.
+    if: ${{ !cancelled() }}
     needs:
       - testing  # Code coverage only needs to wait for test jobs.
     steps:
@@ -446,7 +449,7 @@ jobs:
 
 
   static-checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       TOX_PARALLEL_NO_SPINNER: 1
 
@@ -477,7 +480,7 @@ jobs:
   # The actual docs are built and published via Read The Docs.
   apidocs:
     name: API docs build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python
@@ -494,7 +497,7 @@ jobs:
 
   narrativedocs:
     name: Narrative docs build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python
@@ -517,7 +520,7 @@ jobs:
   # The files are published only when a tag is created using the next job, release-publish
   release-build:
     name: Build and check release, then upload artifact
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: actions/checkout@v6
 
@@ -582,7 +585,7 @@ jobs:
   all-successful:
     # Is very important to force running this always, as otherwise it will be
     #  skipped by default.
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # Here should be the list of all the other jobs defined in this file.
     needs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -219,14 +219,6 @@ jobs:
             runs-on: 'ubuntu-24.04'
 
           - python-version: '3.15.0-beta.1'
-            tox-env: 'nodeps-withcov-windows'
-            job-name: 'nodeps-windows-select'
-            runs-on: 'windows-2022'
-            # Should be removed once we can run distributed tests on Windows
-            # https://github.com/twisted/twisted/issues/12521
-            trial-args: '--reactor=select'
-
-          - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-macos'
             runs-on: 'macos-14'
@@ -268,7 +260,7 @@ jobs:
       if: matrix.platform-deps == 'gtk-platform'
       run: |
         # *-dev dependencies are for pygobject
-        # https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.42.0/setup.py#L129-L134
+        # https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.56.3/meson.build#L35-44
         sudo apt-get update
         sudo apt-get install -y \
           libgirepository-2.0-dev \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -217,11 +217,17 @@ jobs:
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-linux'
             runs-on: 'ubuntu-24.04'
+            # The arguments can be removed once trial tests are fixed.
+            # https://github.com/twisted/twisted/issues/12645
+            trial-target: '-- twisted.application twisted.conch twisted.cred twisted.enterprise twisted.internet twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.python twisted.runner twisted.scripts twisted.spread twisted.test twisted.web twisted.words'
 
           - python-version: '3.15.0-beta.1'
             tox-env: 'nodeps-withcov-posix'
             job-name: 'nodeps-macos'
             runs-on: 'macos-14'
+            # The arguments can be removed once trial tests are fixed.
+            # https://github.com/twisted/twisted/issues/12645
+            trial-target: '-- twisted.application twisted.conch twisted.cred twisted.enterprise twisted.internet twisted.logger twisted.mail twisted.names twisted.pair twisted.persisted twisted.protocols twisted.python twisted.runner twisted.scripts twisted.spread twisted.test twisted.web twisted.words'
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -275,6 +275,7 @@ jobs:
           libcairo2-dev \
           libffi-dev \
           gir1.2-gtk-3.0 \
+          girepository-2.0 \
           xvfb
 
     - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,8 +278,10 @@ include = [
         name = "Misc"
         showcontent = false
 
+# Next time you need to work on black consider migration to ruff
+# https://github.com/twisted/twisted/issues/12646
 [tool.black]
-target-version = ['py310', 'py311', 'py312', 'py313', 'py314', 'py315']
+target-version = ['py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ authors = [
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "zope.interface >= 5",
@@ -51,7 +51,7 @@ dependencies = [
 # We trust semantic versioning and auto-upgrading to a bugfix release
 # should be OK.
 test = [
-    "cython-test-exception-raiser >= 1.0.2, <2",
+    "cython-test-exception-raiser ~= 26.4.1",
     "PyHamcrest >= 2",
     "hypothesis >= 6.56",
     "httpx[http2] >= 0.27",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,9 +110,9 @@ all-non-platform = [
 
 macos-platform = [
     "twisted[all-non-platform]",
-    "pyobjc-core >= 12 ; python_version >= '3.10'",
-    "pyobjc-framework-CFNetwork >= 12; python_version >= '3.10'",
-    "pyobjc-framework-Cocoa >= 12; python_version >= '3.10'",
+    "pyobjc-core >= 12",
+    "pyobjc-framework-CFNetwork >= 12",
+    "pyobjc-framework-Cocoa >= 12",
 ]
 
 windows-platform = [
@@ -127,8 +127,7 @@ osx-platform = [
 
 gtk-platform = [
     "twisted[all-non-platform]",
-    "pygobject; python_version >= '3.10'",
-    "pygobject < 3.52.1; python_version < '3.10'",
+    "pygobject",
 ]
 
 mypy = [
@@ -280,7 +279,7 @@ include = [
         showcontent = false
 
 [tool.black]
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314', 'py315']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [
 description = "An asynchronous networking framework written in Python"
 license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-requires-python = ">=3.9.12"
+requires-python = ">=3.10.20"
 authors = [
     { name = "Twisted Matrix Community", email = "twisted@python.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [
 description = "An asynchronous networking framework written in Python"
 license = { text = "MIT License" }
 # When updating this value, make sure our CI matrix includes a matching minimum version.
-requires-python = ">=3.10.20"
+requires-python = ">=3.10"
 authors = [
     { name = "Twisted Matrix Community", email = "twisted@python.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,20 +60,20 @@ test = [
 # List of dependencies required to build the documentation and test the
 # release scripts and process.
 dev-release = [
-    "towncrier ~= 23.6",
     "pydoctor ~= 25.4.0",
     "sphinx-rtd-theme ~= 1.3",
     "sphinx >= 6, <7",
+    "twisted[dev]",
 ]
 
 # All the extra tools used to help with the development process.
 dev = [
     "twisted[test]",
-    "twisted[dev-release]",
     "pyflakes ~= 2.2",
     "python-subunit ~= 1.4",
     "twistedchecker ~= 0.7",
     "coverage ~= 7.5",
+    "towncrier ~= 23.6",
 ]
 
 tls = [

--- a/src/twisted/newsfragments/12640.feature
+++ b/src/twisted/newsfragments/12640.feature
@@ -1,0 +1,1 @@
+Python 3.14 is now supported.


### PR DESCRIPTION
## Scope and purpose

Fixes #12642
Fixes #12430

This updates GitHub Actions and prepare for a future release where Python 3.9 is no longer supported.


* It also enabled all Python 3.14 as it looks like all issues were fixed.

* It also enables a few Python 3.15 tests to help adding support for 3.15

* It uses a new release of the test helper... which is waiting a review here https://github.com/twisted/cython-test-exception-raiser/pull/20


* Run tests on Ubuntu 24.04 (from 22.04) by default... I expect that Ubuntu 22.04 will be removed at some time and I 24.04 was required for GTK tests.

* Separate sphinx + pydoctor deps, and don't install them on all dev enviromnents. Most devs don't build the docs... pydoctor apidocs take a very long time to build...and some sphinx extensions are not yet available on Python 3.15

* Enable all Python 3.14 tests

* Enable some Python 3.15 tests ... trial tests are skipped and will be fixed in https://github.com/twisted/twisted/pull/12602