### PR TITLE
#12664 Fix deprecation warnings from pyOpenSSL 26.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ mypy = [
     "mypy==2.1.0",
     "mypy-zope==1.0.15",
     "types-setuptools",
-    "types-pyOpenSSL",
 ]
 
 [project.scripts]

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -798,9 +798,12 @@ class KeyPair(PublicKey):
 
     @classmethod
     def generate(Class, kind=crypto.TYPE_RSA, size=2048):
-        if kind != crypto.TYPE_RSA:
+        if kind == crypto.TYPE_RSA:
+            key = rsa.generate_private_key(public_exponent=65537, key_size=size)
+        elif kind == crypto.TYPE_DSA:
+            key = dsa.generate_private_key(key_size=size)
+        else:
             raise ValueError(f"Unsupported key type: {kind!r}")
-        key = rsa.generate_private_key(public_exponent=65537, key_size=size)
         return Class(crypto.PKey.from_cryptography_key(key))
 
     def newCertificate(self, newCertData, format=crypto.FILETYPE_ASN1):

--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 import warnings
 from binascii import hexlify
 from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from hashlib import md5
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeAlias, TypeVar, cast
 
 from zope.interface import Interface, implementer
 
@@ -22,6 +23,7 @@ import attr
 from constantly import FlagConstant, Flags, NamedConstant, Names
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, rsa
 from cryptography.x509.oid import NameOID
 from incremental import Version
 
@@ -53,7 +55,18 @@ from ._service_identity import (
 )
 
 if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519
+
     from twisted.protocols.tls import TLSMemoryBIOProtocol
+
+    # The private key types accepted by SSL.Context.use_privatekey.
+    _ContextPrivateKey: TypeAlias = (
+        dsa.DSAPrivateKey
+        | ec.EllipticCurvePrivateKey
+        | ed25519.Ed25519PrivateKey
+        | ed448.Ed448PrivateKey
+        | rsa.RSAPrivateKey
+    )
 
 _log = Logger()
 
@@ -245,15 +258,19 @@ class DistinguishedName(dict[str, bytes]):
         for k, v in kw.items():
             setattr(self, k, v)
 
-    def _copyFrom(self, x509name):
-        for name in _x509names:
-            value = getattr(x509name, name, None)
-            if value is not None:
-                setattr(self, name, value)
+    def _copyFrom(self, x509name: x509.Name) -> None:
+        for attribute in x509name:
+            name = _x509OIDNames.get(attribute.oid)
+            if name is not None:
+                setattr(self, name, attribute.value)
 
-    def _copyInto(self, x509name):
-        for k, v in self.items():
-            setattr(x509name, k, nativeString(v))
+    def _toNameObject(self) -> x509.Name:
+        return x509.Name(
+            [
+                x509.NameAttribute(_x509NameOIDs[k], nativeString(v))
+                for k, v in self.items()
+            ]
+        )
 
     def __repr__(self) -> str:
         return "<DN %s>" % (dict.__repr__(self)[1:-1])
@@ -311,7 +328,7 @@ class CertBase:
 
     def _copyName(self, suffix):
         dn = DistinguishedName()
-        dn._copyFrom(getattr(self.original, "get_" + suffix)())
+        dn._copyFrom(getattr(self.original.to_cryptography(), suffix))
         return dn
 
     def getSubject(self):
@@ -742,7 +759,23 @@ class KeyPair(PublicKey):
         return Class(crypto.load_privatekey(format, data))
 
     def dump(self, format=crypto.FILETYPE_ASN1):
-        return crypto.dump_privatekey(format, self.original)
+        key = self.original.to_cryptography_key()
+        # These (encoding, format) pairs match the output of pyOpenSSL's
+        # dump_privatekey byte-for-byte.
+        if format == crypto.FILETYPE_ASN1:
+            return key.private_bytes(
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        elif format == crypto.FILETYPE_PEM:
+            return key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        else:
+            raise ValueError(f"Unsupported format: {format!r}")
 
     @deprecated(Version("Twisted", 15, 0, 0), "a real persistence system")
     def __getstate__(self):
@@ -765,9 +798,10 @@ class KeyPair(PublicKey):
 
     @classmethod
     def generate(Class, kind=crypto.TYPE_RSA, size=2048):
-        pkey = crypto.PKey()
-        pkey.generate_key(kind, size)
-        return Class(pkey)
+        if kind != crypto.TYPE_RSA:
+            raise ValueError(f"Unsupported key type: {kind!r}")
+        key = rsa.generate_private_key(public_exponent=65537, key_size=size)
+        return Class(crypto.PKey.from_cryptography_key(key))
 
     def newCertificate(self, newCertData, format=crypto.FILETYPE_ASN1):
         return PrivateCertificate.load(newCertData, self, format)
@@ -775,14 +809,7 @@ class KeyPair(PublicKey):
     def requestObject(self, distinguishedName, digestAlgorithm="sha256"):
         req = (
             x509.CertificateSigningRequestBuilder()
-            .subject_name(
-                x509.Name(
-                    [
-                        x509.NameAttribute(_x509NameOIDs[k], nativeString(v))
-                        for k, v in distinguishedName.items()
-                    ]
-                )
-            )
+            .subject_name(distinguishedName._toNameObject())
             .sign(
                 self.original.to_cryptography_key(),
                 _digestAlgorithms[digestAlgorithm](),
@@ -855,15 +882,28 @@ class KeyPair(PublicKey):
         Sign a CertificateRequest instance, returning a Certificate instance.
         """
         req = requestObject.original
-        cert = crypto.X509()
-        issuerDistinguishedName._copyInto(cert.get_issuer())
-        requestObject._subjectToDistinguishedName()._copyInto(cert.get_subject())
-        cert.set_pubkey(crypto.PKey.from_cryptography_key(req.public_key()))
-        cert.gmtime_adj_notBefore(0)
-        cert.gmtime_adj_notAfter(secondsToExpiry)
-        cert.set_serial_number(serialNumber)
-        cert.sign(self.original, digestAlgorithm)
-        return Certificate(cert)
+        notBefore = datetime.now(timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .issuer_name(issuerDistinguishedName._toNameObject())
+            .subject_name(req.subject)
+            .public_key(req.public_key())
+            .serial_number(serialNumber)
+            .not_valid_before(notBefore)
+            .not_valid_after(notBefore + timedelta(seconds=secondsToExpiry))
+            # This API historically issued version 1 certificates, which may
+            # act as CAs.  Version 3 certificates need basicConstraints to say
+            # so explicitly, or they cannot sign other certificates.
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=None),
+                critical=False,
+            )
+            .sign(
+                self.original.to_cryptography_key(),
+                _digestAlgorithms[digestAlgorithm](),
+            )
+        )
+        return Certificate(crypto.X509.from_cryptography(cert))
 
     def selfSignedCert(self, serialNumber, **kw):
         dn = DN(**kw)
@@ -1123,7 +1163,7 @@ class ClientTLSOptions:
 
 def _verifyCB(
     tlsProtocol: TLSMemoryBIOProtocol, hostIsDNS: bool, hostnameASCII: str
-) -> Callable[[Connection, X509, int, int, bool], bool]:
+) -> Callable[[Connection, X509, int, int, int], bool]:
     svcid: ServiceID
     if hostIsDNS:
         svcid = DNS_ID(hostnameASCII)
@@ -1133,9 +1173,9 @@ def _verifyCB(
     weakProtoRef: TLSMemoryBIOProtocol | None = tlsProtocol
 
     def verifyCallback(
-        conn: Connection, cert: X509, err: int, depth: int, ok: bool
+        conn: Connection, cert: X509, err: int, depth: int, ok: int
     ) -> bool:
-        ourVerifyResult = ok
+        ourVerifyResult = bool(ok)
         nonlocal weakProtoRef
         try:
             if depth != 0:
@@ -1641,7 +1681,7 @@ class OpenSSLCertificateOptions:
         ctx = self.getContext()
         cxn = Connection(ctx)
         if acceptable := protosFromProtocol(protocol, self._acceptableProtocols or ()):
-            cxn.set_alpn_protos(acceptable)
+            cxn.set_alpn_protos(list(acceptable))
         return cxn
 
     def _makeContext(self, skipCiphers: bool = False) -> SSL.Context:
@@ -1659,10 +1699,16 @@ class OpenSSLCertificateOptions:
         ctx.set_mode(self._mode)
 
         if self.certificate is not None and self.privateKey is not None:
-            ctx.use_certificate(self.certificate)
-            ctx.use_privatekey(self.privateKey)
+            # pyOpenSSL deprecates passing its own X509/PKey types here, so
+            # convert them to cryptography objects first.
+            ctx.use_certificate(self.certificate.to_cryptography())
+            # to_cryptography_key is declared as possibly returning a public
+            # key, but this PKey always holds a private key.
+            ctx.use_privatekey(
+                cast("_ContextPrivateKey", self.privateKey.to_cryptography_key())
+            )
             for extraCert in self.extraCertChain:
-                ctx.add_extra_chain_cert(extraCert)
+                ctx.add_extra_chain_cert(extraCert.to_cryptography())
             # Sanity check
             ctx.check_privatekey()
 

--- a/src/twisted/newsfragments/12664.removal
+++ b/src/twisted/newsfragments/12664.removal
@@ -1,1 +1,0 @@
-twisted.internet.ssl.KeyPair.generate no longer supports generating DSA keys (or any key type other than RSA).

--- a/src/twisted/newsfragments/12664.removal
+++ b/src/twisted/newsfragments/12664.removal
@@ -1,0 +1,1 @@
+twisted.internet.ssl.KeyPair.generate no longer supports generating DSA keys (or any key type other than RSA).

--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -5,6 +5,7 @@
 Tests for twisted SSL support.
 """
 
+import datetime
 import os
 
 import hamcrest
@@ -19,10 +20,11 @@ from twisted.test.test_tcp import ProperlyCloseFilesMixin
 from twisted.trial.unittest import TestCase
 
 try:
-    from OpenSSL import SSL, crypto
+    from OpenSSL import SSL
 
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
     from cryptography.x509.oid import NameOID
 
     from twisted.internet import ssl
@@ -166,36 +168,34 @@ def generateCertificateObjects(organization, organizationalUnit):
 
     @return: a tuple of (key, request, certificate) objects.
     """
-    pkey = crypto.PKey()
-    pkey.generate_key(crypto.TYPE_RSA, 2048)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization),
+            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, organizationalUnit),
+        ]
+    )
     req = (
         x509.CertificateSigningRequestBuilder()
-        .subject_name(
-            x509.Name(
-                [
-                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization),
-                    x509.NameAttribute(
-                        NameOID.ORGANIZATIONAL_UNIT_NAME, organizationalUnit
-                    ),
-                ]
-            )
-        )
-        .sign(pkey.to_cryptography_key(), hashes.SHA256())
+        .subject_name(name)
+        .sign(key, hashes.SHA256())
     )
 
     # Here comes the actual certificate
-    cert = crypto.X509()
-    cert.set_serial_number(1)
-    cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(60)  # Testing certificates need not be long lived
-    subject = cert.get_subject()
-    subject.O = organization
-    subject.OU = organizationalUnit
-    cert.set_issuer(cert.get_subject())
-    cert.set_pubkey(pkey)
-    cert.sign(pkey, "md5")
+    notBefore = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(1)
+        .not_valid_before(notBefore)
+        # Testing certificates need not be long lived
+        .not_valid_after(notBefore + datetime.timedelta(seconds=60))
+        .sign(key, hashes.SHA256())
+    )
 
-    return pkey, req, cert
+    return key, req, cert
 
 
 def generateCertificateFiles(basename, organization, organizationalUnit):
@@ -203,12 +203,19 @@ def generateCertificateFiles(basename, organization, organizationalUnit):
     Create certificate files key, req and cert prefixed by C{basename} for
     given C{organization} and C{organizationalUnit}.
     """
-    pkey, req, cert = generateCertificateObjects(organization, organizationalUnit)
+    key, req, cert = generateCertificateObjects(organization, organizationalUnit)
 
     for ext, data in [
-        ("key", crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey)),
+        (
+            "key",
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ),
+        ),
         ("req", req.public_bytes(serialization.Encoding.PEM)),
-        ("cert", crypto.dump_certificate(crypto.FILETYPE_PEM, cert)),
+        ("cert", cert.public_bytes(serialization.Encoding.PEM)),
     ]:
         fName = os.extsep.join((basename, ext)).encode("utf-8")
         FilePath(fName).setContent(data)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -31,14 +31,13 @@ from twisted.internet.interfaces import (
     IProtocolNegotiationFactory,
 )
 from twisted.internet.task import Clock
-from twisted.python.compat import nativeString
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.python.modules import getModule
 from twisted.python.reflect import requireModule
 from twisted.test.iosim import IOPump, connectedServerAndClient
 from twisted.trial import util
-from twisted.trial.unittest import SkipTest, SynchronousTestCase, TestCase
+from twisted.trial.unittest import SynchronousTestCase, TestCase
 
 skipSSL = ""
 
@@ -46,7 +45,7 @@ if requireModule("OpenSSL"):
     import ipaddress
 
     from OpenSSL import SSL
-    from OpenSSL.crypto import FILETYPE_PEM, TYPE_RSA, X509, PKey, get_elliptic_curves
+    from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_TEXT, TYPE_DSA, X509, PKey
 
     from cryptography import x509
     from cryptography.hazmat.backends import default_backend
@@ -126,29 +125,37 @@ A_PEER_CERTIFICATE_PEM = """
 A_KEYPAIR = getModule(__name__).filePath.sibling("server.pem").getContent()
 
 
-def counter(counter=itertools.count()):
+def counter(counter=itertools.count(1)):
     """
-    Each time we're called, return the next integer in the natural numbers.
+    Each time we're called, return the next integer in the natural numbers,
+    starting from 1 (certificate serial numbers must be positive).
     """
     return next(counter)
 
 
 def makeCertificate(**kw):
-    keypair = PKey()
-    keypair.generate_key(TYPE_RSA, 2048)
+    privateKey = generate_private_key(public_exponent=65537, key_size=2048)
+    name = sslverify.DN(**kw)._toNameObject()
+    notBefore = datetime.datetime.now(datetime.timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .issuer_name(name)
+        .subject_name(name)
+        .public_key(privateKey.public_key())
+        .serial_number(counter())
+        .not_valid_before(notBefore)
+        .not_valid_after(notBefore + datetime.timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(privateKey, hashes.SHA256())
+    )
 
-    certificate = X509()
-    certificate.gmtime_adj_notBefore(0)
-    certificate.gmtime_adj_notAfter(60 * 60 * 24 * 365)  # One year
-    for xname in certificate.get_issuer(), certificate.get_subject():
-        for k, v in kw.items():
-            setattr(xname, k, nativeString(v))
-
-    certificate.set_serial_number(counter())
-    certificate.set_pubkey(keypair)
-    certificate.sign(keypair, "md5")
-
-    return keypair, certificate
+    return (
+        PKey.from_cryptography_key(privateKey),
+        X509.from_cryptography(certificate),
+    )
 
 
 oneDay = datetime.timedelta(1, 0, 0)
@@ -976,9 +983,15 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         )
         opts._contextFactory = FakeContext
         ctx = opts.getContext()
-        self.assertEqual(self.sKey, ctx._privateKey)
-        self.assertEqual(self.sCert, ctx._certificate)
-        self.assertEqual(self.extraCertChain, ctx._extraCertChain)
+        self.assertEqual(
+            self.sKey.to_cryptography_key().private_numbers(),
+            ctx._privateKey.private_numbers(),
+        )
+        self.assertEqual(self.sCert.to_cryptography(), ctx._certificate)
+        self.assertEqual(
+            [cert.to_cryptography() for cert in self.extraCertChain],
+            ctx._extraCertChain,
+        )
 
     def test_extraChainDoesNotBreakPyOpenSSL(self):
         """
@@ -1959,9 +1972,6 @@ class OpenSSLOptionsECDHIntegrationTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Connections use ECDH when OpenSSL supports it.
         """
-        if not get_elliptic_curves():
-            raise SkipTest("OpenSSL does not support ECDH.")
-
         onData = defer.Deferred()
         # TLS 1.3 cipher suites do not specify the key exchange
         # mechanism:
@@ -3465,6 +3475,29 @@ class KeyPairTests(TestCase):
             sslverify.KeyPair(self.sKey).__setstate__,
             state,
         )
+
+    def test_generateOnlySupportsRSA(self):
+        """
+        L{sslverify.KeyPair.generate} rejects key types other than RSA.
+        """
+        self.assertRaises(ValueError, sslverify.KeyPair.generate, TYPE_DSA)
+
+    def test_dumpPEM(self):
+        """
+        A L{sslverify.KeyPair} dumped to PEM can be loaded back.
+        """
+        keyPair = sslverify.KeyPair(self.sKey)
+        data = keyPair.dump(FILETYPE_PEM)
+        self.assertEqual(
+            keyPair.keyHash(), sslverify.KeyPair.load(data, FILETYPE_PEM).keyHash()
+        )
+
+    def test_dumpUnsupportedFormat(self):
+        """
+        L{sslverify.KeyPair.dump} rejects formats other than C{FILETYPE_PEM}
+        and C{FILETYPE_ASN1}.
+        """
+        self.assertRaises(ValueError, sslverify.KeyPair(self.sKey).dump, FILETYPE_TEXT)
 
     def test_noTrailingNewlinePemCert(self):
         noTrailingNewlineKeyPemPath = getModule("twisted.test").filePath.sibling(

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -50,7 +50,7 @@ if requireModule("OpenSSL"):
     from cryptography import x509
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric import dsa, ec
     from cryptography.hazmat.primitives.asymmetric.rsa import (
         RSAPrivateKey,
         generate_private_key,
@@ -3476,11 +3476,26 @@ class KeyPairTests(TestCase):
             state,
         )
 
-    def test_generateOnlySupportsRSA(self):
+    def test_generateRSA(self):
         """
-        L{sslverify.KeyPair.generate} rejects key types other than RSA.
+        L{sslverify.KeyPair.generate} generates an RSA key by default.
         """
-        self.assertRaises(ValueError, sslverify.KeyPair.generate, TYPE_DSA)
+        keyPair = sslverify.KeyPair.generate(size=1024)
+        self.assertIsInstance(keyPair.original.to_cryptography_key(), RSAPrivateKey)
+
+    def test_generateDSA(self):
+        """
+        L{sslverify.KeyPair.generate} generates a DSA key when passed
+        L{crypto.TYPE_DSA}.
+        """
+        keyPair = sslverify.KeyPair.generate(TYPE_DSA, size=1024)
+        self.assertIsInstance(keyPair.original.to_cryptography_key(), dsa.DSAPrivateKey)
+
+    def test_generateUnsupportedType(self):
+        """
+        L{sslverify.KeyPair.generate} rejects key types other than RSA and DSA.
+        """
+        self.assertRaises(ValueError, sslverify.KeyPair.generate, object())
 
     def test_dumpPEM(self):
         """


### PR DESCRIPTION
pyOpenSSL 26.3.0 deprecates most of OpenSSL.crypto (X509Name, X509 mutation methods, PKey.generate_key, dump_privatekey, get_elliptic_curves) and warns when pyOpenSSL X509/PKey objects are passed to SSL.Context.use_certificate/use_privatekey/ add_extra_chain_cert.  Migrate the remaining users to pyca/cryptography APIs:

- DistinguishedName now copies from/to cryptography x509.Name objects, and CertBase name accessors go through X509.to_cryptography().
- KeyPair.generate, KeyPair.dump, and KeyPair.signRequestObject use cryptography key generation, serialization, and CertificateBuilder. Certificates issued by signRequestObject are now version 3, so they gain a basicConstraints CA extension to preserve their historical (version 1) ability to sign other certificates.
- OpenSSLCertificateOptions._makeContext converts certificates and keys to cryptography objects before loading them into the context.
- The makeCertificate/generateCertificateObjects test helpers build certificates with CertificateBuilder, and the deprecated get_elliptic_curves ECDH support check is removed.

https://claude.ai/code/session_019dKipsLLUcb2NkNFog8JGS

## Scope and purpose

Fixes #12664
Fixes #12638