### PR TITLE
Correct InvalidLogLevelError docs for the invalid level value

### DIFF
--- a/src/twisted/logger/_levels.py
+++ b/src/twisted/logger/_levels.py
@@ -11,12 +11,13 @@ from constantly import NamedConstant, Names
 
 class InvalidLogLevelError(Exception):
     """
-    Someone tried to use a L{LogLevel} that is unknown to the logging system.
+    Someone tried to use a log level that is unknown to the logging system.
     """
 
-    def __init__(self, level: NamedConstant) -> None:
+    def __init__(self, level: object) -> None:
         """
-        @param level: A log level from L{LogLevel}.
+        @param level: An invalid log level name or value that could not be
+            resolved to a L{LogLevel}.
         """
         super().__init__(str(level))
         self.level = level


### PR DESCRIPTION
﻿## Summary
- Document that `InvalidLogLevelError.level` is the invalid input value (usually a string name), not a `LogLevel` constant.
- Align the `__init__` type annotation with actual usage (`levelWithName` raises with the unresolved `name`).

## Test plan
- [x] Docs-only change; existing `twisted.logger` tests unchanged

Fixes #9587
