### PR TITLE
bind addresses for conch forwarding

### DIFF
--- a/src/twisted/conch/client/direct.py
+++ b/src/twisted/conch/client/direct.py
@@ -50,7 +50,10 @@ class SSHClientFactory(protocol.ClientFactory["transport.SSHClientTransport"]):
         trans = SSHClientTransport(self)
         if self.options["ciphers"]:
             trans.supportedCiphers = self.options["ciphers"]
-        if self.options["macs"]:
+        macs = self.options["macs"]
+        if macs:
+            assert isinstance(macs, list), repr(macs)
+            assert all(isinstance(each, bytes) for each in macs)
             trans.supportedMACs = self.options["macs"]
         if self.options["compress"]:
             trans.supportedCompressions[0:1] = [b"zlib"]

--- a/src/twisted/conch/client/options.py
+++ b/src/twisted/conch/client/options.py
@@ -11,11 +11,15 @@ from twisted.python import usage
 
 
 class ConchOptions(usage.Options):
+    """
+    Common command-line options for conch clients.
+    """
+
     optParameters: list[list[str | int | None]] = [
         ["user", "l", None, "Log in using this user name."],
         ["identity", "i", None],
         ["ciphers", "c", None],
-        ["macs", "m", None],
+        ["macs", "m", None, "Specify MAC algorithms for protocol version 2."],
         ["port", "p", None, "Connect to this port.  Server must be on the same port."],
         ["option", "o", None, "Ignored OpenSSH options"],
         ["host-key-algorithms", "", None],
@@ -60,32 +64,31 @@ class ConchOptions(usage.Options):
         ],
     )
 
-    def __init__(self, *args, **kw):
-        usage.Options.__init__(self, *args, **kw)
-        self.identitys = []
+    def __init__(self, *args: object, **kw: object) -> None:
+        super().__init__()
+        self.identitys: list[str] = []
         self.conns = None
 
-    def opt_identity(self, i):
+    def opt_identity(self, i: str) -> None:
         """Identity for public-key authentication"""
         self.identitys.append(i)
 
-    def opt_ciphers(self, ciphers):
+    def opt_ciphers(self, ciphers: str) -> None:
         "Select encryption algorithms"
-        ciphers = ciphers.split(",")
-        for cipher in ciphers:
+        cipherList = ciphers.split(",")
+        for cipher in cipherList:
             if cipher not in SSHCiphers.cipherMap:
                 sys.exit("Unknown cipher type '%s'" % cipher)
-        self["ciphers"] = ciphers
+        self["ciphers"] = cipherList
 
-    def opt_macs(self, macs):
+    def opt_macs(self, macs: str | bytes) -> None:
         "Specify MAC algorithms"
-        if isinstance(macs, str):
-            macs = macs.encode("utf-8")
-        macs = macs.split(b",")
-        for mac in macs:
+        macsBytes = macs.encode("utf-8") if isinstance(macs, str) else macs
+        macsList = macsBytes.split(b",")
+        for mac in macsList:
             if mac not in SSHCiphers.macMap:
                 sys.exit("Unknown mac type '%r'" % mac)
-        self["macs"] = macs
+        self["macs"] = macsList
 
     def opt_host_key_algorithms(self, hkas):
         "Select host key algorithms"
@@ -108,3 +111,107 @@ class ConchOptions(usage.Options):
 #        "Enable compression"
 #        self.enableCompression = 1
 #        SSHClientTransport.supportedCompressions[0:1] = ['zlib']
+
+
+def _parseForwardSpec(f: str) -> tuple[tuple[str, int], tuple[str, int]] | None:
+    """
+    Parse a forward spec string like C{([lhost:]lport:host:port)} and return
+    C{((lhost, lport), (host, port))}.  Returns None if spec string is invalid.
+    Defaults lhost to 127.0.0.1 if not provided.
+    """
+    *maybeLhost, lport, host, port = f.split(":")
+    if len(maybeLhost) not in (0, 1):
+        return None
+    [lhost, *_] = [*maybeLhost, "127.0.0.1"]
+    if not (lport.isdigit() and port.isdigit()):
+        return None
+    return ((lhost, int(lport)), (host, int(port)))
+
+
+class CommonOptions(ConchOptions):
+    synopsis = """
+    Usage: {cli} [options] host [command]
+    """
+    optParameters = [
+        ["escape", "e", "~", "Set escape character; ``none'' = disable"],
+        [
+            "localforward",
+            "L",
+            None,
+            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
+        ],
+        [
+            "remoteforward",
+            "R",
+            None,
+            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
+        ],
+    ]
+
+    optFlags = [
+        ["tty", "t", "TTY; allocate a TTY even if command is given."],
+        ["notty", "T", "Do not allocate a TTY."],
+        ["noshell", "N", "Do not execute a shell or command."],
+        ["subsystem", "s", "Invoke command (mandatory) as SSH2 subsystem."],
+    ]
+
+    compData = usage.Completions(
+        mutuallyExclusive=[("tty", "notty")],
+        optActions={
+            "localforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+            "remoteforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+        },
+        extraActions=[
+            usage.CompleteUserAtHost(),
+            usage.Completer(descr="command"),
+            usage.Completer(descr="argument", repeat=True),
+        ],
+    )
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+        self.remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+
+    def opt_escape(self, esc: str) -> None:
+        """
+        Set escape character; ``none'' = disable
+        """
+        if esc == "none":
+            self["escape"] = None
+        elif esc[0] == "^" and len(esc) == 2:
+            self["escape"] = chr(ord(esc[1]) - 64)
+        elif len(esc) == 1:
+            self["escape"] = esc
+        else:
+            sys.exit(f"Bad escape character '{esc}'.")
+
+    def opt_localforward(self, f: str) -> None:
+        """
+        Forward local port to remote address ([lhost:]lport:host:port)
+        """
+        forwardSpec = _parseForwardSpec(f)
+        if forwardSpec is None:
+            sys.exit(
+                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
+        self.localForwards.append(forwardSpec)
+
+    def opt_remoteforward(self, f: str) -> None:
+        """
+        Forward remote port to local address ([rhost:]rport:host:port)
+        """
+        forwardSpec = _parseForwardSpec(f)
+        if forwardSpec is None:
+            sys.exit(
+                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
+        self.remoteForwards.append(forwardSpec)
+
+    def parseArgs(self, host: str = "", *command: str) -> None:
+        self["host"] = host
+        self["command"] = " ".join(command)

--- a/src/twisted/conch/newsfragments/12674.bugfix
+++ b/src/twisted/conch/newsfragments/12674.bugfix
@@ -1,0 +1,1 @@
+port forwardings of the conch/tkconch scripts now bind to 127.0.0.1 by default.

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -66,8 +66,12 @@ class ClientOptions(ConchOptions):
     compData = usage.Completions(
         mutuallyExclusive=[("tty", "notty")],
         optActions={
-            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "localforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+            "remoteforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -105,14 +109,15 @@ class ClientOptions(ConchOptions):
             return None
         return ((lhost, int(lport)), (host, int(port)))
 
-
     def opt_localforward(self, f):
         """
         Forward local port to remote address ([lhost:]lport:host:port)
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
@@ -121,7 +126,9 @@ class ClientOptions(ConchOptions):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.remoteForwards.append(forwardSpec)
 
     def parseArgs(self, host, *command):
@@ -254,7 +261,7 @@ def onConnect():
                 forwarding.SSHListenForwardingFactory(
                     conn, remoteAddr, SSHListenClientForwardingChannel
                 ),
-                interface=localAddr[0]
+                interface=localAddr[0],
             )
             conn.localForwards.append(s)
     if options.remoteForwards:
@@ -262,7 +269,8 @@ def onConnect():
             _log.info(
                 "asking for remote forwarding for {remoteAddr}:{connAddr}",
                 remoteAddr=remoteAddr,
-                connAddr=connAddr)
+                connAddr=connAddr,
+            )
             conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
@@ -292,7 +300,8 @@ def beforeShutdown():
         _log.info(
             "cancelling {remoteAddr}:{localAddr}",
             remoteAddr=remoteAddr,
-            localAddr=localAddr)
+            localAddr=localAddr,
+        )
         conn.cancelRemoteForwarding(remoteAddr)
 
 
@@ -350,7 +359,8 @@ class SSHConnection(connection.SSHConnection):
         _log.debug(
             "requesting remote forwarding {remoteAddr}:{connAddr}",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
         d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
@@ -358,7 +368,8 @@ class SSHConnection(connection.SSHConnection):
         _log.debug(
             "accepted remote forwarding {remoteAddr}:{connAddr}",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         self.remoteForwards[remoteAddr] = connAddr
         _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
@@ -366,7 +377,8 @@ class SSHConnection(connection.SSHConnection):
         _log.warn(
             "remote forwarding {remoteAddr}:{connAddr} failed",
             remoteAddr=remoteAddr,
-            connAddr=connAddr)
+            connAddr=connAddr,
+        )
         _log.debug("{f}", f=f)
 
     def cancelRemoteForwarding(self, remotePort):
@@ -391,7 +403,10 @@ class SSHConnection(connection.SSHConnection):
             connectAddr = self.remoteForwards[remoteAddr]
             _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return SSHConnectForwardingChannel(
-                connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
+                connectAddr,
+                remoteWindow=windowSize,
+                remoteMaxPacket=maxPacket,
+                conn=self,
             )
         else:
             raise ConchError(

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -23,8 +23,11 @@ from twisted.conch.client.options import ConchOptions
 from twisted.conch.error import ConchError
 from twisted.conch.ssh import channel, common, connection, forwarding, session
 from twisted.internet import reactor, stdio, task
-from twisted.python import log, usage
+from twisted.logger import Logger, globalLogBeginner, textFileLogObserver
+from twisted.python import usage
 from twisted.python.compat import ioType, networkString
+
+_log = Logger()
 
 
 class ClientOptions(ConchOptions):
@@ -164,11 +167,11 @@ def run():
                 f = open(options["logfile"], "a+")
         else:
             f = sys.stderr
-        realout = sys.stdout
-        log.startLogging(f)
-        sys.stdout = realout
+        globalLogBeginner.beginLoggingTo(
+            [textFileLogObserver(f)], redirectStandardIO=False
+        )
     else:
-        log.discardLogs()
+        globalLogBeginner.beginLoggingTo([], redirectStandardIO=False)
     doConnect()
     fd = sys.stdin.fileno()
     try:
@@ -196,12 +199,10 @@ def run():
 
 
 def handleError():
-    from twisted.python import failure
-
     global exitStatus
     exitStatus = 2
     reactor.callLater(0.01, _stopReactor)
-    log.err(failure.Failure())
+    _log.failure("error in conch")
     raise
 
 
@@ -258,7 +259,10 @@ def onConnect():
             conn.localForwards.append(s)
     if options.remoteForwards:
         for remoteAddr, connAddr in options.remoteForwards:
-            log.msg(f"asking for remote forwarding for {remoteAddr}:{connAddr}")
+            _log.info(
+                "asking for remote forwarding for {remoteAddr}:{connAddr}",
+                remoteAddr=remoteAddr,
+                connAddr=connAddr)
             conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
@@ -285,7 +289,10 @@ def reConnect():
 def beforeShutdown():
     remoteForwards = options.remoteForwards
     for remoteAddr, localAddr in remoteForwards:
-        log.msg(f"cancelling {remoteAddr}:{localAddr}")
+        _log.info(
+            "cancelling {remoteAddr}:{localAddr}",
+            remoteAddr=remoteAddr,
+            localAddr=localAddr)
         conn.cancelRemoteForwarding(remoteAddr)
 
 
@@ -340,18 +347,27 @@ class SSHConnection(connection.SSHConnection):
     def requestRemoteAddrForwarding(self, remoteAddr, connAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
-        log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
+        _log.debug(
+            "requesting remote forwarding {remoteAddr}:{connAddr}",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
         d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
         d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
     def _cbRemoteForwarding(self, result, remoteAddr, connAddr):
-        log.msg(f"accepted remote forwarding {remoteAddr}:{connAddr}")
+        _log.debug(
+            "accepted remote forwarding {remoteAddr}:{connAddr}",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
         self.remoteForwards[remoteAddr] = connAddr
-        log.msg(repr(self.remoteForwards))
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
     def _ebRemoteForwarding(self, f, remoteAddr, connAddr):
-        log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
-        log.msg(f)
+        _log.warn(
+            "remote forwarding {remoteAddr}:{connAddr} failed",
+            remoteAddr=remoteAddr,
+            connAddr=connAddr)
+        _log.debug("{f}", f=f)
 
     def cancelRemoteForwarding(self, remotePort):
         self.cancelRemoteAddrForwarding(("127.0.0.1", remotePort))
@@ -359,21 +375,21 @@ class SSHConnection(connection.SSHConnection):
     def cancelRemoteAddrForwarding(self, remoteAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
-        log.msg(f"cancelling remote forwarding {remoteAddr}")
+        _log.debug("cancelling remote forwarding {remoteAddr}", remoteAddr=remoteAddr)
         try:
             del self.remoteForwards[remoteAddr]
         except Exception:
             pass
-        log.msg(repr(self.remoteForwards))
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
-        log.msg(f"FTCP {data!r}")
+        _log.debug("FTCP {data!r}", data=data)
         remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
-        log.msg(self.remoteForwards)
-        log.msg(remoteAddr)
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
+        _log.debug("{remoteAddr!r}", remoteAddr=remoteAddr)
         if remoteAddr in self.remoteForwards:
             connectAddr = self.remoteForwards[remoteAddr]
-            log.msg(f"connect forwarding {connectAddr}")
+            _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return SSHConnectForwardingChannel(
                 connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
             )
@@ -383,10 +399,10 @@ class SSHConnection(connection.SSHConnection):
             )
 
     def channelClosed(self, channel):
-        log.msg(f"connection closing {channel}")
-        log.msg(self.channels)
+        _log.debug("connection closing {channel}", channel=channel)
+        _log.debug("{channels!r}", channels=self.channels)
         if len(self.channels) == 1:  # Just us left
-            log.msg("stopping connection")
+            _log.debug("stopping connection")
             stopConnection()
         else:
             # Because of the unix thing
@@ -397,12 +413,12 @@ class SSHSession(channel.SSHChannel):
     name = b"session"
 
     def channelOpen(self, foo):
-        log.msg(f"session {self.id} open")
+        _log.debug("session {sessionId} open", sessionId=self.id)
         if options["agent"]:
             d = self.conn.sendRequest(
                 self, b"auth-agent-req@openssh.com", b"", wantReply=1
             )
-            d.addBoth(lambda x: log.msg(x))
+            d.addBoth(lambda x: _log.debug("{result!r}", result=x))
         if options["noshell"]:
             return
         if (options["command"] and options["tty"]) or not options["notty"]:
@@ -448,7 +464,7 @@ class SSHSession(channel.SSHChannel):
         elif self.escapeMode == 2:
             self.escapeMode = 1  # So we can chain escapes together
             if char == b".":  # Disconnect
-                log.msg("disconnecting from escape")
+                _log.info("disconnecting from escape")
                 stopConnection()
                 return
             elif char == b"\x1a":  # ^Z, suspend
@@ -463,7 +479,7 @@ class SSHSession(channel.SSHChannel):
                 reactor.callLater(0, _)
                 return
             elif char == b"R":  # Rekey connection
-                log.msg("rekeying connection")
+                _log.info("rekeying connection")
                 self.conn.transport.sendKexInit()
                 return
             elif char == b"#":  # Display connections
@@ -489,29 +505,29 @@ class SSHSession(channel.SSHChannel):
 
     def extReceived(self, t, data):
         if t == connection.EXTENDED_DATA_STDERR:
-            log.msg(f"got {len(data)} stderr data")
+            _log.debug("got {n} stderr data", n=len(data))
             if ioType(sys.stderr) == str:
                 sys.stderr.buffer.write(data)
             else:
                 sys.stderr.write(data)
 
     def eofReceived(self):
-        log.msg("got eof")
+        _log.debug("got eof")
         self.stdio.loseWriteConnection()
 
     def closeReceived(self):
-        log.msg(f"remote side closed {self}")
+        _log.debug("remote side closed {session}", session=self)
         self.conn.sendClose(self)
 
     def closed(self):
         global old
-        log.msg(f"closed {self}")
-        log.msg(repr(self.conn.channels))
+        _log.debug("closed {session}", session=self)
+        _log.debug("{channels!r}", channels=self.conn.channels)
 
     def request_exit_status(self, data):
         global exitStatus
         exitStatus = int(struct.unpack(">L", data)[0])
-        log.msg(f"exit status: {exitStatus}")
+        _log.debug("exit status: {exitStatus}", exitStatus=exitStatus)
 
     def sendEOF(self):
         self.conn.sendEOF(self)
@@ -555,7 +571,7 @@ def _enterRawMode():
         old = tty.tcgetattr(fd)
         new = old[:]
     except BaseException:
-        log.msg("not a typewriter!")
+        _log.warn("not a typewriter!")
     else:
         # iflage
         new[0] = new[0] | tty.IGNPAR

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -273,7 +273,7 @@ def onConnect():
                 remoteAddr=remoteAddr,
                 connAddr=connAddr,
             )
-            conn.requestRemoteForwarding(remoteAddr, connAddr)
+            conn.requestRemoteAddrForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
         conn.openChannel(SSHSession())
@@ -304,7 +304,7 @@ def beforeShutdown():
             remoteAddr=remoteAddr,
             localAddr=localAddr,
         )
-        conn.cancelRemoteForwarding(remoteAddr)
+        conn.cancelRemoteAddrForwarding(remoteAddr)
 
 
 def stopConnection():

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -19,7 +19,7 @@ import tty
 from typing import Any
 
 from twisted.conch.client import connect, default
-from twisted.conch.client.options import ConchOptions
+from twisted.conch.client.options import CommonOptions
 from twisted.conch.error import ConchError
 from twisted.conch.ssh import channel, common, connection, forwarding, session
 from twisted.internet import reactor, stdio, task
@@ -30,112 +30,19 @@ from twisted.python.compat import ioType, networkString
 _log = Logger()
 
 
-class ClientOptions(ConchOptions):
-    synopsis = """Usage:   conch [options] host [command]
+class ClientOptions(CommonOptions):
+    synopsis = """Usage:   conch
+ [options] host [command]
 """
     longdesc = (
         "conch is a SSHv2 client that allows logging into a remote "
         "machine and executing commands."
     )
 
-    optParameters = [
-        ["escape", "e", "~"],
-        [
-            "localforward",
-            "L",
-            None,
-            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
-        ],
-        [
-            "remoteforward",
-            "R",
-            None,
-            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
-        ],
-    ]
-
     optFlags = [
         ["null", "n", "Redirect input from /dev/null."],
         ["fork", "f", "Fork to background after authentication."],
-        ["tty", "t", "Tty; allocate a tty even if command is given."],
-        ["notty", "T", "Do not allocate a tty."],
-        ["noshell", "N", "Do not execute a shell or command."],
-        ["subsystem", "s", "Invoke command (mandatory) as SSH2 subsystem."],
     ]
-
-    compData = usage.Completions(
-        mutuallyExclusive=[("tty", "notty")],
-        optActions={
-            "localforward": usage.Completer(
-                descr="[listen-addr:]listen-port:host:port"
-            ),
-            "remoteforward": usage.Completer(
-                descr="[listen-addr:]listen-port:host:port"
-            ),
-        },
-        extraActions=[
-            usage.CompleteUserAtHost(),
-            usage.Completer(descr="command"),
-            usage.Completer(descr="argument", repeat=True),
-        ],
-    )
-
-    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
-    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
-
-    def opt_escape(self, esc):
-        """
-        Set escape character; ``none'' = disable
-        """
-        if esc == "none":
-            self["escape"] = None
-        elif esc[0] == "^" and len(esc) == 2:
-            self["escape"] = chr(ord(esc[1]) - 64)
-        elif len(esc) == 1:
-            self["escape"] = esc
-        else:
-            sys.exit(f"Bad escape character '{esc}'.")
-
-    def _parseForwardSpec(
-        self, f: str
-    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
-        """
-        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
-        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
-        """
-        *maybeLhost, lport, host, port = f.split(":")
-        if len(maybeLhost) not in (0, 1):
-            return None
-        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
-        if not (lport.isdigit() and port.isdigit()):
-            return None
-        return ((lhost, int(lport)), (host, int(port)))
-
-    def opt_localforward(self, f):
-        """
-        Forward local port to remote address ([lhost:]lport:host:port)
-        """
-        forwardSpec = self._parseForwardSpec(f)
-        if forwardSpec is None:
-            sys.exit(
-                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
-            )
-        self.localForwards.append(forwardSpec)
-
-    def opt_remoteforward(self, f):
-        """
-        Forward remote port to local address ([rhost:]rport:host:port)
-        """
-        forwardSpec = self._parseForwardSpec(f)
-        if forwardSpec is None:
-            sys.exit(
-                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
-            )
-        self.remoteForwards.append(forwardSpec)
-
-    def parseArgs(self, host, *command):
-        self["host"] = host
-        self["command"] = " ".join(command)
 
 
 # Rest of code in "run"

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -41,13 +41,13 @@ class ClientOptions(ConchOptions):
             "localforward",
             "L",
             None,
-            "listen-port:host:port   Forward local port to remote address",
+            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
         ],
         [
             "remoteforward",
             "R",
             None,
-            "listen-port:host:port   Forward remote port to local address",
+            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
         ],
     ]
 
@@ -63,8 +63,8 @@ class ClientOptions(ConchOptions):
     compData = usage.Completions(
         mutuallyExclusive=[("tty", "notty")],
         optActions={
-            "localforward": usage.Completer(descr="listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="listen-port:host:port"),
+            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -73,8 +73,8 @@ class ClientOptions(ConchOptions):
         ],
     )
 
-    localForwards: list[tuple[int, tuple[int, int]]] = []
-    remoteForwards: list[tuple[int, tuple[int, int]]] = []
+    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
 
     def opt_escape(self, esc):
         """
@@ -91,21 +91,35 @@ class ClientOptions(ConchOptions):
 
     def opt_localforward(self, f):
         """
-        Forward local port to remote address (lport:host:port)
+        Forward local port to remote address ([lhost:]lport:host:port)
         """
-        localPort, remoteHost, remotePort = f.split(":")  # Doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            localHost = "127.0.0.1"
+            localPort, remoteHost, remotePort = f.split(":")
+        elif colonCount == 3:
+            localHost, localPort, remoteHost, remotePort = f.split(":")
+        else:
+            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         localPort = int(localPort)
         remotePort = int(remotePort)
-        self.localForwards.append((localPort, (remoteHost, remotePort)))
+        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
 
     def opt_remoteforward(self, f):
         """
-        Forward remote port to local address (rport:host:port)
+        Forward remote port to local address ([rhost:]rport:host:port)
         """
-        remotePort, connHost, connPort = f.split(":")  # Doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            remoteHost = "127.0.0.1"
+            remotePort, connHost, connPort = f.split(":")
+        elif colonCount == 3:
+            remoteHost, remotePort, connHost, connPort = f.split(":")
+        else:
+            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         remotePort = int(remotePort)
         connPort = int(connPort)
-        self.remoteForwards.append((remotePort, (connHost, connPort)))
+        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
 
     def parseArgs(self, host, *command):
         self["host"] = host
@@ -233,18 +247,19 @@ def onConnect():
     if hasattr(conn.transport, "sendIgnore"):
         _KeepAlive(conn)
     if options.localForwards:
-        for localPort, hostport in options.localForwards:
+        for localAddr, remoteAddr in options.localForwards:
             s = reactor.listenTCP(
-                localPort,
+                localAddr[1],
                 forwarding.SSHListenForwardingFactory(
-                    conn, hostport, SSHListenClientForwardingChannel
+                    conn, remoteAddr, SSHListenClientForwardingChannel
                 ),
+                interface=localAddr[0]
             )
             conn.localForwards.append(s)
     if options.remoteForwards:
-        for remotePort, hostport in options.remoteForwards:
-            log.msg(f"asking for remote forwarding for {remotePort}:{hostport}")
-            conn.requestRemoteForwarding(remotePort, hostport)
+        for remoteAddr, connAddr in options.remoteForwards:
+            log.msg(f"asking for remote forwarding for {remoteAddr}:{connAddr}")
+            conn.requestRemoteForwarding(remoteAddr, connAddr)
         reactor.addSystemEventTrigger("before", "shutdown", beforeShutdown)
     if not options["noshell"] or options["agent"]:
         conn.openChannel(SSHSession())
@@ -269,9 +284,9 @@ def reConnect():
 
 def beforeShutdown():
     remoteForwards = options.remoteForwards
-    for remotePort, hostport in remoteForwards:
-        log.msg(f"cancelling {remotePort}:{hostport}")
-        conn.cancelRemoteForwarding(remotePort)
+    for remoteAddr, localAddr in remoteForwards:
+        log.msg(f"cancelling {remoteAddr}:{localAddr}")
+        conn.cancelRemoteForwarding(remoteAddr)
 
 
 def stopConnection():
@@ -319,42 +334,42 @@ class SSHConnection(connection.SSHConnection):
             s.loseConnection()
         stopConnection()
 
-    def requestRemoteForwarding(self, remotePort, hostport):
-        data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+    def requestRemoteForwarding(self, remoteAddr, connAddr):
+        data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
-        log.msg(f"requesting remote forwarding {remotePort}:{hostport}")
-        d.addCallback(self._cbRemoteForwarding, remotePort, hostport)
-        d.addErrback(self._ebRemoteForwarding, remotePort, hostport)
+        log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
+        d.addCallback(self._cbRemoteForwarding, remoteAddr, connAddr)
+        d.addErrback(self._ebRemoteForwarding, remoteAddr, connAddr)
 
-    def _cbRemoteForwarding(self, result, remotePort, hostport):
-        log.msg(f"accepted remote forwarding {remotePort}:{hostport}")
-        self.remoteForwards[remotePort] = hostport
+    def _cbRemoteForwarding(self, result, remoteAddr, connAddr):
+        log.msg(f"accepted remote forwarding {remoteAddr}:{connAddr}")
+        self.remoteForwards[remoteAddr] = connAddr
         log.msg(repr(self.remoteForwards))
 
-    def _ebRemoteForwarding(self, f, remotePort, hostport):
-        log.msg(f"remote forwarding {remotePort}:{hostport} failed")
+    def _ebRemoteForwarding(self, f, remoteAddr, connAddr):
+        log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
         log.msg(f)
 
-    def cancelRemoteForwarding(self, remotePort):
-        data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+    def cancelRemoteForwarding(self, remoteAddr):
+        data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
-        log.msg(f"cancelling remote forwarding {remotePort}")
+        log.msg(f"cancelling remote forwarding {remoteAddr}")
         try:
-            del self.remoteForwards[remotePort]
+            del self.remoteForwards[remoteAddr]
         except Exception:
             pass
         log.msg(repr(self.remoteForwards))
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
         log.msg(f"FTCP {data!r}")
-        remoteHP, origHP = forwarding.unpackOpen_forwarded_tcpip(data)
+        remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
         log.msg(self.remoteForwards)
-        log.msg(remoteHP)
-        if remoteHP[1] in self.remoteForwards:
-            connectHP = self.remoteForwards[remoteHP[1]]
-            log.msg(f"connect forwarding {connectHP}")
+        log.msg(remoteAddr)
+        if remoteAddr in self.remoteForwards:
+            connectAddr = self.remoteForwards[remoteAddr]
+            log.msg(f"connect forwarding {connectAddr}")
             return SSHConnectForwardingChannel(
-                connectHP, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
+                connectAddr, remoteWindow=windowSize, remoteMaxPacket=maxPacket, conn=self
             )
         else:
             raise ConchError(

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -89,37 +89,37 @@ class ClientOptions(ConchOptions):
         else:
             sys.exit(f"Bad escape character '{esc}'.")
 
+    def _parseForwardSpec(self, f):
+        """
+        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
+        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
+        """
+        *maybeLhost, lport, host, port = f.split(":")
+        if len(maybeLhost) not in (0, 1):
+            return None
+        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
+        if not (lport.isdigit() and port.isdigit()):
+            return None
+        return ((lhost, int(lport)), (host, int(port)))
+
+
     def opt_localforward(self, f):
         """
         Forward local port to remote address ([lhost:]lport:host:port)
         """
-        colonCount = f.count(":")
-        if colonCount == 2:
-            localHost = "127.0.0.1"
-            localPort, remoteHost, remotePort = f.split(":")
-        elif colonCount == 3:
-            localHost, localPort, remoteHost, remotePort = f.split(":")
-        else:
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        localPort = int(localPort)
-        remotePort = int(remotePort)
-        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
+        self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
         """
         Forward remote port to local address ([rhost:]rport:host:port)
         """
-        colonCount = f.count(":")
-        if colonCount == 2:
-            remoteHost = "127.0.0.1"
-            remotePort, connHost, connPort = f.split(":")
-        elif colonCount == 3:
-            remoteHost, remotePort, connHost, connPort = f.split(":")
-        else:
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        remotePort = int(remotePort)
-        connPort = int(connPort)
-        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
+        self.remoteForwards.append(forwardSpec)
 
     def parseArgs(self, host, *command):
         self["host"] = host

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -96,7 +96,9 @@ class ClientOptions(ConchOptions):
         else:
             sys.exit(f"Bad escape character '{esc}'.")
 
-    def _parseForwardSpec(self, f):
+    def _parseForwardSpec(
+        self, f: str
+    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
         """
         Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
         Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.

--- a/src/twisted/conch/scripts/conch.py
+++ b/src/twisted/conch/scripts/conch.py
@@ -334,7 +334,10 @@ class SSHConnection(connection.SSHConnection):
             s.loseConnection()
         stopConnection()
 
-    def requestRemoteForwarding(self, remoteAddr, connAddr):
+    def requestRemoteForwarding(self, remotePort, hostport):
+        self.requestRemoteAddrForwarding(("127.0.0.1", remotePort), hostport)
+
+    def requestRemoteAddrForwarding(self, remoteAddr, connAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         d = self.sendGlobalRequest(b"tcpip-forward", data, wantReply=1)
         log.msg(f"requesting remote forwarding {remoteAddr}:{connAddr}")
@@ -350,7 +353,10 @@ class SSHConnection(connection.SSHConnection):
         log.msg(f"remote forwarding {remoteAddr}:{connAddr} failed")
         log.msg(f)
 
-    def cancelRemoteForwarding(self, remoteAddr):
+    def cancelRemoteForwarding(self, remotePort):
+        self.cancelRemoteAddrForwarding(("127.0.0.1", remotePort))
+
+    def cancelRemoteAddrForwarding(self, remoteAddr):
         data = forwarding.packGlobal_tcpip_forward(remoteAddr)
         self.sendGlobalRequest(b"cancel-tcpip-forward", data)
         log.msg(f"cancelling remote forwarding {remoteAddr}")

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -31,7 +31,10 @@ from twisted.conch.ssh import (
 )
 from twisted.conch.ui import tkvt100
 from twisted.internet import defer, protocol, reactor, tksupport
-from twisted.python import log, usage
+from twisted.logger import Logger, globalLogBeginner, textFileLogObserver
+from twisted.python import usage
+
+_log = Logger()
 
 
 class TkConchMenu(Tkinter.Frame):
@@ -209,17 +212,16 @@ class TkConchMenu(Tkinter.Frame):
             self.master.quit()
             self.master.destroy()
             if options["log"]:
-                realout = sys.stdout
-                log.startLogging(sys.stderr)
-                sys.stdout = realout
+                globalLogBeginner.beginLoggingTo(
+                    [textFileLogObserver(sys.stderr)], redirectStandardIO=False
+                )
             else:
-                log.discardLogs()
-            log.deferr = handleError  # HACK
+                globalLogBeginner.beginLoggingTo([], redirectStandardIO=False)
             if not options.identitys:
                 options.identitys = ["~/.ssh/id_rsa", "~/.ssh/id_dsa"]
             host = options["host"]
             port = int(options["port"] or 22)
-            log.msg((host, port))
+            _log.debug("connecting to {host}:{port}", host=host, port=port)
             reactor.connectTCP(host, port, SSHClientFactory())
             frame.master.deiconify()
             frame.master.title(
@@ -425,11 +427,9 @@ def run():
 
 
 def handleError():
-    from twisted.python import failure
-
     global exitStatus
     exitStatus = 2
-    log.err(failure.Failure())
+    _log.failure("error in tkconch")
     reactor.stop()
     raise
 
@@ -469,7 +469,7 @@ class SSHClientTransport(transport.SSHClientTransport):
     def receiveDebug(self, alwaysDisplay, message, lang):
         global options
         if alwaysDisplay or options["log"]:
-            log.msg("Received Debug Message: %s" % message)
+            _log.debug("Received Debug Message: {message}", message=message)
 
     def verifyHostKey(self, pubKey, fingerprint):
         # d = defer.Deferred()
@@ -518,7 +518,7 @@ class SSHClientTransport(transport.SSHClientTransport):
                 encodedKey = base64.b64encode(pubKey)
                 known_hosts.write(f"\n{khHost} {keyType} {encodedKey}")
         except BaseException:
-            log.deferr()
+            _log.failure("failed to record host key")
             raise error.ConchError
 
     def connectionSecure(self):
@@ -542,7 +542,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
         if not files:
             return None
         file = files[0]
-        log.msg(file)
+        _log.debug("trying identity file {file}", file=file)
         self.usedFiles.append(file)
         file = os.path.expanduser(file)
         file += ".pub"
@@ -593,23 +593,23 @@ class SSHConnection(connection.SSHConnection):
                 )
         if options.remoteForwards:
             for remoteAddr, connAddr in options.remoteForwards:
-                log.msg(
-                    "asking for remote forwarding for {}:{}".format(
-                        remoteAddr, connAddr
-                    )
+                _log.info(
+                    "asking for remote forwarding for {remoteAddr}:{connAddr}",
+                    remoteAddr=remoteAddr,
+                    connAddr=connAddr,
                 )
                 data = forwarding.packGlobal_tcpip_forward(remoteAddr)
                 self.sendGlobalRequest(b"tcpip-forward", data)
                 self.remoteForwards[remoteAddr] = connAddr
 
     def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
-        log.msg(f"FTCP {data!r}")
+        _log.debug("FTCP {data!r}", data=data)
         remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
-        log.msg(self.remoteForwards)
-        log.msg(remoteAddr)
+        _log.debug("{remoteForwards!r}", remoteForwards=self.remoteForwards)
+        _log.debug("{remoteAddr!r}", remoteAddr=remoteAddr)
         if remoteAddr in self.remoteForwards:
             connectAddr = self.remoteForwards[remoteAddr]
-            log.msg(f"connect forwarding {connectAddr}")
+            _log.debug("connect forwarding {connectAddr}", connectAddr=connectAddr)
             return forwarding.SSHConnectForwardingChannel(
                 connectAddr,
                 remoteWindow=windowSize,
@@ -659,7 +659,6 @@ class SSHSession(channel.SSHChannel):
         self.conn.transport.transport.setTcpNoDelay(1)
 
     def handleInput(self, char):
-        # log.msg('handling %s' % repr(char))
         if char in ("\n", "\r"):
             self.escapeMode = 1
             self.write(char)
@@ -668,7 +667,7 @@ class SSHSession(channel.SSHChannel):
         elif self.escapeMode == 2:
             self.escapeMode = 1  # so we can chain escapes together
             if char == ".":  # disconnect
-                log.msg("disconnecting from escape")
+                _log.info("disconnecting from escape")
                 reactor.stop()
                 return
             elif char == "\x1a":  # ^Z, suspend
@@ -676,7 +675,7 @@ class SSHSession(channel.SSHChannel):
                 os.kill(os.getpid(), signal.SIGSTOP)
                 return
             elif char == "R":  # rekey connection
-                log.msg("rekeying connection")
+                _log.info("rekeying connection")
                 self.conn.transport.sendKexInit()
                 return
             self.write("~" + char)
@@ -692,23 +691,23 @@ class SSHSession(channel.SSHChannel):
 
     def extReceived(self, t, data):
         if t == connection.EXTENDED_DATA_STDERR:
-            log.msg("got %s stderr data" % len(data))
+            _log.debug("got {n} stderr data", n=len(data))
             sys.stderr.write(data)
             sys.stderr.flush()
 
     def eofReceived(self):
-        log.msg("got eof")
+        _log.debug("got eof")
         sys.stdin.close()
 
     def closed(self):
-        log.msg("closed %s" % self)
+        _log.debug("closed {session}", session=self)
         if len(self.conn.channels) == 1:  # just us left
             reactor.stop()
 
     def request_exit_status(self, data):
         global exitStatus
         exitStatus = int(struct.unpack(">L", data)[0])
-        log.msg("exit status: %s" % exitStatus)
+        _log.info("exit status: {exitStatus}", exitStatus=exitStatus)
 
     def sendEOF(self):
         self.conn.sendEOF(self)

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -290,31 +290,36 @@ class GeneralOptions(usage.Options):
     def opt_identity(self, i):
         self.identitys.append(i)
 
+    def _parseForwardSpec(self, f):
+        """
+        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
+        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
+        """
+        *maybeLhost, lport, host, port = f.split(":")
+        if len(maybeLhost) not in (0, 1):
+            return None
+        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
+        if not (lport.isdigit() and port.isdigit()):
+            return None
+        return ((lhost, int(lport)), (host, int(port)))
+
     def opt_localforward(self, f):
-        colonCount = f.count(":")
-        if colonCount == 2:
-            localHost = "127.0.0.1"
-            localPort, remoteHost, remotePort = f.split(":")
-        elif colonCount == 3:
-            localHost, localPort, remoteHost, remotePort = f.split(":")
-        else:
+        """
+        Forward local port to remote address ([lhost:]lport:host:port)
+        """
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        localPort = int(localPort)
-        remotePort = int(remotePort)
-        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
+        self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
-        colonCount = f.count(":")
-        if colonCount == 2:
-            remoteHost = "127.0.0.1"
-            remotePort, connHost, connPort = f.split(":")
-        elif colonCount == 3:
-            remoteHost, remotePort, connHost, connPort = f.split(":")
-        else:
+        """
+        Forward remote port to local address ([rhost:]rport:host:port)
+        """
+        forwardSpec = self._parseForwardSpec(f)
+        if forwardSpec is None:
             sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
-        remotePort = int(remotePort)
-        connPort = int(connPort)
-        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
+        self.remoteForwards.append(forwardSpec)
 
     def opt_compress(self):
         SSHClientTransport.supportedCompressions[0:1] = ["zlib"]

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -275,8 +275,12 @@ class GeneralOptions(usage.Options):
         optActions={
             "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
             "macs": usage.CompleteList([v.decode() for v in _macs]),
-            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "localforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
+            "remoteforward": usage.Completer(
+                descr="[listen-addr:]listen-port:host:port"
+            ),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -311,7 +315,9 @@ class GeneralOptions(usage.Options):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.localForwards.append(forwardSpec)
 
     def opt_remoteforward(self, f):
@@ -320,7 +326,9 @@ class GeneralOptions(usage.Options):
         """
         forwardSpec = self._parseForwardSpec(f)
         if forwardSpec is None:
-            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
+            sys.exit(
+                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
+            )
         self.remoteForwards.append(forwardSpec)
 
     def opt_compress(self):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -574,6 +574,7 @@ class SSHUserAuthClient(userauth.SSHUserAuthClient):
 
 class SSHConnection(connection.SSHConnection):
     def serviceStarted(self):
+        self.remoteForwards = {}
         if not options["noshell"]:
             self.openChannel(SSHSession())
         if options.localForwards:
@@ -593,8 +594,27 @@ class SSHConnection(connection.SSHConnection):
                     )
                 )
                 data = forwarding.packGlobal_tcpip_forward(remoteAddr)
-                self.sendGlobalRequest("tcpip-forward", data)
+                self.sendGlobalRequest(b"tcpip-forward", data)
                 self.remoteForwards[remoteAddr] = connAddr
+
+    def channel_forwarded_tcpip(self, windowSize, maxPacket, data):
+        log.msg(f"FTCP {data!r}")
+        remoteAddr, _ = forwarding.unpackOpen_forwarded_tcpip(data)
+        log.msg(self.remoteForwards)
+        log.msg(remoteAddr)
+        if remoteAddr in self.remoteForwards:
+            connectAddr = self.remoteForwards[remoteAddr]
+            log.msg(f"connect forwarding {connectAddr}")
+            return forwarding.SSHConnectForwardingChannel(
+                connectAddr,
+                remoteWindow=windowSize,
+                remoteMaxPacket=maxPacket,
+                conn=self,
+            )
+        else:
+            raise error.ConchError(
+                connection.OPEN_CONNECT_FAILED, "don't know about that port"
+            )
 
 
 class SSHSession(channel.SSHChannel):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -238,13 +238,13 @@ class GeneralOptions(usage.Options):
             "localforward",
             "L",
             None,
-            "listen-port:host:port   Forward local port to remote address",
+            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
         ],
         [
             "remoteforward",
             "R",
             None,
-            "listen-port:host:port   Forward remote port to local address",
+            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
         ],
     ]
 
@@ -267,8 +267,8 @@ class GeneralOptions(usage.Options):
         optActions={
             "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
             "macs": usage.CompleteList([v.decode() for v in _macs]),
-            "localforward": usage.Completer(descr="listen-port:host:port"),
-            "remoteforward": usage.Completer(descr="listen-port:host:port"),
+            "localforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
+            "remoteforward": usage.Completer(descr="[listen-addr:]listen-port:host:port"),
         },
         extraActions=[
             usage.CompleteUserAtHost(),
@@ -278,23 +278,37 @@ class GeneralOptions(usage.Options):
     )
 
     identitys: list[str] = []
-    localForwards: list[tuple[int, tuple[int, int]]] = []
-    remoteForwards: list[tuple[int, tuple[int, int]]] = []
+    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
+    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
 
     def opt_identity(self, i):
         self.identitys.append(i)
 
     def opt_localforward(self, f):
-        localPort, remoteHost, remotePort = f.split(":")  # doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            localHost = "127.0.0.1"
+            localPort, remoteHost, remotePort = f.split(":")
+        elif colonCount == 3:
+            localHost, localPort, remoteHost, remotePort = f.split(":")
+        else:
+            sys.exit(f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         localPort = int(localPort)
         remotePort = int(remotePort)
-        self.localForwards.append((localPort, (remoteHost, remotePort)))
+        self.localForwards.append(((localHost, localPort), (remoteHost, remotePort)))
 
     def opt_remoteforward(self, f):
-        remotePort, connHost, connPort = f.split(":")  # doesn't do v6 yet
+        colonCount = f.count(":")
+        if colonCount == 2:
+            remoteHost = "127.0.0.1"
+            remotePort, connHost, connPort = f.split(":")
+        elif colonCount == 3:
+            remoteHost, remotePort, connHost, connPort = f.split(":")
+        else:
+            sys.exit(f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported).")
         remotePort = int(remotePort)
         connPort = int(connPort)
-        self.remoteForwards.append((remotePort, (connHost, connPort)))
+        self.remoteForwards.append(((remoteHost, remotePort), (connHost, connPort)))
 
     def opt_compress(self):
         SSHClientTransport.supportedCompressions[0:1] = ["zlib"]
@@ -377,11 +391,11 @@ def run():
     for k, v in options.items():
         if v and hasattr(menu, k):
             getattr(menu, k).insert(Tkinter.END, v)
-    for p, (rh, rp) in options.localForwards:
-        menu.forwards.insert(Tkinter.END, f"L:{p}:{rh}:{rp}")
+    for (lh, lp), (rh, rp) in options.localForwards:
+        menu.forwards.insert(Tkinter.END, f"L:{lh}:{lp}:{rh}:{rp}")
     options.localForwards = []
-    for p, (rh, rp) in options.remoteForwards:
-        menu.forwards.insert(Tkinter.END, f"R:{p}:{rh}:{rp}")
+    for (lh, lp), (rh, rp) in options.remoteForwards:
+        menu.forwards.insert(Tkinter.END, f"R:{lh}:{lp}:{rh}:{rp}")
     options.remoteForwards = []
     frame = tkvt100.VT100Frame(root, callback=None)
     root.geometry(
@@ -557,23 +571,24 @@ class SSHConnection(connection.SSHConnection):
         if not options["noshell"]:
             self.openChannel(SSHSession())
         if options.localForwards:
-            for localPort, hostport in options.localForwards:
+            for localAddr, remoteAddr in options.localForwards:
                 reactor.listenTCP(
-                    localPort,
+                    localAddr[1],
                     forwarding.SSHListenForwardingFactory(
-                        self, hostport, forwarding.SSHListenClientForwardingChannel
+                        self, remoteAddr, forwarding.SSHListenClientForwardingChannel
                     ),
+                    interface=localAddr[0],
                 )
         if options.remoteForwards:
-            for remotePort, hostport in options.remoteForwards:
+            for remoteAddr, connAddr in options.remoteForwards:
                 log.msg(
                     "asking for remote forwarding for {}:{}".format(
-                        remotePort, hostport
+                        remoteAddr, connAddr
                     )
                 )
-                data = forwarding.packGlobal_tcpip_forward(("0.0.0.0", remotePort))
+                data = forwarding.packGlobal_tcpip_forward(remoteAddr)
                 self.sendGlobalRequest("tcpip-forward", data)
-                self.remoteForwards[remotePort] = hostport
+                self.remoteForwards[remoteAddr] = connAddr
 
 
 class SSHSession(channel.SSHChannel):

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -296,7 +296,9 @@ class GeneralOptions(usage.Options):
     def opt_identity(self, i):
         self.identitys.append(i)
 
-    def _parseForwardSpec(self, f):
+    def _parseForwardSpec(
+        self, f: str
+    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
         """
         Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
         Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -83,12 +83,12 @@ class TkConchMenu(Tkinter.Frame):
         Tkinter.Button(self, text="Remove", command=self.removeForward).grid(
             column=1, row=8
         )
-        self.forwardPort = Tkinter.Entry(self)
-        self.forwardPort.grid(column=2, row=7, sticky="nesw")
-        Tkinter.Label(self, text="Port").grid(column=3, row=7, sticky="nesw")
-        self.forwardHost = Tkinter.Entry(self)
-        self.forwardHost.grid(column=2, row=8, sticky="nesw")
-        Tkinter.Label(self, text="Host").grid(column=3, row=8, sticky="nesw")
+        self.forwardListenAddress = Tkinter.Entry(self)
+        self.forwardListenAddress.grid(column=2, row=7, sticky="nesw")
+        Tkinter.Label(self, text="Listen Address").grid(column=3, row=7, sticky="nesw")
+        self.forwardConnectAddress = Tkinter.Entry(self)
+        self.forwardConnectAddress.grid(column=2, row=8, sticky="nesw")
+        Tkinter.Label(self, text="Connect Address").grid(column=3, row=8, sticky="nesw")
         self.localForward = Tkinter.Radiobutton(
             self, text="Local", variable=self.localRemoteVar, value="local"
         )
@@ -136,19 +136,25 @@ class TkConchMenu(Tkinter.Frame):
             self.identity.insert(Tkinter.END, r)
 
     def addForward(self):
-        port = self.forwardPort.get()
-        self.forwardPort.delete(0, Tkinter.END)
-        host = self.forwardHost.get()
-        self.forwardHost.delete(0, Tkinter.END)
+        listenHost, _, listenPort = self.forwardListenAddress.get().rpartition(":")
+        listenHost = listenHost or "127.0.0.1"
+        self.forwardListenAddress.delete(0, Tkinter.END)
+        connectHost, _, connectPort = self.forwardConnectAddress.get().rpartition(":")
+        connectHost = connectHost or "127.0.0.1"
+        self.forwardConnectAddress.delete(0, Tkinter.END)
         if self.localRemoteVar.get() == "local":
-            self.forwards.insert(Tkinter.END, f"L:{port}:{host}")
+            self.forwards.insert(
+                Tkinter.END, f"L:{listenHost}:{listenPort}:{connectHost}:{connectPort}"
+            )
         else:
-            self.forwards.insert(Tkinter.END, f"R:{port}:{host}")
+            self.forwards.insert(
+                Tkinter.END, f"R:{listenHost}:{listenPort}:{connectHost}:{connectPort}"
+            )
 
     def removeForward(self):
         cur = self.forwards.curselection()
         if cur:
-            self.forwards.remove(cur[0])
+            self.forwards.delete(cur[0])
 
     def doConnect(self):
         finished = 1

--- a/src/twisted/conch/scripts/tkconch.py
+++ b/src/twisted/conch/scripts/tkconch.py
@@ -19,6 +19,7 @@ import tkinter.messagebox as tkMessageBox
 
 from twisted.conch import error
 from twisted.conch.client.default import isInKnownHosts
+from twisted.conch.client.options import CommonOptions
 from twisted.conch.ssh import (
     channel,
     common,
@@ -231,118 +232,19 @@ class TkConchMenu(Tkinter.Frame):
             self.focus()
 
 
-class GeneralOptions(usage.Options):
-    synopsis = """Usage:    tkconch [options] host [command]
- """
-
-    optParameters = [
-        ["user", "l", None, "Log in using this user name."],
-        ["identity", "i", "~/.ssh/identity", "Identity for public key authentication"],
-        ["escape", "e", "~", "Set escape character; ``none'' = disable"],
-        ["cipher", "c", None, "Select encryption algorithm."],
-        ["macs", "m", None, "Specify MAC algorithms for protocol version 2."],
-        ["port", "p", None, "Connect to this port.  Server must be on the same port."],
-        [
-            "localforward",
-            "L",
-            None,
-            "[listen-addr:]listen-port:host:port   Forward local port to remote address",
-        ],
-        [
-            "remoteforward",
-            "R",
-            None,
-            "[listen-addr:]listen-port:host:port   Forward remote port to local address",
-        ],
-    ]
+class GeneralOptions(CommonOptions):
+    synopsis = """\
+Usage:    tkconch [options] host [command]
+"""
 
     optFlags = [
-        ["tty", "t", "Tty; allocate a tty even if command is given."],
-        ["notty", "T", "Do not allocate a tty."],
-        ["version", "V", "Display version number only."],
         ["compress", "C", "Enable compression."],
-        ["noshell", "N", "Do not execute a shell or command."],
-        ["subsystem", "s", "Invoke command (mandatory) as SSH2 subsystem."],
         ["log", "v", "Log to stderr"],
         ["ansilog", "a", "Print the received data to stdout"],
     ]
 
     _ciphers = transport.SSHClientTransport.supportedCiphers
     _macs = transport.SSHClientTransport.supportedMACs
-
-    compData = usage.Completions(
-        mutuallyExclusive=[("tty", "notty")],
-        optActions={
-            "cipher": usage.CompleteList([v.decode() for v in _ciphers]),
-            "macs": usage.CompleteList([v.decode() for v in _macs]),
-            "localforward": usage.Completer(
-                descr="[listen-addr:]listen-port:host:port"
-            ),
-            "remoteforward": usage.Completer(
-                descr="[listen-addr:]listen-port:host:port"
-            ),
-        },
-        extraActions=[
-            usage.CompleteUserAtHost(),
-            usage.Completer(descr="command"),
-            usage.Completer(descr="argument", repeat=True),
-        ],
-    )
-
-    identitys: list[str] = []
-    localForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
-    remoteForwards: list[tuple[tuple[str, int], tuple[str, int]]] = []
-
-    def opt_identity(self, i):
-        self.identitys.append(i)
-
-    def _parseForwardSpec(
-        self, f: str
-    ) -> tuple[tuple[str, int], tuple[str, int]] | None:
-        """
-        Parse a forward spec string ([lhost:]lport:host:port) and return ((lhost, lport), (host, port)).
-        Returns None if spec string is invalid. Defaults lhost to 127.0.0.1 if not provided.
-        """
-        *maybeLhost, lport, host, port = f.split(":")
-        if len(maybeLhost) not in (0, 1):
-            return None
-        [lhost, *_] = [*maybeLhost, "127.0.0.1"]
-        if not (lport.isdigit() and port.isdigit()):
-            return None
-        return ((lhost, int(lport)), (host, int(port)))
-
-    def opt_localforward(self, f):
-        """
-        Forward local port to remote address ([lhost:]lport:host:port)
-        """
-        forwardSpec = self._parseForwardSpec(f)
-        if forwardSpec is None:
-            sys.exit(
-                f"Invalid local forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
-            )
-        self.localForwards.append(forwardSpec)
-
-    def opt_remoteforward(self, f):
-        """
-        Forward remote port to local address ([rhost:]rport:host:port)
-        """
-        forwardSpec = self._parseForwardSpec(f)
-        if forwardSpec is None:
-            sys.exit(
-                f"Invalid remote forward '{f}' (expected [listen-addr:]listen-port:host:port; IPv6 addresses not supported)."
-            )
-        self.remoteForwards.append(forwardSpec)
-
-    def opt_compress(self):
-        SSHClientTransport.supportedCompressions[0:1] = ["zlib"]
-
-    def parseArgs(self, *args):
-        if args:
-            self["host"] = args[0]
-            self["command"] = " ".join(args[1:])
-        else:
-            self["host"] = ""
-            self["command"] = ""
 
 
 # Rest of code in "run"

--- a/src/twisted/conch/test/test_conch.py
+++ b/src/twisted/conch/test/test_conch.py
@@ -738,7 +738,7 @@ class CmdLineClientTests(ForwardingMixin, TestCase):
 
         def cb_check_log(result):
             logContent = logPath.getContent()
-            self.assertIn(b"Log opened.", logContent)
+            self.assertIn(b"twisted.conch", logContent)
 
         logPath = filepath.FilePath(self.mktemp())
 

--- a/src/twisted/conch/test/test_default.py
+++ b/src/twisted/conch/test/test_default.py
@@ -295,7 +295,7 @@ class ConchOptionsParsing(TestCase):
     Options parsing.
     """
 
-    def test_macs(self):
+    def test_macs(self) -> None:
         """
         Specify MAC algorithms.
         """


### PR DESCRIPTION
## Scope and purpose

Fixes GHSA-jx3x-6fch-925x. Note that, while being a security issue, it was discussed in the corresponding private PR that a public PR should be opened to allow for automated tests and a normal merge procedure.

The Twisted Conch SSH client (src/twisted/conch/scripts/conch.py) binds the TCP port listener for forwarded ports to 0.0.0.0 by default (or asks the server for 0.0.0.0 binding in the case of remote forwards). This can unintentionally expose forwarded services on the local network. This PR changes this behavior to bind to localhost (127.0.0.1) instead, while allowing for an explicit bind to other interfaces.

Fixes #12674.