### PR TITLE
#9101: add ability to enable SO_REUSEADDR and SO_REUSEPORT flags

### DIFF
--- a/docs/core/howto/clients.rst
+++ b/docs/core/howto/clients.rst
@@ -130,7 +130,7 @@ For endpoints, types such as :py:class:`HostnameEndpoint <twisted.internet.endpo
 - ``Binding``: an instance returned from :py:func:`makeBinding <twisted.internet.tcp.makeBinding>`
 
 The modern preference is to use :py:func:`makeBinding <twisted.internet.tcp.makeBinding>`.
-This is also the only way to specify the ``SO_REUSEADDR`` and ``SO_REUSEPORT`` options -- corresponding to the ``reuseAddr`` and ``reusePort`` keyword arguments to ``makeBinding``.
+This is also the only way to specify the ``SO_REUSEADDR`` and ``SO_REUSEPORT`` options -- corresponding to the ``reuseAddress`` and ``reusePort`` keyword arguments to ``makeBinding``.
 
 Legacy ClientCreator
 --------------------

--- a/docs/core/howto/clients.rst
+++ b/docs/core/howto/clients.rst
@@ -114,6 +114,27 @@ For more information on different ways you can make outgoing connections
 to different types of endpoints, as well as parsing strings into endpoints,
 see :doc:`the documentation for the endpoints API <endpoints>` .
 
+Binding to Specific Addresses
+-----------------------------
+
+When connecting, it is possible for clients to bind a socket to a specific address and/or port.
+There are various ways to do this and (on POSIX systems) flags such as ``SO_REUSEADDR`` and ``SO_REUSEPORT`` to consider as well.
+
+Due to backwards-compatibility and API changes, there are variety of ways to specify these intentions, typically as a ``bindAddress=`` keyword argument to relevant functions.
+
+For endpoints, types such as :py:class:`HostnameEndpoint <twisted.internet.endpoints.HostnameEndpoint>`, :py:class:`TCP4ClientEndpoint <twisted.internet.endpoints.TCP4ClientEndpoint>`, :py:class:`TCP6ClientEndpoint <twisted.internet.endpoints.TCP6ClientEndpoint>` etc. accept a ``bindAddress=`` argument that is one of several types:
+
+- ``None``: the default behavior
+- ``bytes | str``: an interface name, expressed as ``bytes`` (or ``str``)
+- ``2-tuple``: an "interface name + port" pair, where the "interface name" is ``bytes`` or ``str``
+- ``Binding``: an instance returned from :py:func:`makeBinding <twisted.internet.tcp.makeBinding>`
+
+The modern preference is to use :py:func:`makeBinding <twisted.internet.tcp.makeBinding>`.
+This is also the only way to specify the ``SO_REUSEADDR`` and ``SO_REUSEPORT`` options -- corresponding to the ``reuseAddr`` and ``reusePort`` keyword arguments to ``makeBinding``.
+
+Legacy ClientCreator
+--------------------
+
 You may come across code using :py:class:`ClientCreator <twisted.internet.protocol.ClientCreator>` , an older API which is not as flexible as
 the endpoint API.  Rather than calling ``connect`` on an endpoint,
 such code will look like this:

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -943,13 +943,9 @@ class HostnameEndpoint:
             self._bindAddress = makeBinding(bindAddress, 0)
         elif isinstance(bindAddress, tuple):
             if len(bindAddress) != 2:
-                raise ValueError(
-                    "tuple passed to bindAddress must be size 2"
-                )
+                raise ValueError("tuple passed to bindAddress must be size 2")
             if not isinstance(bindAddress[1], int):
-                raise ValueError(
-                    "bindAddress tuple must contain integer port"
-                )
+                raise ValueError("bindAddress tuple must contain integer port")
             if isinstance(bindAddress[0], bytes):
                 self._bindAddress = makeBinding(bindAddress[0].decode(), bindAddress[1])
             elif isinstance(bindAddress[0], str):

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -946,10 +946,18 @@ class HostnameEndpoint:
                 raise ValueError(
                     "tuple passed to bindAddress must be size 2"
                 )
+            if not isinstance(bindAddress[1], int):
+                raise ValueError(
+                    "bindAddress tuple must contain integer port"
+                )
             if isinstance(bindAddress[0], bytes):
                 self._bindAddress = makeBinding(bindAddress[0].decode(), bindAddress[1])
             elif isinstance(bindAddress[0], str):
                 self._bindAddress = makeBinding(bindAddress[0], bindAddress[1])
+            else:
+                raise ValueError(
+                    "bindAddress tuple must contain host as first argument"
+                )
         if attemptDelay is None:
             attemptDelay = self._DEFAULT_ATTEMPT_DELAY
         self._attemptDelay = attemptDelay

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -941,7 +941,7 @@ class HostnameEndpoint:
             self._bindAddress = makeBinding(bindAddress.decode(), 0)
         elif isinstance(bindAddress, str):
             self._bindAddress = makeBinding(bindAddress, 0)
-        elif isinstance(bindAddress, tuple):
+        else:  # must be tuple, according to type-hints
             if len(bindAddress) != 2:
                 raise ValueError("tuple passed to bindAddress must be size 2")
             if not isinstance(bindAddress[1], int):

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -942,6 +942,10 @@ class HostnameEndpoint:
         elif isinstance(bindAddress, str):
             self._bindAddress = makeBinding(bindAddress, 0)
         elif isinstance(bindAddress, tuple):
+            if len(bindAddress) != 2:
+                raise ValueError(
+                    "tuple passed to bindAddress must be size 2"
+                )
             if isinstance(bindAddress[0], bytes):
                 self._bindAddress = makeBinding(bindAddress[0].decode(), bindAddress[1])
             elif isinstance(bindAddress[0], str):

--- a/src/twisted/internet/endpoints.py
+++ b/src/twisted/internet/endpoints.py
@@ -37,6 +37,7 @@ from twisted.internet.address import (
     _ProcessAddress,
 )
 from twisted.internet.interfaces import (
+    Binding,
     IAddress,
     IHostnameResolver,
     IHostResolution,
@@ -53,8 +54,10 @@ from twisted.internet.interfaces import (
     IStreamClientEndpointStringParserWithReactor,
     IStreamServerEndpoint,
     IStreamServerEndpointStringParser,
+    _Binding,
 )
 from twisted.internet.protocol import ClientFactory, Factory, ProcessProtocol, Protocol
+from twisted.internet.tcp import makeBinding
 
 try:
     from twisted.internet.stdio import PipeAddress, StandardIO
@@ -620,7 +623,7 @@ class TCP4ClientEndpoint:
         host: str,
         port: int,
         timeout: float = 30,
-        bindAddress: str | tuple[bytes | str, int] | None = None,
+        bindAddress: Binding | str | tuple[bytes | str, int] | None = None,
     ) -> None:
         """
         @param reactor: An L{IReactorTCP} provider
@@ -869,7 +872,7 @@ class HostnameEndpoint:
         host: str | bytes,
         port: int,
         timeout: float = 30,
-        bindAddress: bytes | str | tuple[bytes | str, int] | None = None,
+        bindAddress: Binding | bytes | str | tuple[bytes | str, int] | None = None,
         attemptDelay: float | None = None,
     ) -> None:
         """
@@ -899,7 +902,9 @@ class HostnameEndpoint:
             specific local port. To bind the port, but leave the
             interface unbound, use a tuple of ("", port), or ("0.0.0.0",
             port) for IPv4, or ("::0", port) for IPv6. To leave both
-            interface and port unbound, just use None.
+            interface and port unbound, just use None. You may also pass
+            a Binding instance (as returned from L{makeBinding} to specify
+            further options.
         @type bindAddress: L{str}, L{tuple}, or None
 
         @param attemptDelay: The number of seconds to delay between connection
@@ -927,12 +932,20 @@ class HostnameEndpoint:
         self._port = port
         self._timeout = timeout
 
-        if bindAddress is not None:
-            if isinstance(bindAddress, (bytes, str)):
-                bindAddress = (bindAddress, 0)
+        self._bindAddress = None
+        if bindAddress is None:
+            pass
+        elif isinstance(bindAddress, _Binding):
+            self._bindAddress = bindAddress
+        elif isinstance(bindAddress, bytes):
+            self._bindAddress = makeBinding(bindAddress.decode(), 0)
+        elif isinstance(bindAddress, str):
+            self._bindAddress = makeBinding(bindAddress, 0)
+        elif isinstance(bindAddress, tuple):
             if isinstance(bindAddress[0], bytes):
-                bindAddress = (bindAddress[0].decode(), bindAddress[1])
-        self._bindAddress = bindAddress
+                self._bindAddress = makeBinding(bindAddress[0].decode(), bindAddress[1])
+            elif isinstance(bindAddress[0], str):
+                self._bindAddress = makeBinding(bindAddress[0], bindAddress[1])
         if attemptDelay is None:
             attemptDelay = self._DEFAULT_ATTEMPT_DELAY
         self._attemptDelay = attemptDelay
@@ -1289,7 +1302,9 @@ class SSL4ClientEndpoint:
         self._port = port
         self._sslContextFactory = sslContextFactory
         self._timeout = timeout
-        self._bindAddress = bindAddress
+        self._bindAddress = (
+            makeBinding() if bindAddress is None else makeBinding(*bindAddress)
+        )
 
     def connect(self, protocolFactory):
         """

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -9,9 +9,11 @@ Maintainer: Itamar Shtull-Trauring
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, AnyStr, Callable
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, NewType, Optional
 
 from zope.interface import Attribute, Interface
+
+from attr import frozen
 
 from twisted.python.failure import Failure
 
@@ -675,6 +677,17 @@ class IResolver(IResolverSimple):
         """
 
 
+@frozen
+class _Binding:
+    _addr: Optional[str] = None
+    _port: int = 0
+    _reuseAddr: bool = False
+    _reusePort: bool = False
+
+
+Binding = NewType("Binding", _Binding)
+
+
 class IReactorTCP(Interface):
     def listenTCP(
         port: int,
@@ -717,6 +730,62 @@ class IReactorTCP(Interface):
                         connection has failed.
         @param bindAddress: a (host, port) tuple of local address to bind
                             to, or None.
+
+        @return: An object which provides L{IConnector}. This connector will
+                 call various callbacks on the factory when a connection is
+                 made, failed, or lost - see
+                 L{ClientFactory<twisted.internet.protocol.ClientFactory>}
+                 docs for details.
+        """
+
+
+class IReactorTCP2(IReactorTCP):
+    def listenTCP(
+        port: _Binding | int,
+        factory: ServerFactory,
+        backlog: int = 50,
+        interface: str | None = None,
+    ) -> IListeningPort:
+        """
+        Connects a given protocol factory to the given numeric TCP/IP port.
+
+        @param port: object returned by
+            L{twisted.internet.tcp.makeBinding} describing which
+            address, port and options to use when binding
+        @param factory: a L{twisted.internet.protocol.ServerFactory} instance
+        @param backlog: size of the listen queue
+        @param interface: Unused.
+
+        Note that to bind to all IPv4 and IPv6 addresses, you must call this
+        method twice.
+
+        @return: an object that provides L{IListeningPort}.
+
+        @raise CannotListenError: as defined here
+                                  L{twisted.internet.error.CannotListenError},
+                                  if it cannot listen on this port (e.g., it
+                                  cannot bind to the required port number)
+        """
+
+    def connectTCP(
+        host: str,
+        port: int,
+        factory: ClientFactory[P],
+        timeout: float = 30.0,
+        # TODO: including the "tuple[str,int]" below makes mypy happy
+        # .. but how do we communicate to users "don't do that"?
+        bindAddress: _Binding | tuple[str, int] | None = None,
+    ) -> IConnector:
+        """
+        Connect a TCP client.
+
+        @param host: A hostname or an IPv4 or IPv6 address literal.
+        @param port: a port number
+        @param factory: a L{twisted.internet.protocol.ClientFactory} instance
+        @param timeout: number of seconds to wait before assuming the
+                        connection has failed.
+        @param bindAddress: configuration saying how to bind the
+            address, an object returned from L{twisted.internet.tcp.makeBinding}
 
         @return: An object which provides L{IConnector}. This connector will
                  call various callbacks on the factory when a connection is

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -9,7 +9,7 @@ Maintainer: Itamar Shtull-Trauring
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, AnyStr, Callable, NewType, Optional
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, NewType
 
 from zope.interface import Attribute, Interface
 
@@ -679,9 +679,9 @@ class IResolver(IResolverSimple):
 
 @frozen
 class _Binding:
-    _addr: Optional[str] = None
+    _address: str | None = None
     _port: int = 0
-    _reuseAddr: bool = False
+    _reuseAddress: bool = False
     _reusePort: bool = False
 
 

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from zope.interface import classImplements, implementer
 
 from twisted.internet import address, defer, error, interfaces, main
-from twisted.internet.abstract import _LogOwner, isIPv6Address
+from twisted.internet.abstract import _LogOwner
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.interfaces import IProtocol
 from twisted.internet.iocpreactor import abstract, iocpsupport as _iocp
@@ -430,6 +430,7 @@ class Port(_SocketCloser, _LogOwner):
     socketType = socket.SOCK_STREAM
     _addressType = address.IPv4Address
     sessionno = 0
+    factory = None
 
     # Actual port number being listened on, only set to a non-None
     # value when we are actually listening.

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -33,9 +33,11 @@ from twisted.internet.tcp import (
     _AbortingMixin,
     _BaseBaseClient,
     _BaseTCPClient,
+    _Binding,
     _getsockname,
     _resolveIPv6,
     _SocketCloser,
+    makeBinding,
 )
 from twisted.python import failure, log, reflect
 
@@ -265,7 +267,15 @@ class Client(_BaseBaseClient, _BaseTCPClient, Connection):
     def __init__(self, host, port, bindAddress, connector, reactor):
         # ConnectEx documentation says socket _has_ to be bound
         if bindAddress is None:
-            bindAddress = ("", 0)
+            bindAddress = makeBinding("", 0)
+        elif isinstance(bindAddress, tuple):
+            bindAddress = makeBinding(*bindAddress)
+        else:
+            assert isinstance(
+                bindAddress, _Binding
+            ), "bindAddress must be None, 2-tuple or Binding"
+        # bindAddress is a Binding, str, tuple or None .. so must be a
+        # Binding here if none of the above "if" checks hit
         self.reactor = reactor  # createInternetSocket needs this
         _BaseTCPClient.__init__(self, host, port, bindAddress, connector, reactor)
 
@@ -430,12 +440,27 @@ class Port(_SocketCloser, _LogOwner):
     # Only used for logging.
     _type = "TCP"
 
+    # TODO: this constructor basically duplicates ../tcp.Port's
+    # constuctor (and did before) but we _aren't_ subclassing Port so
+    # this code kind of has to be kept in sync? Is there a better way?
     def __init__(self, port, factory, backlog=50, interface="", reactor=None):
-        self.port = port
+        self.reactor = reactor
+        binding = port
+        if isinstance(binding, int):
+            binding = makeBinding(interface, port, reuseAddr=True)
+        else:
+            assert isinstance(binding, _Binding), "Binding is {}".format(binding)
+            if interface != "" and binding._addr != interface:
+                raise ValueError("Inconsistent interface vs Binding specifiers")
+        # we need to be backwards-compatible to when Port had settable
+        # .port and .interface attributes .. so we extract everything
+        # from Binding here (thus leaving Binding immutable).
+        self.port = binding._port
+        self.interface = "" if binding._addr is None else binding._addr
+        self._reuseAddr = binding._reuseAddr
+        self._reusePort = binding._reusePort
         self.factory = factory
         self.backlog = backlog
-        self.interface = interface
-        self.reactor = reactor
         if isIPv6Address(interface):
             self.addressFamily = socket.AF_INET6
             self._addressType = address.IPv6Address

--- a/src/twisted/internet/iocpreactor/tcp.py
+++ b/src/twisted/internet/iocpreactor/tcp.py
@@ -34,6 +34,7 @@ from twisted.internet.tcp import (
     _BaseBaseClient,
     _BaseTCPClient,
     _Binding,
+    _constructTCPPort,
     _getsockname,
     _resolveIPv6,
     _SocketCloser,
@@ -440,30 +441,9 @@ class Port(_SocketCloser, _LogOwner):
     # Only used for logging.
     _type = "TCP"
 
-    # TODO: this constructor basically duplicates ../tcp.Port's
-    # constuctor (and did before) but we _aren't_ subclassing Port so
-    # this code kind of has to be kept in sync? Is there a better way?
     def __init__(self, port, factory, backlog=50, interface="", reactor=None):
         self.reactor = reactor
-        binding = port
-        if isinstance(binding, int):
-            binding = makeBinding(interface, port, reuseAddr=True)
-        else:
-            assert isinstance(binding, _Binding), "Binding is {}".format(binding)
-            if interface != "" and binding._addr != interface:
-                raise ValueError("Inconsistent interface vs Binding specifiers")
-        # we need to be backwards-compatible to when Port had settable
-        # .port and .interface attributes .. so we extract everything
-        # from Binding here (thus leaving Binding immutable).
-        self.port = binding._port
-        self.interface = "" if binding._addr is None else binding._addr
-        self._reuseAddr = binding._reuseAddr
-        self._reusePort = binding._reusePort
-        self.factory = factory
-        self.backlog = backlog
-        if isIPv6Address(interface):
-            self.addressFamily = socket.AF_INET6
-            self._addressType = address.IPv6Address
+        _constructTCPPort(self, port, factory, backlog, interface)
 
     def __repr__(self) -> str:
         if self._realPortNumber is not None:

--- a/src/twisted/internet/posixbase.py
+++ b/src/twisted/internet/posixbase.py
@@ -17,6 +17,7 @@ from zope.interface import classImplements, implementer
 from twisted.internet import error, tcp, udp
 from twisted.internet.base import ReactorBase
 from twisted.internet.interfaces import (
+    Binding,
     IConnector,
     IHalfCloseableDescriptor,
     IReactorFDSet,
@@ -372,9 +373,10 @@ class PosixReactorBase(_DisconnectSelectableMixin, ReactorBase):
         port: int,
         factory: ClientFactory[P],
         timeout: float = 30.0,
-        bindAddress: tuple[str, int] | None = None,
+        bindAddress: Binding | tuple[str, int] | None = None,
     ) -> IConnector:
-        c = tcp.Connector(host, port, factory, timeout, bindAddress, self)
+        bind = tcp.makeBindingFromArg(bindAddress)
+        c = tcp.Connector(host, port, factory, timeout, bind, self)
         c.connect()
         return c
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -22,6 +22,7 @@ import attr
 
 from twisted.internet.error import ConnectionDone, ConnectionLost
 from twisted.internet.interfaces import (
+    Binding,
     IHalfCloseableProtocol,
     IListeningPort,
     IProtocol,
@@ -29,6 +30,7 @@ from twisted.internet.interfaces import (
     IReactorFDSet,
     ISystemHandle,
     ITCPTransport,
+    _Binding,
 )
 from twisted.internet.protocol import ClientFactory, P
 from twisted.logger import ILogObserver, LogEvent, Logger
@@ -208,6 +210,45 @@ class _AbortingMixin:
         self.reactor.callLater(
             0, self.connectionLost, failure.Failure(error.ConnectionAborted())
         )
+
+
+def makeBinding(
+    iface: str = "", port: int = 0, reuseAddr: bool = False, reusePort: bool = False
+) -> Binding:
+    """
+    Create an object describing how to bind locally.
+
+    This may include an address, a port and other options -- which
+    end up using e.g. C{setsockopt} on Posix.
+
+    C{reuseAddr} maps to C{SO_REUSEADDR} and C{reusePort} maps to
+    C{SO_REUSEPORT} on Posix systems.
+    """
+    return Binding(_Binding(iface, port, reuseAddr, reusePort))
+
+
+# note: it could make sense to have a makeExclusiveBinding() function
+# as well, that returns an object "similar" to above but for
+# Windows-only use-cases, so no reuseAddr or reusePort but adding
+# "exclusive" mapping to SO_EXCLUSIVEADDRUSE
+
+
+def makeBindingFromArg(arg: Binding | tuple[str, int] | None) -> Binding:
+    """
+    Convert a L{bindAddress} argument into a canonical L{Binding}
+    form.
+    """
+    if isinstance(arg, tuple):
+        bind = makeBinding(arg[0], arg[1])
+    elif arg is None:
+        bind = makeBinding("", 0)
+    else:
+        assert isinstance(
+            arg, _Binding
+        ), "arg must be None, 2-tuple or Binding not {}".format(type(arg))
+        addr = "" if arg._addr is None else arg._addr
+        bind = makeBinding(addr, arg._port, arg._reuseAddr, arg._reusePort)
+    return bind
 
 
 @implementer(ITLSTransport, ITCPTransport, ISystemHandle)
@@ -753,12 +794,17 @@ class _BaseTCPClient:
             err = error.ConnectBindError(se.args[0], se.args[1])
             whenDone = None
         if whenDone and bindAddress is not None:
+            assert isinstance(bindAddress, _Binding)
+            if bindAddress._reuseAddr:
+                skt.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if platformType == "posix" and sys.platform != "cygwin":
+                if bindAddress._reusePort:
+                    skt.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             try:
-                assert type(bindAddress) == tuple
-                if abstract.isIPv6Address(bindAddress[0]):
-                    bindinfo = _resolveIPv6(*bindAddress)
+                if abstract.isIPv6Address(bindAddress._addr):
+                    bindinfo = _resolveIPv6(bindAddress._addr, bindAddress._port)
                 else:
-                    bindinfo = bindAddress
+                    bindinfo = bindAddress._addr, bindAddress._port
                 skt.bind(bindinfo)
             except OSError as se:
                 err = error.ConnectBindError(se.args[0], se.args[1])
@@ -1313,13 +1359,30 @@ class Port(base.BasePort, _SocketCloser):
     ):
         """Initialize with a numeric port to listen on."""
         base.BasePort.__init__(self, reactor=reactor)
-        self.port = port
+        binding = port
+        if port is None:
+            # what does port of "None" really mean? socket.bind()
+            # doesn't say and it gets called like this below in
+            # _fromListeningDescriptor
+            binding = makeBinding(interface, port, reuseAddr=True)
+        if isinstance(binding, int):
+            binding = makeBinding(interface, port, reuseAddr=True)
+        else:
+            assert isinstance(binding, _Binding), "Binding is {}".format(binding)
+            if interface != "" and binding._addr != interface:
+                raise ValueError("Inconsistent interface vs Binding specifiers")
+        # we need to be backwards-compatible to when Port had settable
+        # .port and .interface attributes .. so we extract everything
+        # from Binding here (thus leaving Binding immutable).
+        self.port = binding._port
+        self.interface = "" if binding._addr is None else binding._addr
+        self._reuseAddr = binding._reuseAddr
+        self._reusePort = binding._reusePort
         self.factory = factory
         self.backlog = backlog
         if abstract.isIPv6Address(interface):
             self.addressFamily = socket.AF_INET6
             self._addressType = address.IPv6Address
-        self.interface = interface
 
     @classmethod
     def _fromListeningDescriptor(cls, reactor, fd, addressFamily, factory):
@@ -1360,7 +1423,10 @@ class Port(base.BasePort, _SocketCloser):
     def createInternetSocket(self):
         s = base.BasePort.createInternetSocket(self)
         if platformType == "posix" and sys.platform != "cygwin":
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if self._reuseAddr:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if self._reusePort:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         return s
 
     def startListening(self) -> None:
@@ -1551,7 +1617,7 @@ class Connector(base.BaseConnector):
         port: int | str,
         factory: ClientFactory[P],
         timeout: float,
-        bindAddress: str | tuple[str, int] | None,
+        bindAddress: Binding | str | tuple[str, int] | None,
         reactor: Any = None,
     ) -> None:
         if isinstance(port, str):

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -229,8 +229,7 @@ def makeBinding(
 
 # note: it could make sense to have a makeExclusiveBinding() function
 # as well, that returns an object "similar" to above but for
-# Windows-only use-cases, so no reuseAddr or reusePort but adding
-# "exclusive" mapping to SO_EXCLUSIVEADDRUSE
+# see https://github.com/twisted/twisted/issues/12677
 
 
 def makeBindingFromArg(arg: Binding | tuple[str, int] | None) -> Binding:

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -14,7 +14,7 @@ import os
 import socket
 import struct
 import sys
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol as TypingProtocol
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol as TypingProtocol, Optional
 
 from zope.interface import Interface, implementer
 
@@ -32,7 +32,7 @@ from twisted.internet.interfaces import (
     ITCPTransport,
     _Binding,
 )
-from twisted.internet.protocol import ClientFactory, P
+from twisted.internet.protocol import ClientFactory, P, Factory
 from twisted.logger import ILogObserver, LogEvent, Logger
 from twisted.python.runtime import platformType
 
@@ -1360,7 +1360,8 @@ class Port(base.BasePort, _SocketCloser):
     sessionno = 0
     interface = ""
     backlog = 50
-    factory = None
+    factory: Optional[Factory] = None
+    port: Optional[int] = None
 
     _type = "TCP"
 
@@ -1473,7 +1474,8 @@ class Port(base.BasePort, _SocketCloser):
 
         # The order of the next 5 lines is kind of bizarre.  If no one
         # can explain it, perhaps we should re-arrange them.
-        self.factory.doStart()
+        if self.factory is not None:
+            self.factory.doStart()
         self.connected = True
         self.socket = skt
         self.fileno = self.socket.fileno  # type:ignore[method-assign]

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1367,7 +1367,7 @@ class Port(base.BasePort, _SocketCloser):
     sessionno = 0
     interface = ""
     backlog = 50
-    factory: Optional[Factory] = None
+    factory: Optional[Factory] = None  # teach mypy "factory" exists
     port: Optional[int] = None
 
     _type = "TCP"
@@ -1481,8 +1481,7 @@ class Port(base.BasePort, _SocketCloser):
 
         # The order of the next 5 lines is kind of bizarre.  If no one
         # can explain it, perhaps we should re-arrange them.
-        if self.factory is not None:
-            self.factory.doStart()
+        self.factory.doStart()  # type: ignore
         self.connected = True
         self.socket = skt
         self.fileno = self.socket.fileno  # type:ignore[method-assign]

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -219,7 +219,7 @@ class _AbortingMixin:
 
 
 def makeBinding(
-    iface: str = "", port: int = 0, reuseAddr: bool = False, reusePort: bool = False
+    interface: str = "", port: int = 0, reuseAddress: bool = False, reusePort: bool = False
 ) -> Binding:
     """
     Create an object describing how to bind locally.
@@ -227,10 +227,10 @@ def makeBinding(
     This may include an address, a port and other options -- which
     end up using e.g. C{setsockopt} on Posix.
 
-    C{reuseAddr} maps to C{SO_REUSEADDR} and C{reusePort} maps to
+    C{reuseAddress} maps to C{SO_REUSEADDR} and C{reusePort} maps to
     C{SO_REUSEPORT} on Posix systems.
     """
-    return Binding(_Binding(iface, port, reuseAddr, reusePort))
+    return Binding(_Binding(interface, port, reuseAddress, reusePort))
 
 
 # note: it could make sense to have a makeExclusiveBinding() function
@@ -249,8 +249,8 @@ def makeBindingFromArg(arg: Binding | tuple[str, int] | None) -> Binding:
         bind = makeBinding("", 0)
     else:
         # not a tuple or None so it must be a Binding
-        addr = "" if arg._addr is None else arg._addr
-        bind = makeBinding(addr, arg._port, arg._reuseAddr, arg._reusePort)
+        addr = "" if arg._address is None else arg._address
+        bind = makeBinding(addr, arg._port, arg._reuseAddress, arg._reusePort)
     return bind
 
 
@@ -798,16 +798,16 @@ class _BaseTCPClient:
             whenDone = None
         if whenDone and bindAddress is not None:
             assert isinstance(bindAddress, _Binding)
-            if bindAddress._reuseAddr:
+            if bindAddress._reuseAddress:
                 skt.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if platformType == "posix" and sys.platform != "cygwin":
                 if bindAddress._reusePort:
                     skt.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             try:
-                if abstract.isIPv6Address(bindAddress._addr):
-                    bindinfo = _resolveIPv6(bindAddress._addr, bindAddress._port)
+                if abstract.isIPv6Address(bindAddress._address):
+                    bindinfo = _resolveIPv6(bindAddress._address, bindAddress._port)
                 else:
-                    bindinfo = bindAddress._addr, bindAddress._port
+                    bindinfo = bindAddress._address, bindAddress._port
                 skt.bind(bindinfo)
             except OSError as se:
                 err = error.ConnectBindError(se.args[0], se.args[1])
@@ -1300,19 +1300,19 @@ def _constructTCPPort(self, port, factory, backlog, interface):
         # what does port of "None" really mean? socket.bind()
         # doesn't say and it gets called like this below in
         # _fromListeningDescriptor
-        binding = makeBinding(interface, port, reuseAddr=True)
+        binding = makeBinding(interface, port, reuseAddress=True)
     if isinstance(binding, int):
-        binding = makeBinding(interface, port, reuseAddr=True)
+        binding = makeBinding(interface, port, reuseAddress=True)
     else:
         assert isinstance(binding, _Binding), "Binding is {}".format(binding)
-        if interface != "" and binding._addr != interface:
+        if interface != "" and binding._address != interface:
             raise ValueError("Inconsistent interface vs Binding specifiers")
     # we need to be backwards-compatible to when Port had settable
     # .port and .interface attributes .. so we extract everything
     # from Binding here (thus leaving Binding immutable).
     self.port = binding._port
-    self.interface = "" if binding._addr is None else binding._addr
-    self._reuseAddr = binding._reuseAddr
+    self.interface = "" if binding._address is None else binding._address
+    self._reuseAddress = binding._reuseAddress
     self._reusePort = binding._reusePort
     self.factory = factory
     self.backlog = backlog
@@ -1432,7 +1432,7 @@ class Port(base.BasePort, _SocketCloser):
     def createInternetSocket(self):
         s = base.BasePort.createInternetSocket(self)
         if platformType == "posix" and sys.platform != "cygwin":
-            if self._reuseAddr:
+            if self._reuseAddress:
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if self._reusePort:
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -14,7 +14,14 @@ import os
 import socket
 import struct
 import sys
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol as TypingProtocol, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Optional,
+    Protocol as TypingProtocol,
+)
 
 from zope.interface import Interface, implementer
 
@@ -32,7 +39,7 @@ from twisted.internet.interfaces import (
     ITCPTransport,
     _Binding,
 )
-from twisted.internet.protocol import ClientFactory, P, Factory
+from twisted.internet.protocol import ClientFactory, Factory, P
 from twisted.logger import ILogObserver, LogEvent, Logger
 from twisted.python.runtime import platformType
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -19,7 +19,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Optional,
     Protocol as TypingProtocol,
 )
 
@@ -1365,8 +1364,8 @@ class Port(base.BasePort, _SocketCloser):
     sessionno = 0
     interface = ""
     backlog = 50
-    factory: Optional[Factory] = None  # teach mypy "factory" exists
-    port: Optional[int] = None
+    factory: Factory | None = None  # teach mypy "factory" exists
+    port: int | None = None
 
     _type = "TCP"
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1291,6 +1291,33 @@ def _accept(logger, accepts, listener, reservedFD):
             yield client, address
 
 
+def _constructTCPPort(self, port, factory, backlog, interface):
+    binding = port
+    if port is None:
+        # what does port of "None" really mean? socket.bind()
+        # doesn't say and it gets called like this below in
+        # _fromListeningDescriptor
+        binding = makeBinding(interface, port, reuseAddr=True)
+    if isinstance(binding, int):
+        binding = makeBinding(interface, port, reuseAddr=True)
+    else:
+        assert isinstance(binding, _Binding), "Binding is {}".format(binding)
+        if interface != "" and binding._addr != interface:
+            raise ValueError("Inconsistent interface vs Binding specifiers")
+    # we need to be backwards-compatible to when Port had settable
+    # .port and .interface attributes .. so we extract everything
+    # from Binding here (thus leaving Binding immutable).
+    self.port = binding._port
+    self.interface = "" if binding._addr is None else binding._addr
+    self._reuseAddr = binding._reuseAddr
+    self._reusePort = binding._reusePort
+    self.factory = factory
+    self.backlog = backlog
+    if abstract.isIPv6Address(interface):
+        self.addressFamily = socket.AF_INET6
+        self._addressType = address.IPv6Address
+
+
 @implementer(IListeningPort)
 class Port(base.BasePort, _SocketCloser):
     """
@@ -1359,30 +1386,7 @@ class Port(base.BasePort, _SocketCloser):
     ):
         """Initialize with a numeric port to listen on."""
         base.BasePort.__init__(self, reactor=reactor)
-        binding = port
-        if port is None:
-            # what does port of "None" really mean? socket.bind()
-            # doesn't say and it gets called like this below in
-            # _fromListeningDescriptor
-            binding = makeBinding(interface, port, reuseAddr=True)
-        if isinstance(binding, int):
-            binding = makeBinding(interface, port, reuseAddr=True)
-        else:
-            assert isinstance(binding, _Binding), "Binding is {}".format(binding)
-            if interface != "" and binding._addr != interface:
-                raise ValueError("Inconsistent interface vs Binding specifiers")
-        # we need to be backwards-compatible to when Port had settable
-        # .port and .interface attributes .. so we extract everything
-        # from Binding here (thus leaving Binding immutable).
-        self.port = binding._port
-        self.interface = "" if binding._addr is None else binding._addr
-        self._reuseAddr = binding._reuseAddr
-        self._reusePort = binding._reusePort
-        self.factory = factory
-        self.backlog = backlog
-        if abstract.isIPv6Address(interface):
-            self.addressFamily = socket.AF_INET6
-            self._addressType = address.IPv6Address
+        _constructTCPPort(self, port, factory, backlog, interface)
 
     @classmethod
     def _fromListeningDescriptor(cls, reactor, fd, addressFamily, factory):

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -249,9 +249,7 @@ def makeBindingFromArg(arg: Binding | tuple[str, int] | None) -> Binding:
     elif arg is None:
         bind = makeBinding("", 0)
     else:
-        assert isinstance(
-            arg, _Binding
-        ), "arg must be None, 2-tuple or Binding not {}".format(type(arg))
+        # not a tuple or None so it must be a Binding
         addr = "" if arg._addr is None else arg._addr
         bind = makeBinding(addr, arg._port, arg._reuseAddr, arg._reusePort)
     return bind

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -14,13 +14,7 @@ import os
 import socket
 import struct
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Protocol as TypingProtocol,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol as TypingProtocol
 
 from zope.interface import Interface, implementer
 
@@ -219,7 +213,10 @@ class _AbortingMixin:
 
 
 def makeBinding(
-    interface: str = "", port: int = 0, reuseAddress: bool = False, reusePort: bool = False
+    interface: str = "",
+    port: int = 0,
+    reuseAddress: bool = False,
+    reusePort: bool = False,
 ) -> Binding:
     """
     Create an object describing how to bind locally.

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -1360,6 +1360,7 @@ class Port(base.BasePort, _SocketCloser):
     sessionno = 0
     interface = ""
     backlog = 50
+    factory = None
 
     _type = "TCP"
 

--- a/src/twisted/internet/test/reactormixins.py
+++ b/src/twisted/internet/test/reactormixins.py
@@ -277,7 +277,7 @@ class ReactorBuilder:
                     "under itself"
                 )
         try:
-            assert self.reactorFactory is not None
+            assert self.reactorFactory is not None, "reactorFactory is not provided"
             reactor = self.reactorFactory()
             reactor._originalReactorDict = globalReactor.__dict__
             reactor._originalReactorClass = globalReactor.__class__

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2873,6 +2873,19 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
             )
         self.assertIn("must be size 2", str(e.exception))
 
+    def test_portNotInt(self):
+        """
+        A 2-tuple is passed, but the port is not an integer
+        """
+        with self.assertRaises(ValueError) as e:
+            endpoints.HostnameEndpoint(
+                self.drr,
+                b"www.example.com",
+                80,
+                bindAddress=(b"localhost", "1234"),
+            )
+        self.assertIn("must contain integer port", str(e.exception))
+
     def test_notHost(self):
         """
         A tuple is passed, but first element isn't a str/bytes

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -67,6 +67,7 @@ from twisted.internet.interfaces import (
 from twisted.internet.protocol import ClientFactory, Factory, Protocol
 from twisted.internet.stdio import PipeAddress
 from twisted.internet.task import Clock
+from twisted.internet.tcp import makeBinding, makeBindingFromArg
 from twisted.internet.testing import (
     EventLoggingObserver,
     MemoryReactorClock,
@@ -1471,7 +1472,7 @@ class TCP4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -1578,7 +1579,7 @@ class TCP6EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -1625,7 +1626,7 @@ class TCP6EndpointNameResolutionTests(ClientEndpointTestCaseMixin, unittest.Test
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -2142,7 +2143,7 @@ class HostnameEndpointMemoryIPv4ReactorTests(
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -2204,7 +2205,7 @@ class HostnameEndpointMemoryIPv6ReactorTests(
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -2237,7 +2238,7 @@ class HostnameEndpointsOneIPv4Tests(ClientEndpointTestCaseMixin, unittest.TestCa
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -2435,7 +2436,7 @@ class HostnameEndpointsOneIPv6Tests(ClientEndpointTestCaseMixin, unittest.TestCa
                 address.port,
                 clientFactory,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -2828,25 +2829,30 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
     def setUp(self):
         self.drr = deterministicResolvingReactor(MemoryReactor(), ["127.0.0.1"])
 
+    def test_binding(self):
+        ba = makeBinding("1.2.3.4", 1234)
+        ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
+        self.assertEqual(ep._bindAddress, makeBinding("1.2.3.4", 1234))
+
     def test_bytes(self):
         ba = b"1.2.3.4"
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
-        self.assertEqual(ep._bindAddress, ("1.2.3.4", 0))
+        self.assertEqual(ep._bindAddress, makeBinding("1.2.3.4", 0))
 
     def test_str(self):
         ba = "1.2.3.4"
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
-        self.assertEqual(ep._bindAddress, ("1.2.3.4", 0))
+        self.assertEqual(ep._bindAddress, makeBinding("1.2.3.4", 0))
 
     def test_tuple_bytes(self):
         ba = (b"1.2.3.4", 1234)
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
-        self.assertEqual(ep._bindAddress, ("1.2.3.4", 1234))
+        self.assertEqual(ep._bindAddress, makeBinding("1.2.3.4", 1234))
 
     def test_tuple_str(self):
         ba = ("1.2.3.4", 1234)
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
-        self.assertEqual(ep._bindAddress, ("1.2.3.4", 1234))
+        self.assertEqual(ep._bindAddress, makeBinding("1.2.3.4", 1234))
 
     def test_none(self) -> None:
         ba = None
@@ -2993,7 +2999,7 @@ class SSL4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                 clientFactory,
                 self.clientSSLContext,
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -3222,7 +3228,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
                 address.port,
                 TLSWrapperFactoryChecker(self, clientFactory),
                 connectArgs.get("timeout", 30),
-                connectArgs.get("bindAddress", None),
+                makeBindingFromArg(connectArgs.get("bindAddress", None)),
             ),
             address,
         )
@@ -4082,7 +4088,7 @@ class SSLClientStringTests(unittest.TestCase):
         self.assertEqual(client._host, "example.net")
         self.assertEqual(client._port, 4321)
         self.assertEqual(client._timeout, 3)
-        self.assertEqual(client._bindAddress, ("10.0.0.3", 0))
+        self.assertEqual(client._bindAddress, makeBinding("10.0.0.3", 0))
         certOptions = client._sslContextFactory
         self.assertIsInstance(certOptions, CertificateOptions)
         self.assertEqual(certOptions.method, TLS_METHOD)
@@ -4134,7 +4140,7 @@ class SSLClientStringTests(unittest.TestCase):
         self.assertEqual(client._host, "example.net")
         self.assertEqual(client._port, 4321)
         self.assertEqual(client._timeout, 3)
-        self.assertEqual(client._bindAddress, ("10.0.0.3", 0))
+        self.assertEqual(client._bindAddress, makeBinding("10.0.0.3", 0))
 
     def test_sslWithDefaults(self):
         """
@@ -4761,7 +4767,7 @@ class WrapClientTLSParserTests(unittest.TestCase):
         self.assertEqual(hostnameEndpoint._hostBytes, b"example.com")
         self.assertEqual(hostnameEndpoint._port, 443)
         self.assertEqual(hostnameEndpoint._timeout, 10)
-        self.assertEqual(hostnameEndpoint._bindAddress, ("127.0.0.1", 0))
+        self.assertEqual(hostnameEndpoint._bindAddress, makeBinding("127.0.0.1", 0))
 
     def test_hostnameEndpointConstructionNoParameters(self) -> None:
         """
@@ -4831,8 +4837,8 @@ class WrapClientTLSParserTests(unittest.TestCase):
         )
         d = endpoint.connect(Factory.forProtocol(Protocol))
         host, port, factory, timeout, bindAddress = reactor.tcpClients.pop()
-        self.assertIs(type(bindAddress), tuple)
-        self.assertEqual(bindAddress, ("127.0.0.1", 0))
+        self.assertIs(type(bindAddress), interfaces._Binding)
+        self.assertEqual(bindAddress, makeBinding("127.0.0.1", 0))
         clientProtocol = factory.buildProtocol(None)
         self.assertNoResult(d)
         assert clientProtocol is not None

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2908,7 +2908,7 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
             attemptDelay=12.5,
         )
         attempts = Attempts()
-        port_d = ep.connect(attempts)
+        ep.connect(attempts)
 
         comp = ConnectionCompleter(self.reactor)
 
@@ -2922,7 +2922,7 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
 
         self.reactor.advance(7.0)
         # now the delay has passed, so we should be trying again
-        pump = comp.succeedOnce()
+        comp.succeedOnce()
         assert len(Attempts.instances) == 1
 
 

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2827,7 +2827,8 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
     """
 
     def setUp(self):
-        self.drr = deterministicResolvingReactor(MemoryReactor(), ["127.0.0.1"])
+        self.reactor = MemoryReactor()
+        self.drr = deterministicResolvingReactor(self.reactor, ["127.0.0.42"])
 
     def test_binding(self):
         ba = makeBinding("1.2.3.4", 1234)
@@ -2870,6 +2871,60 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
                 80,
                 bindAddress=(b"localhost", 1234, "not a 2-tuple")
             )
+
+    def test_notHost(self):
+        """
+        A tuple is passed, but first element isn't a str/bytes
+        """
+        with self.assertRaises(ValueError):
+            endpoints.HostnameEndpoint(
+                self.drr,
+                b"www.example.com",
+                80,
+                bindAddress=(4321, 1234)
+            )
+
+    def test_attemptDelay(self):
+        """
+        Pass a non-default attemptDelay
+        """
+
+        # we need two results for this test
+        self.drr = deterministicResolvingReactor(self.reactor, ["127.0.0.42", "127.0.0.43"])
+
+        fac = Factory.forProtocol(Protocol)
+        self.reactor.listenTCP(80, fac)
+
+        class Attempts(Factory):
+            instances = []
+
+            def buildProtocol(self, addr):
+                self.instances.append(Protocol())
+                return self.instances[-1]
+
+        ep = endpoints.HostnameEndpoint(
+            self.drr,
+            b"example.com",
+            80,
+            attemptDelay=12.5,
+        )
+        attempts = Attempts()
+        port_d = ep.connect(attempts)
+
+        comp = ConnectionCompleter(self.reactor)
+
+        assert len(Attempts.instances) == 0
+        comp.failOnce()
+
+        # one connection has already failed, but we shouldn't attempt
+        # the next one until our 12.5s delay expires
+        self.reactor.advance(6.0)
+        assert len(Attempts.instances) == 0
+
+        self.reactor.advance(7.0)
+        # now the delay has passed, so we should be trying again
+        pump = comp.succeedOnce() # debug=True)
+        assert len(Attempts.instances) == 1
 
 
 @skipIf(skipSSL, skipSSLReason)

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2859,6 +2859,18 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
         ep = endpoints.HostnameEndpoint(self.drr, b"example.com", 80, bindAddress=ba)
         self.assertEqual(ep._bindAddress, None)
 
+    def test_notTwoTuple(self):
+        """
+        A tuple is passed, but is not a 2-tuple
+        """
+        with self.assertRaises(ValueError):
+            endpoints.HostnameEndpoint(
+                self.drr,
+                b"www.example.com",
+                80,
+                bindAddress=(b"localhost", 1234, "not a 2-tuple")
+            )
+
 
 @skipIf(skipSSL, skipSSLReason)
 class SSL4EndpointsTests(EndpointTestCaseMixin, unittest.TestCase):

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2864,13 +2864,14 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
         """
         A tuple is passed, but is not a 2-tuple
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             endpoints.HostnameEndpoint(
                 self.drr,
                 b"www.example.com",
                 80,
                 bindAddress=(b"localhost", 1234, "not a 2-tuple"),
             )
+        self.assertIn("must be size 2", str(e.exception))
 
     def test_notHost(self):
         """

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -2869,7 +2869,7 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
                 self.drr,
                 b"www.example.com",
                 80,
-                bindAddress=(b"localhost", 1234, "not a 2-tuple")
+                bindAddress=(b"localhost", 1234, "not a 2-tuple"),
             )
 
     def test_notHost(self):
@@ -2878,10 +2878,7 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             endpoints.HostnameEndpoint(
-                self.drr,
-                b"www.example.com",
-                80,
-                bindAddress=(4321, 1234)
+                self.drr, b"www.example.com", 80, bindAddress=(4321, 1234)
             )
 
     def test_attemptDelay(self):
@@ -2890,7 +2887,9 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
         """
 
         # we need two results for this test
-        self.drr = deterministicResolvingReactor(self.reactor, ["127.0.0.42", "127.0.0.43"])
+        self.drr = deterministicResolvingReactor(
+            self.reactor, ["127.0.0.42", "127.0.0.43"]
+        )
 
         fac = Factory.forProtocol(Protocol)
         self.reactor.listenTCP(80, fac)
@@ -2923,7 +2922,7 @@ class HostnameEndpointBindAddressTypes(unittest.TestCase):
 
         self.reactor.advance(7.0)
         # now the delay has passed, so we should be trying again
-        pump = comp.succeedOnce() # debug=True)
+        pump = comp.succeedOnce()
         assert len(Attempts.instances) == 1
 
 

--- a/src/twisted/internet/test/test_protocol.py
+++ b/src/twisted/internet/test/test_protocol.py
@@ -26,6 +26,7 @@ from twisted.internet.protocol import (
     Protocol,
     ProtocolToConsumerAdapter,
 )
+from twisted.internet.tcp import makeBinding
 from twisted.internet.testing import MemoryReactorClock, StringTransport
 from twisted.logger import LogLevel, globalLogPublisher
 from twisted.python.failure import Failure
@@ -72,7 +73,7 @@ class ClientCreatorTests(TestCase):
             self.assertEqual(host, "example.com")
             self.assertEqual(port, 1234)
             self.assertEqual(timeout, 4321)
-            self.assertEqual(bindAddress, ("1.2.3.4", 9876))
+            self.assertEqual(bindAddress, makeBinding("1.2.3.4", 9876))
             return factory
 
         self._basicConnectTest(check)

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -1061,15 +1061,14 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         """
 
         def check(client):
-            if platformType == "posix" and sys.platform != "cygwin":
-                reuseAddr = bool(
-                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
-                )
-                self.assertEqual(reuseAddr, False)
-                reusePort = bool(
-                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
-                )
-                self.assertEqual(reusePort, False)
+            reuseAddr = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            )
+            self.assertEqual(reuseAddr, False)
+            reusePort = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+            )
+            self.assertEqual(reusePort, False)
 
         self._checkTestBindAddressConnect(makeBinding, check)
         self._checkTestBindAddressListen(makeBinding, check)
@@ -1080,15 +1079,14 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
     )
     def test_bindAddressReusePort(self):
         def check(client):
-            if platformType == "posix" and sys.platform != "cygwin":
-                reuseAddr = bool(
-                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
-                )
-                self.assertEqual(reuseAddr, False)
-                reusePort = bool(
-                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
-                )
-                self.assertEqual(reusePort, True)
+            reuseAddr = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            )
+            self.assertEqual(reuseAddr, False)
+            reusePort = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+            )
+            self.assertEqual(reusePort, True)
 
         def bind(a, b):
             return makeBinding(a, b, reusePort=True, reuseAddress=False)

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -1091,7 +1091,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
                 self.assertEqual(reusePort, True)
 
         def bind(a, b):
-            return makeBinding(a, b, reusePort=True, reuseAddr=False)
+            return makeBinding(a, b, reusePort=True, reuseAddress=False)
 
         self._checkTestBindAddressConnect(bind, check)
         self._checkTestBindAddressListen(bind, check)
@@ -1112,7 +1112,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
             self.assertEqual(reusePort, False)
 
         def bind(a, b):
-            return makeBinding(a, b, reuseAddr=True)
+            return makeBinding(a, b, reuseAddress=True)
 
         self._checkTestBindAddressConnect(bind, check)
         self._checkTestBindAddressListen(bind, check)
@@ -1136,7 +1136,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
             self.assertEqual(reusePort, True)
 
         def bind(a, b):
-            return makeBinding(a, b, reuseAddr=True, reusePort=True)
+            return makeBinding(a, b, reuseAddress=True, reusePort=True)
 
         self._checkTestBindAddressConnect(bind, check)
         self._checkTestBindAddressListen(bind, check)

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -1051,20 +1051,6 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
 
         self._checkTestBindAddressListen(lambda host, port: port, check_server)
 
-    def test_bindAddressIllegal(self):
-        """
-        An error happens when passing something unsupported
-        """
-
-        class Unsupported:
-            pass
-
-        def bind(host, port):
-            return Unsupported()
-
-        with self.assertRaises((AssertionError, SkipTest)):
-            self._checkTestBindAddressConnect(bind, lambda _: None)
-
     @skipIf(
         not (platformType == "posix" and sys.platform != "cygwin"),
         "Only works on POSIX",

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -13,6 +13,7 @@ import gc
 import io
 import os
 import socket
+import sys
 from collections.abc import Mapping, Sequence
 from functools import wraps
 from typing import Any, Callable, ClassVar
@@ -72,6 +73,7 @@ from twisted.internet.tcp import (
     _IFileDescriptorReservation,
     _NullFileDescriptorReservation,
     _resolveIPv6,
+    makeBinding,
 )
 from twisted.internet.test.connectionmixins import (
     BrokenContextFactory,
@@ -99,7 +101,7 @@ from twisted.logger import Logger
 from twisted.python import log
 from twisted.python.compat import _PYPY
 from twisted.python.failure import Failure
-from twisted.python.runtime import platform
+from twisted.python.runtime import platform, platformType
 from twisted.test.test_tcp import (
     ClientStartStopFactory,
     ClosingFactory,
@@ -921,6 +923,241 @@ class TCP6ClientTestsBuilder(TCPClientTestsBase):
         # it so that the connect call for the IPv6 address test simply uses an
         # address literal.
         self.fakeDomainName = self.endpoints.interface
+
+
+class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
+    """
+    Test the various combinations of bindAddress arguments
+    """
+
+    requiredInterfaces = (IReactorTCP,)
+    fakeDomainName = "some-fake.domain.example.com"
+    family = socket.AF_INET
+    addressClass = IPv4Address
+
+    def _actuallyTestBindAddressConnect(self, createBinding, confirmClient):
+        """
+        Harness to test passing bindAddress= variants to connectTCP
+        """
+        host, port = findFreePort(self.interface, self.family)[:2]
+        reactor = self.buildReactor()
+        fakeDomain = self.fakeDomainName
+        reactor.installResolver(FakeResolver({fakeDomain: self.interface}))
+
+        clientFactory = Stop(reactor)
+        bindAddress = createBinding(host, port)
+
+        log.msg(f"Connect attempt with bindAddress {bindAddress}")
+        connector = reactor.connectTCP(
+            fakeDomain,
+            port,
+            clientFactory,
+            bindAddress=bindAddress,
+        )
+        client = connector.transport
+        laddr = client.socket.getsockname()
+        self.assertEqual(laddr[1], port)
+        confirmClient(client)
+
+    def _actuallyTestBindAddressListen(self, createBinding, confirmPort):
+        """
+        Harness to test passing bindAddress= variants to listenTCP
+        """
+        host, port = findFreePort(self.interface, self.family)[:2]
+        reactor = self.buildReactor()
+
+        serverFactory = MyServerFactory()
+        bindAddress = createBinding(host, port)
+
+        log.msg(f"Listen with bindAddress {bindAddress}")
+        tcpport = reactor.listenTCP(
+            bindAddress,
+            serverFactory,
+        )
+        addr = tcpport.getHost()
+        self.assertEqual(addr.port, port)
+        confirmPort(tcpport)
+
+    def test_bindAddressListenInconsistent(self):
+        """
+        Both an interface= and port= with Binding cannot be
+        specifed at once
+        """
+        host, port = findFreePort(self.interface, self.family)[:2]
+        reactor = self.buildReactor()
+
+        serverFactory = MyServerFactory()
+        bindAddress = makeBinding(host, port)
+
+        log.msg(f"Listen with bindAddress {bindAddress}")
+        with self.assertRaises(ValueError):
+            _ = reactor.listenTCP(
+                bindAddress,
+                serverFactory,
+                interface="inconsistent interface",
+            )
+
+    def test_bindAddressListenConsistent(self):
+        """
+        It is okay to specify both a Binding and an interface as long as
+        they're consistent.
+        """
+        host, port = findFreePort(self.interface, self.family)[:2]
+        reactor = self.buildReactor()
+
+        serverFactory = MyServerFactory()
+        bindAddress = makeBinding(host, port)
+
+        _ = reactor.listenTCP(
+            bindAddress,
+            serverFactory,
+            interface=host,
+        )
+
+    def test_bindAddressLegacy(self):
+        """
+        We can use a (host, port) 2-tuple for the binding
+        """
+
+        def check_client(client):
+            reuseAddr = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            )
+            self.assertEqual(reuseAddr, False)
+            if platformType == "posix" and sys.platform != "cygwin":
+                reusePort = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+                )
+                self.assertEqual(reusePort, False)
+
+        self._actuallyTestBindAddressConnect(
+            lambda host, port: tuple((host, port)), check_client
+        )
+
+    def test_bindAddressLegacyServerDefault(self):
+        """
+        Legacy defaults for SO_REUSEADDR and SO_REUSEPORT are
+        different for the connect vs listen APIs: SO_REUSEADDR was
+        always specified in Twisted 26.4.0 and earlier for listen
+        ports.
+        """
+
+        def check_server(client):
+            if platformType == "posix" and sys.platform != "cygwin":
+                reuseAddr = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+                )
+                self.assertEqual(reuseAddr, True)
+                reusePort = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+                )
+                self.assertEqual(reusePort, False)
+
+        self._actuallyTestBindAddressListen(lambda host, port: port, check_server)
+
+    def test_bindAddressIllegal(self):
+        """
+        An error happens when passing something unsupported
+        """
+
+        class Unsupported:
+            pass
+
+        def bind(host, port):
+            return Unsupported()
+
+        with self.assertRaises((AssertionError, SkipTest)):
+            self._actuallyTestBindAddressConnect(bind, lambda _: None)
+
+    @skipIf(
+        not (platformType == "posix" and sys.platform != "cygwin"),
+        "Only works on POSIX",
+    )
+    def test_bindAddressBasic(self):
+        """
+        Defaults for makeBinding are correct
+        """
+
+        def check(client):
+            if platformType == "posix" and sys.platform != "cygwin":
+                reuseAddr = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+                )
+                self.assertEqual(reuseAddr, False)
+                reusePort = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+                )
+                self.assertEqual(reusePort, False)
+
+        self._actuallyTestBindAddressConnect(makeBinding, check)
+        self._actuallyTestBindAddressListen(makeBinding, check)
+
+    @skipIf(
+        not (platformType == "posix" and sys.platform != "cygwin"),
+        "Only works on POSIX",
+    )
+    def test_bindAddressReusePort(self):
+        def check(client):
+            if platformType == "posix" and sys.platform != "cygwin":
+                reuseAddr = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+                )
+                self.assertEqual(reuseAddr, False)
+                reusePort = bool(
+                    client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+                )
+                self.assertEqual(reusePort, True)
+
+        def bind(a, b):
+            return makeBinding(a, b, reusePort=True, reuseAddr=False)
+
+        self._actuallyTestBindAddressConnect(bind, check)
+        self._actuallyTestBindAddressListen(bind, check)
+
+    @skipIf(
+        not (platformType == "posix" and sys.platform != "cygwin"),
+        "Only works on POSIX",
+    )
+    def test_bindAddressReuseAddr(self):
+        def check(client):
+            reuseAddr = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            )
+            reusePort = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+            )
+            self.assertEqual(reuseAddr, True)
+            self.assertEqual(reusePort, False)
+
+        def bind(a, b):
+            return makeBinding(a, b, reuseAddr=True)
+
+        self._actuallyTestBindAddressConnect(bind, check)
+        self._actuallyTestBindAddressListen(bind, check)
+
+    @skipIf(
+        not (platformType == "posix" and sys.platform != "cygwin"),
+        "Only works on POSIX",
+    )
+    def test_bindAddressReuseAddrPort(self):
+        def check(client):
+            reuseAddr = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            )
+            reusePort = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+            )
+            self.assertEqual(reuseAddr, True)
+            reusePort = bool(
+                client.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
+            )
+            self.assertEqual(reusePort, True)
+
+        def bind(a, b):
+            return makeBinding(a, b, reuseAddr=True, reusePort=True)
+
+        self._actuallyTestBindAddressConnect(bind, check)
+        self._actuallyTestBindAddressListen(bind, check)
 
 
 class TCPConnectorTestsBuilder(ReactorBuilder):
@@ -2567,6 +2804,7 @@ globals().update(TCP4ConnectorTestsBuilder.makeTestCaseClasses())
 globals().update(TCP6ConnectorTestsBuilder.makeTestCaseClasses())
 globals().update(TCPTransportTestsBuilder.makeTestCaseClasses())
 globals().update(AdoptStreamConnectionTestsBuilder.makeTestCaseClasses())
+globals().update(TestBindAddressBuilder.makeTestCaseClasses())
 
 
 class ServerAbortsTwice(ConnectableProtocol):

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -935,7 +935,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
     family = socket.AF_INET
     addressClass = IPv4Address
 
-    def _actuallyTestBindAddressConnect(self, createBinding, confirmClient):
+    def _checkTestBindAddressConnect(self, createBinding, confirmClient):
         """
         Harness to test passing bindAddress= variants to connectTCP
         """
@@ -959,7 +959,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         self.assertEqual(laddr[1], port)
         confirmClient(client)
 
-    def _actuallyTestBindAddressListen(self, createBinding, confirmPort):
+    def _checkTestBindAddressListen(self, createBinding, confirmPort):
         """
         Harness to test passing bindAddress= variants to listenTCP
         """
@@ -1030,7 +1030,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
                 )
                 self.assertEqual(reusePort, False)
 
-        self._actuallyTestBindAddressConnect(
+        self._checkTestBindAddressConnect(
             lambda host, port: tuple((host, port)), check_client
         )
 
@@ -1053,7 +1053,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
                 )
                 self.assertEqual(reusePort, False)
 
-        self._actuallyTestBindAddressListen(lambda host, port: port, check_server)
+        self._checkTestBindAddressListen(lambda host, port: port, check_server)
 
     def test_bindAddressIllegal(self):
         """
@@ -1067,7 +1067,7 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
             return Unsupported()
 
         with self.assertRaises((AssertionError, SkipTest)):
-            self._actuallyTestBindAddressConnect(bind, lambda _: None)
+            self._checkTestBindAddressConnect(bind, lambda _: None)
 
     @skipIf(
         not (platformType == "posix" and sys.platform != "cygwin"),
@@ -1089,8 +1089,8 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
                 )
                 self.assertEqual(reusePort, False)
 
-        self._actuallyTestBindAddressConnect(makeBinding, check)
-        self._actuallyTestBindAddressListen(makeBinding, check)
+        self._checkTestBindAddressConnect(makeBinding, check)
+        self._checkTestBindAddressListen(makeBinding, check)
 
     @skipIf(
         not (platformType == "posix" and sys.platform != "cygwin"),
@@ -1111,8 +1111,8 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         def bind(a, b):
             return makeBinding(a, b, reusePort=True, reuseAddr=False)
 
-        self._actuallyTestBindAddressConnect(bind, check)
-        self._actuallyTestBindAddressListen(bind, check)
+        self._checkTestBindAddressConnect(bind, check)
+        self._checkTestBindAddressListen(bind, check)
 
     @skipIf(
         not (platformType == "posix" and sys.platform != "cygwin"),
@@ -1132,8 +1132,8 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         def bind(a, b):
             return makeBinding(a, b, reuseAddr=True)
 
-        self._actuallyTestBindAddressConnect(bind, check)
-        self._actuallyTestBindAddressListen(bind, check)
+        self._checkTestBindAddressConnect(bind, check)
+        self._checkTestBindAddressListen(bind, check)
 
     @skipIf(
         not (platformType == "posix" and sys.platform != "cygwin"),
@@ -1156,8 +1156,8 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         def bind(a, b):
             return makeBinding(a, b, reuseAddr=True, reusePort=True)
 
-        self._actuallyTestBindAddressConnect(bind, check)
-        self._actuallyTestBindAddressListen(bind, check)
+        self._checkTestBindAddressConnect(bind, check)
+        self._checkTestBindAddressListen(bind, check)
 
 
 class TCPConnectorTestsBuilder(ReactorBuilder):

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -617,7 +617,6 @@ class TCPClientTestsBase(ReactorBuilder, ConnectionTestsMixin, StreamClientTests
             while True:
                 port = findFreePort(self.interface, self.family)
                 bindAddress = (self.interface, port[1])
-                log.msg(f"Connect attempt with bindAddress {bindAddress}")
                 try:
                     reactor.connectTCP(
                         fakeDomain,
@@ -947,7 +946,6 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         clientFactory = Stop(reactor)
         bindAddress = createBinding(host, port)
 
-        log.msg(f"Connect attempt with bindAddress {bindAddress}")
         connector = reactor.connectTCP(
             fakeDomain,
             port,
@@ -969,7 +967,6 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         serverFactory = MyServerFactory()
         bindAddress = createBinding(host, port)
 
-        log.msg(f"Listen with bindAddress {bindAddress}")
         tcpport = reactor.listenTCP(
             bindAddress,
             serverFactory,
@@ -989,7 +986,6 @@ class TestBindAddressBuilder(TCPCreator, ReactorBuilder):
         serverFactory = MyServerFactory()
         bindAddress = makeBinding(host, port)
 
-        log.msg(f"Listen with bindAddress {bindAddress}")
         with self.assertRaises(ValueError):
             _ = reactor.listenTCP(
                 bindAddress,

--- a/src/twisted/internet/testing.py
+++ b/src/twisted/internet/testing.py
@@ -19,7 +19,7 @@ from zope.interface.verify import verifyClass
 
 from typing_extensions import ParamSpec, Self
 
-from twisted.internet import address, error, protocol, task
+from twisted.internet import address, error, protocol, task, tcp
 from twisted.internet.abstract import _dataMustBeBytes, isIPv6Address
 from twisted.internet.address import IPv4Address, IPv6Address, UNIXAddress
 from twisted.internet.defer import Deferred, ensureDeferred, succeed
@@ -735,7 +735,8 @@ class MemoryReactor:
         Fake L{IReactorTCP.connectTCP}, that logs the call and
         returns an L{IConnector}.
         """
-        self.tcpClients.append((host, port, factory, timeout, bindAddress))
+        bind = tcp.makeBindingFromArg(bindAddress)
+        self.tcpClients.append((host, port, factory, timeout, bind))
         if isIPv6Address(host):
             conn = _FakeConnector(IPv6Address("TCP", host, port))
         else:

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -422,7 +422,12 @@ class Port(_UNIXPort, tcp.Port):
                         # If it fails, there's not much else we can
                         # do.  The bind() below will fail with an
                         # exception that actually propagates.
-                        if stat.S_ISSOCK(os.stat(self._bindPath).st_mode):
+
+                        # The S_ISSOCK check is to avoid deleting
+                        # non-socket files, for example from a typo or
+                        # other mistake in the provided path. See also:
+                        # https://github.com/twisted/twisted/issues/12785
+                        if stat.S_ISSOCK(os.stat(self._bindPath).st_mode):  # pragma: no branch
                             os.remove(self._bindPath)
                     except BaseException:
                         pass

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -355,7 +355,7 @@ class Port(_UNIXPort, tcp.Port):
         reactor: Any = None,
         wantPID: int = 0,
     ) -> None:
-        tcp.Port.__init__(self, None, factory, backlog, reactor=reactor)
+        tcp.Port.__init__(self, 0, factory, backlog, reactor=reactor)
         self._bindPath = self._buildAddr(fileName).name
         self.mode = mode
         self.wantPID = wantPID

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -355,9 +355,8 @@ class Port(_UNIXPort, tcp.Port):
         reactor: Any = None,
         wantPID: int = 0,
     ) -> None:
-        tcp.Port.__init__(
-            self, self._buildAddr(fileName).name, factory, backlog, reactor=reactor
-        )
+        tcp.Port.__init__(self, None, factory, backlog, reactor=reactor)
+        self._bindPath = self._buildAddr(fileName).name
         self.mode = mode
         self.wantPID = wantPID
         self._preexistingSocket = None
@@ -386,7 +385,7 @@ class Port(_UNIXPort, tcp.Port):
         if hasattr(self, "socket"):
             return "<{} on {!r}>".format(
                 factoryName,
-                _coerceToFilesystemEncoding("", self.port),
+                _coerceToFilesystemEncoding("", self._bindPath),
             )
         else:
             return f"<{factoryName} (not listening)>"
@@ -406,13 +405,15 @@ class Port(_UNIXPort, tcp.Port):
             "%s starting on %r"
             % (
                 self._getLogPrefix(self.factory),
-                _coerceToFilesystemEncoding("", self.port),
+                _coerceToFilesystemEncoding("", self._bindPath),
             )
         )
         if self.wantPID:
-            self.lockFile = lockfile.FilesystemLock(self.port + b".lock")
+            self.lockFile = lockfile.FilesystemLock(self._bindPath + b".lock")
             if not self.lockFile.lock():
-                raise error.CannotListenError(None, self.port, "Cannot acquire lock")
+                raise error.CannotListenError(
+                    None, self._bindPath, "Cannot acquire lock"
+                )
             else:
                 if not self.lockFile.clean:
                     try:
@@ -421,8 +422,8 @@ class Port(_UNIXPort, tcp.Port):
                         # If it fails, there's not much else we can
                         # do.  The bind() below will fail with an
                         # exception that actually propagates.
-                        if stat.S_ISSOCK(os.stat(self.port).st_mode):
-                            os.remove(self.port)
+                        if stat.S_ISSOCK(os.stat(self._bindPath).st_mode):
+                            os.remove(self._bindPath)
                     except BaseException:
                         pass
 
@@ -434,13 +435,13 @@ class Port(_UNIXPort, tcp.Port):
                 self._preexistingSocket = None
             else:
                 skt = self.createInternetSocket()
-                skt.bind(self.port)
+                skt.bind(self._bindPath)
         except OSError as le:
-            raise error.CannotListenError(None, self.port, le)
+            raise error.CannotListenError(None, self._bindPath, le)
         else:
-            if _inFilesystemNamespace(self.port):
+            if _inFilesystemNamespace(self._bindPath):
                 # Make the socket readable and writable to the world.
-                os.chmod(self.port, self.mode)
+                os.chmod(self._bindPath, self.mode)
             skt.listen(self.backlog)
             self.connected = True
             self.socket = skt
@@ -457,14 +458,14 @@ class Port(_UNIXPort, tcp.Port):
             % (
                 _coerceToFilesystemEncoding(
                     "",
-                    self.port,
+                    self._bindPath,
                 )
             )
         )
 
     def connectionLost(self, reason):
-        if _inFilesystemNamespace(self.port):
-            os.unlink(self.port)
+        if _inFilesystemNamespace(self._bindPath):
+            os.unlink(self._bindPath)
         if self.lockFile is not None:
             self.lockFile.unlock()
         tcp.Port.connectionLost(self, reason)

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -427,7 +427,9 @@ class Port(_UNIXPort, tcp.Port):
                         # non-socket files, for example from a typo or
                         # other mistake in the provided path. See also:
                         # https://github.com/twisted/twisted/issues/12785
-                        if stat.S_ISSOCK(os.stat(self._bindPath).st_mode):  # pragma: no branch
+                        if stat.S_ISSOCK(
+                            os.stat(self._bindPath).st_mode
+                        ):  # pragma: no branch
                             os.remove(self._bindPath)
                     except BaseException:
                         pass

--- a/src/twisted/newsfragments/9101.feature
+++ b/src/twisted/newsfragments/9101.feature
@@ -1,0 +1,1 @@
+It is now possible to set the SO_REUSEPORT and SO_REUSEADDR TCP socket flags from user code.

--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -982,7 +982,7 @@ class _StandardEndpointFactory:
         @type connectTimeout: L{float} or L{None}
 
         @param bindAddress: The local address for client sockets to bind to.
-        @type bindAddress: L{bytes} or L{None}
+        @type bindAddress: L{Binding} or L{tuple} or L{bytes} or L{None}
         """
         self._reactor = reactor
         self._policyForHTTPS = contextFactory
@@ -1067,7 +1067,7 @@ class Agent(_AgentBase):
         @type connectTimeout: L{float}
 
         @param bindAddress: The local address for client sockets to bind to.
-        @type bindAddress: L{bytes}
+        @type bindAddress: L{Binding} or L{tuple} or L{bytes} or L{None}
 
         @param pool: An L{HTTPConnectionPool} instance, or L{None}, in which
             case a non-persistent L{HTTPConnectionPool} instance will be

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -31,6 +31,7 @@ from twisted.internet.error import (
 from twisted.internet.interfaces import IOpenSSLClientConnectionCreator
 from twisted.internet.protocol import Factory, Protocol
 from twisted.internet.task import Clock
+from twisted.internet.tcp import makeBinding
 from twisted.internet.test.test_endpoints import deterministicResolvingReactor
 from twisted.internet.testing import (
     AccumulatingProtocol,
@@ -1255,7 +1256,7 @@ class AgentTests(
         agent = client.Agent(self.reactor, bindAddress="192.168.0.1")
         agent.request(b"GET", b"http://foo/")
         address = self.reactor.tcpClients.pop()[4]
-        self.assertEqual(("192.168.0.1", 0), address)
+        self.assertEqual(makeBinding("192.168.0.1", 0), address)
 
     @skipIf(not sslPresent, "SSL not present, cannot run SSL tests.")
     def test_bindAddressSSL(self):
@@ -1266,7 +1267,7 @@ class AgentTests(
         agent = client.Agent(self.reactor, bindAddress="192.168.0.1")
         agent.request(b"GET", b"https://foo/")
         address = self.reactor.tcpClients.pop()[4]
-        self.assertEqual(("192.168.0.1", 0), address)
+        self.assertEqual(makeBinding("192.168.0.1", 0), address)
 
     def test_responseIncludesRequest(self):
         """


### PR DESCRIPTION
## Scope and purpose

Fixes #9101 
Fixes #12575

- [x] tests to cover the new interfaces / functionality
- [x] final name for `IReactorTCP2`
- [x] properly appease mypy about line 774 in interfaces.py?
- [x] are we only running the setsockopt calls on posix?
- [x] needs newsfragment


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
