### PR TITLE
Update Black Code Style link in coding standards

### DIFF
--- a/docs/development/coding-standard.rst
+++ b/docs/development/coding-standard.rst
@@ -72,7 +72,7 @@ When you update existing files, if there is no copyright header, add one.
 Whitespace
 ----------
 
-Code must be formatted according to the `The Black Code Style <https://github.com/psf/black/blob/master/docs/the_black_code_style.md>`_.
+Code must be formatted according to the `The Black Code Style <https://github.com/psf/black/blob/main/docs/the_black_code_style/current_style.md>`_.
 This entire source tree can be reformatted by running:
 
 .. code-block:: console

--- a/docs/development/coding-standard.rst
+++ b/docs/development/coding-standard.rst
@@ -688,7 +688,7 @@ Fallback
 
 In case of conventions not enforced in this document, the reference documents to use in fallback are:
 
-* `The Black code style <https://github.com/psf/black/blob/master/docs/the_black_code_style.md>`_
+* `The Black code style <https://github.com/psf/black/blob/main/docs/the_black_code_style/current_style.md>`_
 * `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ for Python code
 * `PEP 7 <https://www.python.org/dev/peps/pep-0007/>`_ for C code
 


### PR DESCRIPTION
Update  Black Code style link in coding standards with current black code style.

Fixes #12693 

## Scope and purpose

Update the Black Code Style hyperlink in the coding standards documentation to point to the correct, active ReadTheDocs URL. The original URL on the master branch of black code style does not exist because the repository structure changed.
 
This is a trivial documentation fix, there is no Issue ID 



## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
