### PR TITLE
#12721 Remove unused `_makeGetterFactory` method from `twisted.web.client`

### DIFF
--- a/src/twisted/web/client.py
+++ b/src/twisted/web/client.py
@@ -228,36 +228,6 @@ def _urljoin(base, url):
     return urljoin(url, b"#" + (urlFrag or baseFrag)).strip(b"#")
 
 
-def _makeGetterFactory(url, factoryFactory, contextFactory=None, *args, **kwargs):
-    """
-    Create and connect an HTTP page getting factory.
-
-    Any additional positional or keyword arguments are used when calling
-    C{factoryFactory}.
-
-    @param factoryFactory: Factory factory that is called with C{url}, C{args}
-        and C{kwargs} to produce the getter
-
-    @param contextFactory: Context factory to use when creating a secure
-        connection, defaulting to L{None}
-
-    @return: The factory created by C{factoryFactory}
-    """
-    uri = URI.fromBytes(_ensureValidURI(url.strip()))
-    factory = factoryFactory(url, *args, **kwargs)
-    from twisted.internet import reactor
-
-    if uri.scheme == b"https":
-        from twisted.internet import ssl
-
-        if contextFactory is None:
-            contextFactory = ssl.ClientContextFactory()
-        reactor.connectSSL(nativeString(uri.host), uri.port, factory, contextFactory)
-    else:
-        reactor.connectTCP(nativeString(uri.host), uri.port, factory)
-    return factory
-
-
 # The code which follows is based on the new HTTP client implementation.  It
 # should be significantly better than anything above, though it is not yet
 # feature equivalent.

--- a/src/twisted/web/newsfragments/12721.removal
+++ b/src/twisted/web/newsfragments/12721.removal
@@ -1,0 +1,1 @@
+`_makeGetterFactory` method in `twisted.web.client` has been removed.

--- a/src/twisted/web/newsfragments/12721.removal
+++ b/src/twisted/web/newsfragments/12721.removal
@@ -1,1 +1,1 @@
-`_makeGetterFactory` method in `twisted.web.client` has been removed.
+`_makeGetterFactory` method in `twisted.web.client` has been removed.  We would not normally remark upon a private API's removal, but we are aware of some 3rd party usage. Please remember that you should not depend on private names within Twisted as they may be removed without notice!


### PR DESCRIPTION
## Scope and purpose

Fixes #12721

The private method is not used anywhere in-tree in Twisted today. It is not typed or covered by tests. Let's remove the code to simplify the project.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
