### PR TITLE
#12697 Remove a few dead code paths when using Python 3.10+

### DIFF
--- a/admin/dump_all_version_info.py
+++ b/admin/dump_all_version_info.py
@@ -10,15 +10,7 @@ print(sys.version)
 print(sys.platform)
 print("::endgroup::")
 
-if sys.version_info >= (3, 10):
-    _entry_points = importlib.metadata.entry_points
-else:
-
-    def _entry_points(*, group: str, name: str):
-        for ep in importlib.metadata.entry_points().get(group, []):
-            if ep.name == name:
-                yield ep
-
+_entry_points = importlib.metadata.entry_points
 
 if os.environ.get("CI", "").lower() == "true":
     # On CI show the exact deps found at runtime.

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -164,21 +164,6 @@ def _resolveDirectory(fn):
     return fn
 
 
-def _getMethodNameInClass(method):
-    """
-    Find the attribute name on the method's class which refers to the method.
-
-    For some methods, notably decorators which have not had __name__ set correctly:
-
-    getattr(method.im_class, method.__name__) != method
-    """
-    if getattr(method.im_class, method.__name__, object()) != method:
-        for alias in dir(method.im_class):
-            if getattr(method.im_class, alias, object()) == method:
-                return alias
-    return method.__name__
-
-
 class DestructiveTestSuite(TestSuite):
     """
     A test suite which remove the tests once run, to minimize memory usage.

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -35,16 +35,15 @@ import sys
 import types
 import unittest as pyunit
 import warnings
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from importlib.machinery import SourceFileLoader
-from typing import Callable, Protocol, TextIO, Union
+from typing import ParamSpec, Protocol, TextIO, TypeAlias, TypeGuard
 
 from zope.interface import implementer
 
 from attrs import define
 from incremental import Version
-from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 
 from twisted.internet import defer
 from twisted.python import failure, filepath, log, modules, reflect
@@ -246,12 +245,12 @@ class TrialSuite(TestSuite):
             self._bail()
 
 
-_Loadable: TypeAlias = Union[
-    modules.PythonAttribute,
-    modules.PythonModule,
-    pyunit.TestCase,
-    type[pyunit.TestCase],
-]
+_Loadable: TypeAlias = (
+    modules.PythonAttribute
+    | modules.PythonModule
+    | pyunit.TestCase
+    | type[pyunit.TestCase]
+)
 
 
 def name(thing: _Loadable) -> str:

--- a/src/twisted/trial/runner.py
+++ b/src/twisted/trial/runner.py
@@ -114,20 +114,9 @@ def filenameToModule(fn):
     @return: A module object.
     @raise ValueError: If C{fn} does not exist.
     """
-    oldFn = fn
-
-    if (3, 8) <= sys.version_info < (3, 10) and not os.path.isabs(fn):
-        # module.__spec__.__file__ is supposed to be absolute in py3.8+
-        # importlib.util.spec_from_file_location does this automatically from
-        # 3.10+
-        # This was backported to 3.8 and 3.9, but then reverted in 3.8.11 and
-        # 3.9.6
-        # See https://twistedmatrix.com/trac/ticket/10230
-        # and https://bugs.python.org/issue44070
-        fn = os.path.join(os.getcwd(), fn)
 
     if not os.path.exists(fn):
-        raise ValueError(f"{oldFn!r} doesn't exist")
+        raise ValueError(f"{fn!r} doesn't exist")
 
     moduleName = reflect.filenameToModuleName(fn)
     try:

--- a/src/twisted/web/test/test_template.py
+++ b/src/twisted/web/test/test_template.py
@@ -7,7 +7,6 @@ Tests for L{twisted.web.template}
 
 from __future__ import annotations
 
-import sys
 from io import StringIO
 
 from zope.interface import implementer
@@ -176,14 +175,9 @@ class ElementTests(TestCase):
         raise a comprehensible exception.
         """
         te = self.assertRaises(TypeError, renderer)
-        if sys.version_info >= (3, 10):
-            self.assertEqual(
-                str(te), "Expose.__call__() missing 1 required positional argument: 'f'"
-            )
-        else:
-            self.assertEqual(
-                str(te), "__call__() missing 1 required positional argument: 'f'"
-            )
+        self.assertEqual(
+            str(te), "Expose.__call__() missing 1 required positional argument: 'f'"
+        )
 
     def test_renderGetDirectlyError(self) -> None:
         """


### PR DESCRIPTION
## Scope and purpose

Fixes #12697

Twisted today supports only Python 3.10 and newer. So these changes are just clean up / maintenance. Less code to maintain :)

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
