### PR TITLE
twisted.words.xish.domish: bound stanza size to prevent a memory DoS

### DIFF
--- a/src/twisted/words/newsfragments/12707.bugfix
+++ b/src/twisted/words/newsfragments/12707.bugfix
@@ -1,0 +1,1 @@
+The domish XML element streams in twisted.words.xish (used to parse XMPP) now limit the byte size and element count of a single stanza, so a peer can no longer exhaust server memory by sending an unbounded stanza.

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -5,6 +5,7 @@
 Tests for L{twisted.words.xish.domish}, a DOM-like library for XMPP.
 """
 
+from typing import TYPE_CHECKING
 
 from zope.interface.verify import verifyObject
 
@@ -221,7 +222,13 @@ class ElementTests(unittest.TestCase):
         self.assertIn(c4, elts)
 
 
-class DomishStreamTestsMixin:
+if TYPE_CHECKING:
+    TestMixinBase = unittest.TestCase
+else:
+    TestMixinBase = object
+
+
+class DomishStreamTestsMixin(TestMixinBase):
     """
     Mixin defining tests for different stream implementations.
 
@@ -637,13 +644,13 @@ class SerializerTests(unittest.TestCase):
 
     def testRawXMLWithUnicodeSerialization(self):
         e = domish.Element((None, "foo"))
-        e.addRawXml("<degree>\u00B0</degree>")
-        self.assertEqual(e.toXml(), "<foo><degree>\u00B0</degree></foo>")
+        e.addRawXml("<degree>\u00b0</degree>")
+        self.assertEqual(e.toXml(), "<foo><degree>\u00b0</degree></foo>")
 
     def testUnicodeSerialization(self):
         e = domish.Element((None, "foo"))
         e["test"] = "my value\u0221e"
-        e.addContent("A degree symbol...\u00B0")
+        e.addContent("A degree symbol...\u00b0")
         self.assertEqual(
-            e.toXml(), "<foo test='my value\u0221e'" ">A degree symbol...\u00B0</foo>"
+            e.toXml(), "<foo test='my value\u0221e'" ">A degree symbol...\u00b0</foo>"
         )

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -369,12 +369,11 @@ class DomishStreamTestsMixin:
         """
         self.stream.maxElementCount = 100
         self.stream.parse(b"<stream><container>")
-
-        def flood():
-            for _ in range(200):
-                self.stream.parse(b"<child/>")
-
-        self.assertRaisesRegex(domish.ParserError, "Maximum element count", flood)
+        # A burst of more than maxElementCount child elements is rejected.
+        burst = b"<child/>" * 200
+        self.assertRaisesRegex(
+            domish.ParserError, "Maximum element count", self.stream.parse, burst
+        )
 
     def test_stanzaSizeLimit(self):
         """
@@ -387,12 +386,14 @@ class DomishStreamTestsMixin:
         self.stream.maxStanzaSize = 1024
         self.stream.parse(b"<stream>")
         self.stream.parse(b"<message>")
-
-        def flood():
-            for _ in range(16):
-                self.stream.parse(b"<body>" + b"x" * 256 + b"</body>")
-
-        self.assertRaisesRegex(domish.ParserError, "Maximum stanza size", flood)
+        chunk = b"<body>" + b"x" * 256 + b"</body>"
+        # Chunks under the cap are accepted as the stanza grows...
+        for _ in range(3):
+            self.stream.parse(chunk)
+        # ...until a further chunk pushes the open stanza over the limit.
+        self.assertRaisesRegex(
+            domish.ParserError, "Maximum stanza size", self.stream.parse, chunk
+        )
 
     def test_stanzaSizeCountsAttributeValues(self):
         """

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -361,7 +361,7 @@ class DomishStreamTestsMixin:
         self.assertEqual("testns", self.elements[1].defaultUri)
         self.assertEqual({}, self.elements[1].localPrefixes)
 
-    def test_elementCountLimit(self):
+    def test_elementCountLimit(self) -> None:
         """
         An unfinished stanza containing more than C{maxElementCount} elements is
         rejected with L{domish.ParserError}, bounding the number of elements a
@@ -375,7 +375,7 @@ class DomishStreamTestsMixin:
             domish.ParserError, "Maximum element count", self.stream.parse, burst
         )
 
-    def test_stanzaSizeLimit(self):
+    def test_stanzaSizeLimit(self) -> None:
         """
         A single stanza whose accumulated byte size exceeds C{maxStanzaSize}
         while it is still open is rejected before it completes.  The input is
@@ -395,7 +395,7 @@ class DomishStreamTestsMixin:
             domish.ParserError, "Maximum stanza size", self.stream.parse, chunk
         )
 
-    def test_stanzaSizeCountsAttributeValues(self):
+    def test_stanzaSizeCountsAttributeValues(self) -> None:
         """
         Bytes carried in an attribute value count toward C{maxStanzaSize}, so a
         stanza cannot evade the size limit by placing its payload in a single
@@ -412,7 +412,7 @@ class DomishStreamTestsMixin:
             domish.ParserError, "Maximum stanza size", self.stream.parse, oversized
         )
 
-    def test_stanzaSizeExactBoundary(self):
+    def test_stanzaSizeExactBoundary(self) -> None:
         """
         A stanza whose accumulated raw size is exactly C{maxStanzaSize} is
         accepted. One byte beyond is rejected. This pins the strict-greater-than
@@ -431,7 +431,7 @@ class DomishStreamTestsMixin:
             domish.ParserError, "Maximum stanza size", self.stream.parse, b"x"
         )
 
-    def test_elementCountExactBoundary(self):
+    def test_elementCountExactBoundary(self) -> None:
         """
         Exactly C{maxElementCount} elements are accepted. One more is rejected.
         This pins the element-count boundary against an off-by-one.
@@ -445,7 +445,7 @@ class DomishStreamTestsMixin:
             domish.ParserError, "Maximum element count", self.stream.parse, b"<a/>"
         )
 
-    def test_sizeLimitsResetPerStanza(self):
+    def test_sizeLimitsResetPerStanza(self) -> None:
         """
         The size and element counters reset when each top-level stanza is
         emitted, so an arbitrarily long sequence of small stanzas, whose

--- a/src/twisted/words/test/test_domish.py
+++ b/src/twisted/words/test/test_domish.py
@@ -361,6 +361,103 @@ class DomishStreamTestsMixin:
         self.assertEqual("testns", self.elements[1].defaultUri)
         self.assertEqual({}, self.elements[1].localPrefixes)
 
+    def test_elementCountLimit(self):
+        """
+        An unfinished stanza containing more than C{maxElementCount} elements is
+        rejected with L{domish.ParserError}, bounding the number of elements a
+        single stanza can accumulate.
+        """
+        self.stream.maxElementCount = 100
+        self.stream.parse(b"<stream><container>")
+
+        def flood():
+            for _ in range(200):
+                self.stream.parse(b"<child/>")
+
+        self.assertRaisesRegex(domish.ParserError, "Maximum element count", flood)
+
+    def test_stanzaSizeLimit(self):
+        """
+        A single stanza whose accumulated byte size exceeds C{maxStanzaSize}
+        while it is still open is rejected before it completes.  The input is
+        delivered in small chunks, as it arrives on a real connection, so the
+        limit trips while the stanza is still growing rather than only once it
+        has been fully buffered.
+        """
+        self.stream.maxStanzaSize = 1024
+        self.stream.parse(b"<stream>")
+        self.stream.parse(b"<message>")
+
+        def flood():
+            for _ in range(16):
+                self.stream.parse(b"<body>" + b"x" * 256 + b"</body>")
+
+        self.assertRaisesRegex(domish.ParserError, "Maximum stanza size", flood)
+
+    def test_stanzaSizeCountsAttributeValues(self):
+        """
+        Bytes carried in an attribute value count toward C{maxStanzaSize}, so a
+        stanza cannot evade the size limit by placing its payload in a single
+        large attribute value that the parser may buffer internally without
+        emitting it to a character-data callback (the exact regression a revert
+        to callback-based sizing would reintroduce, since an attribute value is
+        not delivered through a character-data callback).
+        """
+        self.stream.maxStanzaSize = 1024
+        self.stream.parse(b"<stream>")
+        self.stream.parse(b"<message>")
+        oversized = b"<x foo='" + b"A" * 4096 + b"'/>"
+        self.assertRaisesRegex(
+            domish.ParserError, "Maximum stanza size", self.stream.parse, oversized
+        )
+
+    def test_stanzaSizeExactBoundary(self):
+        """
+        A stanza whose accumulated raw size is exactly C{maxStanzaSize} is
+        accepted. One byte beyond is rejected. This pins the strict-greater-than
+        boundary so a C{>} to C{>=} regression, which would reject a stanza
+        sitting exactly on the documented limit, is caught.
+        """
+        root = b"<stream>"
+        self.stream.parse(root)
+        openTag = b"<message>"
+        padding = 100
+        self.stream.maxStanzaSize = len(root) + len(openTag) + padding
+        # Exactly at the cap: accepted.
+        self.stream.parse(openTag + b"x" * padding)
+        # One byte beyond the cap: rejected.
+        self.assertRaisesRegex(
+            domish.ParserError, "Maximum stanza size", self.stream.parse, b"x"
+        )
+
+    def test_elementCountExactBoundary(self):
+        """
+        Exactly C{maxElementCount} elements are accepted. One more is rejected.
+        This pins the element-count boundary against an off-by-one.
+        """
+        self.stream.maxElementCount = 100
+        self.stream.parse(b"<stream><container>")  # container is element 1
+        for _ in range(99):  # elements 2..100
+            self.stream.parse(b"<a/>")
+        # The 101st element trips the limit.
+        self.assertRaisesRegex(
+            domish.ParserError, "Maximum element count", self.stream.parse, b"<a/>"
+        )
+
+    def test_sizeLimitsResetPerStanza(self):
+        """
+        The size and element counters reset when each top-level stanza is
+        emitted, so an arbitrarily long sequence of small stanzas, whose
+        combined size and element count far exceed the limits, is delivered
+        without error.
+        """
+        self.stream.maxStanzaSize = 1024
+        self.stream.maxElementCount = 100
+        self.stream.parse(b"<stream>")
+        for _ in range(200):
+            self.stream.parse(b"<message><body>hi</body></message>")
+        self.assertEqual(len(self.elements), 200)
+
 
 class DomishExpatStreamTests(DomishStreamTestsMixin, unittest.TestCase):
     """

--- a/src/twisted/words/xish/domish.py
+++ b/src/twisted/words/xish/domish.py
@@ -609,6 +609,10 @@ def elementStream():
 
 
 class SuxElementStream(sux.XMLParser):
+    # Same bounds as ExpatElementStream.
+    maxStanzaSize = 10 * 1024 * 1024
+    maxElementCount = 100000
+
     def __init__(self):
         self.connectionMade()
         self.DocumentStartEvent = None
@@ -619,12 +623,17 @@ class SuxElementStream(sux.XMLParser):
         self.documentStarted = False
         self.defaultNsStack = []
         self.prefixStack = []
+        self.elementCount = 0
+        self.stanzaSize = 0
 
     def parse(self, buffer):
+        self.stanzaSize += len(buffer)
         try:
             self.dataReceived(buffer)
         except sux.ParseError as e:
             raise ParserError(str(e))
+        if self.stanzaSize > self.maxStanzaSize:
+            raise ParserError("Maximum stanza size exceeded")
 
     def findUri(self, prefix):
         # Walk prefix stack backwards, looking for the uri
@@ -686,6 +695,9 @@ class SuxElementStream(sux.XMLParser):
 
         # Document already started
         if self.documentStarted:
+            self.elementCount += 1
+            if self.elementCount > self.maxElementCount:
+                raise ParserError("Maximum element count exceeded")
             # Starting a new packet
             if self.currElem is None:
                 self.currElem = e
@@ -770,6 +782,8 @@ class SuxElementStream(sux.XMLParser):
                 self.currElem.parent = self.rootElem
                 self.ElementEvent(self.currElem)
                 self.currElem = None
+                self.elementCount = 0
+                self.stanzaSize = 0
 
             # Anything else is just some element wrapping up
             else:
@@ -777,6 +791,11 @@ class SuxElementStream(sux.XMLParser):
 
 
 class ExpatElementStream:
+    # Per-stanza byte and element caps, reset when the stanza is emitted. Bytes
+    # are counted in parse() so the parser's internal buffering is bounded too.
+    maxStanzaSize = 10 * 1024 * 1024
+    maxElementCount = 100000
+
     def __init__(self):
         import pyexpat
 
@@ -794,12 +813,17 @@ class ExpatElementStream:
         self.defaultNsStack = [""]
         self.documentStarted = 0
         self.localPrefixes = {}
+        self.elementCount = 0
+        self.stanzaSize = 0
 
     def parse(self, buffer):
+        self.stanzaSize += len(buffer)
         try:
             self.parser.Parse(buffer)
         except self.error as e:
             raise ParserError(str(e))
+        if self.stanzaSize > self.maxStanzaSize:
+            raise ParserError("Maximum stanza size exceeded")
 
     def _onStartElement(self, name, attrs):
         # Generate a qname tuple from the provided name.  See
@@ -829,6 +853,9 @@ class ExpatElementStream:
 
         # Document already started
         if self.documentStarted == 1:
+            self.elementCount += 1
+            if self.elementCount > self.maxElementCount:
+                raise ParserError("Maximum element count exceeded")
             if self.currElem != None:
                 self.currElem.children.append(e)
                 e.parent = self.currElem
@@ -849,6 +876,8 @@ class ExpatElementStream:
         elif self.currElem.parent is None:
             self.ElementEvent(self.currElem)
             self.currElem = None
+            self.elementCount = 0
+            self.stanzaSize = 0
 
         # Anything else is just some element in the current
         # packet wrapping up


### PR DESCRIPTION
Fixes #12707

This bounds the size of a single XML stanza in the `twisted.words.xish.domish` element streams, which parse XMPP. Right now a stanza can grow without limit, both in bytes and in element count, so a peer can open one element and keep feeding it until the server runs out of memory. This is reachable before authentication on an XMPP stream.

The fix adds two caps, `maxStanzaSize` (10 MB) and `maxElementCount` (100000), reset each time a top-level stanza is emitted. The byte count comes from the raw input in `parse()`, so it also covers bytes the parser buffers internally, such as a large attribute value. Both parsers, expat and the pure-Python fallback, get the same limits.

New tests cover the element-count and byte-size limits, the exact boundaries, attribute values counting toward the size, and the counters resetting per stanza. The full `twisted.words.test.test_domish` passes and I added a newsfragment.
