### PR TITLE
#12736 Optimize `twisted.internet.test.test_endpoints` runtime

### DIFF
--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -12,6 +12,7 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from errno import EPERM
+from functools import cache
 from socket import AF_INET, AF_INET6, IPPROTO_TCP, SOCK_STREAM, AddressFamily, gaierror
 from types import FunctionType
 from typing import TYPE_CHECKING, Any
@@ -143,6 +144,16 @@ try:
 except ImportError as e:
     skipSSL = True
     skipSSLReason = str(e)
+
+
+@cache
+def _certificatesForEndpointTests(
+    serviceIdentity: str,
+) -> tuple[Certificate, PrivateCertificate]:
+    """
+    Generate and cache certificates for L{TLSEndpointsTests}.
+    """
+    return certificatesForAuthorityAndServer(serviceIdentity)
 
 
 class TestProtocol(Protocol):
@@ -3114,7 +3125,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
             "clientServiceIdentity",
             self.serverServiceIdentity,
         )
-        ca, server = certificatesForAuthorityAndServer(self.serverServiceIdentity)
+        ca, server = _certificatesForEndpointTests(self.serverServiceIdentity)
 
         self.serverCert = server
         shouldSendServerName = getattr(


### PR DESCRIPTION
## Scope and purpose

Fixes #12736

Cache the TLS certificate using functools in a test's setup method. This reduces test time locally for me from 17.584s to 3.395s

To test this I used this method:

`trial --reporter=timing src/twisted/internet/test/test_endpoints.py > after.txt`

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
