### PR TITLE
fdesc: Use `os.set_inheritable`

### DIFF
--- a/src/twisted/internet/fdesc.py
+++ b/src/twisted/internet/fdesc.py
@@ -39,27 +39,18 @@ def setBlocking(fd):
     fcntl.fcntl(fd, fcntl.F_SETFL, flags)
 
 
-if fcntl is None:
-    # fcntl isn't available on Windows.  By default, handles aren't
-    # inherited on Windows, so we can do nothing here.
-    _setCloseOnExec = _unsetCloseOnExec = lambda fd: None
-else:
+def _setCloseOnExec(fd: int) -> None:
+    """
+    Make a file descriptor non-inheritable across exec.
+    """
+    os.set_inheritable(fd, False)
 
-    def _setCloseOnExec(fd):
-        """
-        Make a file descriptor close-on-exec.
-        """
-        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-        flags = flags | fcntl.FD_CLOEXEC
-        fcntl.fcntl(fd, fcntl.F_SETFD, flags)
 
-    def _unsetCloseOnExec(fd):
-        """
-        Make a file descriptor close-on-exec.
-        """
-        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-        flags = flags & ~fcntl.FD_CLOEXEC
-        fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+def _unsetCloseOnExec(fd: int) -> None:
+    """
+    Make a file descriptor inheritable across exec.
+    """
+    os.set_inheritable(fd, True)
 
 
 def readFromFD(fd, callback):

--- a/src/twisted/test/test_fdesc.py
+++ b/src/twisted/test/test_fdesc.py
@@ -7,16 +7,13 @@ Tests for L{twisted.internet.fdesc}.
 
 import errno
 import os
-import sys
 
 try:
     import fcntl
 except ImportError:
-    skip = "not supported on this platform"
-else:
-    from twisted.internet import fdesc
+    fcntl = None  # type: ignore[assignment]
 
-from twisted.python.util import untilConcludes
+from twisted.internet import fdesc
 from twisted.trial import unittest
 
 
@@ -24,6 +21,9 @@ class NonBlockingTests(unittest.SynchronousTestCase):
     """
     Tests for L{fdesc.setNonBlocking} and L{fdesc.setBlocking}.
     """
+
+    if fcntl is None:
+        skip = "fcntl is not supported on this platform"  # type: ignore[unreachable]
 
     def test_setNonBlocking(self):
         """
@@ -52,6 +52,9 @@ class ReadWriteTests(unittest.SynchronousTestCase):
     """
     Tests for L{fdesc.readFromFD}, L{fdesc.writeToFD}.
     """
+
+    if fcntl is None:
+        skip = "fcntl is not supported on this platform"  # type: ignore[unreachable]
 
     def setUp(self):
         """
@@ -201,58 +204,28 @@ class CloseOnExecTests(unittest.SynchronousTestCase):
     Tests for L{fdesc._setCloseOnExec} and L{fdesc._unsetCloseOnExec}.
     """
 
-    program = """
-import os, errno
-try:
-    os.write(%d, b'lul')
-except OSError as e:
-    if e.errno == errno.EBADF:
-        os._exit(0)
-    os._exit(5)
-except BaseException:
-    os._exit(10)
-else:
-    os._exit(20)
-"""
-
-    def _execWithFileDescriptor(self, fObj):
-        pid = os.fork()
-        if pid == 0:
-            try:
-                os.execv(
-                    sys.executable,
-                    [sys.executable, "-c", self.program % (fObj.fileno(),)],
-                )
-            except BaseException:
-                import traceback
-
-                traceback.print_exc()
-                os._exit(30)
-        else:
-            # On Linux wait(2) doesn't seem ever able to fail with EINTR but
-            # POSIX seems to allow it and on macOS it happens quite a lot.
-            return untilConcludes(os.waitpid, pid, 0)[1]
-
-    def test_setCloseOnExec(self):
+    def test_setCloseOnExec(self) -> None:
         """
-        A file descriptor passed to L{fdesc._setCloseOnExec} is not inherited
-        by a new process image created with one of the exec family of
-        functions.
+        L{fdesc._setCloseOnExec} makes a file descriptor non-inheritable.
         """
-        with open(self.mktemp(), "wb") as fObj:
-            fdesc._setCloseOnExec(fObj.fileno())
-            status = self._execWithFileDescriptor(fObj)
-            self.assertTrue(os.WIFEXITED(status))
-            self.assertEqual(os.WEXITSTATUS(status), 0)
+        readFD, writeFD = os.pipe()
+        self.addCleanup(os.close, readFD)
+        self.addCleanup(os.close, writeFD)
 
-    def test_unsetCloseOnExec(self):
+        os.set_inheritable(readFD, True)
+        fdesc._setCloseOnExec(readFD)
+
+        self.assertFalse(os.get_inheritable(readFD))
+
+    def test_unsetCloseOnExec(self) -> None:
         """
-        A file descriptor passed to L{fdesc._unsetCloseOnExec} is inherited by
-        a new process image created with one of the exec family of functions.
+        L{fdesc._unsetCloseOnExec} makes a file descriptor inheritable.
         """
-        with open(self.mktemp(), "wb") as fObj:
-            fdesc._setCloseOnExec(fObj.fileno())
-            fdesc._unsetCloseOnExec(fObj.fileno())
-            status = self._execWithFileDescriptor(fObj)
-            self.assertTrue(os.WIFEXITED(status))
-            self.assertEqual(os.WEXITSTATUS(status), 20)
+        readFD, writeFD = os.pipe()
+        self.addCleanup(os.close, readFD)
+        self.addCleanup(os.close, writeFD)
+
+        os.set_inheritable(readFD, False)
+        fdesc._unsetCloseOnExec(readFD)
+
+        self.assertTrue(os.get_inheritable(readFD))


### PR DESCRIPTION
## Scope and purpose

Fixes #12731

Update `_setCloseOnExec` and `_unsetCloseOnExec` to use `os.set_inheritable`, available since Python 3.4. CPython handles platforms differently. With this change the functions should work on Windows. This allows Twisted to drop a specific handling for Windows which made these functions no-op (empty lambdas).

The tests are also simplified a bit. Allow `CloseOnExecTests` to run on all platforms since `fcntl` is not needed for example for Windows.

This should bring a tiny speed improvement on Linux, for example in TCP throughput test.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
