### PR TITLE
#12538 force RST packets to be re-sent by sending data after the peer aborts in abortConnection tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,14 +185,14 @@ jobs:
           # extension.
           # There is very little PYPY specific code so there is not much to
           # gain from reporting coverage.
-          - python-version: 'pypy3.11-v7.3.20'
+          - python-version: 'pypy3.11-v7.3.23'
             tox-env: 'alldeps-nocov-posix'
             job-name: 'no-coverage'
             skip-coverage: yes
 
           # We still run some tests with coverage,
           # as there are test with specific code branches for pypy.
-          - python-version: 'pypy3.11-v7.3.21'
+          - python-version: 'pypy3.11-v7.3.23'
             tox-env: 'nodeps-withcov-posix'
             trial-target: '-- twisted.test.test_compat twisted.test.test_defer twisted.internet.test.test_socket twisted.trial.test.test_tests'
             job-name: 'with-coverage'

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import socket
 from gc import collect
+from typing import Any
 from weakref import ref
 
 from zope.interface.verify import verifyObject
@@ -17,13 +18,16 @@ from zope.interface.verify import verifyObject
 from twisted.internet.defer import Deferred, gatherResults
 from twisted.internet.interfaces import IConnector, IReactorFDSet
 from twisted.internet.protocol import ClientFactory, Protocol, ServerFactory
-from twisted.internet.test.reactormixins import needsRunningReactor
+from twisted.internet.test.reactormixins import ReactorBuilder, needsRunningReactor
+from twisted.logger import Logger
 from twisted.python import context, log
 from twisted.python.failure import Failure
 from twisted.python.log import ILogContext, err, msg
 from twisted.python.runtime import platform
 from twisted.test.test_tcp import ClosingProtocol
 from twisted.trial.unittest import SkipTest
+
+_log = Logger()
 
 
 def findFreePort(interface="127.0.0.1", family=socket.AF_INET, type=socket.SOCK_STREAM):
@@ -71,7 +75,17 @@ class ConnectableProtocol(Protocol):
 
     disconnectReason = None
 
-    def _setAttributes(self, reactor, done):
+    def goodbye(self) -> None:
+        """
+        The other end of the connection has been aborted.  Force the operating
+        system to notice that an RST should be delivered, by writing some data.
+        """
+        assert self.transport is not None
+        self.transport.write(b"GOODBYE")
+
+    def _setAttributes(
+        self, reactor: Any, done: Deferred[None], peer: ConnectableProtocol
+    ) -> None:
         """
         Set attributes on the protocol that are known only externally; this
         will be called by L{runProtocolsWithReactor} when this protocol is
@@ -84,11 +98,13 @@ class ConnectableProtocol(Protocol):
         """
         self.reactor = reactor
         self._done = done
+        self.peer = peer
 
     def connectionLost(self, reason):
         self.disconnectReason = reason
         self._done.callback(None)
         del self._done
+        del self.peer
 
 
 class EndpointCreator:
@@ -127,8 +143,11 @@ class _SingleProtocolFactory(ClientFactory):
 
 
 def runProtocolsWithReactor(
-    reactorBuilder, serverProtocol, clientProtocol, endpointCreator
-):
+    reactorBuilder: ReactorBuilder,
+    serverProtocol: ConnectableProtocol,
+    clientProtocol: ConnectableProtocol,
+    endpointCreator: EndpointCreator,
+) -> Any:
     """
     Connect two protocols using endpoints and a new reactor instance.
 
@@ -149,31 +168,37 @@ def runProtocolsWithReactor(
     @return: The reactor run by this test.
     """
     reactor = reactorBuilder.buildReactor()
-    serverProtocol._setAttributes(reactor, Deferred())
-    clientProtocol._setAttributes(reactor, Deferred())
-    serverFactory = _SingleProtocolFactory(serverProtocol)
-    clientFactory = _SingleProtocolFactory(clientProtocol)
 
-    # Listen on a port:
-    serverEndpoint = endpointCreator.server(reactor)
-    d = serverEndpoint.listen(serverFactory)
-
-    # Connect to the port:
-    def gotPort(p):
+    async def steps() -> None:
+        clientDone: Deferred[None] = Deferred()
+        serverDone: Deferred[None] = Deferred()
+        serverProtocol._setAttributes(reactor, serverDone, clientProtocol)
+        clientProtocol._setAttributes(reactor, clientDone, serverProtocol)
+        serverFactory = _SingleProtocolFactory(serverProtocol)
+        clientFactory = _SingleProtocolFactory(clientProtocol)
+        # Listen on a port:
+        serverEndpoint = endpointCreator.server(reactor)
+        p = await serverEndpoint.listen(serverFactory)
+        # Connect to the port:
         clientEndpoint = endpointCreator.client(reactor, p.getHost())
-        return clientEndpoint.connect(clientFactory)
+        await clientEndpoint.connect(clientFactory)
 
-    d.addCallback(gotPort)
+        async def waitForOne(
+            theOne: Deferred[None], theOther: ConnectableProtocol
+        ) -> None:
+            await theOne
+            theOther.goodbye()
 
-    # Stop reactor when both connections are lost:
-    def failed(result):
-        log.err(result, "Connection setup failed.")
+        oneWay = Deferred.fromCoroutine(waitForOne(serverDone, clientProtocol))
+        theOtherWay = Deferred.fromCoroutine(waitForOne(clientDone, serverProtocol))
+        await oneWay
+        await theOtherWay
+        reactor.stop()
 
-    disconnected = gatherResults([serverProtocol._done, clientProtocol._done])
-    d.addCallback(lambda _: disconnected)
-    d.addErrback(failed)
-    d.addCallback(lambda _: needsRunningReactor(reactor, reactor.stop))
+    def report(failure: Failure) -> None:
+        _log.failure("while running reactor", failure)
 
+    reactor.callWhenRunning(lambda: Deferred.fromCoroutine(steps()).addErrback(report))
     reactorBuilder.runReactor(reactor)
     return reactor
 

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -79,6 +79,14 @@ class ConnectableProtocol(Protocol):
         """
         The other end of the connection has been aborted.  Force the operating
         system to notice that an RST should be delivered, by writing some data.
+
+        As described in https://github.com/python/cpython/issues/153117 ,
+        macOS, and in particular macOS 26, may fail to deliver RST packets,
+        even over local interfaces, when connections are aborted; this prevents
+        tests from hanging while waiting for a notification that will never
+        come.  By sending data to the now-possibly-defunct peer, we force the
+        OS to emit another RST packet and I{notice} that the connection has
+        been reset.
         """
         assert self.transport is not None
         self.transport.write(b"GOODBYE")
@@ -187,6 +195,8 @@ def runProtocolsWithReactor(
             theOne: Deferred[None], theOther: ConnectableProtocol
         ) -> None:
             await theOne
+            # See docstring on L{ConnectableProtocol.goodbye} for more
+            # information.
             theOther.goodbye()
 
         oneWay = Deferred.fromCoroutine(waitForOne(serverDone, clientProtocol))

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -76,7 +76,7 @@ class ConnectableProtocol(Protocol):
 
     disconnectReason = None
 
-    def goodbye(self) -> None:
+    def writeToDetectPeerDisconnection(self) -> None:
         """
         The other end of the connection has been aborted.  Force the operating
         system to notice that an RST should be delivered, by writing some data.
@@ -156,7 +156,7 @@ def runProtocolsWithReactor(
     serverProtocol: ConnectableProtocol,
     clientProtocol: ConnectableProtocol,
     endpointCreator: EndpointCreator,
-    sayGoodbye: bool = True,
+    writeToPeerAfterAbort: bool = True,
 ) -> Any:
     """
     Connect two protocols using endpoints and a new reactor instance.
@@ -199,8 +199,8 @@ def runProtocolsWithReactor(
             await theOne
             # See docstring on L{ConnectableProtocol.goodbye} for more
             # information.
-            if sayGoodbye:
-                theOther.goodbye()
+            if writeToPeerAfterAbort:
+                theOther.writeToDetectPeerDisconnection()
 
         oneWay = Deferred.fromCoroutine(waitForOne(serverDone, clientProtocol))
         theOtherWay = Deferred.fromCoroutine(waitForOne(clientDone, serverProtocol))

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -88,8 +88,8 @@ class ConnectableProtocol(Protocol):
         OS to emit another RST packet and I{notice} that the connection has
         been reset.
         """
-        assert self.transport is not None
-        self.transport.write(b"GOODBYE")
+        if self.transport is not None:
+            self.transport.write(b"GOODBYE")
 
     def _setAttributes(
         self, reactor: Any, done: Deferred[None], peer: ConnectableProtocol

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -155,6 +155,7 @@ def runProtocolsWithReactor(
     serverProtocol: ConnectableProtocol,
     clientProtocol: ConnectableProtocol,
     endpointCreator: EndpointCreator,
+    sayGoodbye: bool = True,
 ) -> Any:
     """
     Connect two protocols using endpoints and a new reactor instance.
@@ -197,7 +198,8 @@ def runProtocolsWithReactor(
             await theOne
             # See docstring on L{ConnectableProtocol.goodbye} for more
             # information.
-            theOther.goodbye()
+            if sayGoodbye:
+                theOther.goodbye()
 
         oneWay = Deferred.fromCoroutine(waitForOne(serverDone, clientProtocol))
         theOtherWay = Deferred.fromCoroutine(waitForOne(clientDone, serverProtocol))

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -89,8 +89,8 @@ class ConnectableProtocol(Protocol):
         OS to emit another RST packet and I{notice} that the connection has
         been reset.
         """
-        if self.transport is not None:
-            self.transport.write(b"GOODBYE")
+        assert self.transport is not None
+        self.transport.write(b"GOODBYE")
 
     def _setAttributes(
         self, reactor: Any, done: Deferred[None], peer: ConnectableProtocol

--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -9,6 +9,7 @@ Various helpers for tests for connection-oriented transports.
 from __future__ import annotations
 
 import socket
+from functools import partial
 from gc import collect
 from typing import Any
 from weakref import ref
@@ -207,10 +208,11 @@ def runProtocolsWithReactor(
         await theOtherWay
         reactor.stop()
 
-    def report(failure: Failure) -> None:
-        _log.failure("while running reactor", failure)
-
-    reactor.callWhenRunning(lambda: Deferred.fromCoroutine(steps()).addErrback(report))
+    reactor.callWhenRunning(
+        lambda: Deferred.fromCoroutine(steps()).addErrback(
+            partial(_log.failure, "while running reactor")
+        )
+    )
     reactorBuilder.runReactor(reactor)
     return reactor
 

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -8,7 +8,6 @@ Tests for implementations of L{IReactorProcess}.
     platforms and native L{str} keys/values on Windows.
 """
 
-
 import io
 import json
 import os
@@ -616,9 +615,15 @@ sys.stdout.flush()"""
                 raise TestException("processedExited raised")
 
         protocol = Protocol()
-        transport = reactor.spawnProcess(
-            protocol, pyExe, [pyExe, b"-c", b""], usePTY=self.usePTY
-        )
+        transport = None
+
+        def whenRun() -> None:
+            nonlocal transport
+            transport = reactor.spawnProcess(
+                protocol, pyExe, [pyExe, b"-c", b""], usePTY=self.usePTY
+            )
+
+        reactor.callWhenRunning(whenRun)
         self.runReactor(reactor)
 
         # Manually clean-up broken process handler.

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2808,20 +2808,6 @@ class AbortConnectionMixin:
             clientConnectionLostReason=ConnectionLost,
         )
 
-    macKernelBug = skipIf(
-        False,
-        """
-        These tests possibly implicate a macOS kernel bug as described in
-        https://github.com/python/cpython/issues/153117 .  However, as
-        experiments in https://github.com/twisted/twisted/pull/12695 suggest,
-        it is not sufficient to simply disable the asyncio reactor to work
-        around the issue.  The tests themselves are also somewhat poorly
-        written and simply hang rather than failing cleanly, so they do not
-        provide a lot of value.  They are skipped pending this investigation.
-        """,
-    )
-
-    @macKernelBug
     def test_resumeProducingAbort(self):
         """
         abortConnection() is called in resumeProducing, before any bytes have
@@ -2830,7 +2816,6 @@ class AbortConnectionMixin:
         """
         self.runAbortTest(ProducerAbortingClient, ConnectableProtocol)
 
-    @macKernelBug
     def test_resumeProducingAbortLater(self):
         """
         abortConnection() is called in resumeProducing, after some
@@ -2838,7 +2823,6 @@ class AbortConnectionMixin:
         """
         self.runAbortTest(ProducerAbortingClientLater, AbortServerWritingProtocol)
 
-    @macKernelBug
     def test_fullWriteBuffer(self):
         """
         abortConnection() triggered by the write buffer being full.
@@ -2852,7 +2836,6 @@ class AbortConnectionMixin:
         """
         self.runAbortTest(StreamingProducerClient, NoReadServer)
 
-    @macKernelBug
     def test_fullWriteBufferAfterByteExchange(self):
         """
         abortConnection() is triggered by a write buffer being full.

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -254,7 +254,7 @@ class TCPPortTests(SynchronousTestCase):
         def noNewSocket() -> socket.socket:
             raise OSError("socket creation failure")
 
-        self.server.createInternetSocket = noNewSocket  # type:ignore[method-assign]
+        self.server.createInternetSocket = noNewSocket  # type: ignore[method-assign]
         with self.assertRaises(CannotListenError):
             self.server.startListening()
 
@@ -2443,9 +2443,9 @@ class ReadAbortServerProtocol(AbortServerWritingProtocol):
     possibly arrive.
     """
 
-    def dataReceived(self, data):
-        if data.replace(b"X", b""):
-            raise Exception("Unexpectedly received data.")
+    def dataReceived(self, data: bytes) -> None:
+        if surprise := data.replace(b"X", b""):
+            raise Exception(f"Unexpectedly received data: {repr(surprise)}")
 
 
 class NoReadServer(ConnectableProtocol):
@@ -2809,7 +2809,7 @@ class AbortConnectionMixin:
         )
 
     macKernelBug = skipIf(
-        platform.isMacOSX(),
+        False,
         """
         These tests possibly implicate a macOS kernel bug as described in
         https://github.com/python/cpython/issues/153117 .  However, as
@@ -2836,9 +2836,7 @@ class AbortConnectionMixin:
         abortConnection() is called in resumeProducing, after some
         bytes have been exchanged. The protocol should be disconnected.
         """
-        return self.runAbortTest(
-            ProducerAbortingClientLater, AbortServerWritingProtocol
-        )
+        self.runAbortTest(ProducerAbortingClientLater, AbortServerWritingProtocol)
 
     @macKernelBug
     def test_fullWriteBuffer(self):
@@ -2863,7 +2861,7 @@ class AbortConnectionMixin:
         allowing a TLS handshake if we're testing TLS. The connection will
         then be lost.
         """
-        return self.runAbortTest(StreamingProducerClientLater, EventualNoReadServer)
+        self.runAbortTest(StreamingProducerClientLater, EventualNoReadServer)
 
     def test_dataReceivedThrows(self):
         """

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2444,8 +2444,9 @@ class ReadAbortServerProtocol(AbortServerWritingProtocol):
     """
 
     def dataReceived(self, data: bytes) -> None:
-        if surprise := data.replace(b"X", b""):
-            raise Exception(f"Unexpectedly received data: {repr(surprise)}")
+        assert not (
+            surprise := data.replace(b"X", b"")
+        ), f"Unexpectedly received data: {repr(surprise)}"
 
 
 class NoReadServer(ConnectableProtocol):

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2808,12 +2808,20 @@ class AbortConnectionMixin:
             clientConnectionLostReason=ConnectionLost,
         )
 
-    # This test is flaky on macOS on Azure and we skip it due to lack of active macOS developers.
-    # If you care about Twisted on macOS, consider enabling this tests and find out why we get random failures.
-    @skipIf(
-        os.environ.get("CI", "").lower() == "true" and platform.isMacOSX(),
-        "Flaky on macOS on Azure.",
+    macKernelBug = skipIf(
+        platform.isMacOSX(),
+        """
+        These tests possibly implicate a macOS kernel bug as described in
+        https://github.com/python/cpython/issues/153117 .  However, as
+        experiments in https://github.com/twisted/twisted/pull/12695 suggest,
+        it is not sufficient to simply disable the asyncio reactor to work
+        around the issue.  The tests themselves are also somewhat poorly
+        written and simply hang rather than failing cleanly, so they do not
+        provide a lot of value.  They are skipped pending this investigation.
+        """,
     )
+
+    @macKernelBug
     def test_resumeProducingAbort(self):
         """
         abortConnection() is called in resumeProducing, before any bytes have
@@ -2822,12 +2830,7 @@ class AbortConnectionMixin:
         """
         self.runAbortTest(ProducerAbortingClient, ConnectableProtocol)
 
-    # This test is flaky on macOS on Azure and we skip it due to lack of active macOS developers.
-    # If you care about Twisted on macOS, consider enabling this tests and find out why we get random failures.
-    @skipIf(
-        os.environ.get("CI", "").lower() == "true" and platform.isMacOSX(),
-        "Flaky on macOS on Azure.",
-    )
+    @macKernelBug
     def test_resumeProducingAbortLater(self):
         """
         abortConnection() is called in resumeProducing, after some
@@ -2837,6 +2840,7 @@ class AbortConnectionMixin:
             ProducerAbortingClientLater, AbortServerWritingProtocol
         )
 
+    @macKernelBug
     def test_fullWriteBuffer(self):
         """
         abortConnection() triggered by the write buffer being full.

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2444,7 +2444,7 @@ class ReadAbortServerProtocol(AbortServerWritingProtocol):
     """
 
     def dataReceived(self, data: bytes) -> None:
-        assert not (  # pragma: no-cover
+        assert not (  # pragma: no cover
             surprise := data.replace(b"X", b"")
         ), f"Unexpectedly received data: {repr(surprise)}"
 

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2444,7 +2444,7 @@ class ReadAbortServerProtocol(AbortServerWritingProtocol):
     """
 
     def dataReceived(self, data: bytes) -> None:
-        assert not (
+        assert not (  # pragma: no-cover
             surprise := data.replace(b"X", b"")
         ), f"Unexpectedly received data: {repr(surprise)}"
 

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2854,6 +2854,7 @@ class AbortConnectionMixin:
         """
         self.runAbortTest(StreamingProducerClient, NoReadServer)
 
+    @macKernelBug
     def test_fullWriteBufferAfterByteExchange(self):
         """
         abortConnection() is triggered by a write buffer being full.

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -299,7 +299,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SaveAddress()
         client = SaveAddress()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
         self.assertEqual(server.addresses["host"], client.addresses["peer"])
         self.assertEqual(server.addresses["peer"], client.addresses["host"])
@@ -337,7 +337,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         d.addErrback(err, "Sending file descriptor encountered a problem")
         d.addBoth(lambda ignored: server.transport.loseConnection())
 
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
     @skipIf(not sendmsg, sendmsgSkipReason)
     def test_sendFileDescriptorTriggersPauseProducing(self):
@@ -384,7 +384,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SendsManyFileDescriptors()
         client = DoesNotRead()
         server.other = client
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
         self.assertTrue(server.paused, "sendFileDescriptor producer was not paused")
 
@@ -406,7 +406,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         d.addBoth(result.append)
         d.addBoth(lambda ignored: server.transport.loseConnection())
 
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
         self.assertIsInstance(result[0], Failure)
         result[0].trap(ConnectionClosed)
@@ -614,7 +614,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = RecordEndpointAddresses(probeClient.fileno(), b"junk")
         client = ConnectableProtocol()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
         # Get rid of the original reference to the socket.
         probeClient.close()
@@ -687,7 +687,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SendFileDescriptor(cargo.fileno(), b"example data")
         client = RecordEvents()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
+        runProtocolsWithReactor(self, server, client, self.endpoints, False)
 
         self.assertEqual("file-descriptor", client.events[0])
         self.assertEqual(b"example data", bytes(client.events[1:]))

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -668,6 +668,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         L{IUNIXTransport.sendFileDescriptor} sends file descriptors before
         L{ITransport.write} sends normal bytes.
         """
+        oself = self
 
         @implementer(IFileDescriptorReceiver)
         class RecordEvents(ConnectableProtocol):
@@ -675,21 +676,21 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
                 ConnectableProtocol.connectionMade(self)
                 self.events = []
 
-            def fileDescriptorReceived(innerSelf, descriptor):
-                self.addCleanup(close, descriptor)
-                innerSelf.events.append(type(descriptor))
+            def fileDescriptorReceived(self, descriptor):
+                oself.addCleanup(close, descriptor)
+                self.events.append("file-descriptor")
 
             def dataReceived(self, data):
                 self.events.extend(data)
 
         cargo = socket()
-        server = SendFileDescriptor(cargo.fileno(), b"junk")
+        server = SendFileDescriptor(cargo.fileno(), b"example data")
         client = RecordEvents()
 
         runProtocolsWithReactor(self, server, client, self.endpoints)
 
-        self.assertEqual(int, client.events[0])
-        self.assertEqual(b"junk", bytes(client.events[1:]))
+        self.assertEqual("file-descriptor", client.events[0])
+        self.assertEqual(b"example data", bytes(client.events[1:]))
 
 
 class UNIXDatagramTestsBuilder(UNIXFamilyMixin, ReactorBuilder):

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -687,7 +687,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SendFileDescriptor(cargo.fileno(), b"example data")
         client = RecordEvents()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
         self.assertEqual("file-descriptor", client.events[0])
         self.assertEqual(b"example data", bytes(client.events[1:]))

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -299,7 +299,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SaveAddress()
         client = SaveAddress()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
         self.assertEqual(server.addresses["host"], client.addresses["peer"])
         self.assertEqual(server.addresses["peer"], client.addresses["host"])
@@ -337,7 +337,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         d.addErrback(err, "Sending file descriptor encountered a problem")
         d.addBoth(lambda ignored: server.transport.loseConnection())
 
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
     @skipIf(not sendmsg, sendmsgSkipReason)
     def test_sendFileDescriptorTriggersPauseProducing(self):
@@ -384,7 +384,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = SendsManyFileDescriptors()
         client = DoesNotRead()
         server.other = client
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
         self.assertTrue(server.paused, "sendFileDescriptor producer was not paused")
 
@@ -406,7 +406,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         d.addBoth(result.append)
         d.addBoth(lambda ignored: server.transport.loseConnection())
 
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
         self.assertIsInstance(result[0], Failure)
         result[0].trap(ConnectionClosed)
@@ -614,7 +614,7 @@ class UNIXTestsBuilder(UNIXFamilyMixin, ReactorBuilder, ConnectionTestsMixin):
         server = RecordEndpointAddresses(probeClient.fileno(), b"junk")
         client = ConnectableProtocol()
 
-        runProtocolsWithReactor(self, server, client, self.endpoints)
+        runProtocolsWithReactor(self, server, client, self.endpoints, sayGoodbye=False)
 
         # Get rid of the original reference to the socket.
         probeClient.close()

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -15,9 +15,8 @@ from zope.interface.verify import verifyObject
 
 from hypothesis import given, strategies as st
 
-from twisted.internet import reactor
 from twisted.internet.interfaces import IOpenSSLContextFactory
-from twisted.internet.task import Clock, deferLater
+from twisted.internet.task import Clock
 from twisted.python.compat import iterbytes
 from twisted.test.iosim import IOPump
 
@@ -698,30 +697,23 @@ class TLSMemoryBIOTests(TestCase):
 
         return self.writeBeforeHandshakeTest(SimpleSendingProtocol, data)
 
-    def test_writeUnicodeRaisesTypeError(self):
+    async def test_writeUnicodeRaisesTypeError(self) -> None:
         """
         Writing C{unicode} to L{TLSMemoryBIOProtocol} throws a C{TypeError}.
         """
         notBytes = "hello"
         result = []
+        oself = self
 
         class SimpleSendingProtocol(Protocol):
             def connectionMade(self):
-                try:
+                with oself.assertRaises(TypeError):
                     self.transport.write(notBytes)
-                    self.transport.write(b"bytes")
-                    self.transport.loseConnection()
-                except TypeError:
-                    result.append(True)
-                    self.transport.abortConnection()
+                self.transport.write(b"bytes")
+                result.append(True)
 
-        def flush_logged_errors():
-            self.assertEqual(len(self.flushLoggedErrors(ConnectionLost, TypeError)), 2)
-
-        d = self.writeBeforeHandshakeTest(SimpleSendingProtocol, b"bytes")
-        d.addBoth(lambda ign: self.assertEqual(result, [True]))
-        d.addBoth(lambda ign: deferLater(reactor, 0, flush_logged_errors))
-        return d
+        await self.writeBeforeHandshakeTest(SimpleSendingProtocol, b"bytes")
+        self.assertEqual(result, [True])
 
     def test_multipleWrites(self):
         """
@@ -897,7 +889,7 @@ class TLSMemoryBIOTests(TestCase):
         # weren't notified of a handshake failure that would cause the test to
         # fail.
         def cbConnectionDone(result):
-            (clientProtocol, serverProtocol) = result
+            clientProtocol, serverProtocol = result
             clientProtocol.lostConnectionReason.trap(ConnectionDone)
             serverProtocol.lostConnectionReason.trap(ConnectionDone)
 
@@ -1571,7 +1563,7 @@ class TLSProducerTests(TestCase):
 
         def f() -> None:
             oldStyle: IOpenSSLContextFactory = (
-                ExtremelyOldStyle()  # type:ignore[assignment]
+                ExtremelyOldStyle()  # type: ignore[assignment]
             )
             TLSMemoryBIOFactory(oldStyle, True, Factory.forProtocol(Protocol))
 
@@ -1601,9 +1593,9 @@ class TLSProducerTests(TestCase):
                 return "just broken"
 
         broken1: IOpenSSLContextFactory = (
-            HasGetContextButBroken()  # type:ignore[assignment]
+            HasGetContextButBroken()  # type: ignore[assignment]
         )
-        broken2: IOpenSSLContextFactory = JustBroken()  # type:ignore[assignment]
+        broken2: IOpenSSLContextFactory = JustBroken()  # type: ignore[assignment]
 
         def test1() -> None:
             with self.assertRaises(TypeError) as te:

--- a/src/twisted/protocols/tls.py
+++ b/src/twisted/protocols/tls.py
@@ -59,7 +59,7 @@ from twisted.internet.interfaces import (
     ITransport,
 )
 from twisted.internet.main import CONNECTION_LOST
-from twisted.internet.protocol import Protocol
+from twisted.internet.protocol import Protocol, connectionDone
 from twisted.protocols.policies import ProtocolWrapper, WrappingFactory
 from twisted.python.failure import Failure
 from ._tls_legacy import SomeConnectionCreator, _convertToAppropriateFactory
@@ -631,6 +631,7 @@ class _AggregateSmallWrites:
     def __init__(self, write: Callable[[bytes], object], clock: IReactorTime):
         self._write = write
         self._clock = clock
+        self._closed = False
         self._buffer: list[bytes] = []
         self._bufferLeft = self.MAX_BUFFER_SIZE
         self._scheduled: IDelayedCall | None = None
@@ -642,7 +643,7 @@ class _AggregateSmallWrites:
 
         Accumulating too much data can result in higher memory usage.
         """
-        self._buffer.append(data)
+        self._buffer.append(data + b"")
         self._bufferLeft -= len(data)
 
         if self._bufferLeft < 0:
@@ -672,6 +673,11 @@ class _AggregateSmallWrites:
             self._write(b"".join(self._buffer))
             del self._buffer[:]
 
+    def close(self) -> None:
+        if self._scheduled is not None:
+            self._scheduled.cancel()
+        self._scheduledFlush()
+
 
 def _get_default_clock() -> IReactorTime:
     """
@@ -683,6 +689,17 @@ def _get_default_clock() -> IReactorTime:
     from twisted.internet import reactor
 
     return cast(IReactorTime, reactor)
+
+
+class _NullAggregator:
+    def write(self, data: bytes) -> None:
+        ...
+
+    def close(self) -> None:
+        ...
+
+    def flush(self) -> None:
+        ...
 
 
 class BufferingTLSTransport(TLSMemoryBIOProtocol):
@@ -703,6 +720,8 @@ class BufferingTLSTransport(TLSMemoryBIOProtocol):
     # L{TLSMemoryBIOFactory.protocols} having the correct instances, whereas
     # subclassing makes that work.
 
+    _aggregator: _AggregateSmallWrites | _NullAggregator
+
     def __init__(
         self,
         factory: TLSMemoryBIOFactory,
@@ -718,11 +737,19 @@ class BufferingTLSTransport(TLSMemoryBIOProtocol):
         self.write = self._aggregator.write  # type: ignore[method-assign]
 
     def writeSequence(self, sequence: Iterable[bytes]) -> None:
+        # We want to get any L{TypeError}s out of the way before passing
+        # through a potential non-C{bytes} object through to the aggregator.
         self._aggregator.write(b"".join(sequence))
 
     def loseConnection(self) -> None:
         self._aggregator.flush()
         super().loseConnection()
+
+    def connectionLost(self, reason: Failure = connectionDone) -> None:
+        self._aggregator.close()
+        self._aggregator = _NullAggregator()
+        self.write = self._aggregator.write  # type: ignore[method-assign]
+        super().connectionLost(reason)
 
 
 class TLSMemoryBIOFactory(WrappingFactory[TLSMemoryBIOProtocol]):


### PR DESCRIPTION
## Scope and purpose

Fixes #12538