### PR TITLE
#12729 Optimize twisted.web.http.toChunk

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -507,11 +507,9 @@ def stringToDatetime(dateString):
     return int(timegm(year, month, day, hour, min, sec))
 
 
-def toChunk(data):
+def toChunk(data: bytes) -> tuple[bytes, bytes, bytes, bytes]:
     """
     Convert string to a chunk.
-
-    @type data: C{bytes}
 
     @returns: a tuple of C{bytes} representing the chunked encoding of data
     """

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -515,7 +515,7 @@ def toChunk(data):
 
     @returns: a tuple of C{bytes} representing the chunked encoding of data
     """
-    return (networkString(f"{len(data):x}"), b"\r\n", data, b"\r\n")
+    return b"%x" % len(data), b"\r\n", data, b"\r\n"
 
 
 def fromChunk(data: bytes) -> tuple[bytes, bytes]:

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -513,6 +513,7 @@ def toChunk(data: bytes) -> tuple[bytes, bytes, bytes, bytes]:
 
     @returns: a tuple of C{bytes} representing the chunked encoding of data
     """
+    # We use bytes formatting here for best performace.
     return b"%x" % len(data), b"\r\n", data, b"\r\n"
 
 

--- a/src/twisted/web/newsfragments/12729.feature
+++ b/src/twisted/web/newsfragments/12729.feature
@@ -1,0 +1,1 @@
+twisted.web.http.Request.write now performs chunked writes ~12% faster


### PR DESCRIPTION
## Scope and purpose

Fixes #12729

Looked a bit at `test_http11_server_chunked_response` benchmark to see if I could reduce the annoying variance and found this possible optimisation. I don't expect it will affect the variance though (don't see any difference locally). But it is faster which is nice.

This should speed up chunked writes in `twisted.web.http.Request.write` in the benchmark test.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
