### PR TITLE
#12656 Exit non-zero when twistd gets an unknown subcommand

### DIFF
--- a/src/twisted/application/app.py
+++ b/src/twisted/application/app.py
@@ -669,6 +669,7 @@ def run(runApp, ServerOptions):
         commstr = " ".join(sys.argv[0:2])
         print(config)
         print(f"{commstr}: {ue}")
+        sys.exit(1)
     else:
         runApp(config)
 

--- a/src/twisted/newsfragments/12656.bugfix
+++ b/src/twisted/newsfragments/12656.bugfix
@@ -1,0 +1,1 @@
+`twistd` now exits with a non-zero status when given an unknown subcommand.

--- a/src/twisted/test/test_twistd.py
+++ b/src/twisted/test/test_twistd.py
@@ -5,7 +5,6 @@
 Tests for L{twisted.application.app} and L{twisted.scripts.twistd}.
 """
 
-
 import errno
 import inspect
 import os
@@ -2136,7 +2135,6 @@ def stubApplicationRunnerFactoryCreator(signum):
 
 
 class ExitWithSignalTests(TestCase):
-
     """
     Tests for L{twisted.application.app._exitWithSignal}.
     """
@@ -2208,3 +2206,21 @@ class ExitWithSignalTests(TestCase):
         twistd.runApp(self.config)
         self.assertEqual(self.fakeKillArgs[0], os.getpid())
         self.assertEqual(self.fakeKillArgs[1], signal.SIGINT)
+
+
+class RunTests(TestCase):
+    """
+    Tests for L{twisted.application.app.run}.
+    """
+
+    def test_usageErrorExitsNonZero(self):
+        """
+        L{app.run} exits with a non-zero status code when L{ServerOptions}
+        raises L{usage.error} (e.g. an unknown subcommand is given).
+        """
+        self.patch(sys, "argv", ["twistd", "no-such-command"])
+        self.patch(sys, "stdout", StringIO())
+        exc = self.assertRaises(
+            SystemExit, app.run, lambda config: None, twistd.ServerOptions
+        )
+        self.assertEqual(exc.code, 1)


### PR DESCRIPTION
## Scope and purpose

Fixes #12656

`twistd -n no-such-command` was printing the error message but returning exit code 0 instead of 1. This happened because `app.run()` caught `usage.error`, printed a message, and returned normally without calling `sys.exit`. The fix adds `sys.exit(1)` in the exception handler so callers and shell scripts can detect failure.

A regression test in `RunTests` patches `sys.argv` and `sys.stdout`, calls `app.run()` with an unknown subcommand, and asserts `SystemExit` with code 1 is raised.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like "#1234 Brief description".
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.