### PR TITLE
#12734 Add limits to the maximum packet size accepted from SSH server.

### DIFF
--- a/src/twisted/conch/newsfragments/12734.bugfix
+++ b/src/twisted/conch/newsfragments/12734.bugfix
@@ -1,0 +1,3 @@
+twisted.conch.ssh.connection.SSHConnection.ssh_CHANNEL_OPEN_CONFIRMATION
+now validates the minimum and maximum value for the remote maximum packet size.
+It rejects values outside of the 32KB and 256KB range.

--- a/src/twisted/conch/newsfragments/12734.removal
+++ b/src/twisted/conch/newsfragments/12734.removal
@@ -1,0 +1,3 @@
+twisted.conch.ssh.connection.SSHConnection.ssh_CHANNEL_OPEN_CONFIRMATION now
+rejects server that returns a maximum packet size smaller than 32KB.
+As per RFC 4253 section 6.1, implementation should support at lest 32KB.

--- a/src/twisted/conch/ssh/connection.py
+++ b/src/twisted/conch/ssh/connection.py
@@ -39,10 +39,27 @@ class SSHConnection(service.SSHService):
     @ivar deferreds: a L{dict} mapping a local channel ID to a C{list} of
         C{Deferreds} for outstanding channel requests.  Also, the 'global'
         key stores the C{list} of pending global request C{Deferred}s.
+    @ivar MINIMUM_PACKET_SIZE: the minimum allowed size for an SSH packet.
+        When the server returns an SSH_CHANNEL_OPEN_CONFIRMATION with a smaller
+        value, the connection is closed.  Should be greater than 0.
+        Allows setting a lower value for backward compatibility with
+        legacy/embedded SSH servers.
+    @ivar MAXIMUM_PACKET_SIZE: the maximum allowed size for an SSH packet.
+        When the server returns an SSH_CHANNEL_OPEN_CONFIRMATION with a larger
+        value, the connection is closed.
+        Reject large packet to prevent filling up the memory.
+        Allows setting a larger value for better performance.
     """
 
     name = b"ssh-connection"
     _log = Logger()
+
+    # RFC 4253 Section-6.1
+    # https://datatracker.ietf.org/doc/html/rfc4253#section-6.1
+    MINIMUM_PACKET_SIZE = 32768
+    # RFC 4253 Section-6.1 only talks about reasonable size.
+    # Behave like OpenSSH.
+    MAXIMUM_PACKET_SIZE = 256 * 1024
 
     def __init__(self):
         self.localChannelID = 0  # this is the current # to use for channel ID
@@ -195,11 +212,29 @@ class SSHConnection(service.SSHService):
         (localChannel, remoteChannel, windowSize, maxPacket) = struct.unpack(
             ">4L", packet[:16]
         )
+
         specificData = packet[16:]
         channel = self.channels[localChannel]
-        channel.conn = self
         self.localToRemoteChannel[localChannel] = remoteChannel
         self.channelsToRemoteChannel[channel] = remoteChannel
+
+        if maxPacket < self.MINIMUM_PACKET_SIZE:
+            channel.openFailed(
+                error.ConchError("server requested maximum packet size too small")
+            )
+            self.sendEOF(channel)
+            self.sendClose(channel)
+            return
+
+        if maxPacket > self.MAXIMUM_PACKET_SIZE:
+            channel.openFailed(
+                error.ConchError("server requested maximum packet size too big")
+            )
+            self.sendEOF(channel)
+            self.sendClose(channel)
+            return
+
+        channel.conn = self
         channel.remoteWindowLeft = windowSize
         channel.remoteMaxPacket = maxPacket
         channel.channelOpen(specificData)

--- a/src/twisted/conch/test/test_connection.py
+++ b/src/twisted/conch/test/test_connection.py
@@ -241,7 +241,12 @@ class ConnectionTests(unittest.TestCase):
         channel2 = TestChannel()
         self.conn.openChannel(channel1)
         self.conn.openChannel(channel2)
-        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(b"\x00\x00\x00\x00" * 4)
+        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(
+            b"\x00\x00\x00\x00"
+            + b"\x00\x00\x00\xff"  # Local channel
+            + b"\x00\x00\x00\x02"  # Remote channel
+            + b"\x00\x00\x80\x00"  # Window size  # Max packet size
+        )
         self.assertTrue(channel1.gotOpen)
         self.assertFalse(channel1.gotClosed)
         self.assertFalse(channel2.gotOpen)
@@ -401,19 +406,102 @@ class ConnectionTests(unittest.TestCase):
         """
         self._lookupChannelErrorTest(123)
 
-    def test_CHANNEL_OPEN_CONFIRMATION(self):
+    def test_CHANNEL_OPEN_CONFIRMATION_success(self):
         """
         Test that channel open confirmation packets cause the channel to be
         notified that it's open.
         """
         channel = TestChannel()
         self.conn.openChannel(channel)
-        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(b"\x00\x00\x00\x00" * 5)
+        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(
+            b"\x00\x00\x00\x00"
+            + b"\x00\x00\x00\x02"  # Local channel
+            + b"\x00\x00\x00\x03"  # Remote channel
+            + b"\x00\x00\xde\x04"  # Window size.
+            + b"\x00\x00\x00\x05"  # Max packet size.  # Custom channel data.
+        )
+        self.assertEqual(channel.remoteWindowLeft, 3)
+        self.assertEqual(channel.remoteMaxPacket, 56836)
+        self.assertEqual(channel.specificData, b"\x00\x00\x00\x05")
+        self.assertEqual(self.conn.channelsToRemoteChannel[channel], 2)
+        self.assertEqual(self.conn.localToRemoteChannel[0], 2)
+        self.assertTrue(channel.gotOpen)
+
+    def test_CHANNEL_OPEN_CONFIRMATION_maxPacketSizeTooSmall(self):
+        """
+        It closes the channel right away when the server returns a value
+        that is too small.
+        """
+        channel = TestChannel()
+        # Client request the open.
+        self.conn.openChannel(channel)
+        self.transport.packets = []  # Ignore the open request packet.
+        # Server send back the response.
+        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(
+            b"\x00\x00\x00\x00"
+            + b"\x00\x00\x00\x02"  # Local channel
+            + b"\x00\x00\x00\x01"  # Remote channel
+            + b"\x00\x00\x00\x04"  # Window size.
+            + b"\x00\x00\x00\x05"  # Max packet size.  # Custom channel data.
+        )
+
+        self._checkFailedOpenConfirmation(
+            channel, "server requested maximum packet size too small"
+        )
+
+    def test_CHANNEL_OPEN_CONFIRMATION_maxPacketSizeTooLarge(self):
+        """
+        It closes the channel right away when the server returns a value
+        that is too large.
+        """
+        channel = TestChannel()
+        # Client request the open.
+        self.conn.openChannel(channel)
+        self.transport.packets = []  # Ignore the open request packet.
+        # Server send back the response.
+        self.conn.ssh_CHANNEL_OPEN_CONFIRMATION(
+            b"\x00\x00\x00\x00"
+            + b"\x00\x00\x00\x02"  # Local channel
+            + b"\x00\x00\x00\x01"  # Remote channel
+            + b"\x00\x05\x00\x00"  # Window size.
+            + b"\x00\x00\x00\x05"  # Max packet size.  # Custom channel data.
+        )
+
+        self._checkFailedOpenConfirmation(
+            channel, "server requested maximum packet size too big"
+        )
+
+    def _checkFailedOpenConfirmation(
+        self, channel: channel.SSHChannel, details: str
+    ) -> None:
+        """
+        Shared code for checking that a channel was not opened on the client
+        side and the request was sent to close it on the server side.
+        """
+
+        # The channel is not opened, but is also not closed
+        # since it was not opened yet.
         self.assertEqual(channel.remoteWindowLeft, 0)
         self.assertEqual(channel.remoteMaxPacket, 0)
-        self.assertEqual(channel.specificData, b"\x00\x00\x00\x00")
-        self.assertEqual(self.conn.channelsToRemoteChannel[channel], 0)
-        self.assertEqual(self.conn.localToRemoteChannel[0], 0)
+        self.assertFalse(channel.gotOpen)
+        self.assertFalse(channel.gotClosed)
+        self.assertEqual(channel.specificData, b"")
+
+        # Client send the messages to server.
+        self.assertEqual(
+            self.transport.packets,
+            [
+                (connection.MSG_CHANNEL_EOF, b"\x00\x00\x00\x02"),
+                (connection.MSG_CHANNEL_CLOSE, b"\x00\x00\x00\x02"),
+            ],
+        )
+
+        # The channel connections are still active, waiting for server
+        # to close the channel.
+        self.assertEqual(self.conn.channelsToRemoteChannel[channel], 2)
+        self.assertEqual(self.conn.localToRemoteChannel[0], 2)
+        self.assertIsInstance(channel.openFailureReason, error.ConchError)
+        self.assertEqual(details, channel.openFailureReason.args[0])
 
     def test_CHANNEL_OPEN_FAILURE(self):
         """

--- a/src/twisted/conch/test/test_connection.py
+++ b/src/twisted/conch/test/test_connection.py
@@ -471,9 +471,7 @@ class ConnectionTests(unittest.TestCase):
             channel, "server requested maximum packet size too big"
         )
 
-    def _checkFailedOpenConfirmation(
-        self, channel: channel.SSHChannel, details: str
-    ) -> None:
+    def _checkFailedOpenConfirmation(self, channel: TestChannel, details: str) -> None:
         """
         Shared code for checking that a channel was not opened on the client
         side and the request was sent to close it on the server side.


### PR DESCRIPTION
## Scope and purpose

Fixes #12734 

This is primary a security fix to make sure we reject servers that return a size of 0 ... or in general values that are too small or too big.

For this PR I read the RFC (multiple times) but it didn't helped, so I have use Google AI mode to get a summary of what values are accepted by other SSH server and client implementations.

And Google got this page https://unam.re/blog/sending-large-packets-ssh

The implementation is done without any LLM generated code.

## Changes

Add max and min values. There should be no need to modify these values, but they are here if conch SSH needs to exchange data with SSH peers that have different limits.

On error it calles `channel.openFailed`.
In this past this was used only when the server rejected the channel.
I think that is important for the channel to know that it was never opened and that open failed... not due to server...but due to client validation.


I hope the defaults are good enough.

This is kind of a backward compability breakage, since we now reject values that are too small or too big.

For values that are too small, I condered this a violation of the RFC, since RFC asks for at least 32KB.

For values that are too big, I think that all public server implementation reject big packets , so I went with OpenSSH as  de-facto standard.

I have implemented the limits as instance variables, so custom implementation can change the limits.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
