### PR TITLE
#12726 Do not let unpause() break an implicit Deferred chain

### DIFF
--- a/src/twisted/internet/defer.py
+++ b/src/twisted/internet/defer.py
@@ -932,6 +932,13 @@ class Deferred(Awaitable[_SelfResultT]):
         self.paused -= 1
         if self.paused:
             return
+        if self._chainedTo is not None:
+            # Waiting on another L{Deferred}'s result.  That wait is
+            # implemented with an internal pause which C{unpause} must not
+            # release, or this L{Deferred} would resume with the wrong result
+            # and run the other one's callbacks.
+            self.paused += 1
+            return
         if self.called:
             self._runCallbacks()
 

--- a/src/twisted/test/test_defer.py
+++ b/src/twisted/test/test_defer.py
@@ -749,6 +749,29 @@ class DeferredTests(unittest.SynchronousTestCase, ImmediateFailureMixin):
         second.addCallback(result.append)
         self.assertEqual(result, [None])
 
+    def test_unpauseDoesNotBreakImplicitChain(self) -> None:
+        """
+        L{Deferred.unpause} does not release the internal pause which
+        implements waiting on a L{Deferred} returned from a callback, so the
+        waiting L{Deferred} still fires only once the other one has a result.
+        """
+        first: Deferred[None] = Deferred()
+        second: Deferred[None] = Deferred()
+        first.addCallback(lambda ignored: second)
+        result: list[None] = []
+        first.addCallback(result.append)
+        first.callback(None)
+        self.assertIs(first._chainedTo, second)
+
+        first.unpause()
+
+        self.assertIs(first._chainedTo, second)
+        self.assertEqual(result, [])
+
+        second.callback(None)
+        self.assertIsNone(first._chainedTo)
+        self.assertEqual(result, [None])
+
     def test_gatherResults(self) -> None:
         # test successful list of deferreds
         results: list[list[int]] = []


### PR DESCRIPTION
## Scope and purpose

Fixes #12726

When a callback returns another `Deferred`, `_runCallbacks` pauses the waiting `Deferred` and records it in `_chainedTo`. That internal wait uses the same counter as the public `pause()`/`unpause()` API, so calling `unpause()` dropped the counter to zero and the waiting `Deferred` resumed immediately — running its remaining callbacks with the wrong result and executing the other `Deferred`'s callbacks.

`unpause()` now leaves the counter untouched while `_chainedTo` is set, so the wait ends only when the other `Deferred` delivers its result.

Trade-off: `unpause()` becomes a no-op (rather than an error) while chained, matching the existing lenient behaviour of the pause counter.

## Contributor Checklist:

* Title starts with the issue number: `#12726 ...`
* News fragment: not yet added; I can push `src/twisted/newsfragments/12726.bugfix` on request.
* Automated tests updated: `test_unpauseDoesNotBreakImplicitChain` in `src/twisted/test/test_defer.py`, which fails on the original source (`_chainedTo` is `None` after `unpause()`) and passes with the fix. Full `twisted.test.test_defer` is green (182 tests).
