### PR TITLE
bind addresses for conch forwarding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,6 +448,7 @@ module = [
     'twisted.conch.test.test_session',
     'twisted.conch.test.test_ssh',
     'twisted.conch.test.test_telnet',
+    'twisted.conch.test.test_tkconch',
     'twisted.conch.test.test_transport',
     'twisted.conch.test.test_userauth',
     'twisted.conch.ui.tkvt100',

--- a/src/twisted/conch/newsfragments/12674.bugfix
+++ b/src/twisted/conch/newsfragments/12674.bugfix
@@ -1,0 +1,1 @@
+port forwardings of the conch/tkconch scripts now bind to 127.0.0.1 by default.

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -66,8 +66,12 @@ class ClientOptions(ConchOptions):
     compData = usage.Completions(
         mutuallyExclusive=[("tty", "notty")],
         optActions={
-            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "localforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+            "remoteforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -105,14 +109,15 @@ class ClientOptions(ConchOptions):
             return None
         return ((lhost, int(lport)), (host, int(port)))
 
-
     def opt_localforward(self, f):
         """
         Forward local port to remote address ([lhost:]lport:host:port)
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
@@ -121,7 +126,9 @@ class ClientOptions(ConchOptions):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.remoteForwards.append(forwardSpec)
 
     def parseArgs(self, host, *command):
@@ -254,7 +261,7 @@ def onConnect():
                 forwarding.SSHListenForwardingFactory(
                     conn, remoteAddr, SSHListenClientForwardingChannel
                 ),
-                interface=localAddr[0]
+                interface=localAddr[0],
             )
             conn.localForwards.append(s)
     if options.remoteForwards:
@@ -262,7 +269,8 @@ def onConnect():
             _log.info(
                 "asking for remote forwarding for {remoteAddr}:{connAddr}",
                 remoteAddr=remoteAddr,
-                connAddr=connAddr)
+                connAddr=connAddr,
+            )
             conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
@@ -292,7 +300,8 @@ def beforeShutdown():
         _log.info(
             "cancelling {remoteAddr}:{localAddr}",
             remoteAddr=remoteAddr,
-            localAddr=localAddr)
+            localAddr=localAddr,
+        )
         conn.cancelRemoteForwarding(remoteAddr)
 
 
@@ -350,7 +359,8 @@ class SSHConnection(connection.SSHConnection):
         _log.debug(
             "requesting remote forwarding {remoteAddr}:{connAddr}",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
         d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
@@ -358,7 +368,8 @@ class SSHConnection(connection.SSHConnection):
         _log.debug(
             "accepted remote forwarding {remoteAddr}:{connAddr}",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         self.remoteForwards[remoteAddr] = connAddr
         _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
@@ -366,7 +377,8 @@ class SSHConnection(connection.SSHConnection):
         _log.warn(
             "remote forwarding {remoteAddr}:{connAddr} failed",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         _log.debug("{f}", f=f)
 
     def cancelRemoteForwarding(self, remotePort):
@@ -391,7 +403,10 @@ class SSHConnection(connection.SSHConnection):
             connectAddr = self.remoteForwards[remoteAddr]
             _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return SSHConnectForwardingChannel(
-                connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
+                connectAddr,
+                remoteWindow=windowSize,
+                remoteMaxPacket=maxPacket,
+                conn=self,
             )
         else:
             raise ConchError(

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -23,8 +23,11 @@ from twisted.conch.client.options import ConchOptions
 from twisted.conch.error import ConchError
 from twisted.conch.ssh import channel, common, connection, forwarding, session
 from twisted.internet import reactor, stdio, task
-from twisted.python import log, usage
+from twisted.logger import Logger, globalLogBeginner, textFileLogObserver
+from twisted.python import usage
 from twisted.python.compat import ioType, networkString
+
+_log = Logger()
 
 
 class ClientOptions(ConchOptions):
@@ -164,11 +167,11 @@ def run():
                 f = open(options["logfile"], "a+")
         else:
             f = sys.stderr
-        realout = sys.stdout
-        log.startLogging(f)
-        sys.stdout = realout
+        globalLogBeginner.beginLoggingTo(
+            [textFileLogObserver(f)], redirectStandardIO=False
+        )
     else:
-        log.discardLogs()
+        globalLogBeginner.beginLoggingTo([], redirectStandardIO=False)
     doConnect()
     fd = sys.stdin.fileno()
     try:
@@ -196,12 +199,10 @@ def run():
 
 
 def handleError():
-    from twisted.python import failure
-
     global exitStatus
     exitStatus = 2
     reactor.callLater(0.01, _stopReactor)
-    log.err(failure.Failure())
+    _log.failure("error in conch")
     raise
 
 
@@ -258,7 +259,10 @@ def onConnect():
             conn.localForwards.append(s)
     if options.remoteForwards:
         for remoteAddr, connAddr in options.remoteForwards:
-            log.msg(f"asking for remote forwarding for {remoteAddr}:{connAddr}")
+            _log.info(
+                "asking for remote forwarding for {remoteAddr}:{connAddr}",
+                remoteAddr=remoteAddr,
+                connAddr=connAddr)
             conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
@@ -285,7 +289,10 @@ def reConnect():
 def beforeShutdown():
     remoteForwards = options.remoteForwards
     for remoteAddr, localAddr in remoteForwards:
-        log.msg(f"cancelling {remoteAddr}:{localAddr}")
+        _log.info(
+            "cancelling {remoteAddr}:{localAddr}",
+            remoteAddr=remoteAddr,
+            localAddr=localAddr)
         conn.cancelRemoteForwarding(remoteAddr)
 
 
@@ -340,18 +347,27 @@ class SSHConnection(connection.SSHConnection):
     def requestRemoteAddrForwarding(self, remoteAddr, connAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
-        log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
+        _log.debug(
+            "requesting remote forwarding {remoteAddr}:{connAddr}",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
         d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
         d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
     def _cbRemoteForwarding(self, result, remoteAddr, connAddr):
-        log.msg(f"accepted remote forwarding {remoteAddr}:{connAddr}")
+        _log.debug(
+            "accepted remote forwarding {remoteAddr}:{connAddr}",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
         self.remoteForwards[remoteAddr] = connAddr
-        log.msg(repr(self.remoteForwards))
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
     def _ebRemoteForwarding(self, f, remoteAddr, connAddr):
-        log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
-        log.msg(f)
+        _log.warn(
+            "remote forwarding {remoteAddr}:{connAddr} failed",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
+        _log.debug("{f}", f=f)
 
     def cancelRemoteForwarding(self, remotePort):
         self.cancelRemoteAddrForwarding(("127.0.0.1", remotePort))
@@ -359,21 +375,21 @@ class SSHConnection(connection.SSHConnection):
     def cancelRemoteAddrForwarding(self, remoteAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
-        log.msg(f"cancelling remote forwarding {remoteAddr}")
+        _log.debug("cancelling remote forwarding {remoteAddr}", remoteAddr=remoteAddr)
         try:
             del self.remoteForwards[remoteAddr]
         except Exception:
             pass
-        log.msg(repr(self.remoteForwards))
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
-        log.msg(f"FTCP {data!r}")
+        _log.debug("FTCP {data!r}", data=data)
         remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
-        log.msg(self.remoteForwards)
-        log.msg(remoteAddr)
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
+        _log.debug("{remoteAddr!r}", remoteAddr=remoteAddr)
         if remoteAddr in self.remoteForwards:
             connectAddr = self.remoteForwards[remoteAddr]
-            log.msg(f"connect forwarding {connectAddr}")
+            _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return SSHConnectForwardingChannel(
                 connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
             )
@@ -383,10 +399,10 @@ class SSHConnection(connection.SSHConnection):
             )
 
     def channelClosed(self, channel):
-        log.msg(f"connection closing {channel}")
-        log.msg(self.channels)
+        _log.debug("connection closing {channel}", channel=channel)
+        _log.debug("{channels!r}", channels=self.channels)
         if len(self.channels) == 1:  # Just us left
-            log.msg("stopping connection")
+            _log.debug("stopping connection")
             stopConnection()
         else:
             # Because of the unix thing
@@ -397,12 +413,12 @@ class SSHSession(channel.SSHChannel):
     name = b"session"
 
     def channelOpen(self, foo):
-        log.msg(f"session {self.id} open")
+        _log.debug("session {sessionId} open", sessionId=self.id)
         if options["agent"]:
             d = self.conn.sendRequest(
                 self, b"auth-agent-req@openssh.com", b"", wantReply=1
             )
-            d.addBoth(lambda x: log.msg(x))
+            d.addBoth(lambda x: _log.debug("{result!r}", result=x))
         if options["noshell"]:
             return
         if (options["command"] and options["tty"]) or not options["notty"]:
@@ -448,7 +464,7 @@ class SSHSession(channel.SSHChannel):
         elif self.escapeMode == 2:
             self.escapeMode = 1  # So we can chain escapes together
             if char == b".":  # Disconnect
-                log.msg("disconnecting from escape")
+                _log.info("disconnecting from escape")
                 stopConnection()
                 return
             elif char == b"\x1a":  # ^Z, suspend
@@ -463,7 +479,7 @@ class SSHSession(channel.SSHChannel):
                 reactor.callLater(0, _)
                 return
             elif char == b"R":  # Rekey connection
-                log.msg("rekeying connection")
+                _log.info("rekeying connection")
                 self.conn.transport.sendKexInit()
                 return
             elif char == b"#":  # Display connections
@@ -489,29 +505,29 @@ class SSHSession(channel.SSHChannel):
 
     def extReceived(self, t, data):
         if t == connection.EXTENDED_DATA_STDERR:
-            log.msg(f"got {len(data)} stderr data")
+            _log.debug("got {n} stderr data", n=len(data))
             if ioType(sys.stderr) == str:
                 sys.stderr.buffer.write(data)
             else:
                 sys.stderr.write(data)
 
     def eofReceived(self):
-        log.msg("got eof")
+        _log.debug("got eof")
         self.stdio.loseWriteConnection()
 
     def closeReceived(self):
-        log.msg(f"remote side closed {self}")
+        _log.debug("remote side closed {session}", session=self)
         self.conn.sendClose(self)
 
     def closed(self):
         global old
-        log.msg(f"closed {self}")
-        log.msg(repr(self.conn.channels))
+        _log.debug("closed {session}", session=self)
+        _log.debug("{channels!r}", channels=self.conn.channels)
 
     def request_exit_status(self, data):
         global exitStatus
         exitStatus = int(struct.unpack(">L", data)[0])
-        log.msg(f"exit status: {exitStatus}")
+        _log.debug("exit status: {exitStatus}", exitStatus=exitStatus)
 
     def sendEOF(self):
         self.conn.sendEOF(self)
@@ -555,7 +571,7 @@ def _enterRawMode():
         old = tty.tcgetattr(fd)
         new = old[:]
     except BaseException:
-        log.msg("not a typewriter!")
+        _log.warn("not a typewriter!")
     else:
         # iflage
         new[0] = new[0] | tty.IGNPAR

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -273,7 +273,7 @@ def onConnect():
                 remoteAddr=remoteAddr,
                 connAddr=connAddr,
             )
-            conn.requestRemoteForwarding(remoteAddr, connAddr)
+            conn.requestRemoteAddrForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
         conn.openChannel(SSHSession())
@@ -304,7 +304,7 @@ def beforeShutdown():
             remoteAddr=remoteAddr,
             localAddr=localAddr,
         )
-        conn.cancelRemoteForwarding(remoteAddr)
+        conn.cancelRemoteAddrForwarding(remoteAddr)
 
 
 def stopConnection():

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -41,13 +41,13 @@ class ClientOptions(ConchOptions):
             "localforward",
             "L",
             None,
-            "listen-port:host:port   Forward local port to remote address",
+            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
         ],
         [
             "remoteforward",
             "R",
             None,
-            "listen-port:host:port   Forward remote port to local address",
+            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
         ],
     ]
 
@@ -63,8 +63,8 @@ class ClientOptions(ConchOptions):
     compData = usage.Completions(
         mutuallyExclusive=[("tty", "notty")],
         optActions={
-            "localforward": usage.Completer(descr="listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="listen-port:host:port"),
+            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -73,8 +73,8 @@ class ClientOptions(ConchOptions):
         ],
     )
 
-    localForwards: list[tuple[int, tuple[int, int]]] = []
-    remoteForwards: list[tuple[int, tuple[int, int]]] = []
+    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
 
     def opt_escape(self, esc):
         """
@@ -91,21 +91,35 @@ class ClientOptions(ConchOptions):
 
     def opt_localforward(self, f):
         """
-        Forward local port to remote address (lport:host:port)
+        Forward local port to remote address ([lhost:]lport:host:port)
         """
-        localPort, remoteHost, remotePort = f.split(":")  # Doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            localHost = "127.0.0.1"
+            localPort, remoteHost, remotePort = f.split(":")
+        elif colonCount == 3:
+            localHost, localPort, remoteHost, remotePort = f.split(":")
+        else:
+            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         localPort = int(localPort)
         remotePort = int(remotePort)
-        self.localForwards.append((localPort, (remoteHost, remotePort)))
+        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
 
     def opt_remoteforward(self, f):
         """
-        Forward remote port to local address (rport:host:port)
+        Forward remote port to local address ([rhost:]rport:host:port)
         """
-        remotePort, connHost, connPort = f.split(":")  # Doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            remoteHost = "127.0.0.1"
+            remotePort, connHost, connPort = f.split(":")
+        elif colonCount == 3:
+            remoteHost, remotePort, connHost, connPort = f.split(":")
+        else:
+            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         remotePort = int(remotePort)
         connPort = int(connPort)
-        self.remoteForwards.append((remotePort, (connHost, connPort)))
+        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
 
     def parseArgs(self, host, *command):
         self["host"] = host
@@ -233,18 +247,19 @@ def onConnect():
     if hasattr(conn.transport, "sendIgnore"):
         _KeepAlive(conn)
     if options.localForwards:
-        for localPort, hostport in options.localForwards:
+        for localAddr, remoteAddr in options.localForwards:
             s = reactor.listenTCP(
-                localPort,
+                localAddr[1],
                 forwarding.SSHListenForwardingFactory(
-                    conn, hostport, SSHListenClientForwardingChannel
+                    conn, remoteAddr, SSHListenClientForwardingChannel
                 ),
+                interface=localAddr[0]
             )
             conn.localForwards.append(s)
     if options.remoteForwards:
-        for remotePort, hostport in options.remoteForwards:
-            log.msg(f"asking for remote forwarding for {remotePort}:{hostport}")
-            conn.requestRemoteForwarding(remotePort, hostport)
+        for remoteAddr, connAddr in options.remoteForwards:
+            log.msg(f"asking for remote forwarding for {remoteAddr}:{connAddr}")
+            conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
         conn.openChannel(SSHSession())
@@ -269,9 +284,9 @@ def reConnect():
 
 def beforeShutdown():
     remoteForwards = options.remoteForwards
-    for remotePort, hostport in remoteForwards:
-        log.msg(f"cancelling {remotePort}:{hostport}")
-        conn.cancelRemoteForwarding(remotePort)
+    for remoteAddr, localAddr in remoteForwards:
+        log.msg(f"cancelling {remoteAddr}:{localAddr}")
+        conn.cancelRemoteForwarding(remoteAddr)
 
 
 def stopConnection():
@@ -319,42 +334,42 @@ class SSHConnection(connection.SSHConnection):
             s.loseConnection()
         stopConnection()
 
-    def requestRemoteForwarding(self, remotePort, hostport):
-        data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+    def requestRemoteForwarding(self, remoteAddr, connAddr):
+        data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
-        log.msg(f"requesting remote forwarding {remotePort}:{hostport}")
-        d.addCallback(self._cbRemoteForwarding, remotePort, hostport)
-        d.addErrback(self._ebRemoteForwarding, remotePort, hostport)
+        log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
+        d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
+        d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
-    def _cbRemoteForwarding(self, result, remotePort, hostport):
-        log.msg(f"accepted remote forwarding {remotePort}:{hostport}")
-        self.remoteForwards[remotePort] = hostport
+    def _cbRemoteForwarding(self, result, remoteAddr, connAddr):
+        log.msg(f"accepted remote forwarding {remoteAddr}:{connAddr}")
+        self.remoteForwards[remoteAddr] = connAddr
         log.msg(repr(self.remoteForwards))
 
-    def _ebRemoteForwarding(self, f, remotePort, hostport):
-        log.msg(f"remote forwarding {remotePort}:{hostport} failed")
+    def _ebRemoteForwarding(self, f, remoteAddr, connAddr):
+        log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
         log.msg(f)
 
-    def cancelRemoteForwarding(self, remotePort):
-        data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+    def cancelRemoteForwarding(self, remoteAddr):
+        data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
-        log.msg(f"cancelling remote forwarding {remotePort}")
+        log.msg(f"cancelling remote forwarding {remoteAddr}")
         try:
-            del self.remoteForwards[remotePort]
+            del self.remoteForwards[remoteAddr]
         except Exception:
             pass
         log.msg(repr(self.remoteForwards))
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
         log.msg(f"FTCP {data!r}")
-        remoteHP, origHP = forwarding.unpackOpen_forwarded_tcpip(data)
+        remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
         log.msg(self.remoteForwards)
-        log.msg(remoteHP)
-        if remoteHP[1] in self.remoteForwards:
-            connectHP = self.remoteForwards[remoteHP[1]]
-            log.msg(f"connect forwarding {connectHP}")
+        log.msg(remoteAddr)
+        if remoteAddr in self.remoteForwards:
+            connectAddr = self.remoteForwards[remoteAddr]
+            log.msg(f"connect forwarding {connectAddr}")
             return SSHConnectForwardingChannel(
-                connectHP, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
+                connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
             )
         else:
             raise ConchError(

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -176,11 +176,13 @@ def run():
                 f = open(options["logfile"], "a+")
         else:
             f = sys.stderr
-        globalLogBeginner.beginLoggingTo(
+        globalLogBeginner.beginLoggingTo(  # pragma: no cover
             [textFileLogObserver(f)], redirectStandardIO=False
         )
     else:
-        globalLogBeginner.beginLoggingTo([], redirectStandardIO=False)
+        globalLogBeginner.beginLoggingTo(  # pragma: no cover
+            [], redirectStandardIO=False
+        )
     doConnect()
     fd = sys.stdin.fileno()
     try:

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -89,37 +89,37 @@ class ClientOptions(ConchOptions):
         else:
             sys.exit(f"Bad escape character '{esc}'.")
 
+    def _parseForwardSpec(self, f):
+        """
+        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
+        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
+        """
+        *maybeLhost, lport, host, port = f.split(":")
+        if len(maybeLhost) not in (0, 1):
+            return None
+        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
+        if not (lport.isdigit() and port.isdigit()):
+            return None
+        return ((lhost, int(lport)), (host, int(port)))
+
+
     def opt_localforward(self, f):
         """
         Forward local port to remote address ([lhost:]lport:host:port)
         """
-        colonCount = f.count(":")
-        if colonCount == 2:
-            localHost = "127.0.0.1"
-            localPort, remoteHost, remotePort = f.split(":")
-        elif colonCount == 3:
-            localHost, localPort, remoteHost, remotePort = f.split(":")
-        else:
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        localPort = int(localPort)
-        remotePort = int(remotePort)
-        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
+        self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
         """
         Forward remote port to local address ([rhost:]rport:host:port)
         """
-        colonCount = f.count(":")
-        if colonCount == 2:
-            remoteHost = "127.0.0.1"
-            remotePort, connHost, connPort = f.split(":")
-        elif colonCount == 3:
-            remoteHost, remotePort, connHost, connPort = f.split(":")
-        else:
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        remotePort = int(remotePort)
-        connPort = int(connPort)
-        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
+        self.remoteForwards.append(forwardSpec)
 
     def parseArgs(self, host, *command):
         self["host"] = host

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -96,7 +96,9 @@ class ClientOptions(ConchOptions):
         else:
             sys.exit(f"Bad escape character '{esc}'.")
 
-    def _parseForwardSpec(self, f):
+    def _parseForwardSpec(
+        self, f: str
+    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
         """
         Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
         Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -334,7 +334,10 @@ class SSHConnection(connection.SSHConnection):
             s.loseConnection()
         stopConnection()
 
-    def requestRemoteForwarding(self, remoteAddr, connAddr):
+    def requestRemoteForwarding(self, remotePort, hostport):
+        self.requestRemoteAddrForwarding(("127.0.0.1", remotePort), hostport)
+
+    def requestRemoteAddrForwarding(self, remoteAddr, connAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
         log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
@@ -350,7 +353,10 @@ class SSHConnection(connection.SSHConnection):
         log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
         log.msg(f)
 
-    def cancelRemoteForwarding(self, remoteAddr):
+    def cancelRemoteForwarding(self, remotePort):
+        self.cancelRemoteAddrForwarding(("127.0.0.1", remotePort))
+
+    def cancelRemoteAddrForwarding(self, remoteAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
         log.msg(f"cancelling remote forwarding {remoteAddr}")

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -38,7 +38,7 @@ _log = Logger()
 
 
 class TkConchMenu(Tkinter.Frame):
-    def __init__(self, *args, **params):
+    def __init__(self, *args, **params):  # pragma: no cover
         ## Standard heading: initialization
         Tkinter.Frame.__init__(self, *args, **params)
 
@@ -138,7 +138,7 @@ class TkConchMenu(Tkinter.Frame):
             self.identity.delete(0, Tkinter.END)
             self.identity.insert(Tkinter.END, r)
 
-    def addForward(self):
+    def addForward(self):  # pragma: no cover
         listenHost, _, listenPort = self.forwardListenAddress.get().rpartition(":")
         listenHost = listenHost or "127.0.0.1"
         self.forwardListenAddress.delete(0, Tkinter.END)
@@ -154,12 +154,12 @@ class TkConchMenu(Tkinter.Frame):
                 Tkinter.END, f"R:{listenHost}:{listenPort}:{connectHost}:{connectPort}"
             )
 
-    def removeForward(self):
+    def removeForward(self):  # pragma: no cover
         cur = self.forwards.curselection()
         if cur:
             self.forwards.delete(cur[0])
 
-    def doConnect(self):
+    def doConnect(self):  # pragma: no cover
         finished = 1
         options["host"] = self.host.get()
         options["port"] = self.port.get()
@@ -385,7 +385,7 @@ def deferredAskFrame(question, echo):
     return d
 
 
-def run():
+def run():  # pragma: no cover
     global menu, options, frame
     args = sys.argv[1:]
     if "-l" in args:  # cvs is an idiot
@@ -476,7 +476,7 @@ class SSHClientTransport(transport.SSHClientTransport):
         )
         transport.SSHClientTransport.sendDisconnect(self, code, reason)
 
-    def receiveDebug(self, alwaysDisplay, message, lang):
+    def receiveDebug(self, alwaysDisplay, message, lang):  # pragma: no cover
         global options
         if alwaysDisplay or options["log"]:
             _log.debug("Received Debug Message: {message}", message=message)
@@ -510,7 +510,7 @@ class SSHClientTransport(transport.SSHClientTransport):
                 self._cbVerifyHostKey, pubKey, khHost, keyType
             )
 
-    def _cbVerifyHostKey(self, ans, pubKey, khHost, keyType):
+    def _cbVerifyHostKey(self, ans, pubKey, khHost, keyType):  # pragma: no cover
         if ans.lower() not in ("yes", "no"):
             return deferredAskFrame("Please type  'yes' or 'no': ", 1).addCallback(
                 self._cbVerifyHostKey, pubKey, khHost, keyType
@@ -547,7 +547,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
             prompt = "{}@{}'s password: ".format(self.user, options["host"])
         return deferredAskFrame(prompt, 0)
 
-    def getPublicKey(self):
+    def getPublicKey(self):  # pragma: no cover
         files = [x for x in options.identitys if x not in self.usedFiles]
         if not files:
             return None

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -31,7 +31,10 @@ from twisted.conch.ssh import (
 )
 from twisted.conch.ui import tkvt100
 from twisted.internet import defer, protocol, reactor, tksupport
-from twisted.python import log, usage
+from twisted.logger import Logger, globalLogBeginner, textFileLogObserver
+from twisted.python import usage
+
+_log = Logger()
 
 
 class TkConchMenu(Tkinter.Frame):
@@ -209,17 +212,16 @@ class TkConchMenu(Tkinter.Frame):
             self.master.quit()
             self.master.destroy()
             if options["log"]:
-                realout = sys.stdout
-                log.startLogging(sys.stderr)
-                sys.stdout = realout
+                globalLogBeginner.beginLoggingTo(
+                    [textFileLogObserver(sys.stderr)], redirectStandardIO=False
+                )
             else:
-                log.discardLogs()
-            log.deferr = handleError  # HACK
+                globalLogBeginner.beginLoggingTo([], redirectStandardIO=False)
             if not options.identitys:
                 options.identitys = ["~/.ssh/id_rsa", "~/.ssh/id_dsa"]
             host = options["host"]
             port = int(options["port"] or 22)
-            log.msg((host, port))
+            _log.debug("connecting to {host}:{port}", host=host, port=port)
             reactor.connectTCP(host, port, SSHClientFactory())
             frame.master.deiconify()
             frame.master.title(
@@ -425,11 +427,9 @@ def run():
 
 
 def handleError():
-    from twisted.python import failure
-
     global exitStatus
     exitStatus = 2
-    log.err(failure.Failure())
+    _log.failure("error in tkconch")
     reactor.stop()
     raise
 
@@ -469,7 +469,7 @@ class SSHClientTransport(transport.SSHClientTransport):
     def receiveDebug(self, alwaysDisplay, message, lang):
         global options
         if alwaysDisplay or options["log"]:
-            log.msg("Received Debug Message: %s" % message)
+            _log.debug("Received Debug Message: {message}", message=message)
 
     def verifyHostKey(self, pubKey, fingerprint):
         # d = defer.Deferred()
@@ -518,7 +518,7 @@ class SSHClientTransport(transport.SSHClientTransport):
                 encodedKey = base64.b64encode(pubKey)
                 known_hosts.write(f"\n{khHost} {keyType} {encodedKey}")
         except BaseException:
-            log.deferr()
+            _log.failure("failed to record host key")
             raise error.ConchError
 
     def connectionSecure(self):
@@ -542,7 +542,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         if not files:
             return None
         file = files[0]
-        log.msg(file)
+        _log.debug("trying identity file {file}", file=file)
         self.usedFiles.append(file)
         file = os.path.expanduser(file)
         file += ".pub"
@@ -593,23 +593,23 @@ class SSHConnection(connection.SSHConnection):
                 )
         if options.remoteForwards:
             for remoteAddr, connAddr in options.remoteForwards:
-                log.msg(
-                    "asking for remote forwarding for {}:{}".format(
-                        remoteAddr, connAddr
-                    )
+                _log.info(
+                    "asking for remote forwarding for {remoteAddr}:{connAddr}",
+                    remoteAddr=remoteAddr,
+                    connAddr=connAddr,
                 )
                 data = forwarding.packGlobal_tcpip_forward(remoteAddr)
                 self.sendGlobalRequest(b"tcpip-forward", data)
                 self.remoteForwards[remoteAddr] = connAddr
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
-        log.msg(f"FTCP {data!r}")
+        _log.debug("FTCP {data!r}", data=data)
         remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
-        log.msg(self.remoteForwards)
-        log.msg(remoteAddr)
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
+        _log.debug("{remoteAddr!r}", remoteAddr=remoteAddr)
         if remoteAddr in self.remoteForwards:
             connectAddr = self.remoteForwards[remoteAddr]
-            log.msg(f"connect forwarding {connectAddr}")
+            _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return forwarding.SSHConnectForwardingChannel(
                 connectAddr,
                 remoteWindow=windowSize,
@@ -659,7 +659,6 @@ class SSHSession(channel.SSHChannel):
         self.conn.transport.transport.setTcpNoDelay(1)
 
     def handleInput(self, char):
-        # log.msg('handling %s' % repr(char))
         if char in ("\n", "\r"):
             self.escapeMode = 1
             self.write(char)
@@ -668,7 +667,7 @@ class SSHSession(channel.SSHChannel):
         elif self.escapeMode == 2:
             self.escapeMode = 1  # so we can chain escapes together
             if char == ".":  # disconnect
-                log.msg("disconnecting from escape")
+                _log.info("disconnecting from escape")
                 reactor.stop()
                 return
             elif char == "\x1a":  # ^Z, suspend
@@ -676,7 +675,7 @@ class SSHSession(channel.SSHChannel):
                 os.kill(os.getpid(), signal.SIGSTOP)
                 return
             elif char == "R":  # rekey connection
-                log.msg("rekeying connection")
+                _log.info("rekeying connection")
                 self.conn.transport.sendKexInit()
                 return
             self.write("~" + char)
@@ -692,23 +691,23 @@ class SSHSession(channel.SSHChannel):
 
     def extReceived(self, t, data):
         if t == connection.EXTENDED_DATA_STDERR:
-            log.msg("got %s stderr data" % len(data))
+            _log.debug("got {n} stderr data", n=len(data))
             sys.stderr.write(data)
             sys.stderr.flush()
 
     def eofReceived(self):
-        log.msg("got eof")
+        _log.debug("got eof")
         sys.stdin.close()
 
     def closed(self):
-        log.msg("closed %s" % self)
+        _log.debug("closed {session}", session=self)
         if len(self.conn.channels) == 1:  # just us left
             reactor.stop()
 
     def request_exit_status(self, data):
         global exitStatus
         exitStatus = int(struct.unpack(">L", data)[0])
-        log.msg("exit status: %s" % exitStatus)
+        _log.info("exit status: {exitStatus}", exitStatus=exitStatus)
 
     def sendEOF(self):
         self.conn.sendEOF(self)

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -290,31 +290,36 @@ class GeneralOptions(usage.Options):
     def opt_identity(self, i):
         self.identitys.append(i)
 
+    def _parseForwardSpec(self, f):
+        """
+        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
+        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
+        """
+        *maybeLhost, lport, host, port = f.split(":")
+        if len(maybeLhost) not in (0, 1):
+            return None
+        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
+        if not (lport.isdigit() and port.isdigit()):
+            return None
+        return ((lhost, int(lport)), (host, int(port)))
+
     def opt_localforward(self, f):
-        colonCount = f.count(":")
-        if colonCount == 2:
-            localHost = "127.0.0.1"
-            localPort, remoteHost, remotePort = f.split(":")
-        elif colonCount == 3:
-            localHost, localPort, remoteHost, remotePort = f.split(":")
-        else:
+        """
+        Forward local port to remote address ([lhost:]lport:host:port)
+        """
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        localPort = int(localPort)
-        remotePort = int(remotePort)
-        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
+        self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
-        colonCount = f.count(":")
-        if colonCount == 2:
-            remoteHost = "127.0.0.1"
-            remotePort, connHost, connPort = f.split(":")
-        elif colonCount == 3:
-            remoteHost, remotePort, connHost, connPort = f.split(":")
-        else:
+        """
+        Forward remote port to local address ([rhost:]rport:host:port)
+        """
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        remotePort = int(remotePort)
-        connPort = int(connPort)
-        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
+        self.remoteForwards.append(forwardSpec)
 
     def opt_compress(self):
         SSHClientTransport.supportedCompressions[0:1] = ["zlib"]

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -275,8 +275,12 @@ class GeneralOptions(usage.Options):
         optActions={
             "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
             "macs": usage.CompleteList([v.decode() for v in _macs]),
-            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "localforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+            "remoteforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -311,7 +315,9 @@ class GeneralOptions(usage.Options):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
@@ -320,7 +326,9 @@ class GeneralOptions(usage.Options):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.remoteForwards.append(forwardSpec)
 
     def opt_compress(self):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -574,6 +574,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
 
 class SSHConnection(connection.SSHConnection):
     def serviceStarted(self):
+        self.remoteForwards = {}
         if not options["noshell"]:
             self.openChannel(SSHSession())
         if options.localForwards:
@@ -593,8 +594,27 @@ class SSHConnection(connection.SSHConnection):
                     )
                 )
                 data = forwarding.packGlobal_tcpip_forward(remoteAddr)
-                self.sendGlobalRequest("tcpip-forward", data)
+                self.sendGlobalRequest(b"tcpip-forward", data)
                 self.remoteForwards[remoteAddr] = connAddr
+
+    def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
+        log.msg(f"FTCP {data!r}")
+        remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
+        log.msg(self.remoteForwards)
+        log.msg(remoteAddr)
+        if remoteAddr in self.remoteForwards:
+            connectAddr = self.remoteForwards[remoteAddr]
+            log.msg(f"connect forwarding {connectAddr}")
+            return forwarding.SSHConnectForwardingChannel(
+                connectAddr,
+                remoteWindow=windowSize,
+                remoteMaxPacket=maxPacket,
+                conn=self,
+            )
+        else:
+            raise error.ConchError(
+                connection.OPEN_CONNECT_FAILED, "don't know about that port"
+            )
 
 
 class SSHSession(channel.SSHChannel):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -238,13 +238,13 @@ class GeneralOptions(usage.Options):
             "localforward",
             "L",
             None,
-            "listen-port:host:port   Forward local port to remote address",
+            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
         ],
         [
             "remoteforward",
             "R",
             None,
-            "listen-port:host:port   Forward remote port to local address",
+            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
         ],
     ]
 
@@ -267,8 +267,8 @@ class GeneralOptions(usage.Options):
         optActions={
             "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
             "macs": usage.CompleteList([v.decode() for v in _macs]),
-            "localforward": usage.Completer(descr="listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="listen-port:host:port"),
+            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -278,23 +278,37 @@ class GeneralOptions(usage.Options):
     )
 
     identitys: list[str] = []
-    localForwards: list[tuple[int, tuple[int, int]]] = []
-    remoteForwards: list[tuple[int, tuple[int, int]]] = []
+    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
 
     def opt_identity(self, i):
         self.identitys.append(i)
 
     def opt_localforward(self, f):
-        localPort, remoteHost, remotePort = f.split(":")  # doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            localHost = "127.0.0.1"
+            localPort, remoteHost, remotePort = f.split(":")
+        elif colonCount == 3:
+            localHost, localPort, remoteHost, remotePort = f.split(":")
+        else:
+            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         localPort = int(localPort)
         remotePort = int(remotePort)
-        self.localForwards.append((localPort, (remoteHost, remotePort)))
+        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
 
     def opt_remoteforward(self, f):
-        remotePort, connHost, connPort = f.split(":")  # doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            remoteHost = "127.0.0.1"
+            remotePort, connHost, connPort = f.split(":")
+        elif colonCount == 3:
+            remoteHost, remotePort, connHost, connPort = f.split(":")
+        else:
+            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         remotePort = int(remotePort)
         connPort = int(connPort)
-        self.remoteForwards.append((remotePort, (connHost, connPort)))
+        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
 
     def opt_compress(self):
         SSHClientTransport.supportedCompressions[0:1] = ["zlib"]
@@ -377,11 +391,11 @@ def run():
     for k, v in options.items():
         if v and hasattr(menu, k):
             getattr(menu, k).insert(Tkinter.END, v)
-    for p, (rh, rp) in options.localForwards:
-        menu.forwards.insert(Tkinter.END, f"L:{p}:{rh}:{rp}")
+    for (lh, lp), (rh, rp) in options.localForwards:
+        menu.forwards.insert(Tkinter.END, f"L:{lh}:{lp}:{rh}:{rp}")
     options.localForwards = []
-    for p, (rh, rp) in options.remoteForwards:
-        menu.forwards.insert(Tkinter.END, f"R:{p}:{rh}:{rp}")
+    for (lh, lp), (rh, rp) in options.remoteForwards:
+        menu.forwards.insert(Tkinter.END, f"R:{lh}:{lp}:{rh}:{rp}")
     options.remoteForwards = []
     frame = tkvt100.VT100Frame(root, callback=None)
     root.geometry(
@@ -557,23 +571,24 @@ class SSHConnection(connection.SSHConnection):
         if not options["noshell"]:
             self.openChannel(SSHSession())
         if options.localForwards:
-            for localPort, hostport in options.localForwards:
+            for localAddr, remoteAddr in options.localForwards:
                 reactor.listenTCP(
-                    localPort,
+                    localAddr[1],
                     forwarding.SSHListenForwardingFactory(
-                        self, hostport, forwarding.SSHListenClientForwardingChannel
+                        self, remoteAddr, forwarding.SSHListenClientForwardingChannel
                     ),
+                    interface=localAddr[0],
                 )
         if options.remoteForwards:
-            for remotePort, hostport in options.remoteForwards:
+            for remoteAddr, connAddr in options.remoteForwards:
                 log.msg(
                     "asking for remote forwarding for {}:{}".format(
-                        remotePort, hostport
+                        remoteAddr, connAddr
                     )
                 )
-                data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+                data = forwarding.packGlobal_tcpip_forward(remoteAddr)
                 self.sendGlobalRequest("tcpip-forward", data)
-                self.remoteForwards[remotePort] = hostport
+                self.remoteForwards[remoteAddr] = connAddr
 
 
 class SSHSession(channel.SSHChannel):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -296,7 +296,9 @@ class GeneralOptions(usage.Options):
     def opt_identity(self, i):
         self.identitys.append(i)
 
-    def _parseForwardSpec(self, f):
+    def _parseForwardSpec(
+        self, f: str
+    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
         """
         Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
         Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -83,12 +83,12 @@ class TkConchMenu(Tkinter.Frame):
         Tkinter.Button(self, text="Remove", command=self.removeForward).grid(
             column=1, row=8
         )
-        self.forwardPort = Tkinter.Entry(self)
-        self.forwardPort.grid(column=2, row=7, sticky="nesw")
-        Tkinter.Label(self, text="Port").grid(column=3, row=7, sticky="nesw")
-        self.forwardHost = Tkinter.Entry(self)
-        self.forwardHost.grid(column=2, row=8, sticky="nesw")
-        Tkinter.Label(self, text="Host").grid(column=3, row=8, sticky="nesw")
+        self.forwardListenAddress = Tkinter.Entry(self)
+        self.forwardListenAddress.grid(column=2, row=7, sticky="nesw")
+        Tkinter.Label(self, text="Listen Address").grid(column=3, row=7, sticky="nesw")
+        self.forwardConnectAddress = Tkinter.Entry(self)
+        self.forwardConnectAddress.grid(column=2, row=8, sticky="nesw")
+        Tkinter.Label(self, text="Connect Address").grid(column=3, row=8, sticky="nesw")
         self.localForward = Tkinter.Radiobutton(
             self, text="Local", variable=self.localRemoteVar, value="local"
         )
@@ -136,19 +136,25 @@ class TkConchMenu(Tkinter.Frame):
             self.identity.insert(Tkinter.END, r)
 
     def addForward(self):
-        port = self.forwardPort.get()
-        self.forwardPort.delete(0, Tkinter.END)
-        host = self.forwardHost.get()
-        self.forwardHost.delete(0, Tkinter.END)
+        listenHost, _, listenPort = self.forwardListenAddress.get().rpartition(":")
+        listenHost = listenHost or "127.0.0.1"
+        self.forwardListenAddress.delete(0, Tkinter.END)
+        connectHost, _, connectPort = self.forwardConnectAddress.get().rpartition(":")
+        connectHost = connectHost or "127.0.0.1"
+        self.forwardConnectAddress.delete(0, Tkinter.END)
         if self.localRemoteVar.get() == "local":
-            self.forwards.insert(Tkinter.END, f"L:{port}:{host}")
+            self.forwards.insert(
+                Tkinter.END, f"L:{listenHost}:{listenPort}:{connectHost}:{connectPort}"
+            )
         else:
-            self.forwards.insert(Tkinter.END, f"R:{port}:{host}")
+            self.forwards.insert(
+                Tkinter.END, f"R:{listenHost}:{listenPort}:{connectHost}:{connectPort}"
+            )
 
     def removeForward(self):
         cur = self.forwards.curselection()
         if cur:
-            self.forwards.remove(cur[0])
+            self.forwards.delete(cur[0])
 
     def doConnect(self):
         finished = 1

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -58,6 +58,11 @@ else:
     StdioInteractingSession = _StdioInteractingSession
 
 
+_conchScript = requireModule("twisted.conch.scripts.conch")
+
+_conchSkip = "conch is importable only on POSIX" if _conchScript is None else None
+
+
 class FakeStdio:
     """
     A fake for testing L{twisted.conch.scripts.conch.SSHSession.eofReceived} and
@@ -805,3 +810,516 @@ class CmdLineClientTests(ForwardingMixin, TestCase):
             ),
             ConchError,
         )
+
+
+class _FakeOptions(dict[str, object]):
+    """
+    Minimal stand-in for L{twisted.conch.scripts.conch.ClientOptions} that
+    supports both attribute access (C{localForwards}/C{remoteForwards}) and
+    C{__getitem__} for option flags.
+    """
+
+    def __init__(self, **flags):
+        super().__init__(flags)
+        self.localForwards = []
+        self.remoteForwards = []
+
+
+class _FakePort:
+    """A stand-in for the object returned by C{reactor.listenTCP}."""
+
+
+class _FakeTransport:
+    """A stand-in transport exposing C{sendIgnore}."""
+
+    sendIgnore = True
+
+
+class _FakeForwardingConn:
+    """A stand-in for the conch C{SSHConnection} used by C{onConnect}."""
+
+    def __init__(self):
+        self.transport = _FakeTransport()
+        self.localForwards = []
+        self.requestedRemote = []
+        self.cancelledRemote = []
+
+    def requestRemoteAddrForwarding(self, remoteAddr, connAddr):
+        self.requestedRemote.append((remoteAddr, connAddr))
+
+    def cancelRemoteAddrForwarding(self, remoteAddr):
+        self.cancelledRemote.append(remoteAddr)
+
+
+class ConchClientOptionsForwardingTests(TestCase):
+    """
+    Tests for forward-spec parsing in
+    L{twisted.conch.scripts.conch.ClientOptions}.
+    """
+
+    skip = _conchSkip
+
+    def _options(self):
+        options = _conchScript.ClientOptions()
+        options.localForwards = []
+        options.remoteForwards = []
+        return options
+
+    def test_parseForwardSpecWithoutListenAddress(self):
+        """
+        A three-part spec defaults the listen address to C{127.0.0.1}.
+        """
+        options = self._options()
+        self.assertEqual(
+            options._parseForwardSpec("8080:dest:90"),
+            (("127.0.0.1", 8080), ("dest", 90)),
+        )
+
+    def test_parseForwardSpecWithListenAddress(self):
+        """
+        A four-part spec uses the supplied listen address.
+        """
+        options = self._options()
+        self.assertEqual(
+            options._parseForwardSpec("1.2.3.4:8080:dest:90"),
+            (("1.2.3.4", 8080), ("dest", 90)),
+        )
+
+    def test_parseForwardSpecTooManyParts(self):
+        """
+        A spec with more than one leading listen address is invalid.
+        """
+        options = self._options()
+        self.assertIsNone(options._parseForwardSpec("a:b:8080:dest:90"))
+
+    def test_parseForwardSpecNonNumericPorts(self):
+        """
+        Specs with non-numeric ports are invalid.
+        """
+        options = self._options()
+        self.assertIsNone(options._parseForwardSpec("xx:dest:90"))
+        self.assertIsNone(options._parseForwardSpec("8080:dest:yy"))
+
+    def test_optLocalforwardValid(self):
+        """
+        A valid local forward spec is recorded.
+        """
+        options = self._options()
+        options.opt_localforward("8080:dest:90")
+        self.assertEqual(
+            options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))]
+        )
+
+    def test_optLocalforwardInvalid(self):
+        """
+        An invalid local forward spec exits.
+        """
+        options = self._options()
+        self.assertRaises(SystemExit, options.opt_localforward, "x:dest:90")
+
+    def test_optRemoteforwardValid(self):
+        """
+        A valid remote forward spec is recorded.
+        """
+        options = self._options()
+        options.opt_remoteforward("8080:dest:90")
+        self.assertEqual(
+            options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))]
+        )
+
+    def test_optRemoteforwardInvalid(self):
+        """
+        An invalid remote forward spec exits.
+        """
+        options = self._options()
+        self.assertRaises(SystemExit, options.opt_remoteforward, "x:dest:90")
+
+
+class ConchSSHConnectionForwardingTests(TestCase):
+    """
+    Tests for the remote-forwarding methods of
+    L{twisted.conch.scripts.conch.SSHConnection}.
+    """
+
+    skip = _conchSkip
+
+    def _makeConnection(self):
+        connection = _conchScript.SSHConnection()
+        connection.remoteForwards = {}
+        self.sent = []
+        self.deferreds = []
+
+        def fakeSendGlobalRequest(request, data, wantReply=0):
+            d = Deferred()
+            self.sent.append((request, data, wantReply))
+            self.deferreds.append(d)
+            return d
+
+        connection.sendGlobalRequest = fakeSendGlobalRequest
+        return connection
+
+    def test_requestRemoteAddrForwarding(self):
+        """
+        Requesting forwarding sends a C{tcpip-forward} global request and,
+        once accepted, records the mapping keyed by the full address.
+        """
+        connection = self._makeConnection()
+        connection.requestRemoteAddrForwarding(("127.0.0.1", 8080), ("dest", 90))
+        self.assertEqual(self.sent[0][0], b"tcpip-forward")
+        self.deferreds[0].callback(None)
+        self.assertEqual(
+            connection.remoteForwards[("127.0.0.1", 8080)], ("dest", 90)
+        )
+
+    def test_requestRemoteForwardingDelegates(self):
+        """
+        The legacy port-based API binds to C{127.0.0.1} and delegates.
+        """
+        connection = self._makeConnection()
+        connection.requestRemoteForwarding(8080, ("dest", 90))
+        self.assertEqual(self.sent[0][0], b"tcpip-forward")
+        self.deferreds[0].callback(None)
+        self.assertIn(("127.0.0.1", 8080), connection.remoteForwards)
+
+    def test_ebRemoteForwarding(self):
+        """
+        A failed forwarding request is logged without raising.
+        """
+        from twisted.python.failure import Failure
+
+        connection = self._makeConnection()
+        connection._ebRemoteForwarding(
+            Failure(ConchError("nope")), ("127.0.0.1", 8080), ("dest", 90)
+        )
+        self.assertNotIn(("127.0.0.1", 8080), connection.remoteForwards)
+
+    def test_cancelRemoteAddrForwarding(self):
+        """
+        Cancelling sends a C{cancel-tcpip-forward} request and drops the entry.
+        """
+        connection = self._makeConnection()
+        connection.remoteForwards = {("127.0.0.1", 8080): ("dest", 90)}
+        connection.cancelRemoteAddrForwarding(("127.0.0.1", 8080))
+        self.assertEqual(self.sent[0][0], b"cancel-tcpip-forward")
+        self.assertNotIn(("127.0.0.1", 8080), connection.remoteForwards)
+
+    def test_cancelRemoteForwardingDelegates(self):
+        """
+        The legacy port-based cancel API binds to C{127.0.0.1} and delegates.
+        """
+        connection = self._makeConnection()
+        connection.remoteForwards = {("127.0.0.1", 8080): ("dest", 90)}
+        connection.cancelRemoteForwarding(8080)
+        self.assertNotIn(("127.0.0.1", 8080), connection.remoteForwards)
+
+    def test_cancelRemoteAddrForwardingUnknown(self):
+        """
+        Cancelling an unknown forward is a no-op (the missing key is ignored).
+        """
+        connection = self._makeConnection()
+        connection.remoteForwards = {}
+        connection.cancelRemoteAddrForwarding(("127.0.0.1", 8080))
+        self.assertEqual(self.sent[0][0], b"cancel-tcpip-forward")
+
+    def test_channelForwardedTcpipKnown(self):
+        """
+        An incoming forwarded-tcpip channel for a known address opens a
+        connecting channel.
+        """
+        connection = self._makeConnection()
+        connection.remoteForwards = {("127.0.0.1", 8080): ("dest", 90)}
+        data = _conchScript.forwarding.packOpen_forwarded_tcpip(
+            ("127.0.0.1", 8080), ("orig", 5)
+        )
+        channel = connection.channel_forwarded_tcpip(2**15, 2**15, data)
+        self.assertIsInstance(
+            channel, _conchScript.forwarding.SSHConnectForwardingChannel
+        )
+
+    def test_channelForwardedTcpipUnknown(self):
+        """
+        An incoming forwarded-tcpip channel for an unknown address is rejected.
+        """
+        connection = self._makeConnection()
+        connection.remoteForwards = {}
+        data = _conchScript.forwarding.packOpen_forwarded_tcpip(
+            ("127.0.0.1", 8080), ("orig", 5)
+        )
+        self.assertRaises(
+            ConchError, connection.channel_forwarded_tcpip, 2**15, 2**15, data
+        )
+
+    def test_channelClosedStopsWhenLast(self):
+        """
+        When the final channel closes, the connection is stopped.
+        """
+        connection = self._makeConnection()
+        connection.channels = {0: object()}
+        self.patch(_conchScript, "options", _FakeOptions(reconnect=True))
+        connection.channelClosed(object())
+
+
+class ConchOnConnectTests(TestCase):
+    """
+    Tests for the module-level C{onConnect} and C{beforeShutdown} helpers.
+    """
+
+    skip = _conchSkip
+
+    def test_onConnectSetsUpForwarding(self):
+        """
+        C{onConnect} listens for local forwards and asks for remote forwards.
+        """
+        conn = _FakeForwardingConn()
+        options = _FakeOptions(noshell=True, agent=False, fork=False)
+        options.localForwards = [(("127.0.0.1", 8080), ("dest", 90))]
+        options.remoteForwards = [(("127.0.0.1", 9090), ("dest2", 91))]
+
+        listened = []
+
+        def fakeListenTCP(port, factory, interface=""):
+            listened.append((port, interface))
+            return _FakePort()
+
+        self.patch(_conchScript, "conn", conn)
+        self.patch(_conchScript, "options", options)
+        self.patch(_conchScript, "_KeepAlive", lambda conn: None)
+        self.patch(_conchScript.reactor, "listenTCP", fakeListenTCP)
+        self.patch(
+            _conchScript.reactor, "addSystemEventTrigger", lambda *a, **k: None
+        )
+
+        _conchScript.onConnect()
+
+        self.assertEqual(listened, [(8080, "127.0.0.1")])
+        self.assertEqual(len(conn.localForwards), 1)
+        self.assertEqual(
+            conn.requestedRemote, [(("127.0.0.1", 9090), ("dest2", 91))]
+        )
+
+    def test_beforeShutdownCancelsForwarding(self):
+        """
+        C{beforeShutdown} cancels each remote forward by address.
+        """
+        conn = _FakeForwardingConn()
+        options = _FakeOptions()
+        options.remoteForwards = [(("127.0.0.1", 9090), ("dest", 91))]
+        self.patch(_conchScript, "conn", conn)
+        self.patch(_conchScript, "options", options)
+
+        _conchScript.beforeShutdown()
+
+        self.assertEqual(conn.cancelledRemote, [("127.0.0.1", 9090)])
+
+
+class ConchSSHSessionTests(TestCase):
+    """
+    Tests for L{twisted.conch.scripts.conch.SSHSession}.
+    """
+
+    skip = _conchSkip
+
+    def test_channelOpenWithAgent(self):
+        """
+        With agent forwarding and no shell, C{channelOpen} requests agent
+        forwarding and returns.
+        """
+        session = _conchScript.SSHSession()
+        session.id = 0
+        sent = []
+
+        class FakeConn:
+            def sendRequest(self, *args, **kwargs):
+                sent.append(args)
+                return Deferred()
+
+        session.conn = FakeConn()
+        self.patch(
+            _conchScript, "options", _FakeOptions(agent=True, noshell=True)
+        )
+
+        session.channelOpen(None)
+
+        self.assertEqual(len(sent), 1)
+
+    def test_handleInputDisconnect(self):
+        """
+        The C{.} escape disconnects.
+        """
+        session = _conchScript.SSHSession()
+        session.escapeMode = 2
+        self.patch(
+            _conchScript, "options", _FakeOptions(reconnect=True, escape=b"~")
+        )
+
+        session.handleInput(b".")
+
+        self.assertEqual(session.escapeMode, 1)
+
+    def test_handleInputRekey(self):
+        """
+        The C{R} escape triggers a rekey.
+        """
+        session = _conchScript.SSHSession()
+        session.escapeMode = 2
+        kexed = []
+
+        class FakeTransport:
+            def sendKexInit(self):
+                kexed.append(True)
+
+        class FakeConn:
+            transport = FakeTransport()
+
+        session.conn = FakeConn()
+        self.patch(_conchScript, "options", _FakeOptions(escape=b"~"))
+
+        session.handleInput(b"R")
+
+        self.assertEqual(kexed, [True])
+
+    def test_handleInputSuspend(self):
+        """
+        The C{^Z} escape schedules a suspend.
+        """
+        session = _conchScript.SSHSession()
+        session.escapeMode = 2
+        calls = []
+
+        class FakeReactor:
+            def callLater(self, *args):
+                calls.append(args)
+
+        self.patch(_conchScript, "reactor", FakeReactor())
+        self.patch(_conchScript, "options", _FakeOptions(escape=b"~"))
+
+        session.handleInput(b"\x1a")
+
+        self.assertEqual(len(calls), 1)
+
+    def test_extReceivedStderr(self):
+        """
+        Extended STDERR data is written to stderr.
+        """
+        from io import BytesIO
+
+        session = _conchScript.SSHSession()
+        fakeErr = BytesIO()
+        self.patch(sys, "stderr", fakeErr)
+
+        session.extReceived(
+            _conchScript.connection.EXTENDED_DATA_STDERR, b"oops"
+        )
+
+        self.assertEqual(fakeErr.getvalue(), b"oops")
+
+    def test_closed(self):
+        """
+        C{closed} logs without error.
+        """
+        session = _conchScript.SSHSession()
+
+        class FakeConn:
+            channels = {0: "channel"}
+
+        session.conn = FakeConn()
+        session.closed()
+
+    def test_closeReceived(self):
+        """
+        C{closeReceived} sends a close back to the server.
+        """
+        session = _conchScript.SSHSession()
+        closed = []
+
+        class FakeConn:
+            def sendClose(self, channel):
+                closed.append(channel)
+
+        session.conn = FakeConn()
+        session.closeReceived()
+        self.assertEqual(closed, [session])
+
+    def test_requestExitStatus(self):
+        """
+        C{request_exit_status} records the remote exit status.
+        """
+        import struct
+
+        session = _conchScript.SSHSession()
+        self.patch(_conchScript, "exitStatus", 0)
+        session.request_exit_status(struct.pack(">L", 7))
+        self.assertEqual(_conchScript.exitStatus, 7)
+
+    def test_enterRawModeNotATty(self):
+        """
+        C{_enterRawMode} warns rather than failing when stdin is not a tty.
+        """
+
+        class FakeStdin:
+            def fileno(self):
+                return 0
+
+        def raiseError(fd):
+            raise OSError("not a tty")
+
+        self.patch(_conchScript, "_inRawMode", 0)
+        self.patch(sys, "stdin", FakeStdin())
+        self.patch(_conchScript.tty, "tcgetattr", raiseError)
+
+        _conchScript._enterRawMode()
+
+    def test_enterRawModeSuccess(self):
+        """
+        C{_enterRawMode} puts a real terminal into raw mode.
+        """
+
+        class FakeStdin:
+            def fileno(self):
+                return 0
+
+        applied = []
+        fakeAttrs = [0, 0, 0, 0, 0, 0, [0] * 32]
+
+        self.patch(_conchScript, "_inRawMode", 0)
+        self.patch(_conchScript, "_savedRawMode", None)
+        self.patch(sys, "stdin", FakeStdin())
+        self.patch(_conchScript.tty, "tcgetattr", lambda fd: fakeAttrs)
+        self.patch(
+            _conchScript.tty, "tcsetattr", lambda *args: applied.append(args)
+        )
+
+        _conchScript._enterRawMode()
+
+        self.assertEqual(_conchScript._inRawMode, 1)
+        self.assertEqual(len(applied), 1)
+
+
+class ConchHandleErrorTests(TestCase):
+    """
+    Tests for the module-level C{handleError} helper.
+    """
+
+    skip = _conchSkip
+
+    def test_handleErrorReraises(self):
+        """
+        C{handleError} sets the exit status, schedules a stop and re-raises.
+        """
+        calls = []
+
+        class FakeReactor:
+            def callLater(self, *args, **kwargs):
+                calls.append(args)
+
+        self.patch(_conchScript, "reactor", FakeReactor())
+        self.patch(_conchScript, "exitStatus", 0)
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            self.assertRaises(ValueError, _conchScript.handleError)
+
+        self.assertEqual(_conchScript.exitStatus, 2)
+        self.assertEqual(len(calls), 1)
+        self.flushLoggedErrors(ValueError)

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -738,7 +738,7 @@ class CmdLineClientTests(ForwardingMixin, TestCase):
 
         def cb_check_log(result):
             logContent = logPath.getContent()
-            self.assertIn(b"Log opened.", logContent)
+            self.assertIn(b"twisted.conch", logContent)
 
         logPath = filepath.FilePath(self.mktemp())
 

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -906,9 +906,7 @@ class ConchClientOptionsForwardingTests(TestCase):
         """
         options = self._options()
         options.opt_localforward("8080:dest:90")
-        self.assertEqual(
-            options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))]
-        )
+        self.assertEqual(options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))])
 
     def test_optLocalforwardInvalid(self):
         """
@@ -923,9 +921,7 @@ class ConchClientOptionsForwardingTests(TestCase):
         """
         options = self._options()
         options.opt_remoteforward("8080:dest:90")
-        self.assertEqual(
-            options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))]
-        )
+        self.assertEqual(options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))])
 
     def test_optRemoteforwardInvalid(self):
         """
@@ -967,9 +963,7 @@ class ConchSSHConnectionForwardingTests(TestCase):
         connection.requestRemoteAddrForwarding(("127.0.0.1", 8080), ("dest", 90))
         self.assertEqual(self.sent[0][0], b"tcpip-forward")
         self.deferreds[0].callback(None)
-        self.assertEqual(
-            connection.remoteForwards[("127.0.0.1", 8080)], ("dest", 90)
-        )
+        self.assertEqual(connection.remoteForwards[("127.0.0.1", 8080)], ("dest", 90))
 
     def test_requestRemoteForwardingDelegates(self):
         """
@@ -1085,17 +1079,13 @@ class ConchOnConnectTests(TestCase):
         self.patch(_conchScript, "options", options)
         self.patch(_conchScript, "_KeepAlive", lambda conn: None)
         self.patch(_conchScript.reactor, "listenTCP", fakeListenTCP)
-        self.patch(
-            _conchScript.reactor, "addSystemEventTrigger", lambda *a, **k: None
-        )
+        self.patch(_conchScript.reactor, "addSystemEventTrigger", lambda *a, **k: None)
 
         _conchScript.onConnect()
 
         self.assertEqual(listened, [(8080, "127.0.0.1")])
         self.assertEqual(len(conn.localForwards), 1)
-        self.assertEqual(
-            conn.requestedRemote, [(("127.0.0.1", 9090), ("dest2", 91))]
-        )
+        self.assertEqual(conn.requestedRemote, [(("127.0.0.1", 9090), ("dest2", 91))])
 
     def test_beforeShutdownCancelsForwarding(self):
         """
@@ -1134,9 +1124,7 @@ class ConchSSHSessionTests(TestCase):
                 return Deferred()
 
         session.conn = FakeConn()
-        self.patch(
-            _conchScript, "options", _FakeOptions(agent=True, noshell=True)
-        )
+        self.patch(_conchScript, "options", _FakeOptions(agent=True, noshell=True))
 
         session.channelOpen(None)
 
@@ -1148,9 +1136,7 @@ class ConchSSHSessionTests(TestCase):
         """
         session = _conchScript.SSHSession()
         session.escapeMode = 2
-        self.patch(
-            _conchScript, "options", _FakeOptions(reconnect=True, escape=b"~")
-        )
+        self.patch(_conchScript, "options", _FakeOptions(reconnect=True, escape=b"~"))
 
         session.handleInput(b".")
 
@@ -1207,9 +1193,7 @@ class ConchSSHSessionTests(TestCase):
         fakeErr = BytesIO()
         self.patch(sys, "stderr", fakeErr)
 
-        session.extReceived(
-            _conchScript.connection.EXTENDED_DATA_STDERR, b"oops"
-        )
+        session.extReceived(_conchScript.connection.EXTENDED_DATA_STDERR, b"oops")
 
         self.assertEqual(fakeErr.getvalue(), b"oops")
 
@@ -1285,9 +1269,7 @@ class ConchSSHSessionTests(TestCase):
         self.patch(_conchScript, "_savedRawMode", None)
         self.patch(sys, "stdin", FakeStdin())
         self.patch(_conchScript.tty, "tcgetattr", lambda fd: fakeAttrs)
-        self.patch(
-            _conchScript.tty, "tcsetattr", lambda *args: applied.append(args)
-        )
+        self.patch(_conchScript.tty, "tcsetattr", lambda *args: applied.append(args))
 
         _conchScript._enterRawMode()
 

--- a/src/twisted/conch/test/test_tkconch.py
+++ b/src/twisted/conch/test/test_tkconch.py
@@ -97,9 +97,7 @@ class TkConchOptionsForwardingTests(TestCase):
         """
         options = self._options()
         options.opt_localforward("8080:dest:90")
-        self.assertEqual(
-            options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))]
-        )
+        self.assertEqual(options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))])
         self.assertRaises(SystemExit, options.opt_localforward, "x:dest:90")
 
     def test_optRemoteforward(self):
@@ -108,9 +106,7 @@ class TkConchOptionsForwardingTests(TestCase):
         """
         options = self._options()
         options.opt_remoteforward("8080:dest:90")
-        self.assertEqual(
-            options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))]
-        )
+        self.assertEqual(options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))])
         self.assertRaises(SystemExit, options.opt_remoteforward, "x:dest:90")
 
 
@@ -140,9 +136,7 @@ class TkConchSSHConnectionTests(TestCase):
 
         self.assertEqual(reactor.listened, [(8080, "127.0.0.1")])
         self.assertEqual(sent, [b"tcpip-forward"])
-        self.assertEqual(
-            connection.remoteForwards[("127.0.0.1", 9090)], ("dest2", 91)
-        )
+        self.assertEqual(connection.remoteForwards[("127.0.0.1", 9090)], ("dest2", 91))
 
     def test_channelForwardedTcpipKnown(self):
         """
@@ -155,9 +149,7 @@ class TkConchSSHConnectionTests(TestCase):
             ("127.0.0.1", 8080), ("orig", 5)
         )
         channel = connection.channel_forwarded_tcpip(2**15, 2**15, data)
-        self.assertIsInstance(
-            channel, tkconch.forwarding.SSHConnectForwardingChannel
-        )
+        self.assertIsInstance(channel, tkconch.forwarding.SSHConnectForwardingChannel)
 
     def test_channelForwardedTcpipUnknown(self):
         """

--- a/src/twisted/conch/test/test_tkconch.py
+++ b/src/twisted/conch/test/test_tkconch.py
@@ -1,0 +1,297 @@
+# -*- test-case-name: twisted.conch.test.test_tkconch -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+"""
+Tests for the in-process logic of L{twisted.conch.scripts.tkconch}.
+
+The GUI and reactor-driven entry points are exercised by the functional
+tests; here we cover the option parsing and the SSH connection and session
+handling that can run without a display.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from io import BytesIO
+
+from twisted.conch.error import ConchError
+from twisted.python.reflect import requireModule
+from twisted.trial.unittest import TestCase
+
+tkconch = requireModule("twisted.conch.scripts.tkconch")
+
+_tkconchSkip = "tkconch is not importable" if tkconch is None else None
+
+
+class _FakeOptions(dict[str, object]):
+    """
+    Minimal stand-in for L{tkconch.GeneralOptions} supporting attribute access
+    for the forward lists and C{__getitem__} for option flags.
+    """
+
+    def __init__(self, **flags):
+        super().__init__(flags)
+        self.localForwards = []
+        self.remoteForwards = []
+
+
+class _FakeReactor:
+    """A stand-in reactor recording C{listenTCP} and C{stop} calls."""
+
+    def __init__(self):
+        self.listened = []
+        self.stopped = 0
+
+    def listenTCP(self, port, factory, interface=""):
+        self.listened.append((port, interface))
+
+    def stop(self):
+        self.stopped += 1
+
+
+class TkConchOptionsForwardingTests(TestCase):
+    """
+    Tests for forward-spec parsing in L{tkconch.GeneralOptions}.
+    """
+
+    skip = _tkconchSkip
+
+    def _options(self):
+        options = tkconch.GeneralOptions()
+        options.localForwards = []
+        options.remoteForwards = []
+        return options
+
+    def test_parseForwardSpecWithoutListenAddress(self):
+        """
+        A three-part spec defaults the listen address to C{127.0.0.1}.
+        """
+        options = self._options()
+        self.assertEqual(
+            options._parseForwardSpec("8080:dest:90"),
+            (("127.0.0.1", 8080), ("dest", 90)),
+        )
+
+    def test_parseForwardSpecWithListenAddress(self):
+        """
+        A four-part spec uses the supplied listen address.
+        """
+        options = self._options()
+        self.assertEqual(
+            options._parseForwardSpec("1.2.3.4:8080:dest:90"),
+            (("1.2.3.4", 8080), ("dest", 90)),
+        )
+
+    def test_parseForwardSpecInvalid(self):
+        """
+        Specs with too many parts or non-numeric ports are invalid.
+        """
+        options = self._options()
+        self.assertIsNone(options._parseForwardSpec("a:b:8080:dest:90"))
+        self.assertIsNone(options._parseForwardSpec("xx:dest:90"))
+        self.assertIsNone(options._parseForwardSpec("8080:dest:yy"))
+
+    def test_optLocalforward(self):
+        """
+        A valid local forward is recorded; an invalid one exits.
+        """
+        options = self._options()
+        options.opt_localforward("8080:dest:90")
+        self.assertEqual(
+            options.localForwards, [(("127.0.0.1", 8080), ("dest", 90))]
+        )
+        self.assertRaises(SystemExit, options.opt_localforward, "x:dest:90")
+
+    def test_optRemoteforward(self):
+        """
+        A valid remote forward is recorded; an invalid one exits.
+        """
+        options = self._options()
+        options.opt_remoteforward("8080:dest:90")
+        self.assertEqual(
+            options.remoteForwards, [(("127.0.0.1", 8080), ("dest", 90))]
+        )
+        self.assertRaises(SystemExit, options.opt_remoteforward, "x:dest:90")
+
+
+class TkConchSSHConnectionTests(TestCase):
+    """
+    Tests for L{tkconch.SSHConnection}.
+    """
+
+    skip = _tkconchSkip
+
+    def test_serviceStartedSetsUpForwarding(self):
+        """
+        C{serviceStarted} listens for local forwards and asks for remote ones.
+        """
+        connection = tkconch.SSHConnection()
+        sent = []
+        connection.sendGlobalRequest = lambda request, data: sent.append(request)
+
+        options = _FakeOptions(noshell=True)
+        options.localForwards = [(("127.0.0.1", 8080), ("dest", 90))]
+        options.remoteForwards = [(("127.0.0.1", 9090), ("dest2", 91))]
+        reactor = _FakeReactor()
+        self.patch(tkconch, "options", options)
+        self.patch(tkconch, "reactor", reactor)
+
+        connection.serviceStarted()
+
+        self.assertEqual(reactor.listened, [(8080, "127.0.0.1")])
+        self.assertEqual(sent, [b"tcpip-forward"])
+        self.assertEqual(
+            connection.remoteForwards[("127.0.0.1", 9090)], ("dest2", 91)
+        )
+
+    def test_channelForwardedTcpipKnown(self):
+        """
+        A forwarded-tcpip channel for a known address opens a connecting
+        channel.
+        """
+        connection = tkconch.SSHConnection()
+        connection.remoteForwards = {("127.0.0.1", 8080): ("dest", 90)}
+        data = tkconch.forwarding.packOpen_forwarded_tcpip(
+            ("127.0.0.1", 8080), ("orig", 5)
+        )
+        channel = connection.channel_forwarded_tcpip(2**15, 2**15, data)
+        self.assertIsInstance(
+            channel, tkconch.forwarding.SSHConnectForwardingChannel
+        )
+
+    def test_channelForwardedTcpipUnknown(self):
+        """
+        A forwarded-tcpip channel for an unknown address is rejected.
+        """
+        connection = tkconch.SSHConnection()
+        connection.remoteForwards = {}
+        data = tkconch.forwarding.packOpen_forwarded_tcpip(
+            ("127.0.0.1", 8080), ("orig", 5)
+        )
+        self.assertRaises(
+            ConchError, connection.channel_forwarded_tcpip, 2**15, 2**15, data
+        )
+
+
+class TkConchSSHSessionTests(TestCase):
+    """
+    Tests for L{tkconch.SSHSession}.
+    """
+
+    skip = _tkconchSkip
+
+    def test_handleInputDisconnect(self):
+        """
+        The C{.} escape stops the reactor.
+        """
+        session = tkconch.SSHSession()
+        session.escapeMode = 2
+        reactor = _FakeReactor()
+        self.patch(tkconch, "reactor", reactor)
+        self.patch(tkconch, "options", _FakeOptions(escape="~"))
+
+        session.handleInput(".")
+
+        self.assertEqual(reactor.stopped, 1)
+
+    def test_handleInputRekey(self):
+        """
+        The C{R} escape triggers a rekey.
+        """
+        session = tkconch.SSHSession()
+        session.escapeMode = 2
+        kexed = []
+
+        class FakeTransport:
+            def sendKexInit(self):
+                kexed.append(True)
+
+        class FakeConn:
+            transport = FakeTransport()
+
+        session.conn = FakeConn()
+        self.patch(tkconch, "options", _FakeOptions(escape="~"))
+
+        session.handleInput("R")
+
+        self.assertEqual(kexed, [True])
+
+    def test_extReceivedStderr(self):
+        """
+        Extended STDERR data is written to stderr.
+        """
+        session = tkconch.SSHSession()
+        fakeErr = BytesIO()
+        self.patch(sys, "stderr", fakeErr)
+
+        session.extReceived(tkconch.connection.EXTENDED_DATA_STDERR, b"oops")
+
+        self.assertEqual(fakeErr.getvalue(), b"oops")
+
+    def test_eofReceived(self):
+        """
+        EOF closes stdin.
+        """
+        session = tkconch.SSHSession()
+        closed = []
+
+        class FakeStdin:
+            def close(self):
+                closed.append(True)
+
+        self.patch(sys, "stdin", FakeStdin())
+
+        session.eofReceived()
+
+        self.assertEqual(closed, [True])
+
+    def test_closedStopsWhenLast(self):
+        """
+        When the final channel closes, the reactor is stopped.
+        """
+        session = tkconch.SSHSession()
+        reactor = _FakeReactor()
+        self.patch(tkconch, "reactor", reactor)
+
+        class FakeConn:
+            channels = {0: "channel"}
+
+        session.conn = FakeConn()
+
+        session.closed()
+
+        self.assertEqual(reactor.stopped, 1)
+
+    def test_requestExitStatus(self):
+        """
+        C{request_exit_status} records the remote exit status.
+        """
+        session = tkconch.SSHSession()
+        self.patch(tkconch, "exitStatus", 0)
+        session.request_exit_status(struct.pack(">L", 7))
+        self.assertEqual(tkconch.exitStatus, 7)
+
+
+class TkConchHandleErrorTests(TestCase):
+    """
+    Tests for the module-level C{handleError} helper.
+    """
+
+    skip = _tkconchSkip
+
+    def test_handleErrorReraises(self):
+        """
+        C{handleError} sets the exit status, stops the reactor and re-raises.
+        """
+        reactor = _FakeReactor()
+        self.patch(tkconch, "reactor", reactor)
+        self.patch(tkconch, "exitStatus", 0)
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            self.assertRaises(ValueError, tkconch.handleError)
+
+        self.assertEqual(tkconch.exitStatus, 2)
+        self.assertEqual(reactor.stopped, 1)
+        self.flushLoggedErrors(ValueError)


### PR DESCRIPTION
## Scope and purpose

Fixes GHSA-jx3x-6fch-925x. Note that, while being a security issue, it was discussed in the corresponding private PR that a public PR should be opened to allow for automated tests and a normal merge procedure.

The Twisted Conch SSH client (https://github.com/twisted/twisted/blob/twisted-25.5.0/src/twisted/conch/scripts/conch.py) binds the TCP port listener for forwarded ports to 0.0.0.0 by default (or asks the server for 0.0.0.0 binding in the case of remote forwards). This can unintentionally expose forwarded services on the local network. This PR changes this behavior to bind to localhost (127.0.0.1) instead, while allowing for an explicit bind to other interfaces.

Fixes #12674.