### PR TITLE
#12744 Remove deprecated `twisted.internet.error.PotentialZombieWarning`

### DIFF
--- a/src/twisted/internet/error.py
+++ b/src/twisted/internet/error.py
@@ -5,12 +5,7 @@
 Exceptions and errors for use in twisted.internet modules.
 """
 
-
 import socket
-
-from incremental import Version
-
-from twisted.python import deprecate
 
 
 class BindError(Exception):
@@ -272,32 +267,6 @@ class AlreadyCancelled(ValueError):
         return s
 
 
-class PotentialZombieWarning(Warning):
-    """
-    Emitted when L{IReactorProcess.spawnProcess} is called in a way which may
-    result in termination of the created child process not being reported.
-
-    Deprecated in Twisted 10.0.
-    """
-
-    MESSAGE = (
-        "spawnProcess called, but the SIGCHLD handler is not "
-        "installed. This probably means you have not yet "
-        "called reactor.run, or called "
-        "reactor.run(installSignalHandler=0). You will probably "
-        "never see this process finish, and it may become a "
-        "zombie process."
-    )
-
-
-deprecate.deprecatedModuleAttribute(
-    Version("Twisted", 10, 0, 0),
-    "There is no longer any potential for zombie process.",
-    __name__,
-    "PotentialZombieWarning",
-)
-
-
 class ProcessDone(ConnectionDone):
     __doc__ = MESSAGE = "A process has ended without apparent errors"
 
@@ -494,7 +463,6 @@ __all__ = [
     "ConnectionFdescWentAway",
     "AlreadyCalled",
     "AlreadyCancelled",
-    "PotentialZombieWarning",
     "ProcessDone",
     "ProcessTerminated",
     "ProcessExitedAlready",

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -1166,32 +1166,6 @@ class PTYProcessTestsBuilder(ProcessTestsBuilderBase):
 globals().update(PTYProcessTestsBuilder.makeTestCaseClasses())
 
 
-class PotentialZombieWarningTests(TestCase):
-    """
-    Tests for L{twisted.internet.error.PotentialZombieWarning}.
-    """
-
-    def test_deprecated(self):
-        """
-        Accessing L{PotentialZombieWarning} via the
-        I{PotentialZombieWarning} attribute of L{twisted.internet.error}
-        results in a deprecation warning being emitted.
-        """
-        from twisted.internet import error
-
-        error.PotentialZombieWarning
-
-        warnings = self.flushWarnings([self.test_deprecated])
-        self.assertEqual(warnings[0]["category"], DeprecationWarning)
-        self.assertEqual(
-            warnings[0]["message"],
-            "twisted.internet.error.PotentialZombieWarning was deprecated in "
-            "Twisted 10.0.0: There is no longer any potential for zombie "
-            "process.",
-        )
-        self.assertEqual(len(warnings), 1)
-
-
 class ProcessIsUnimportableOnUnsupportedPlatormsTests(TestCase):
     """
     Tests to ensure that L{twisted.internet.process} is unimportable on

--- a/src/twisted/newsfragments/12744.removal
+++ b/src/twisted/newsfragments/12744.removal
@@ -1,0 +1,1 @@
+`twisted.internet.error.PotentialZombieWarning`, deprecated since Twisted 10.0, has been removed.


### PR DESCRIPTION
## Scope and purpose

Remove deprecated `twisted.internet.error.PotentialZombieWarning`

It has been deprecated since Twisted 10.0

Fixes #12744

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
