### PR TITLE
#12670 Remove `_ServerFactoryIPv4Address` class from `twisted.internet.address`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -812,7 +812,6 @@ module = [
     'twisted.internet._posixserialport',
     'twisted.internet._posixstdio',
     'twisted.internet._producer_helpers',
-    'twisted.internet.address',
     'twisted.internet.default',
     'twisted.internet.epollreactor',
     'twisted.internet.gireactor',

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -103,34 +103,25 @@ class UNIXAddress:
 
     name: bytes | None = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))
 
-    if getattr(os.path, "samefile", None) is not None:
-
-        def __eq__(self, other: object) -> bool:
-            """
-            Overriding C{attrs} to ensure the os level samefile
-            check is done if the name attributes do not match.
-            """
-            if not isinstance(other, self.__class__):
-                return NotImplemented
-            res = self.name == other.name
-            if not res and self.name and other.name:
-                try:
-                    return os.path.samefile(self.name, other.name)
-                except OSError:
-                    pass
-                except (TypeError, ValueError) as e:
-                    # On Linux, abstract namespace UNIX sockets start with a
-                    # \0, which os.path doesn't like.
-                    if not platform.isLinux():
-                        raise e
-            return res
-
-    else:
-
-        def __eq__(self, other: object) -> bool:
-            if isinstance(other, self.__class__):
-                return self.name == other.name
+    def __eq__(self, other: object) -> bool:
+        """
+        Overriding C{attrs} to ensure the os level samefile
+        check is done if the name attributes do not match.
+        """
+        if not isinstance(other, self.__class__):
             return NotImplemented
+        res = self.name == other.name
+        if not res and self.name and other.name:
+            try:
+                return os.path.samefile(self.name, other.name)
+            except OSError:
+                pass
+            except (TypeError, ValueError) as e:
+                # On Linux, abstract namespace UNIX sockets start with a
+                # \0, which os.path doesn't like.
+                if not platform.isLinux():
+                    raise e
+        return res
 
     def __repr__(self) -> str:
         name = self.name

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -29,10 +29,8 @@ class IPv4Address:
 
     @ivar host: A string containing a dotted-quad IPv4 address; for example,
         "127.0.0.1".
-    @type host: C{str}
 
     @ivar port: An integer representing the port number.
-    @type port: C{int}
     """
 
     type: Literal["TCP"] | Literal["UDP"] = attr.ib(
@@ -53,18 +51,14 @@ class IPv6Address:
 
     @ivar host: A string containing a colon-separated, hexadecimal formatted
         IPv6 address; for example, "::1".
-    @type host: C{str}
 
     @ivar port: An integer representing the port number.
-    @type port: C{int}
 
     @ivar flowInfo: the IPv6 flow label.  This can be used by QoS routers to
         identify flows of traffic; you may generally safely ignore it.
-    @type flowInfo: L{int}
 
     @ivar scopeID: the IPv6 scope identifier - roughly analagous to what
         interface traffic destined for this address must be transmitted over.
-    @type scopeID: L{int} or L{str}
     """
 
     type: Literal["TCP"] | Literal["UDP"] = attr.ib(
@@ -90,10 +84,8 @@ class HostnameAddress:
     A L{HostnameAddress} represents the address of a L{HostnameEndpoint}.
 
     @ivar hostname: A hostname byte string; for example, b"example.com".
-    @type hostname: L{bytes}
 
     @ivar port: An integer representing the port number.
-    @type port: L{int}
     """
 
     hostname: bytes
@@ -107,7 +99,6 @@ class UNIXAddress:
     Object representing a UNIX socket endpoint.
 
     @ivar name: The filename associated with this socket.
-    @type name: C{bytes}
     """
 
     name: bytes | None = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -7,7 +7,7 @@ Address objects for network connections.
 
 
 import os
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from zope.interface import implementer
 
@@ -35,7 +35,7 @@ class IPv4Address:
     @type port: C{int}
     """
 
-    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+    type: Literal["TCP"] | Literal["UDP"] = attr.ib(
         validator=attr.validators.in_(["TCP", "UDP"])
     )
     host: str
@@ -67,13 +67,13 @@ class IPv6Address:
     @type scopeID: L{int} or L{str}
     """
 
-    type: Union[Literal["TCP"], Literal["UDP"]] = attr.ib(
+    type: Literal["TCP"] | Literal["UDP"] = attr.ib(
         validator=attr.validators.in_(["TCP", "UDP"])
     )
     host: str
     port: int
     flowInfo: int = 0
-    scopeID: Union[str, int] = 0
+    scopeID: str | int = 0
 
 
 @implementer(IAddress)
@@ -110,9 +110,7 @@ class UNIXAddress:
     @type name: C{bytes}
     """
 
-    name: Optional[bytes] = attr.ib(
-        converter=attr.converters.optional(_asFilesystemBytes)
-    )
+    name: bytes | None = attr.ib(converter=attr.converters.optional(_asFilesystemBytes))
 
     if getattr(os.path, "samefile", None) is not None:
 

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -137,7 +137,7 @@ class UNIXAddress:
         show = _coerceToFilesystemEncoding("", name) if name is not None else None
         return f"UNIXAddress({show!r})"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self.name is None:
             return hash((self.__class__, None))
         try:

--- a/src/twisted/internet/address.py
+++ b/src/twisted/internet/address.py
@@ -8,7 +8,6 @@ Address objects for network connections.
 
 import os
 from typing import Literal, Optional, Union
-from warnings import warn
 
 from zope.interface import implementer
 
@@ -157,25 +156,3 @@ class UNIXAddress:
             return hash((s1.st_ino, s1.st_dev))
         except OSError:
             return hash(self.name)
-
-
-# These are for buildFactory backwards compatibility due to
-# stupidity-induced inconsistency.
-
-
-class _ServerFactoryIPv4Address(IPv4Address):
-    """Backwards compatibility hack. Just like IPv4Address in practice."""
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, tuple):
-            warn(
-                "IPv4Address.__getitem__ is deprecated.  " "Use attributes instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            return (self.host, self.port) == other
-        elif isinstance(other, IPv4Address):
-            a = (self.type, self.host, self.port)
-            b = (other.type, other.host, other.port)
-            return a == b
-        return NotImplemented

--- a/src/twisted/internet/test/test_address.py
+++ b/src/twisted/internet/test/test_address.py
@@ -201,6 +201,24 @@ class UNIXAddressTests(SynchronousTestCase):
                 hash(UNIXAddress(self._socketAddress)), hash(UNIXAddress(linkName))
             )
 
+    def test_comparisonOfMissingFiles(self):
+        """
+        UNIXAddress objects for different missing filesystem paths are not
+        equal.
+        """
+        self.assertNotEqual(
+            UNIXAddress(self._socketAddress), UNIXAddress(self._otherAddress)
+        )
+
+    def test_abstractNamespaceComparisonRaises(self):
+        """
+        Outside Linux, comparing abstract namespace paths raises the
+        L{ValueError} from L{os.path.samefile}.
+        """
+        self.patch(platform, "isLinux", lambda: False)
+        with self.assertRaises(ValueError):
+            self.assertEqual(UNIXAddress(b"\0socket"), UNIXAddress(b"\0other"))
+
 
 @skipIf(unixSkip, "platform doesn't support UNIX sockets.")
 class EmptyUNIXAddressTests(SynchronousTestCase, AddressTestCaseMixin):

--- a/src/twisted/internet/test/test_address.py
+++ b/src/twisted/internet/test/test_address.py
@@ -210,14 +210,22 @@ class UNIXAddressTests(SynchronousTestCase):
             UNIXAddress(self._socketAddress), UNIXAddress(self._otherAddress)
         )
 
+    @skipIf(platform.isLinux(), "Linux supports abstract namespace sockets.")
     def test_abstractNamespaceComparisonRaises(self):
         """
-        Outside Linux, comparing abstract namespace paths raises the
-        L{ValueError} from L{os.path.samefile}.
+        Comparing abstract namespace paths raises the L{ValueError} from
+        L{os.path.samefile}.
         """
-        self.patch(platform, "isLinux", lambda: False)
         with self.assertRaises(ValueError):
             self.assertEqual(UNIXAddress(b"\0socket"), UNIXAddress(b"\0other"))
+
+    @skipIf(not platform.isLinux(), "Abstract namespace sockets are Linux-only.")
+    def test_abstractNamespaceComparisonDoesNotRaiseOnLinux(self):
+        """
+        On Linux, comparing abstract namespace paths does not raise
+        L{ValueError}.
+        """
+        self.assertNotEqual(UNIXAddress(b"\0socket"), UNIXAddress(b"\0other"))
 
 
 @skipIf(unixSkip, "platform doesn't support UNIX sockets.")


### PR DESCRIPTION
## Scope and purpose

Fixes #12670

The private class has not been used in-tree since at least Twisted 12. Below are the history I've found (note that I did use AI to help me parse the long git history)

The class was added in:
Git SHA: https://github.com/twisted/twisted/commit/bda98191a5d6391ce3c788ed9bf56bbfd8a5a63f
Date: 2004-03-20

The last use of the class in Twisted was this commit:
Git SHA: https://github.com/twisted/twisted/commit/ca6799b3ee01ec06fd9828f3a3b5d44314db85d0
Date: 2011-12-11

Additional misc changes:
* Update typing annotation for Python 3.10+
* Drop `@type` in doc strings for annotated code.
* Drop `twisted.internet.address` from mypy overrides so that the entire file shall now be fully typed always.
* Removed a check for `os.path.samefile` existance, on Python 3.10+ all major platforms support this including Windows.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
