### PR TITLE
#12723 mypy: upgrade 2.1.0 -> 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,8 @@ gtk-platform = [
 
 mypy = [
     "twisted[dev,all-non-platform]",
-    "mypy==2.1.0",
-    "mypy-zope==1.0.15",
+    "mypy==2.3.0",
+    "mypy-zope==1.0.16",
     "types-setuptools",
     "types-pyOpenSSL",
 ]

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1931,6 +1931,13 @@ def _inlineCallbacks(
         # iscoroutine() is pretty expensive in this context, so avoid calling
         # it unnecessarily:
         if not isDeferred and (iscoroutine(result) or inspect.isgenerator(result)):
+            # cast 'object' to expected generator type
+            if TYPE_CHECKING:
+                result = cast(
+                    Generator[Deferred[Any], object, _T]
+                    | Coroutine[Deferred[Any], object, _T],
+                    result,
+                )
             result = _cancellableInlineCallbacks(result)
             isDeferred = True
 

--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -1931,14 +1931,9 @@ def _inlineCallbacks(
         # iscoroutine() is pretty expensive in this context, so avoid calling
         # it unnecessarily:
         if not isDeferred and (iscoroutine(result) or inspect.isgenerator(result)):
-            # cast 'object' to expected generator type
-            if TYPE_CHECKING:
-                result = cast(
-                    Generator[Deferred[Any], object, _T]
-                    | Coroutine[Deferred[Any], object, _T],
-                    result,
-                )
-            result = _cancellableInlineCallbacks(result)
+            # Avoid casting result. mypy 2.3.0+ expects the Generator's YieldType to be object
+            # but it is actually Deferred.
+            result = _cancellableInlineCallbacks(result)  # type: ignore[arg-type]
             isDeferred = True
 
         if isDeferred:

--- a/src/twisted/internet/interfaces.py
+++ b/src/twisted/internet/interfaces.py
@@ -1657,7 +1657,7 @@ class IFileDescriptor(ILoggingContext):
     An interface representing a UNIX-style numeric file descriptor.
     """
 
-    def fileno() -> object:
+    def fileno() -> int:
         """
         @return: The platform-specified representation of a file descriptor
             number.  Or C{-1} if the descriptor no longer has a valid file

--- a/src/twisted/internet/selectreactor.py
+++ b/src/twisted/internet/selectreactor.py
@@ -16,7 +16,12 @@ from typing import Callable, TypeVar
 from zope.interface import implementer
 
 from twisted.internet import posixbase
-from twisted.internet.interfaces import IReactorFDSet, IReadDescriptor, IWriteDescriptor
+from twisted.internet.interfaces import (
+    IFileDescriptor,
+    IReactorFDSet,
+    IReadDescriptor,
+    IWriteDescriptor,
+)
 from twisted.python import log
 from twisted.python.runtime import platformType
 
@@ -52,7 +57,7 @@ except ImportError:
 else:
     _extraBase = _ThreadedWin32EventsMixin
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound=IFileDescriptor)
 
 
 def _onePreen(

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -18,50 +18,74 @@ from twisted.trial import unittest
 from twisted.trial.unittest import TestCase
 
 
+class _MyVersioned(styles.Versioned):
+    persistenceVersion = 2
+    # persistenceForgets should be a tuple
+    persistenceForgets = ["garbagedata"]  # type: ignore[assignment]
+    v3 = 0
+    v4 = 0
+
+    def __init__(self) -> None:
+        self.somedata = "xxx"
+        self.garbagedata = lambda q: "cant persist"
+
+    def upgradeToVersion3(self) -> None:
+        self.v3 += 1
+
+    def upgradeToVersion4(self) -> None:
+        self.v4 += 1
+
+
+class _ClassWithCustomHash(styles.Versioned):
+    def __init__(self, unique: str, hash: int) -> None:
+        self.unique = unique
+        self.hash = hash
+
+    def __hash__(self) -> int:
+        return self.hash
+
+
+class _ToyClassA(styles.Versioned):
+    pass
+
+
+class _ToyClassB(styles.Versioned):
+    pass
+
+
+class _NullVersioned(styles.Versioned):
+    persistenceVersion = 1
+
+    def __init__(self) -> None:
+        self.ok = 0
+
+    def upgradeToVersion1(self) -> None:
+        self.ok = 1
+
+
+class _LegacyNullVersioned:
+    """
+    Produce pickle data for _NullVersioned with old-style state: no
+    persisted version marker.
+    """
+
+    def __reduce__(self) -> tuple[type[_NullVersioned], tuple[()], dict[str, int]]:
+        return (_NullVersioned, (), {"ok": 0})
+
+
 class VersionTests(TestCase):
     def test_nullVersionUpgrade(self) -> None:
-        global NullVersioned
-
-        class NullVersioned:
-            def __init__(self) -> None:
-                self.ok = 0
-
-        pkcl = pickle.dumps(NullVersioned())
-
-        class NullVersioned(styles.Versioned):  # type: ignore[no-redef]
-            persistenceVersion = 1
-
-            def upgradeToVersion1(self) -> None:
-                self.ok = 1
+        pkcl = pickle.dumps(_LegacyNullVersioned())
 
         mnv = pickle.loads(pkcl)
         styles.doUpgrade()
         assert mnv.ok, "initial upgrade not run!"
 
     def test_versionUpgrade(self) -> None:
-        global MyVersioned
-
-        class MyVersioned(styles.Versioned):
-            persistenceVersion = 2
-            # persistenceForgets should be a tuple
-            persistenceForgets = ["garbagedata"]  # type: ignore[assignment]
-            v3 = 0
-            v4 = 0
-
-            def __init__(self) -> None:
-                self.somedata = "xxx"
-                self.garbagedata = lambda q: "cant persist"
-
-            def upgradeToVersion3(self) -> None:
-                self.v3 += 1
-
-            def upgradeToVersion4(self) -> None:
-                self.v4 += 1
-
-        mv = MyVersioned()
+        mv = _MyVersioned()
         assert not (mv.v3 or mv.v4), "hasn't been upgraded yet"
         pickl = pickle.dumps(mv)
-        MyVersioned.persistenceVersion = 4
+        _MyVersioned.persistenceVersion = 4
         obj = pickle.loads(pickl)
         styles.doUpgrade()
         assert obj.v3, "didn't do version 3 upgrade"
@@ -73,23 +97,14 @@ class VersionTests(TestCase):
         assert obj.v4 == 1, "upgraded unnecessarily"
 
     def test_nonIdentityHash(self) -> None:
-        global ClassWithCustomHash
-
-        class ClassWithCustomHash(styles.Versioned):
-            def __init__(self, unique: str, hash: int) -> None:
-                self.unique = unique
-                self.hash = hash
-
-            def __hash__(self) -> int:
-                return self.hash
-
-        v1 = ClassWithCustomHash("v1", 0)
-        v2 = ClassWithCustomHash("v2", 0)
+        v1 = _ClassWithCustomHash("v1", 0)
+        v2 = _ClassWithCustomHash("v2", 0)
+        self.assertEqual(hash(v1), hash(v2))
 
         pkl = pickle.dumps((v1, v2))
         del v1, v2
-        ClassWithCustomHash.persistenceVersion = 1
-        ClassWithCustomHash.upgradeToVersion1 = lambda self: setattr(  # type: ignore[attr-defined]
+        _ClassWithCustomHash.persistenceVersion = 1
+        _ClassWithCustomHash.upgradeToVersion1 = lambda self: setattr(  # type: ignore[attr-defined]
             self, "upgraded", True
         )
         v1, v2 = pickle.loads(pkl)
@@ -100,31 +115,23 @@ class VersionTests(TestCase):
         self.assertTrue(v2.upgraded)
 
     def test_upgradeDeserializesObjectsRequiringUpgrade(self) -> None:
-        global ToyClassA, ToyClassB
-
-        class ToyClassA(styles.Versioned):
-            pass
-
-        class ToyClassB(styles.Versioned):
-            pass
-
-        x = ToyClassA()
-        y = ToyClassB()
+        x = _ToyClassA()
+        y = _ToyClassB()
         pklA, pklB = pickle.dumps(x), pickle.dumps(y)
         del x, y
-        ToyClassA.persistenceVersion = 1
+        _ToyClassA.persistenceVersion = 1
 
         def upgradeToVersion1(self: Any) -> None:
             self.y = pickle.loads(pklB)
             styles.doUpgrade()
 
-        ToyClassA.upgradeToVersion1 = upgradeToVersion1  # type: ignore[attr-defined]
-        ToyClassB.persistenceVersion = 1
+        _ToyClassA.upgradeToVersion1 = upgradeToVersion1  # type: ignore[attr-defined]
+        _ToyClassB.persistenceVersion = 1
 
         def setUpgraded(self: object) -> None:
             setattr(self, "upgraded", True)
 
-        ToyClassB.upgradeToVersion1 = setUpgraded  # type: ignore[attr-defined]
+        _ToyClassB.upgradeToVersion1 = setUpgraded  # type: ignore[attr-defined]
 
         x = pickle.loads(pklA)
         styles.doUpgrade()

--- a/src/twisted/test/test_persisted.py
+++ b/src/twisted/test/test_persisted.py
@@ -2,17 +2,14 @@
 # See LICENSE for details.
 from __future__ import annotations
 
-# System Imports
 import copyreg
 import io
 import pickle
 import sys
 import textwrap
-from typing import Any, Callable, NoReturn
+from collections.abc import Callable
+from typing import Any, NoReturn, TypeAlias
 
-from typing_extensions import TypeAlias
-
-# Twisted Imports
 from twisted.persisted import aot, crefutil, styles
 from twisted.trial import unittest
 from twisted.trial.unittest import TestCase

--- a/src/twisted/web/_flatten.py
+++ b/src/twisted/web/_flatten.py
@@ -16,6 +16,8 @@ from traceback import extract_tb
 from types import FrameType, GeneratorType
 from typing import Any, Callable, TypeVar, Union, cast
 
+from typing_extensions import Never
+
 from twisted.internet.defer import Deferred, ensureDeferred
 from twisted.python.compat import nativeString
 from twisted.python.failure import Failure
@@ -41,7 +43,7 @@ Flattenable = Union[
     Tag,
     tuple[FlattenableRecursive, ...],
     list[FlattenableRecursive],
-    Generator[FlattenableRecursive, None, None],
+    Generator[FlattenableRecursive, Never, object],
     CharRef,
     Deferred[FlattenableRecursive],
     Coroutine[Deferred[FlattenableRecursive], object, FlattenableRecursive],

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -230,7 +230,7 @@ class Tag:
                 "an exception in the future",
                 DeprecationWarning,
             )
-            return obj  # type: ignore[return-value]
+            return obj
         elif iscoroutine(obj):
             warn(
                 "Cloning a Tag which contains a coroutine is unsafe, "

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -230,7 +230,7 @@ class Tag:
                 "an exception in the future",
                 DeprecationWarning,
             )
-            return obj
+            return obj  # type: ignore[return-value]
         elif iscoroutine(obj):
             warn(
                 "Cloning a Tag which contains a coroutine is unsafe, "


### PR DESCRIPTION
## Scope and purpose

Fixes #12723 

`inspect.isgenerator` typing changed:

https://github.com/python/typeshed/commit/f7ef056b93536ea9759e5ac6d521fc49ee9b7cb6

It was `TypeIs[GeneratorType[Any, Any, Any]]` but changed to `TypeIs[GeneratorType[object, Never, object]]`

TODOs:

- [x] Fix new coverage gap in persisted test
- [x] Investigate the `_stan.py` code more. What is happening there.
- [x] Can we explain why `Deferred[Any]` needs to be changed to `Any` in `defer.py`?

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
