### PR TITLE
#12705 twisted.web HTTP/2: rate-limit stream resets to mitigate Rapid Reset (CVE-2023-44487)

### DIFF
--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -111,6 +111,11 @@ class H2Connection(Protocol, TimeoutMixin):
     _log = Logger()
     _abortingCall = None
 
+    # Token bucket that rate-limits peer stream resets (RST_STREAM) to defend
+    # against HTTP/2 Rapid Reset (CVE-2023-44487), the same shape nghttp2 uses.
+    _resetTokenBurst = 1000
+    _resetTokenRate = 33
+
     def __init__(self, reactor=None):
         config = h2.config.H2Configuration(client_side=False, header_encoding=None)
         self.conn = h2.connection.H2Connection(config=config)
@@ -132,6 +137,10 @@ class H2Connection(Protocol, TimeoutMixin):
         if reactor is None:
             from twisted.internet import reactor
         self._reactor = reactor
+
+        # Reset-rate token bucket, starts full.
+        self._resetTokens = float(self._resetTokenBurst)
+        self._resetTokenTimestamp = self._reactor.seconds()
 
         # Start the data sending function.
         self._reactor.callLater(0, self._sendPrioritisedData)
@@ -159,10 +168,7 @@ class H2Connection(Protocol, TimeoutMixin):
         try:
             events = self.conn.receive_data(data)
         except h2.exceptions.ProtocolError:
-            stillActive = self._tryToWriteControlData()
-            if stillActive:
-                self.transport.loseConnection()
-                self.connectionLost(Failure(), _cancelTimeouts=False)
+            self._terminate(Failure())
             return
 
         # Only reset the timeout if we've received an actual H2
@@ -499,6 +505,25 @@ class H2Connection(Protocol, TimeoutMixin):
         )
         self._requestDone(event.stream_id)
 
+        # Refill for elapsed time, then spend one token. An empty bucket means a
+        # Rapid Reset flood (CVE-2023-44487), so drop the connection with GOAWAY.
+        now = self._reactor.seconds()
+        # reactor.seconds() is a wall clock, so clamp elapsed to stop a backward
+        # NTP step from draining the bucket and disconnecting a well-behaved peer.
+        elapsed = max(0.0, now - self._resetTokenTimestamp)
+        self._resetTokens = min(
+            self._resetTokenBurst,
+            self._resetTokens + elapsed * self._resetTokenRate,
+        )
+        self._resetTokenTimestamp = now
+        if self._resetTokens < 1:
+            self.conn.close_connection(
+                error_code=h2.errors.ErrorCodes.ENHANCE_YOUR_CALM
+            )
+            self._terminate(Failure(ConnectionLost("Too many stream resets")))
+        else:
+            self._resetTokens -= 1
+
     def _handlePriorityUpdate(self, event):
         """
         Internal handler for when a stream priority is updated.
@@ -779,6 +804,18 @@ class H2Connection(Protocol, TimeoutMixin):
         @rtype: L{bool}
         """
         return streamID in self.streams
+
+    def _terminate(self, reason):
+        """
+        Flush any pending control data and tear the connection down, leaving
+        timers armed so that a peer who never reads our data is timed out.
+
+        @param reason: The failure to report to the connection's streams.
+        @type reason: L{Failure}
+        """
+        if self._tryToWriteControlData():
+            self.transport.loseConnection()
+            self.connectionLost(reason, _cancelTimeouts=False)
 
     def _tryToWriteControlData(self):
         """

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -805,13 +805,12 @@ class H2Connection(Protocol, TimeoutMixin):
         """
         return streamID in self.streams
 
-    def _terminate(self, reason):
+    def _terminate(self, reason: Failure) -> None:
         """
         Flush any pending control data and tear the connection down, leaving
         timers armed so that a peer who never reads our data is timed out.
 
         @param reason: The failure to report to the connection's streams.
-        @type reason: L{Failure}
         """
         if self._tryToWriteControlData():
             self.transport.loseConnection()

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -102,6 +102,15 @@ class H2Connection(Protocol, TimeoutMixin):
     @ivar _abortingCall: The L{twisted.internet.base.DelayedCall} that will be
         used to forcibly close the transport if it doesn't close cleanly.
     @type _abortingCall: L{twisted.internet.base.DelayedCall}
+
+    @cvar _resetTokenBurst: The maximum number of peer-initiated stream resets
+        (RST_STREAM) allowed in a burst. With C{_resetTokenRate} this token
+        bucket rate-limits resets to defend against HTTP/2 Rapid Reset
+        (CVE-2023-44487).
+    @type _resetTokenBurst: L{int}
+
+    @cvar _resetTokenRate: The number of reset tokens replenished each second.
+    @type _resetTokenRate: L{int}
     """
 
     factory = None
@@ -111,9 +120,7 @@ class H2Connection(Protocol, TimeoutMixin):
     _log = Logger()
     _abortingCall = None
 
-    # Token bucket that rate-limits peer stream resets (RST_STREAM) to defend
-    # against HTTP/2 Rapid Reset (CVE-2023-44487), the same shape nghttp2 uses.
-    _resetTokenBurst = 1000.0
+    _resetTokenBurst = 1000
     _resetTokenRate = 33
 
     def __init__(self, reactor=None):
@@ -809,6 +816,11 @@ class H2Connection(Protocol, TimeoutMixin):
         """
         Flush any pending control data and tear the connection down, leaving
         timers armed so that a peer who never reads our data is timed out.
+
+        Callers own the GOAWAY: queue one with
+        L{h2.connection.H2Connection.close_connection} first if a specific
+        error code is wanted. The L{dataReceived} protocol-error path passes
+        none and relies on the GOAWAY that hyper-h2 queues itself.
 
         @param reason: The failure to report to the connection's streams.
         """

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -113,7 +113,7 @@ class H2Connection(Protocol, TimeoutMixin):
 
     # Token bucket that rate-limits peer stream resets (RST_STREAM) to defend
     # against HTTP/2 Rapid Reset (CVE-2023-44487), the same shape nghttp2 uses.
-    _resetTokenBurst = 1000
+    _resetTokenBurst = 1000.0
     _resetTokenRate = 33
 
     def __init__(self, reactor=None):
@@ -139,7 +139,7 @@ class H2Connection(Protocol, TimeoutMixin):
         self._reactor = reactor
 
         # Reset-rate token bucket, starts full.
-        self._resetTokens = float(self._resetTokenBurst)
+        self._resetTokens = self._resetTokenBurst
         self._resetTokenTimestamp = self._reactor.seconds()
 
         # Start the data sending function.

--- a/src/twisted/web/_http2.py
+++ b/src/twisted/web/_http2.py
@@ -813,6 +813,7 @@ class H2Connection(Protocol, TimeoutMixin):
         @param reason: The failure to report to the connection's streams.
         """
         if self._tryToWriteControlData():
+            assert self.transport is not None
             self.transport.loseConnection()
             self.connectionLost(reason, _cancelTimeouts=False)
 

--- a/src/twisted/web/newsfragments/12705.bugfix
+++ b/src/twisted/web/newsfragments/12705.bugfix
@@ -1,0 +1,1 @@
+twisted.web's HTTP/2 server now limits the rate at which a remote peer may reset streams, mitigating the HTTP/2 Rapid Reset denial-of-service attack (CVE-2023-44487).

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3072,7 +3072,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
-            connection, frameFactory, nextStreamID, int(connection._resetTokenBurst) + 1
+            connection, frameFactory, nextStreamID, connection._resetTokenBurst + 1
         )
 
         # Assert on GOAWAY presence, not list position, so a later control frame
@@ -3092,7 +3092,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
-            connection, frameFactory, nextStreamID, int(connection._resetTokenBurst)
+            connection, frameFactory, nextStreamID, connection._resetTokenBurst
         )
 
         frames = framesFromBytes(transport.value())
@@ -3111,7 +3111,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         depends on.
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
-        for _ in range(int(connection._resetTokenBurst) + 1):
+        for _ in range(connection._resetTokenBurst + 1):
             streamID = nextStreamID[0]
             nextStreamID[0] += 2
             connection.dataReceived(
@@ -3140,7 +3140,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
             frameFactory,
             nextStreamID,
         ) = self.connectRapidReset()
-        for _ in range(int(connection._resetTokenBurst) * 2):
+        for _ in range(connection._resetTokenBurst * 2):
             self.openThenReset(connection, frameFactory, nextStreamID, 1)
             reactor.advance(1.0 / connection._resetTokenRate)
 
@@ -3163,11 +3163,42 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
             frameFactory,
             nextStreamID,
         ) = self.connectRapidReset()
-        burst = int(connection._resetTokenBurst)
+        burst = connection._resetTokenBurst
         self.openThenReset(connection, frameFactory, nextStreamID, burst)
         reactor.advance(burst / connection._resetTokenRate + 1)
         self.openThenReset(connection, frameFactory, nextStreamID, burst)
 
+        frames = framesFromBytes(transport.value())
+        self.assertFalse(
+            any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)
+        )
+        self.assertFalse(transport.disconnecting)
+
+    def test_backwardClockDoesNotDrainBucket(self) -> None:
+        """
+        A backward wall-clock step, such as an NTP correction, must not drain
+        the token bucket and disconnect a well-behaved peer. The refill clamps
+        a negative elapsed interval to zero, so a reset arriving after the step
+        spends a single token rather than being charged for the jump.
+        """
+        (
+            reactor,
+            connection,
+            transport,
+            frameFactory,
+            nextStreamID,
+        ) = self.connectRapidReset()
+        # Drain part of the bucket, then simulate the wall clock stepping
+        # backward by recording the last reset in the reactor's future.
+        self.openThenReset(connection, frameFactory, nextStreamID, 100)
+        tokensBeforeStep = connection._resetTokens
+        connection._resetTokenTimestamp = reactor.seconds() + 10000
+
+        self.openThenReset(connection, frameFactory, nextStreamID, 1)
+
+        # The clamp holds elapsed at zero, so exactly one token is spent and the
+        # peer is neither over-charged nor disconnected.
+        self.assertEqual(connection._resetTokens, tokensBeforeStep - 1)
         frames = framesFromBytes(transport.value())
         self.assertFalse(
             any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3060,9 +3060,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         token bucket refills causes the connection to be closed with a GOAWAY
         frame carrying ENHANCE_YOUR_CALM.
         """
-        _, connection, transport, frameFactory, nextStreamID = (
-            self.connectRapidReset()
-        )
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
             connection, frameFactory, nextStreamID, connection._resetTokenBurst + 1
         )
@@ -3082,9 +3080,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         trips. This pins the lower side of the boundary so an off-by-one cannot
         disconnect a client that uses its full documented burst allowance.
         """
-        _, connection, transport, frameFactory, nextStreamID = (
-            self.connectRapidReset()
-        )
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
             connection, frameFactory, nextStreamID, connection._resetTokenBurst
         )
@@ -3104,9 +3100,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         disconnected.  This pins the peer-versus-server distinction the defence
         depends on.
         """
-        _, connection, transport, frameFactory, nextStreamID = (
-            self.connectRapidReset()
-        )
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         for _ in range(connection._resetTokenBurst + 1):
             streamID = nextStreamID[0]
             nextStreamID[0] += 2
@@ -3129,9 +3123,13 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         a GOAWAY, even when their number greatly exceeds a single burst: a
         client that steadily cancels requests is not disconnected.
         """
-        reactor, connection, transport, frameFactory, nextStreamID = (
-            self.connectRapidReset()
-        )
+        (
+            reactor,
+            connection,
+            transport,
+            frameFactory,
+            nextStreamID,
+        ) = self.connectRapidReset()
         for _ in range(connection._resetTokenBurst * 2):
             self.openThenReset(connection, frameFactory, nextStreamID, 1)
             reactor.advance(1.0 / connection._resetTokenRate)
@@ -3148,9 +3146,13 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         a pause and a second burst, is accepted because the pause restores
         capacity.
         """
-        reactor, connection, transport, frameFactory, nextStreamID = (
-            self.connectRapidReset()
-        )
+        (
+            reactor,
+            connection,
+            transport,
+            frameFactory,
+            nextStreamID,
+        ) = self.connectRapidReset()
         burst = connection._resetTokenBurst
         self.openThenReset(connection, frameFactory, nextStreamID, burst)
         reactor.advance(burst / connection._resetTokenRate + 1)

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3019,7 +3019,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         (b":authority", b"localhost"),
     ]
 
-    def connectRapidReset(self):
+    def connectRapidReset(
+        self,
+    ) -> "tuple[task.Clock, H2Connection, StringTransport, FrameFactory, list[int]]":
         """
         Build an L{H2Connection} driven by a L{task.Clock} and complete the
         client connection preface.
@@ -3030,14 +3032,22 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         """
         reactor = task.Clock()
         connection = H2Connection(reactor)
-        connection.requestFactory = DummyHTTPHandlerProxy
+        # requestFactory is assigned by the factory at runtime, so it is not
+        # visible to mypy on H2Connection here.
+        connection.requestFactory = DummyHTTPHandlerProxy  # type: ignore[attr-defined]
         transport = StringTransport()
         connection.makeConnection(transport)
         frameFactory = FrameFactory()
         connection.dataReceived(frameFactory.clientConnectionPreface())
         return reactor, connection, transport, frameFactory, [1]
 
-    def openThenReset(self, connection, frameFactory, nextStreamID, count):
+    def openThenReset(
+        self,
+        connection: "H2Connection",
+        frameFactory: FrameFactory,
+        nextStreamID: list[int],
+        count: int,
+    ) -> None:
         """
         Feed C{count} (HEADERS, RST_STREAM) pairs, each opening a request on a
         fresh stream id that the peer immediately cancels.
@@ -3054,7 +3064,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
             ).serialize()
         connection.dataReceived(data)
 
-    def test_resetFloodIsRejected(self):
+    def test_resetFloodIsRejected(self) -> None:
         """
         More than C{_resetTokenBurst} peer resets arriving faster than the
         token bucket refills causes the connection to be closed with a GOAWAY
@@ -3073,7 +3083,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         self.assertEqual(goaways[0].error_code, h2.errors.ErrorCodes.ENHANCE_YOUR_CALM)
         self.assertTrue(transport.disconnecting)
 
-    def test_exactBurstAllowed(self):
+    def test_exactBurstAllowed(self) -> None:
         """
         Exactly C{_resetTokenBurst} peer resets with no time to refill are
         allowed because the bucket starts full. Only the reset beyond the burst
@@ -3091,7 +3101,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         )
         self.assertFalse(transport.disconnecting)
 
-    def test_serverInitiatedResetsDoNotConsumeTokens(self):
+    def test_serverInitiatedResetsDoNotConsumeTokens(self) -> None:
         """
         Server-initiated aborts (L{H2Connection.abortRequest}, e.g. a request
         handler cancelling its own stream) must not consume peer-reset tokens:
@@ -3117,7 +3127,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         )
         self.assertFalse(transport.disconnecting)
 
-    def test_sustainedResetsWithinRateAreAllowed(self):
+    def test_sustainedResetsWithinRateAreAllowed(self) -> None:
         """
         Peer resets that arrive no faster than the bucket refills never trigger
         a GOAWAY, even when their number greatly exceeds a single burst: a
@@ -3140,7 +3150,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         )
         self.assertFalse(transport.disconnecting)
 
-    def test_resetTokensRefillOverTime(self):
+    def test_resetTokensRefillOverTime(self) -> None:
         """
         The bucket refills as time passes: a burst that drains it, followed by
         a pause and a second burst, is accepted because the pause restores

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3072,7 +3072,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
-            connection, frameFactory, nextStreamID, connection._resetTokenBurst + 1
+            connection, frameFactory, nextStreamID, int(connection._resetTokenBurst) + 1
         )
 
         # Assert on GOAWAY presence, not list position, so a later control frame
@@ -3092,7 +3092,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
         self.openThenReset(
-            connection, frameFactory, nextStreamID, connection._resetTokenBurst
+            connection, frameFactory, nextStreamID, int(connection._resetTokenBurst)
         )
 
         frames = framesFromBytes(transport.value())
@@ -3111,7 +3111,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         depends on.
         """
         _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
-        for _ in range(connection._resetTokenBurst + 1):
+        for _ in range(int(connection._resetTokenBurst) + 1):
             streamID = nextStreamID[0]
             nextStreamID[0] += 2
             connection.dataReceived(
@@ -3140,7 +3140,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
             frameFactory,
             nextStreamID,
         ) = self.connectRapidReset()
-        for _ in range(connection._resetTokenBurst * 2):
+        for _ in range(int(connection._resetTokenBurst) * 2):
             self.openThenReset(connection, frameFactory, nextStreamID, 1)
             reactor.advance(1.0 / connection._resetTokenRate)
 
@@ -3163,7 +3163,7 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
             frameFactory,
             nextStreamID,
         ) = self.connectRapidReset()
-        burst = connection._resetTokenBurst
+        burst = int(connection._resetTokenBurst)
         self.openThenReset(connection, frameFactory, nextStreamID, burst)
         reactor.advance(burst / connection._resetTokenRate + 1)
         self.openThenReset(connection, frameFactory, nextStreamID, burst)

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3004,3 +3004,162 @@ class EndToEndTests(unittest.TestCase):
         (httpVersion, content) = await deferToThread(run_http2_query)
         self.assertEqual(httpVersion, "HTTP/2")
         self.assertEqual(content, b"hello world")
+
+
+class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
+    """
+    Tests for the peer stream-reset (RST_STREAM) rate limit that defends
+    against the HTTP/2 Rapid Reset attack (CVE-2023-44487).
+    """
+
+    getRequestHeaders = [
+        (b":method", b"GET"),
+        (b":path", b"/"),
+        (b":scheme", b"https"),
+        (b":authority", b"localhost"),
+    ]
+
+    def connectRapidReset(self):
+        """
+        Build an L{H2Connection} driven by a L{task.Clock} and complete the
+        client connection preface.
+
+        @return: A tuple of the reactor, the connection, its transport, a
+            L{FrameFactory}, and a one-element list holding the next client
+            stream id to use.
+        """
+        reactor = task.Clock()
+        connection = H2Connection(reactor)
+        connection.requestFactory = DummyHTTPHandlerProxy
+        transport = StringTransport()
+        connection.makeConnection(transport)
+        frameFactory = FrameFactory()
+        connection.dataReceived(frameFactory.clientConnectionPreface())
+        return reactor, connection, transport, frameFactory, [1]
+
+    def openThenReset(self, connection, frameFactory, nextStreamID, count):
+        """
+        Feed C{count} (HEADERS, RST_STREAM) pairs, each opening a request on a
+        fresh stream id that the peer immediately cancels.
+        """
+        data = b""
+        for _ in range(count):
+            streamID = nextStreamID[0]
+            nextStreamID[0] += 2
+            data += frameFactory.buildHeadersFrame(
+                self.getRequestHeaders, streamID=streamID
+            ).serialize()
+            data += frameFactory.buildRstStreamFrame(
+                streamID, errorCode=h2.errors.ErrorCodes.CANCEL
+            ).serialize()
+        connection.dataReceived(data)
+
+    def test_resetFloodIsRejected(self):
+        """
+        More than C{_resetTokenBurst} peer resets arriving faster than the
+        token bucket refills causes the connection to be closed with a GOAWAY
+        frame carrying ENHANCE_YOUR_CALM.
+        """
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        self.openThenReset(
+            connection, frameFactory, nextStreamID, connection._resetTokenBurst + 1
+        )
+
+        # Assert on GOAWAY presence, not list position, so a later control frame
+        # after teardown cannot silently flip the assertion.
+        frames = framesFromBytes(transport.value())
+        goaways = [f for f in frames if isinstance(f, hyperframe.frame.GoAwayFrame)]
+        self.assertEqual(len(goaways), 1)
+        self.assertEqual(goaways[0].error_code, h2.errors.ErrorCodes.ENHANCE_YOUR_CALM)
+        self.assertTrue(transport.disconnecting)
+
+    def test_exactBurstAllowed(self):
+        """
+        Exactly C{_resetTokenBurst} peer resets with no time to refill are
+        allowed because the bucket starts full. Only the reset beyond the burst
+        trips. This pins the lower side of the boundary so an off-by-one cannot
+        disconnect a client that uses its full documented burst allowance.
+        """
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        self.openThenReset(
+            connection, frameFactory, nextStreamID, connection._resetTokenBurst
+        )
+
+        frames = framesFromBytes(transport.value())
+        self.assertFalse(
+            any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)
+        )
+        self.assertFalse(transport.disconnecting)
+
+    def test_serverInitiatedResetsDoNotConsumeTokens(self):
+        """
+        Server-initiated aborts (L{H2Connection.abortRequest}, e.g. a request
+        handler cancelling its own stream) must not consume peer-reset tokens:
+        only the remote peer's RST_STREAM floods are rate limited.  A server
+        that aborts far more than a burst of its own streams is never
+        disconnected.  This pins the peer-versus-server distinction the defence
+        depends on.
+        """
+        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        for _ in range(connection._resetTokenBurst + 1):
+            streamID = nextStreamID[0]
+            nextStreamID[0] += 2
+            connection.dataReceived(
+                frameFactory.buildHeadersFrame(
+                    self.getRequestHeaders, streamID=streamID
+                ).serialize()
+            )
+            connection.abortRequest(streamID)
+
+        frames = framesFromBytes(transport.value())
+        self.assertFalse(
+            any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)
+        )
+        self.assertFalse(transport.disconnecting)
+
+    def test_sustainedResetsWithinRateAreAllowed(self):
+        """
+        Peer resets that arrive no faster than the bucket refills never trigger
+        a GOAWAY, even when their number greatly exceeds a single burst: a
+        client that steadily cancels requests is not disconnected.
+        """
+        (
+            reactor,
+            connection,
+            transport,
+            frameFactory,
+            nextStreamID,
+        ) = self.connectRapidReset()
+        for _ in range(connection._resetTokenBurst * 2):
+            self.openThenReset(connection, frameFactory, nextStreamID, 1)
+            reactor.advance(1.0 / connection._resetTokenRate)
+
+        frames = framesFromBytes(transport.value())
+        self.assertFalse(
+            any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)
+        )
+        self.assertFalse(transport.disconnecting)
+
+    def test_resetTokensRefillOverTime(self):
+        """
+        The bucket refills as time passes: a burst that drains it, followed by
+        a pause and a second burst, is accepted because the pause restores
+        capacity.
+        """
+        (
+            reactor,
+            connection,
+            transport,
+            frameFactory,
+            nextStreamID,
+        ) = self.connectRapidReset()
+        burst = connection._resetTokenBurst
+        self.openThenReset(connection, frameFactory, nextStreamID, burst)
+        reactor.advance(burst / connection._resetTokenRate + 1)
+        self.openThenReset(connection, frameFactory, nextStreamID, burst)
+
+        frames = framesFromBytes(transport.value())
+        self.assertFalse(
+            any(isinstance(f, hyperframe.frame.GoAwayFrame) for f in frames)
+        )
+        self.assertFalse(transport.disconnecting)

--- a/src/twisted/web/test/test_http2.py
+++ b/src/twisted/web/test/test_http2.py
@@ -3060,7 +3060,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         token bucket refills causes the connection to be closed with a GOAWAY
         frame carrying ENHANCE_YOUR_CALM.
         """
-        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        _, connection, transport, frameFactory, nextStreamID = (
+            self.connectRapidReset()
+        )
         self.openThenReset(
             connection, frameFactory, nextStreamID, connection._resetTokenBurst + 1
         )
@@ -3080,7 +3082,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         trips. This pins the lower side of the boundary so an off-by-one cannot
         disconnect a client that uses its full documented burst allowance.
         """
-        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        _, connection, transport, frameFactory, nextStreamID = (
+            self.connectRapidReset()
+        )
         self.openThenReset(
             connection, frameFactory, nextStreamID, connection._resetTokenBurst
         )
@@ -3100,7 +3104,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         disconnected.  This pins the peer-versus-server distinction the defence
         depends on.
         """
-        _, connection, transport, frameFactory, nextStreamID = self.connectRapidReset()
+        _, connection, transport, frameFactory, nextStreamID = (
+            self.connectRapidReset()
+        )
         for _ in range(connection._resetTokenBurst + 1):
             streamID = nextStreamID[0]
             nextStreamID[0] += 2
@@ -3123,13 +3129,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         a GOAWAY, even when their number greatly exceeds a single burst: a
         client that steadily cancels requests is not disconnected.
         """
-        (
-            reactor,
-            connection,
-            transport,
-            frameFactory,
-            nextStreamID,
-        ) = self.connectRapidReset()
+        reactor, connection, transport, frameFactory, nextStreamID = (
+            self.connectRapidReset()
+        )
         for _ in range(connection._resetTokenBurst * 2):
             self.openThenReset(connection, frameFactory, nextStreamID, 1)
             reactor.advance(1.0 / connection._resetTokenRate)
@@ -3146,13 +3148,9 @@ class HTTP2RapidResetTests(unittest.TestCase, HTTP2TestHelpers):
         a pause and a second burst, is accepted because the pause restores
         capacity.
         """
-        (
-            reactor,
-            connection,
-            transport,
-            frameFactory,
-            nextStreamID,
-        ) = self.connectRapidReset()
+        reactor, connection, transport, frameFactory, nextStreamID = (
+            self.connectRapidReset()
+        )
         burst = connection._resetTokenBurst
         self.openThenReset(connection, frameFactory, nextStreamID, burst)
         reactor.advance(burst / connection._resetTokenRate + 1)


### PR DESCRIPTION
Fixes #12705

This rate-limits peer stream resets (RST_STREAM) to defend against HTTP/2 Rapid Reset (CVE-2023-44487). Right now `H2Connection` handles every reset with no limit, so a peer can open and reset streams in a loop and keep the server busy without ever hitting the concurrency cap.

The fix is a token bucket in `_requestAborted`, the same shape nghttp2 uses (burst 1000, refill 33/s). When it runs out the connection is closed with `GOAWAY(ENHANCE_YOUR_CALM)`. I kept it in Twisted rather than pushing it into h2, since h2 is sans-IO and never closes connections and it already surfaces the `StreamReset` events this code consumes.

New tests in `HTTP2RapidResetTests` cover a reset flood, the exact burst boundary, sustained resets at the refill rate, refill over time, and that server-side aborts do not count against the peer. The full `twisted.web.test.test_http2` passes and I added a newsfragment.
