### PR TITLE
#12671 Deprecate `twisted.trial.runner.samefile`

### DIFF
--- a/src/twisted/newsfragments/12671.removal
+++ b/src/twisted/newsfragments/12671.removal
@@ -1,0 +1,1 @@
+twisted.trial.runner.samefile is deprecated and replaced by os.path.samefile.

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -95,7 +95,7 @@ def isPackageDirectory(dirname):
 
 
 @deprecated(Version("Twisted", "NEXT", 0, 0), replacement="os.path.samefile")
-def samefile(filename1, filename2):
+def samefile(filename1: str, filename2: str) -> bool:
     """
     A hacky implementation of C{os.path.samefile}. Do not use this.
     """

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -43,10 +43,12 @@ from typing import Callable, Protocol, TextIO, Union
 from zope.interface import implementer
 
 from attrs import define
+from incremental import Version
 from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 
 from twisted.internet import defer
 from twisted.python import failure, filepath, log, modules, reflect
+from twisted.python.deprecate import deprecated
 from twisted.trial import unittest, util
 from twisted.trial._asyncrunner import _ForceGarbageCollectionDecorator, _iterateTests
 from twisted.trial._synctest import _logObserver
@@ -92,10 +94,10 @@ def isPackageDirectory(dirname):
     return False
 
 
+@deprecated(Version("Twisted", "NEXT", 0, 0), replacement="os.path.samefile")
 def samefile(filename1, filename2):
     """
-    A hacky implementation of C{os.path.samefile}. Used by L{filenameToModule}
-    when the platform doesn't provide C{os.path.samefile}. Do not use this.
+    A hacky implementation of C{os.path.samefile}. Do not use this.
     """
     return os.path.abspath(filename1) == os.path.abspath(filename2)
 
@@ -141,9 +143,7 @@ def filenameToModule(fn):
 
     # ensure that the loaded module matches the file
     retFile = os.path.splitext(ret.__file__)[0] + ".py"
-    # not all platforms (e.g. win32) have os.path.samefile
-    same = getattr(os.path, "samefile", samefile)
-    if os.path.isfile(fn) and not same(fn, retFile):
+    if os.path.isfile(fn) and not os.path.samefile(fn, retFile):
         del sys.modules[ret.__name__]
         ret = _importFromFile(fn, moduleName=moduleName)
     return ret

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -981,7 +981,7 @@ class DestructiveTestSuiteTests(unittest.SynchronousTestCase):
 
 
 class RunnerDeprecationTests(unittest.SynchronousTestCase):
-    def test_samefile(self):
+    def test_samefile(self) -> None:
         """
         Test that L{runner.samefile} is deprecated.
         """

--- a/src/twisted/trial/test/test_runner.py
+++ b/src/twisted/trial/test/test_runner.py
@@ -14,6 +14,8 @@ from io import StringIO
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
 
+from incremental import Version
+
 from twisted import plugin
 from twisted.internet import defer
 from twisted.plugins import twisted_trial
@@ -979,6 +981,17 @@ class DestructiveTestSuiteTests(unittest.SynchronousTestCase):
 
 
 class RunnerDeprecationTests(unittest.SynchronousTestCase):
+    def test_samefile(self):
+        """
+        Test that L{runner.samefile} is deprecated.
+        """
+        self.callDeprecated(
+            (Version("Twisted", "NEXT", 0, 0), "os.path.samefile"),
+            runner.samefile,
+            __file__,
+            os.path.abspath(__file__),
+        )
+
     class FakeReporter(reporter.Reporter):
         """
         Fake reporter that does *not* implement done() but *does* implement


### PR DESCRIPTION
## Scope and purpose

Fixes #12671 

On Python 3.10+, all major platforms support `os.path.samefile`, including Windows.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
