### PR TITLE
#12688 Type annotate `twisted.internet.tcp.Connection` and remove one deprecation

### DIFF
--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -30,7 +30,6 @@ from twisted.internet.interfaces import (
 )
 from twisted.internet.protocol import ClientFactory, P
 from twisted.logger import ILogObserver, LogEvent, Logger
-from twisted.python import deprecate, versions
 from twisted.python.runtime import platformType
 
 try:
@@ -255,18 +254,8 @@ class Connection(
     def _dataReceived(self, data):
         if not data:
             return main.CONNECTION_DONE
-        rval = self.protocol.dataReceived(data)
-        if rval is not None:
-            offender = self.protocol.dataReceived
-            warningFormat = (
-                "Returning a value other than None from %(fqpn)s is "
-                "deprecated since %(version)s."
-            )
-            warningString = deprecate.getDeprecationWarningString(
-                offender, versions.Version("Twisted", 11, 0, 0), format=warningFormat
-            )
-            deprecate.warnAboutFunction(offender, warningString)
-        return rval
+        self.protocol.dataReceived(data)
+        return None
 
     def writeSomeData(self, data):
         """

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -20,6 +20,7 @@ from zope.interface import Interface, implementer
 
 import attr
 
+from twisted.internet.error import ConnectionDone, ConnectionLost
 from twisted.internet.interfaces import (
     IHalfCloseableProtocol,
     IListeningPort,
@@ -219,21 +220,27 @@ class Connection(
     connection based socket.
 
     @ivar logstr: prefix used when logging events related to this connection.
-    @type logstr: C{str}
     """
 
-    def __init__(self, skt, protocol, reactor=None):
-        abstract.FileDescriptor.__init__(self, reactor=reactor)
-        self.socket = skt
-        self.socket.setblocking(0)
-        self.fileno = skt.fileno
-        self.protocol = protocol
+    logstr: str = "Uninitialized"
 
-    def getHandle(self):
+    def __init__(
+        self,
+        skt: socket.socket,
+        protocol: IProtocol,
+        reactor: IReactorFDSet | None = None,
+    ):
+        abstract.FileDescriptor.__init__(self, reactor=reactor)
+        self.socket: socket.socket = skt
+        self.socket.setblocking(False)
+        self.fileno: Callable[[], int] = skt.fileno
+        self.protocol: IProtocol = protocol
+
+    def getHandle(self) -> socket.socket:
         """Return the socket for this connection."""
         return self.socket
 
-    def doRead(self):
+    def doRead(self) -> ConnectionLost | ConnectionDone | None:
         """Calls self.protocol.dataReceived with all available data.
 
         This reads up to self.bufferSize bytes of data from its socket, then
@@ -245,19 +252,19 @@ class Connection(
             data = self.socket.recv(self.bufferSize)
         except OSError as se:
             if se.args[0] == EWOULDBLOCK:
-                return
+                return None
             else:
                 return main.CONNECTION_LOST
 
         return self._dataReceived(data)
 
-    def _dataReceived(self, data):
+    def _dataReceived(self, data: bytes | None) -> ConnectionDone | None:
         if not data:
             return main.CONNECTION_DONE
         self.protocol.dataReceived(data)
         return None
 
-    def writeSomeData(self, data):
+    def writeSomeData(self, data: bytes) -> int | ConnectionLost:
         """
         Write as much as possible of the given data to this TCP connection.
 
@@ -277,7 +284,7 @@ class Connection(
             else:
                 return main.CONNECTION_LOST
 
-    def _closeWriteConnection(self):
+    def _closeWriteConnection(self) -> None:
         try:
             self.socket.shutdown(1)
         except OSError:
@@ -291,7 +298,7 @@ class Connection(
                 log.err()
                 self.connectionLost(f)
 
-    def readConnectionLost(self, reason):
+    def readConnectionLost(self, reason: failure.Failure) -> None:
         p = IHalfCloseableProtocol(self.protocol, None)
         if p:
             try:
@@ -302,7 +309,7 @@ class Connection(
         else:
             self.connectionLost(reason)
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason: failure.Failure) -> None:
         """See abstract.FileDescriptor.connectionLost()."""
         # Make sure we're not called twice, which can happen e.g. if
         # abortConnection() is called from protocol's dataReceived and then
@@ -319,16 +326,14 @@ class Connection(
         del self.fileno
         protocol.connectionLost(reason)
 
-    logstr = "Uninitialized"
-
-    def logPrefix(self):
+    def logPrefix(self) -> str:
         """Return the prefix to log with when I own the logging thread."""
         return self.logstr
 
-    def getTcpNoDelay(self):
+    def getTcpNoDelay(self) -> bool:
         return bool(self.socket.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY))
 
-    def setTcpNoDelay(self, enabled):
+    def setTcpNoDelay(self, enabled: bool) -> None:
         try:
             # There are bug reports about failures when setting TCP_NODELAY under certain conditions
             # on macOS: https://github.com/thespianpy/Thespian/issues/70,
@@ -342,10 +347,10 @@ class Connection(
         except OSError as e:  # pragma: no cover
             log.err(e, "got error when setting TCP_NODELAY on TCP socket")
 
-    def getTcpKeepAlive(self):
+    def getTcpKeepAlive(self) -> bool:
         return bool(self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
 
-    def setTcpKeepAlive(self, enabled):
+    def setTcpKeepAlive(self, enabled: bool) -> None:
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, enabled)
 
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -24,7 +24,7 @@ from twisted.internet.interfaces import (
     IHalfCloseableProtocol,
     IListeningPort,
     IProtocol,
-    IReactorTCP,
+    IReactorFDSet,
     ISystemHandle,
     ITCPTransport,
 )
@@ -798,7 +798,7 @@ class Server(_TLSServerMixin, Connection):
         client: tuple[object, ...],
         server: Port,
         sessionno: int,
-        reactor: IReactorTCP,
+        reactor: IReactorFDSet,
     ) -> None:
         """
         Server(sock, protocol, client, server, sessionno)

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -265,19 +265,6 @@ class FakeSocketTests(TestCase):
         self.assertEqual(skt.sendBuffer, [b"foo"])
 
 
-class FakeProtocol(Protocol):
-    """
-    An L{IProtocol} that returns a value from its dataReceived method.
-    """
-
-    def dataReceived(self, data):
-        """
-        Return something other than L{None} to trigger a deprecation warning for
-        that behavior.
-        """
-        return ()
-
-
 @implementer(IReactorFDSet)
 class _FakeFDSetReactor:
     """
@@ -383,32 +370,13 @@ class TCPConnectionTests(TestCase):
     Whitebox tests for L{twisted.internet.tcp.Connection}.
     """
 
-    def test_doReadWarningIsRaised(self):
-        """
-        When an L{IProtocol} implementation that returns a value from its
-        C{dataReceived} method, a deprecated warning is emitted.
-        """
-        skt = FakeSocket(b"someData")
-        protocol = FakeProtocol()
-        conn = Connection(skt, protocol)
-        conn.doRead()
-        warnings = self.flushWarnings([FakeProtocol.dataReceived])
-        self.assertEqual(warnings[0]["category"], DeprecationWarning)
-        self.assertEqual(
-            warnings[0]["message"],
-            "Returning a value other than None from "
-            "twisted.internet.test.test_tcp.FakeProtocol.dataReceived "
-            "is deprecated since Twisted 11.0.0.",
-        )
-        self.assertEqual(len(warnings), 1)
-
     def test_noTLSBeforeStartTLS(self):
         """
         The C{TLS} attribute of a L{Connection} instance is C{False} before
         L{Connection.startTLS} is called.
         """
         skt = FakeSocket(b"")
-        protocol = FakeProtocol()
+        protocol = Protocol()
         conn = Connection(skt, protocol)
         self.assertFalse(conn.TLS)
 
@@ -419,7 +387,7 @@ class TCPConnectionTests(TestCase):
         L{Connection.startTLS} is called.
         """
         skt = FakeSocket(b"")
-        protocol = FakeProtocol()
+        protocol = Protocol()
         conn = Connection(skt, protocol, reactor=_FakeFDSetReactor())
         conn._tlsClientDefault = True
         conn.startTLS(ClientContextFactory(), True)

--- a/src/twisted/newsfragments/12688.removal
+++ b/src/twisted/newsfragments/12688.removal
@@ -1,0 +1,1 @@
+twisted.internet.tcp.Connection no longer supports returning a non-None value from a protocol's dataReceived method, deprecated since Twisted 11.0.0.

--- a/src/twisted/python/util.py
+++ b/src/twisted/python/util.py
@@ -7,7 +7,8 @@ import errno
 import os
 import sys
 import warnings
-from typing import AnyStr
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from typing import Any, AnyStr, ClassVar, ParamSpec, TypeVar
 
 try:
     import grp as _grp
@@ -30,8 +31,6 @@ else:
 
 # For backwards compatibility, some things import this, so just link it
 from collections import OrderedDict
-from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any, Callable, ClassVar, TypeVar
 
 from incremental import Version
 
@@ -45,6 +44,7 @@ deprecatedModuleAttribute(
 )
 
 _T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 
 class InsensitiveDict(MutableMapping[str, _T]):
@@ -740,7 +740,7 @@ def switchUID(uid, gid, euid=False):
             setuid(uid)
 
 
-def untilConcludes(f, *a, **kw):
+def untilConcludes(f: Callable[_P, _T], *a: _P.args, **kw: _P.kwargs) -> _T:
     """
     Call C{f} with the given arguments, handling C{EINTR} by retrying.
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12688 

This is split into three isolated commits, isolated in that they can be reviewed separately:

1. Remove deprecated code: 0fb5518ad5d898271b81fab41a5dabaf8f800c1e
2. Fix one typing error: 19f69022a06be0808582b8e8b18e8ac886a09563
3. Add type annotations to `twisted.internet.tcp.Connection`: 89f6c063bc179c4c1a39b1da1f16caf1135d8af3

I initially only wanted to propose removing the deprecated code, but since I am modifying the code I felt it was natural to also add type annotation (same way new code is treated). I also like increase test coverage in this area :)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
