### PR TITLE
#12732 Add benchmarks for `FileDescriptor` class

### DIFF
--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -2,7 +2,6 @@
 Benchmarks for L{twisted.internet.abstract.FileDescriptor}.
 """
 
-from collections.abc import Callable, Sequence
 from typing import Any
 
 import pytest
@@ -38,7 +37,6 @@ def mixedSmallChunks() -> list[bytes]:
 
 SEQUENCES: dict[str, list[bytes]] = {
     "1x8192": [b"x" * 8192],
-    "4x1024": [b"x" * 1024] * 4,
     "100x1": [b"x"] * 100,
     "mixed-small": mixedSmallChunks(),
 }
@@ -49,26 +47,19 @@ SEQUENCES: dict[str, list[bytes]] = {
     SEQUENCES.values(),
     ids=SEQUENCES,
 )
-@pytest.mark.parametrize(
-    "sequenceFactory",
-    [list, tuple],
-    ids=["list", "tuple"],
-)
 def test_fileDescriptor_writeSequence(
     benchmark: Any,
     chunks: list[bytes],
-    sequenceFactory: Callable[[list[bytes]], Sequence[bytes]],
 ) -> None:
     """
     Benchmark buffering a sequence with L{FileDescriptor.writeSequence}.
     """
-    sequence = sequenceFactory(chunks)
 
     def setup():
-        return (BufferedFileDescriptor(), sequence), {}
+        return (BufferedFileDescriptor(), chunks), {}
 
-    def teardown(descriptor: BufferedFileDescriptor, data: Sequence[bytes]) -> None:
-        assert descriptor._tempDataBuffer == list(data)
+    def teardown(descriptor: BufferedFileDescriptor, data: list[bytes]) -> None:
+        assert descriptor._tempDataBuffer == data
         assert descriptor._tempDataLen == sum(map(len, data))
 
     benchmark.pedantic(

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -36,6 +36,9 @@ class BufferedFileDescriptor(FileDescriptor):
 
         # To simulate a partial write, don't return values larger
         # than the write limit. Otherwise all data is consumed.
+        #
+        # In the real world, the write limit here could represent
+        # the buffer size of the socket in the operating system.
         return min(len(data), self.writeLimit)
 
 
@@ -193,6 +196,38 @@ def test_fileDescriptor_doWriteContinuePartialWrite(benchmark: Any) -> None:
         assert descriptor._tempDataLen == 0
         assert descriptor.dataBuffer == b""
         assert descriptor.offset == 0
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.doWrite,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )
+
+
+def test_fileDescriptor_doWriteContinueSmallPartialWrite(benchmark: Any) -> None:
+    """
+    Benchmark continuing a partial write smaller than C{SEND_LIMIT}.
+    """
+
+    def setup():
+        descriptor = BufferedFileDescriptor()
+        for _ in range(4):
+            descriptor.write(WRITE_DATA)
+
+        # Do a partial write, it writes only 8KB
+        descriptor.writeLimit = len(WRITE_DATA)
+        descriptor.doWrite()
+
+        # Now run benchmark, where we continue writing 24KB data
+        # which is less than SEND_LIMIT.
+        return (descriptor,), {}
+
+    def teardown(descriptor: BufferedFileDescriptor) -> None:
+        assert descriptor._tempDataBuffer == []
+        assert descriptor._tempDataLen == 0
+        assert len(descriptor.dataBuffer) - descriptor.offset == 2 * len(WRITE_DATA)
 
     benchmark.pedantic(
         BufferedFileDescriptor.doWrite,

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -21,7 +21,9 @@ class BufferedFileDescriptor(FileDescriptor):
         FileDescriptor.__init__(self, reactor=MemoryReactor())
 
     def startWriting(self) -> None:
-        pass
+        """
+        No reactor is used, so this function is no-op
+        """
 
 
 def mixedSmallChunks() -> list[bytes]:

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -25,6 +25,17 @@ class BufferedFileDescriptor(FileDescriptor):
         No reactor is used, so this function is no-op
         """
 
+    # No-op
+    stopWriting = startWriting
+
+    def writeSomeData(self, data: bytes) -> int:
+        """
+        Consume all buffered data
+        """
+
+        # There is some cost with len() but should be constant between two benchmarks.
+        return len(data)
+
 
 def mixedSmallChunks() -> list[bytes]:
     """
@@ -44,15 +55,34 @@ SEQUENCES: dict[str, list[bytes]] = {
 }
 
 
-@pytest.mark.parametrize(
-    "chunks",
-    SEQUENCES.values(),
-    ids=SEQUENCES,
-)
-def test_fileDescriptor_writeSequence(
-    benchmark: Any,
-    chunks: list[bytes],
-) -> None:
+WRITE_DATA = b"x" * 8192
+DO_WRITE_DATA = b"x" * (32 * 1024)
+
+
+def test_fileDescriptor_write(benchmark: Any) -> None:
+    """
+    Benchmark writing 8KB with L{FileDescriptor.write}.
+    """
+
+    def setup():
+        return (BufferedFileDescriptor(), WRITE_DATA), {}
+
+    def teardown(descriptor: BufferedFileDescriptor, data: bytes) -> None:
+        # Verify state of buffer and counter
+        assert descriptor._tempDataBuffer == [data]
+        assert descriptor._tempDataLen == len(data)
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.write,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )
+
+
+@pytest.mark.parametrize("chunks", SEQUENCES.values(), ids=SEQUENCES)
+def test_fileDescriptor_writeSequence(benchmark: Any, chunks: list[bytes]) -> None:
     """
     Benchmark buffering a sequence with L{FileDescriptor.writeSequence}.
     """
@@ -66,6 +96,33 @@ def test_fileDescriptor_writeSequence(
 
     benchmark.pedantic(
         BufferedFileDescriptor.writeSequence,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )
+
+
+def test_fileDescriptor_doWrite(benchmark: Any) -> None:
+    """
+    Benchmark writing 32KB with L{FileDescriptor.doWrite}.
+    """
+
+    def setup():
+        descriptor = BufferedFileDescriptor()
+        assert descriptor.writeSomeData(b"") == 0
+        descriptor.write(DO_WRITE_DATA)
+        return (descriptor,), {}
+
+    def teardown(descriptor: BufferedFileDescriptor) -> None:
+        # Verify state of buffer and counter
+        assert descriptor._tempDataBuffer == []
+        assert descriptor._tempDataLen == 0
+        assert descriptor.dataBuffer == b""
+        assert descriptor.offset == 0
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.doWrite,
         setup=setup,
         teardown=teardown,
         rounds=100,

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -12,7 +12,13 @@ from twisted.internet.testing import MemoryReactor
 
 class BufferedFileDescriptor(FileDescriptor):
     """
-    A connected L{FileDescriptor} with no-op reactor integration.
+    A connected L{FileDescriptor} using a fake reactor.
+
+    This object is both a transport L{ITransport} and a writable file descriptor L{IWriteDescriptor}.
+
+    The fake reactor does not call L{IWriteDescriptor.doWrite} since we don't want to rely
+    on the operating system for a writable notification/event. Because of this, the benchmark
+    tests call it manually after buffering data with L{ITransport.write}
     """
 
     connected = True
@@ -20,14 +26,6 @@ class BufferedFileDescriptor(FileDescriptor):
     def __init__(self) -> None:
         FileDescriptor.__init__(self, reactor=MemoryReactor())
         self.writeLimit = self.SEND_LIMIT
-
-    def startWriting(self) -> None:
-        """
-        No reactor is used, so this function is no-op
-        """
-
-    # No-op
-    stopWriting = startWriting
 
     def writeSomeData(self, data: bytes) -> int:
         """
@@ -65,16 +63,16 @@ WRITE_DATA = b"x" * 8192
 
 def test_fileDescriptor_write(benchmark: Any) -> None:
     """
-    Benchmark writing 8KB with L{FileDescriptor.write}.
+    Benchmark writing 8KB with L{ITransport.write}.
     """
 
     def setup():
         return (BufferedFileDescriptor(), WRITE_DATA), {}
 
-    def teardown(descriptor: BufferedFileDescriptor, data: bytes) -> None:
+    def teardown(transport: BufferedFileDescriptor, data: bytes) -> None:
         # Verify state of buffer and counter
-        assert descriptor._tempDataBuffer == [data]
-        assert descriptor._tempDataLen == len(data)
+        assert transport._tempDataBuffer == [data]
+        assert transport._tempDataLen == len(data)
 
     benchmark.pedantic(
         BufferedFileDescriptor.write,
@@ -88,15 +86,15 @@ def test_fileDescriptor_write(benchmark: Any) -> None:
 @pytest.mark.parametrize("chunks", SEQUENCES.values(), ids=SEQUENCES)
 def test_fileDescriptor_writeSequence(benchmark: Any, chunks: list[bytes]) -> None:
     """
-    Benchmark buffering a sequence with L{FileDescriptor.writeSequence}.
+    Benchmark buffering a sequence with L{ITransport.writeSequence}.
     """
 
     def setup():
         return (BufferedFileDescriptor(), chunks), {}
 
-    def teardown(descriptor: BufferedFileDescriptor, data: list[bytes]) -> None:
-        assert descriptor._tempDataBuffer == data
-        assert descriptor._tempDataLen == sum(map(len, data))
+    def teardown(transport: BufferedFileDescriptor, data: list[bytes]) -> None:
+        assert transport._tempDataBuffer == data
+        assert transport._tempDataLen == sum(map(len, data))
 
     benchmark.pedantic(
         BufferedFileDescriptor.writeSequence,
@@ -109,21 +107,21 @@ def test_fileDescriptor_writeSequence(benchmark: Any, chunks: list[bytes]) -> No
 
 def test_fileDescriptor_doWriteFlushBufferedWrites(benchmark: Any) -> None:
     """
-    Benchmark flushing four buffered 8KB writes.
+    Benchmark flushing four buffered 8KB writes with L{IWriteDescriptor.doWrite}.
     """
 
     def setup():
-        descriptor = BufferedFileDescriptor()
+        transport = BufferedFileDescriptor()
         for _ in range(4):
             # Buffer 4x 8KB chunks
-            descriptor.write(WRITE_DATA)
-        return (descriptor,), {}
+            transport.write(WRITE_DATA)
+        return (transport,), {}
 
-    def teardown(descriptor: BufferedFileDescriptor) -> None:
-        assert descriptor._tempDataBuffer == []
-        assert descriptor._tempDataLen == 0
-        assert descriptor.dataBuffer == b""
-        assert descriptor.offset == 0
+    def teardown(transport: BufferedFileDescriptor) -> None:
+        assert transport._tempDataBuffer == []
+        assert transport._tempDataLen == 0
+        assert transport.dataBuffer == b""
+        assert transport.offset == 0
 
     benchmark.pedantic(
         BufferedFileDescriptor.doWrite,
@@ -140,27 +138,27 @@ def test_fileDescriptor_doWriteAppendAfterPartialWrite(benchmark: Any) -> None:
     """
 
     def setup():
-        descriptor = BufferedFileDescriptor()
+        transport = BufferedFileDescriptor()
         for _ in range(4):
             # Buffer 4x 8KB chunks
-            descriptor.write(WRITE_DATA)
+            transport.write(WRITE_DATA)
 
         # Do a partial write, it writes only 8KB
-        descriptor.writeLimit = len(WRITE_DATA)
-        descriptor.doWrite()
+        transport.writeLimit = len(WRITE_DATA)
+        transport.doWrite()
 
         # Now buffer another chunk
-        descriptor.write(WRITE_DATA)
+        transport.write(WRITE_DATA)
 
         # Revert the limit back and run benchmark
-        descriptor.writeLimit = descriptor.SEND_LIMIT
-        return (descriptor,), {}
+        transport.writeLimit = transport.SEND_LIMIT
+        return (transport,), {}
 
-    def teardown(descriptor: BufferedFileDescriptor) -> None:
-        assert descriptor._tempDataBuffer == []
-        assert descriptor._tempDataLen == 0
-        assert descriptor.dataBuffer == b""
-        assert descriptor.offset == 0
+    def teardown(transport: BufferedFileDescriptor) -> None:
+        assert transport._tempDataBuffer == []
+        assert transport._tempDataLen == 0
+        assert transport.dataBuffer == b""
+        assert transport.offset == 0
 
     benchmark.pedantic(
         BufferedFileDescriptor.doWrite,
@@ -177,25 +175,25 @@ def test_fileDescriptor_doWriteContinuePartialWrite(benchmark: Any) -> None:
     """
 
     def setup():
-        descriptor = BufferedFileDescriptor()
+        transport = BufferedFileDescriptor()
         for _ in range(17):
             # Buffer 17 x 8KB chunks
-            descriptor.write(WRITE_DATA)
+            transport.write(WRITE_DATA)
 
         # Do a partial write, it writes only 8KB
-        descriptor.writeLimit = len(WRITE_DATA)
-        descriptor.doWrite()
+        transport.writeLimit = len(WRITE_DATA)
+        transport.doWrite()
 
         # We have 16 x 8KB = 128KB left
-        descriptor.writeLimit = descriptor.SEND_LIMIT
-        return (descriptor,), {}
+        transport.writeLimit = transport.SEND_LIMIT
+        return (transport,), {}
 
-    def teardown(descriptor: BufferedFileDescriptor) -> None:
+    def teardown(transport: BufferedFileDescriptor) -> None:
         # Verify state of buffer and counter
-        assert descriptor._tempDataBuffer == []
-        assert descriptor._tempDataLen == 0
-        assert descriptor.dataBuffer == b""
-        assert descriptor.offset == 0
+        assert transport._tempDataBuffer == []
+        assert transport._tempDataLen == 0
+        assert transport.dataBuffer == b""
+        assert transport.offset == 0
 
     benchmark.pedantic(
         BufferedFileDescriptor.doWrite,
@@ -212,22 +210,24 @@ def test_fileDescriptor_doWriteContinueSmallPartialWrite(benchmark: Any) -> None
     """
 
     def setup():
-        descriptor = BufferedFileDescriptor()
+        transport = BufferedFileDescriptor()
         for _ in range(4):
-            descriptor.write(WRITE_DATA)
+            transport.write(WRITE_DATA)
 
         # Do a partial write, it writes only 8KB
-        descriptor.writeLimit = len(WRITE_DATA)
-        descriptor.doWrite()
+        transport.writeLimit = len(WRITE_DATA)
+        transport.doWrite()
 
         # Now run benchmark, where we continue writing 24KB data
         # which is less than SEND_LIMIT.
-        return (descriptor,), {}
+        return (transport,), {}
 
-    def teardown(descriptor: BufferedFileDescriptor) -> None:
-        assert descriptor._tempDataBuffer == []
-        assert descriptor._tempDataLen == 0
-        assert len(descriptor.dataBuffer) - descriptor.offset == 2 * len(WRITE_DATA)
+    def teardown(transport: BufferedFileDescriptor) -> None:
+        assert transport._tempDataBuffer == []
+        assert transport._tempDataLen == 0
+
+        # There should be 16KB left of data since writeLimit is 8KB
+        assert len(transport.dataBuffer) - transport.offset == 2 * len(WRITE_DATA)
 
     benchmark.pedantic(
         BufferedFileDescriptor.doWrite,

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -19,6 +19,7 @@ class BufferedFileDescriptor(FileDescriptor):
 
     def __init__(self) -> None:
         FileDescriptor.__init__(self, reactor=MemoryReactor())
+        self.writeLimit = self.SEND_LIMIT
 
     def startWriting(self) -> None:
         """
@@ -33,8 +34,9 @@ class BufferedFileDescriptor(FileDescriptor):
         Consume all buffered data
         """
 
-        # There is some cost with len() but should be constant between two benchmarks.
-        return len(data)
+        # To simulate a partial write, don't return values larger
+        # than the write limit. Otherwise all data is consumed.
+        return min(len(data), self.writeLimit)
 
 
 def mixedSmallChunks() -> list[bytes]:
@@ -56,7 +58,6 @@ SEQUENCES: dict[str, list[bytes]] = {
 
 
 WRITE_DATA = b"x" * 8192
-DO_WRITE_DATA = b"x" * (32 * 1024)
 
 
 def test_fileDescriptor_write(benchmark: Any) -> None:
@@ -103,15 +104,87 @@ def test_fileDescriptor_writeSequence(benchmark: Any, chunks: list[bytes]) -> No
     )
 
 
-def test_fileDescriptor_doWrite(benchmark: Any) -> None:
+def test_fileDescriptor_doWriteFlushBufferedWrites(benchmark: Any) -> None:
     """
-    Benchmark writing 32KB with L{FileDescriptor.doWrite}.
+    Benchmark flushing four buffered 8KB writes.
     """
 
     def setup():
         descriptor = BufferedFileDescriptor()
-        assert descriptor.writeSomeData(b"") == 0
-        descriptor.write(DO_WRITE_DATA)
+        for _ in range(4):
+            # Buffer 4x 8KB chunks
+            descriptor.write(WRITE_DATA)
+        return (descriptor,), {}
+
+    def teardown(descriptor: BufferedFileDescriptor) -> None:
+        assert descriptor._tempDataBuffer == []
+        assert descriptor._tempDataLen == 0
+        assert descriptor.dataBuffer == b""
+        assert descriptor.offset == 0
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.doWrite,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )
+
+
+def test_fileDescriptor_doWriteAppendAfterPartialWrite(benchmark: Any) -> None:
+    """
+    Benchmark flushing new data after an earlier partial write.
+    """
+
+    def setup():
+        descriptor = BufferedFileDescriptor()
+        for _ in range(4):
+            # Buffer 4x 8KB chunks
+            descriptor.write(WRITE_DATA)
+
+        # Do a partial write, it writes only 8KB
+        descriptor.writeLimit = len(WRITE_DATA)
+        descriptor.doWrite()
+
+        # Now buffer another chunk
+        descriptor.write(WRITE_DATA)
+
+        # Revert the limit back and run benchmark
+        descriptor.writeLimit = descriptor.SEND_LIMIT
+        return (descriptor,), {}
+
+    def teardown(descriptor: BufferedFileDescriptor) -> None:
+        assert descriptor._tempDataBuffer == []
+        assert descriptor._tempDataLen == 0
+        assert descriptor.dataBuffer == b""
+        assert descriptor.offset == 0
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.doWrite,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )
+
+
+def test_fileDescriptor_doWriteContinuePartialWrite(benchmark: Any) -> None:
+    """
+    Benchmark continuing a large buffer after an earlier partial write.
+    """
+
+    def setup():
+        descriptor = BufferedFileDescriptor()
+        for _ in range(17):
+            # Buffer 17 x 8KB chunks
+            descriptor.write(WRITE_DATA)
+
+        # Do a partial write, it writes only 8KB
+        descriptor.writeLimit = len(WRITE_DATA)
+        descriptor.doWrite()
+
+        # We have 16 x 8KB = 128KB left
+        descriptor.writeLimit = descriptor.SEND_LIMIT
         return (descriptor,), {}
 
     def teardown(descriptor: BufferedFileDescriptor) -> None:

--- a/benchmarks/test_filedescriptor.py
+++ b/benchmarks/test_filedescriptor.py
@@ -1,0 +1,80 @@
+"""
+Benchmarks for L{twisted.internet.abstract.FileDescriptor}.
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import pytest
+
+from twisted.internet.abstract import FileDescriptor
+from twisted.internet.testing import MemoryReactor
+
+
+class BufferedFileDescriptor(FileDescriptor):
+    """
+    A connected L{FileDescriptor} with no-op reactor integration.
+    """
+
+    connected = True
+
+    def __init__(self) -> None:
+        FileDescriptor.__init__(self, reactor=MemoryReactor())
+
+    def startWriting(self) -> None:
+        pass
+
+
+def mixedSmallChunks() -> list[bytes]:
+    """
+    Build a sequence with many small chunks of varied lengths.
+    """
+    sequence = [b"prefix", b":", b" "]
+    for index in range(24):
+        sequence.extend((b"name-%d" % (index,), b"=", b"value", b";"))
+    sequence.append(b"suffix")
+    return sequence
+
+
+SEQUENCES: dict[str, list[bytes]] = {
+    "1x8192": [b"x" * 8192],
+    "4x1024": [b"x" * 1024] * 4,
+    "100x1": [b"x"] * 100,
+    "mixed-small": mixedSmallChunks(),
+}
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    SEQUENCES.values(),
+    ids=SEQUENCES,
+)
+@pytest.mark.parametrize(
+    "sequenceFactory",
+    [list, tuple],
+    ids=["list", "tuple"],
+)
+def test_fileDescriptor_writeSequence(
+    benchmark: Any,
+    chunks: list[bytes],
+    sequenceFactory: Callable[[list[bytes]], Sequence[bytes]],
+) -> None:
+    """
+    Benchmark buffering a sequence with L{FileDescriptor.writeSequence}.
+    """
+    sequence = sequenceFactory(chunks)
+
+    def setup():
+        return (BufferedFileDescriptor(), sequence), {}
+
+    def teardown(descriptor: BufferedFileDescriptor, data: Sequence[bytes]) -> None:
+        assert descriptor._tempDataBuffer == list(data)
+        assert descriptor._tempDataLen == sum(map(len, data))
+
+    benchmark.pedantic(
+        BufferedFileDescriptor.writeSequence,
+        setup=setup,
+        teardown=teardown,
+        rounds=100,
+        iterations=1,
+    )


### PR DESCRIPTION


## Scope and purpose

Fixes #12732

I have some ideas to optimize `FileDescriptor.writeSequence` but it would be very helpful if there are some benchmarks in `trunk` first.

pedantic() is used so any setup and teardown tasks don't appear in the benchmark result


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
