### PR TITLE
#12685 CI: use Tox 4 everywhere and cache all downloaded pip packages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -403,6 +403,11 @@ jobs:
         # The PRs that change the Python version can
         # be merged by ignoring the benchmark results.
         python-version: '3.12'
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
 
     - name: Install dependencies
       run: |
@@ -461,6 +466,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
 
     - name: Install dependencies
       run: |
@@ -485,6 +495,12 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox~=3.0
@@ -502,6 +518,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox~=3.0
@@ -526,6 +547,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          setup.cfg
+          tox.ini
 
     - name: Test
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -255,7 +255,7 @@ jobs:
     - name: Install dependencies
       run: |
         openssl version
-        python -m pip install --upgrade pip tox~=3.0 coverage
+        python -m pip install --upgrade pip tox~=4.0 coverage
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.
@@ -474,7 +474,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox~=4.0
 
     - name: Run the checks
       run: |
@@ -503,7 +503,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox~=4.0
 
     - name: Build apidocs
       run: |
@@ -525,7 +525,7 @@ jobs:
           tox.ini
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=3.0
+        python -m pip install --upgrade pip tox~=4.0
 
     - name: Run the checks
       run: |
@@ -555,7 +555,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip 'tox>4'
+        python -m pip install --upgrade pip tox~=4.0
         tox -e release-prepare
 
     - uses: twisted/python-info-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -255,7 +255,7 @@ jobs:
     - name: Install dependencies
       run: |
         openssl version
-        python -m pip install --upgrade pip tox~=4.0 coverage
+        python -m pip install --upgrade pip tox coverage
 
     # Make sure the matrix is defined in such a way that this is triggered
     # only on Linux.
@@ -474,7 +474,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=4.0
+        python -m pip install --upgrade pip tox
 
     - name: Run the checks
       run: |
@@ -503,7 +503,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=4.0
+        python -m pip install --upgrade pip tox
 
     - name: Build apidocs
       run: |
@@ -525,7 +525,7 @@ jobs:
           tox.ini
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip tox~=4.0
+        python -m pip install --upgrade pip tox
 
     - name: Run the checks
       run: |
@@ -555,7 +555,7 @@ jobs:
 
     - name: Test
       run: |
-        python -m pip install --upgrade pip tox~=4.0
+        python -m pip install --upgrade pip tox
         tox -e release-prepare
 
     - uses: twisted/python-info-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,7 +238,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
 
     # Make sure the matrix is defined in such a way that this is triggered
@@ -406,7 +405,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
 
     - name: Install dependencies
@@ -469,7 +467,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
 
     - name: Install dependencies
@@ -498,7 +495,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
 
     - name: Install dependencies
@@ -521,7 +517,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
     - name: Install dependencies
       run: |
@@ -550,7 +545,6 @@ jobs:
         cache: pip
         cache-dependency-path: |
           pyproject.toml
-          setup.cfg
           tox.ini
 
     - name: Test


### PR DESCRIPTION
## Scope and purpose

Fixes #12685

Changes to improve the CI a little bit, and make it faster/more efficient:

* Use tox 4 consistently so that the CI avoid installing tox twice (first 3.28, then finally 4.56.1 or whatever is newest).
* Use pip caching for all Python steps which install pip packages. There should be no need to download the same package on every CI run if the version is the same :)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
