### PR TITLE
#12746 type annotate `twisted.internet.abstract._ConsumerMixin`

### DIFF
--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from socket import AF_INET, AF_INET6, inet_pton
+from typing import Protocol, cast
 
 from zope.interface import implementer
 
@@ -29,6 +30,30 @@ def _dataMustBeBytes(obj):
 # memoryview prevents the slice from copying
 def _concatenate(bObj, offset, bArray):
     return b"".join([memoryview(bObj)[offset:]] + bArray)
+
+
+class _ConsumerMixinType(Protocol):
+    """
+    The attributes required by L{_ConsumerMixin} from its host class.
+    """
+
+    producer: interfaces.IProducer | None
+    streamingProducer: bool
+
+    @property
+    def connected(self) -> int:
+        ...
+
+    @property
+    def disconnecting(self) -> int:
+        ...
+
+    @property
+    def disconnected(self) -> int:
+        ...
+
+    def startWriting(self) -> None:
+        ...
 
 
 class _ConsumerMixin:
@@ -59,22 +84,20 @@ class _ConsumerMixin:
 
     @ivar producerPaused: A flag indicating whether the producer is currently
         paused.
-    @type producerPaused: L{bool}
 
     @ivar streamingProducer: A flag indicating whether the producer was
         registered as a streaming (ie push) producer or not (ie a pull
         producer).  This will determine whether the consumer may ever need to
         pause and resume it, or if it can merely call C{resumeProducing} on it
         when buffer space is available.
-    @ivar streamingProducer: C{bool} or C{int}
 
     """
 
-    producer = None
-    producerPaused = False
-    streamingProducer = False
+    producer: interfaces.IProducer | None = None
+    producerPaused: bool = False
+    streamingProducer: bool = False
 
-    def startWriting(self):
+    def startWriting(self) -> None:
         """
         Override in a subclass to cause the reactor to monitor this selectable
         for write events.  This will be called once in C{unregisterProducer} if
@@ -83,7 +106,11 @@ class _ConsumerMixin:
         """
         raise NotImplementedError("%r did not implement startWriting")
 
-    def registerProducer(self, producer, streaming):
+    def registerProducer(
+        self: _ConsumerMixinType,
+        producer: interfaces.IProducer,
+        streaming: bool,
+    ) -> None:
         """
         Register to receive data from a producer.
 
@@ -110,9 +137,10 @@ class _ConsumerMixin:
             self.producer = producer
             self.streamingProducer = streaming
             if not streaming:
-                producer.resumeProducing()
+                pullProducer = cast(interfaces.IPullProducer, producer)
+                pullProducer.resumeProducing()
 
-    def unregisterProducer(self):
+    def unregisterProducer(self: _ConsumerMixinType) -> None:
         """
         Stop consuming data from a producer, without disconnecting.
         """
@@ -468,7 +496,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
     # first, the consumer stuff.  This requires no additional work, as
     # any object you can write to can be a consumer, really.
 
-    producer = None
+    producer: interfaces.IProducer | None = None
     bufferSize = 2**2**2**2
 
     def stopConsuming(self):


### PR DESCRIPTION
## Scope and purpose

Fixes #12746 

I am interested in adding annotations to`twisted.internet.abstract.FileDescriptor`, but first `twisted.internet.abstract._ConsumerMixin` needs to be annotated.

I used this as a reference for `_ConsumerMixinType`: https://mypy.readthedocs.io/en/stable/more_types.html#mixin-classes


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
