### PR TITLE
#12654 Upgrade Codspeed and Codecov Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -373,7 +373,7 @@ jobs:
         path: htmlcov
 
     - name: Publish to codecov.io
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       if: ${{ !cancelled() }}
       with:
         files: coverage.xml
@@ -431,7 +431,7 @@ jobs:
           benchmarks
 
     - name: Publish benchmarks coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       if: ${{ !cancelled() }}
       with:
         files: coverage.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -382,7 +382,10 @@ jobs:
 
 
   benchmarks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read  # required for actions/checkout
+      id-token: write # required for OIDC authentication with CodSpeed
 
     steps:
     - uses: actions/checkout@v6
@@ -407,9 +410,9 @@ jobs:
         python -m pip install '.[tls,conch,http2]' pytest pytest-codspeed pytest-cov pytest-benchmark
 
     - name: Run benchmarks
-      uses: CodSpeedHQ/action@v3
+      uses: CodSpeedHQ/action@v4
       with:
-        token: ${{ secrets.CODSPEED_TOKEN }}
+        mode: simulation
         # codspeed runs this command under a CPU emulator, so it's super-slow,
         # so we try to just do the benchmarks and nothing else.
         run: python -m pytest --codspeed benchmarks/


### PR DESCRIPTION
## Scope and purpose

Fixes #12654

Nodejs 24 will be enforced next month. June 16th according to this link: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I expect that this pull request will have an effect on the Benchmark baseline, due to upgrading Ubuntu from 22.04 to 24.04. And I hope that changing the legacy token, to using OIDC won't break anything.

I'm pulling in an upgrade for Codecov here too, it adds support for Nodejs 24.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
