### PR TITLE
#12752 Optimize `test_sslverify` tests execution time

### DIFF
--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -12,7 +12,6 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from errno import EPERM
-from functools import cache
 from socket import AF_INET, AF_INET6, IPPROTO_TCP, SOCK_STREAM, AddressFamily, gaierror
 from types import FunctionType
 from typing import TYPE_CHECKING, Any
@@ -132,7 +131,7 @@ try:
     from twisted.protocols._sni import SNIConnectionCreator
     from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
     from twisted.test.test_sslverify import (
-        certificatesForAuthorityAndServer,
+        _certificatesForAuthorityAndServer,
         makeCertificate,
     )
 
@@ -144,16 +143,6 @@ try:
 except ImportError as e:
     skipSSL = True
     skipSSLReason = str(e)
-
-
-@cache
-def _certificatesForEndpointTests(
-    serviceIdentity: str,
-) -> tuple[Certificate, PrivateCertificate]:
-    """
-    Generate and cache certificates for L{TLSEndpointsTests}.
-    """
-    return certificatesForAuthorityAndServer(serviceIdentity)
 
 
 class TestProtocol(Protocol):
@@ -3125,7 +3114,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
             "clientServiceIdentity",
             self.serverServiceIdentity,
         )
-        ca, server = _certificatesForEndpointTests(self.serverServiceIdentity)
+        ca, server = _certificatesForAuthorityAndServer(self.serverServiceIdentity)
 
         self.serverCert = server
         shouldSendServerName = getattr(
@@ -3348,7 +3337,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         private keys are found a warning is logged.
         """
         logObserver = EventLoggingObserver.createWithCleanup(self, globalLogPublisher)
-        untrustedCA, unusedCert = certificatesForAuthorityAndServer(
+        untrustedCA, unusedCert = _certificatesForAuthorityAndServer(
             self.serverServiceIdentity
         )
         # superclass (Certificate.dumpPEM) does not include private key in
@@ -3664,7 +3653,7 @@ class ServerStringTests(unittest.TestCase):
         p = FilePath(tmp)
         p.createDirectory()
         # create a temporary directory with a certificate in it, so we have a default certificate
-        authCert, serverCert = certificatesForAuthorityAndServer()
+        authCert, serverCert = _certificatesForAuthorityAndServer()
         p.child("some.pem").setContent(serverCert.dumpPEM())
         server = endpoints.serverFromString(
             reactor,

--- a/src/twisted/internet/test/test_endpoints.py
+++ b/src/twisted/internet/test/test_endpoints.py
@@ -131,7 +131,7 @@ try:
     from twisted.protocols._sni import SNIConnectionCreator
     from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
     from twisted.test.test_sslverify import (
-        _certificatesForAuthorityAndServer,
+        certificatesForAuthorityAndServer,
         makeCertificate,
     )
 
@@ -3114,7 +3114,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
             "clientServiceIdentity",
             self.serverServiceIdentity,
         )
-        ca, server = _certificatesForAuthorityAndServer(self.serverServiceIdentity)
+        ca, server = certificatesForAuthorityAndServer(self.serverServiceIdentity)
 
         self.serverCert = server
         shouldSendServerName = getattr(
@@ -3337,7 +3337,7 @@ class TLSEndpointsTests(EndpointTestCaseMixin, unittest.TestCase):
         private keys are found a warning is logged.
         """
         logObserver = EventLoggingObserver.createWithCleanup(self, globalLogPublisher)
-        untrustedCA, unusedCert = _certificatesForAuthorityAndServer(
+        untrustedCA, unusedCert = certificatesForAuthorityAndServer(
             self.serverServiceIdentity
         )
         # superclass (Certificate.dumpPEM) does not include private key in
@@ -3653,7 +3653,7 @@ class ServerStringTests(unittest.TestCase):
         p = FilePath(tmp)
         p.createDirectory()
         # create a temporary directory with a certificate in it, so we have a default certificate
-        authCert, serverCert = _certificatesForAuthorityAndServer()
+        authCert, serverCert = certificatesForAuthorityAndServer()
         p.child("some.pem").setContent(serverCert.dumpPEM())
         server = endpoints.serverFromString(
             reactor,

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2206,9 +2206,9 @@ class ServiceIdentityTests(SynchronousTestCase):
         if serverVerifies or (clientPresentsCertificate and validClientCertificate):
             clientAuthority = TestingAuthority.create()
 
-            if serverVerifies:
-                clientCA = clientAuthority.authorityCertificate()
-                other.update(trustRoot=clientCA)
+        if serverVerifies:
+            clientCA = clientAuthority.authorityCertificate()
+            other.update(trustRoot=clientCA)
 
         if not validCertificate or (
             clientPresentsCertificate and not validClientCertificate

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -765,20 +765,24 @@ class OpenSSLOptionsTestsMixin:
     serverPort = clientConn = None
     onServerLost = onClientLost = None
 
-    def setUp(self):
-        """
-        Create class variables of client and server certificates.
-        """
-        self.sKey, self.sCert = makeCertificate(
-            O=b"Server Test Certificate", CN=b"server"
-        )
-        self.cKey, self.cCert = makeCertificate(
-            O=b"Client Test Certificate", CN=b"client"
-        )
-        self.caCert1 = makeCertificate(O=b"CA Test Certificate 1", CN=b"ca1")[1]
-        self.caCert2 = makeCertificate(O=b"CA Test Certificate", CN=b"ca2")[1]
-        self.caCerts = [self.caCert1, self.caCert2]
-        self.extraCertChain = self.caCerts
+    # Not all tests require a certificate. So lazily create them only when the attribute is acessed.
+    def __getattr__(self, name):
+        if name in ("sKey", "sCert"):
+            self.sKey, self.sCert = makeCertificate(
+                O=b"Server Test Certificate", CN=b"server"
+            )
+        elif name in ("cKey", "cCert"):
+            self.cKey, self.cCert = makeCertificate(
+                O=b"Client Test Certificate", CN=b"client"
+            )
+        elif name in ("caCert1", "caCert2", "caCerts", "extraCertChain"):
+            self.caCert1 = makeCertificate(O=b"CA Test Certificate 1", CN=b"ca1")[1]
+            self.caCert2 = makeCertificate(O=b"CA Test Certificate", CN=b"ca2")[1]
+            self.caCerts = [self.caCert1, self.caCert2]
+            self.extraCertChain = self.caCerts
+        else:
+            raise AttributeError(name)
+        return getattr(self, name)
 
     def tearDown(self):
         if self.serverPort is not None:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -769,24 +769,36 @@ class OpenSSLOptionsTestsMixin:
     serverPort = clientConn = None
     onServerLost = onClientLost = None
 
-    # Not all tests require a certificate. So lazily create them only when the attribute is acessed.
-    def __getattr__(self, name):
-        if name in ("sKey", "sCert"):
+    def _setUpCertificates(
+        self,
+        *,
+        serverCertificate: bool = True,
+        client: bool = False,
+        authorities: bool = False,
+    ) -> None:
+        """
+        Only create certificates and keys required by a test.
+
+        A server key is always created. The server certificate, client certificate,
+        and authority certificates are optional.
+        """
+        if serverCertificate:
             self.sKey, self.sCert = makeCertificate(
                 O=b"Server Test Certificate", CN=b"server"
             )
-        elif name in ("cKey", "cCert"):
+        else:
+            self.sKey = _keyPair(b"server").original
+
+        if client:
             self.cKey, self.cCert = makeCertificate(
                 O=b"Client Test Certificate", CN=b"client"
             )
-        elif name in ("caCert1", "caCert2", "caCerts", "extraCertChain"):
+
+        if authorities:
             self.caCert1 = makeCertificate(O=b"CA Test Certificate 1", CN=b"ca1")[1]
             self.caCert2 = makeCertificate(O=b"CA Test Certificate", CN=b"ca2")[1]
             self.caCerts = [self.caCert1, self.caCert2]
             self.extraCertChain = self.caCerts
-        else:
-            raise AttributeError(name)
-        return getattr(self, name)
 
     def tearDown(self):
         if self.serverPort is not None:
@@ -839,8 +851,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
 
     def setUp(self):
         """
-        Same as L{OpenSSLOptionsTestsMixin.setUp}, but it also patches
-        L{sslverify._ChooseDiffieHellmanEllipticCurve}.
+        Patches L{sslverify._ChooseDiffieHellmanEllipticCurve}.
         """
         super().setUp()
         self.patch(
@@ -853,6 +864,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{privateKey} and C{certificate} make only sense if both are set.
         """
+        self._setUpCertificates(serverCertificate=False)
         self.assertRaises(
             ValueError, sslverify.OpenSSLCertificateOptions, privateKey=self.sKey
         )
@@ -861,6 +873,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{privateKey} and C{certificate} make only sense if both are set.
         """
+        self._setUpCertificates()
         self.assertRaises(
             ValueError, sslverify.OpenSSLCertificateOptions, certificate=self.sCert
         )
@@ -869,6 +882,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Specifying C{privateKey} and C{certificate} initializes correctly.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert
         )
@@ -880,6 +894,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{verify} must not be C{True} without specifying C{caCerts}.
         """
+        self._setUpCertificates()
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -894,6 +909,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         by the caller (to be I{any} value, even the default!) when specifying
         C{trustRoot}.
         """
+        self._setUpCertificates(authorities=True)
         self.assertRaises(
             TypeError,
             sslverify.OpenSSLCertificateOptions,
@@ -916,6 +932,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         It's currently a NOP, but valid.
         """
+        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert, caCerts=self.caCerts
         )
@@ -926,6 +943,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Specifying C{verify} and C{caCerts} initializes correctly.
         """
+        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -940,6 +958,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Setting C{extraCertChain} works if C{certificate} and C{privateKey} are
         set along with it.
         """
+        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -952,6 +971,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         A C{extraCertChain} without C{privateKey} doesn't make sense and is
         thus rejected.
         """
+        self._setUpCertificates(authorities=True)
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -964,6 +984,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         A C{extraCertChain} without C{certificate} doesn't make sense and is
         thus rejected.
         """
+        self._setUpCertificates(serverCertificate=False, authorities=True)
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -977,6 +998,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         specified chain certificates are added to C{Context}s that get
         created.
         """
+        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -992,6 +1014,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{extraCertChain} doesn't break C{OpenSSL.SSL.Context} creation.
         """
+        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1006,6 +1029,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         default is used.  We can't check directly for it because the effective
         cipher string we set varies with platforms.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1019,6 +1043,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         If there is no valid cipher that matches the user's wishes,
         a L{ValueError} is raised.
         """
+        self._setUpCertificates()
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -1033,6 +1058,8 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         If acceptable ciphers are passed, they are used.
         """
+
+        self._setUpCertificates()
 
         @implementer(interfaces.IAcceptableCiphers)
         class FakeAcceptableCiphers:
@@ -1053,6 +1080,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Every context must have C{OP_NO_SSLv2}, C{OP_NO_COMPRESSION}, and
         C{OP_CIPHER_SERVER_PREFERENCE} set.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1068,6 +1096,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Every context must be in C{MODE_RELEASE_BUFFERS} mode.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1081,6 +1110,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         If C{singleUseKeys} is set, every context must have
         C{OP_SINGLE_DH_USE} and C{OP_SINGLE_ECDH_USE} set.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1096,6 +1126,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing C{method} to L{sslverify.OpenSSLCertificateOptions} is
         deprecated.
         """
+        self._setUpCertificates()
         sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1121,6 +1152,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         TLS version v1.2, if no C{method}, or C{insecurelyLowerMinimumTo} is
         given.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert
         )
@@ -1142,6 +1174,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1160,6 +1193,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1178,6 +1212,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1196,6 +1231,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1246,6 +1282,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing out of order TLS versions to C{insecurelyLowerMinimumTo} and
         C{lowerMaximumSecurityTo} will cause it to raise an exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(ValueError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1269,6 +1306,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing out of order TLS versions to C{raiseMinimumTo} and
         C{lowerMaximumSecurityTo} will cause it to raise an exception.
         """
+        self._setUpCertificates()
         with self.assertRaises(ValueError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1289,6 +1327,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} set, and C{lowerMaximumSecurityTo} is
         below the minimum default, the minimum will be made the new maximum.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1313,6 +1352,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to
         SSLv3, it will exclude all others.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1340,6 +1380,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.0,
         it will exclude all others.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1367,6 +1408,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.1,
         it will exclude all others.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1394,6 +1436,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.2,
         it will exclude all others.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1422,6 +1465,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{lowerMaximumSecurityTo} to TLSv1.2, it will exclude both SSLv2/v3 and
         TLSv1.3.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1447,6 +1491,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{raiseMinimumTo} set to TLSv1.2, it will ignore all TLSs below
         1.2 and SSL.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1470,6 +1515,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{raiseMinimumTo} set to a value lower than Twisted's default will
         cause it to use the more secure default.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1497,6 +1543,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} set to TLSv1.2, it will ignore all TLSs below
         1.2 and SSL.
         """
+        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1518,6 +1565,8 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         If C{dhParams} is set, they are loaded into each new context.
         """
+
+        self._setUpCertificates()
 
         class FakeDiffieHellmanParameters:
             _dhFile = FilePath(b"dh.params")
@@ -1721,6 +1770,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Test that __setstate__(__getstate__()) round-trips properly.
         """
+        self._setUpCertificates()
         firstOpts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1784,6 +1834,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that anonymous connections are allowed when certificates aren't
         required on the server.
         """
+        self._setUpCertificates()
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -1802,6 +1853,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that anonymous connections are refused when certificates are
         required on the server.
         """
+        self._setUpCertificates()
         onServerLost = defer.Deferred()
         onClientLost = defer.Deferred()
         self.loopback(
@@ -1836,6 +1888,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that connecting with a certificate not accepted by the server CA
         fails.
         """
+        self._setUpCertificates(client=True)
         onServerLost = defer.Deferred()
         onClientLost = defer.Deferred()
         self.loopback(
@@ -1866,6 +1919,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Test a successful connection with client certificate validation on
         server side.
         """
+        self._setUpCertificates()
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -1889,6 +1943,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Test a successful connection with validation on both server and client
         sides.
         """
+        self._setUpCertificates(client=True)
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -1970,6 +2025,7 @@ class OpenSSLOptionsECDHIntegrationTests(OpenSSLOptionsTestsMixin, TestCase):
         if not get_elliptic_curves():
             raise SkipTest("OpenSSL does not support ECDH.")
 
+        self._setUpCertificates()
         onData = defer.Deferred()
         # TLS 1.3 cipher suites do not specify the key exchange
         # mechanism:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -156,17 +156,27 @@ def _authorityKey(role: str) -> RSAPrivateKey:
     )
 
 
-def makeCertificate(**kw):
-    distinguishedName = sslverify.DistinguishedName(**kw)
-    keyPair = _keyPair(distinguishedName.commonName)
-    certificateRequest = keyPair.certificateRequest(distinguishedName)
-    certificateData = keyPair.signCertificateRequest(
+@cache
+def _certificateData(keyPair: sslverify.KeyPair, **fields: str | bytes) -> bytes:
+    """
+    Create and cache certificate data.
+    """
+    distinguishedName = sslverify.DistinguishedName(**fields)
+    certificateRequest = keyPair.requestObject(distinguishedName)
+    certificate = keyPair.signRequestObject(
         distinguishedName,
         certificateRequest,
-        lambda dn: True,
         counter(),
     )
-    certificate = keyPair.newCertificate(certificateData)
+
+    return certificate.dump()  # type: ignore[no-any-return]
+
+
+def makeCertificate(**kw: str | bytes) -> tuple[PKey, X509]:
+    distinguishedName = sslverify.DistinguishedName(**kw)
+    keyPair = _keyPair(distinguishedName.commonName)
+
+    certificate = keyPair.newCertificate(_certificateData(keyPair, **kw))
 
     return keyPair.original, certificate.original
 
@@ -771,31 +781,19 @@ class OpenSSLOptionsTestsMixin:
     serverPort = clientConn = None
     onServerLost = onClientLost = None
 
-    def _setUpCertificates(
-        self,
-        *,
-        client: bool = False,
-        authorities: bool = False,
-    ) -> None:
-        """
-        Only create certificates and keys required by a test.
-
-        A server certificate is always created. Client certificate and authority certificates are optional.
-        """
+    def setUp(self):
         self.sKey, self.sCert = makeCertificate(
             O=b"Server Test Certificate", CN=b"server"
         )
 
-        if client:
-            self.cKey, self.cCert = makeCertificate(
-                O=b"Client Test Certificate", CN=b"client"
-            )
+        self.cKey, self.cCert = makeCertificate(
+            O=b"Client Test Certificate", CN=b"client"
+        )
 
-        if authorities:
-            self.caCert1 = makeCertificate(O=b"CA Test Certificate 1", CN=b"ca1")[1]
-            self.caCert2 = makeCertificate(O=b"CA Test Certificate", CN=b"ca2")[1]
-            self.caCerts = [self.caCert1, self.caCert2]
-            self.extraCertChain = self.caCerts
+        self.caCert1 = makeCertificate(O=b"CA Test Certificate 1", CN=b"ca1")[1]
+        self.caCert2 = makeCertificate(O=b"CA Test Certificate", CN=b"ca2")[1]
+        self.caCerts = [self.caCert1, self.caCert2]
+        self.extraCertChain = self.caCerts
 
     def tearDown(self):
         if self.serverPort is not None:
@@ -861,7 +859,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{privateKey} and C{certificate} make only sense if both are set.
         """
-        self._setUpCertificates()
         self.assertRaises(
             ValueError, sslverify.OpenSSLCertificateOptions, privateKey=self.sKey
         )
@@ -870,7 +867,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{privateKey} and C{certificate} make only sense if both are set.
         """
-        self._setUpCertificates()
         self.assertRaises(
             ValueError, sslverify.OpenSSLCertificateOptions, certificate=self.sCert
         )
@@ -879,7 +875,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Specifying C{privateKey} and C{certificate} initializes correctly.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert
         )
@@ -891,7 +886,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{verify} must not be C{True} without specifying C{caCerts}.
         """
-        self._setUpCertificates()
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -906,7 +900,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         by the caller (to be I{any} value, even the default!) when specifying
         C{trustRoot}.
         """
-        self._setUpCertificates(authorities=True)
         self.assertRaises(
             TypeError,
             sslverify.OpenSSLCertificateOptions,
@@ -929,7 +922,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         It's currently a NOP, but valid.
         """
-        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert, caCerts=self.caCerts
         )
@@ -940,7 +932,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Specifying C{verify} and C{caCerts} initializes correctly.
         """
-        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -955,7 +946,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Setting C{extraCertChain} works if C{certificate} and C{privateKey} are
         set along with it.
         """
-        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -968,7 +958,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         A C{extraCertChain} without C{privateKey} doesn't make sense and is
         thus rejected.
         """
-        self._setUpCertificates(authorities=True)
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -981,7 +970,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         A C{extraCertChain} without C{certificate} doesn't make sense and is
         thus rejected.
         """
-        self._setUpCertificates(authorities=True)
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -995,7 +983,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         specified chain certificates are added to C{Context}s that get
         created.
         """
-        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1011,7 +998,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{extraCertChain} doesn't break C{OpenSSL.SSL.Context} creation.
         """
-        self._setUpCertificates(authorities=True)
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1026,7 +1012,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         default is used.  We can't check directly for it because the effective
         cipher string we set varies with platforms.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1040,7 +1025,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         If there is no valid cipher that matches the user's wishes,
         a L{ValueError} is raised.
         """
-        self._setUpCertificates()
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,
@@ -1055,8 +1039,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         If acceptable ciphers are passed, they are used.
         """
-
-        self._setUpCertificates()
 
         @implementer(interfaces.IAcceptableCiphers)
         class FakeAcceptableCiphers:
@@ -1077,7 +1059,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Every context must have C{OP_NO_SSLv2}, C{OP_NO_COMPRESSION}, and
         C{OP_CIPHER_SERVER_PREFERENCE} set.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1093,7 +1074,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Every context must be in C{MODE_RELEASE_BUFFERS} mode.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1107,7 +1087,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         If C{singleUseKeys} is set, every context must have
         C{OP_SINGLE_DH_USE} and C{OP_SINGLE_ECDH_USE} set.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1123,7 +1102,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing C{method} to L{sslverify.OpenSSLCertificateOptions} is
         deprecated.
         """
-        self._setUpCertificates()
         sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1149,7 +1127,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         TLS version v1.2, if no C{method}, or C{insecurelyLowerMinimumTo} is
         given.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey, certificate=self.sCert
         )
@@ -1171,7 +1148,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1190,7 +1166,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1209,7 +1184,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1228,7 +1202,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         L{sslverify.OpenSSLCertificateOptions} will cause it to raise an
         exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(TypeError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1279,7 +1252,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing out of order TLS versions to C{insecurelyLowerMinimumTo} and
         C{lowerMaximumSecurityTo} will cause it to raise an exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(ValueError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1303,7 +1275,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Passing out of order TLS versions to C{raiseMinimumTo} and
         C{lowerMaximumSecurityTo} will cause it to raise an exception.
         """
-        self._setUpCertificates()
         with self.assertRaises(ValueError) as e:
             sslverify.OpenSSLCertificateOptions(
                 privateKey=self.sKey,
@@ -1324,7 +1295,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} set, and C{lowerMaximumSecurityTo} is
         below the minimum default, the minimum will be made the new maximum.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1349,7 +1319,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to
         SSLv3, it will exclude all others.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1377,7 +1346,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.0,
         it will exclude all others.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1405,7 +1373,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.1,
         it will exclude all others.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1433,7 +1400,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} and C{lowerMaximumSecurityTo} set to v1.2,
         it will exclude all others.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1462,7 +1428,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{lowerMaximumSecurityTo} to TLSv1.2, it will exclude both SSLv2/v3 and
         TLSv1.3.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1488,7 +1453,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{raiseMinimumTo} set to TLSv1.2, it will ignore all TLSs below
         1.2 and SSL.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1512,7 +1476,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{raiseMinimumTo} set to a value lower than Twisted's default will
         cause it to use the more secure default.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1540,7 +1503,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         C{insecurelyLowerMinimumTo} set to TLSv1.2, it will ignore all TLSs below
         1.2 and SSL.
         """
-        self._setUpCertificates()
         opts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1562,8 +1524,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         If C{dhParams} is set, they are loaded into each new context.
         """
-
-        self._setUpCertificates()
 
         class FakeDiffieHellmanParameters:
             _dhFile = FilePath(b"dh.params")
@@ -1767,7 +1727,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         Test that __setstate__(__getstate__()) round-trips properly.
         """
-        self._setUpCertificates()
         firstOpts = sslverify.OpenSSLCertificateOptions(
             privateKey=self.sKey,
             certificate=self.sCert,
@@ -1831,7 +1790,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that anonymous connections are allowed when certificates aren't
         required on the server.
         """
-        self._setUpCertificates()
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -1850,7 +1808,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that anonymous connections are refused when certificates are
         required on the server.
         """
-        self._setUpCertificates()
         onServerLost = defer.Deferred()
         onClientLost = defer.Deferred()
         self.loopback(
@@ -1885,7 +1842,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Check that connecting with a certificate not accepted by the server CA
         fails.
         """
-        self._setUpCertificates(client=True)
         onServerLost = defer.Deferred()
         onClientLost = defer.Deferred()
         self.loopback(
@@ -1916,7 +1872,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Test a successful connection with client certificate validation on
         server side.
         """
-        self._setUpCertificates()
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -1940,7 +1895,6 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         Test a successful connection with validation on both server and client
         sides.
         """
-        self._setUpCertificates(client=True)
         onData = defer.Deferred()
         self.loopback(
             sslverify.OpenSSLCertificateOptions(
@@ -2022,7 +1976,6 @@ class OpenSSLOptionsECDHIntegrationTests(OpenSSLOptionsTestsMixin, TestCase):
         if not get_elliptic_curves():
             raise SkipTest("OpenSSL does not support ECDH.")
 
-        self._setUpCertificates()
         onData = defer.Deferred()
         # TLS 1.3 cipher suites do not specify the key exchange
         # mechanism:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -294,16 +294,6 @@ def certificatesForAuthorityAndServer(
     )
 
 
-@cache
-def _certificatesForAuthorityAndServer(
-    serviceIdentity: str = "example.com",
-) -> tuple[sslverify.Certificate, sslverify.PrivateCertificate]:
-    """
-    Generate and cache certificates shared by TLS connection tests.
-    """
-    return certificatesForAuthorityAndServer(serviceIdentity)
-
-
 class GreetingServer(protocol.Protocol):
     greeting = b"greetings!"
 
@@ -2146,7 +2136,7 @@ class TrustRootTests(TestCase):
         completely invalid / unknown root CA certificates.  This is simply a
         smoke test to make sure that verification is happening at all.
         """
-        caSelfCert, serverCert = _certificatesForAuthorityAndServer()
+        caSelfCert, serverCert = certificatesForAuthorityAndServer()
         chainedCert = pathContainingDumpOf(self, serverCert, caSelfCert)
         privateKey = pathContainingDumpOf(self, serverCert.privateKey)
 
@@ -2170,7 +2160,7 @@ class TrustRootTests(TestCase):
         Specifying a L{Certificate} object for L{trustRoot} will result in that
         certificate being the only trust root for a client.
         """
-        caCert, serverCert = _certificatesForAuthorityAndServer()
+        caCert, serverCert = certificatesForAuthorityAndServer()
         sProto, cProto, sWrapped, cWrapped, pump = loopbackTLSConnection(
             trustRoot=caCert,
             privateKeyFile=pathContainingDumpOf(self, serverCert.privateKey),
@@ -2674,7 +2664,7 @@ def negotiateProtocol(
     @return: A L{tuple} of the negotiated protocol and the reason the
         connection was lost.
     """
-    caCertificate, serverCertificate = _certificatesForAuthorityAndServer()
+    caCertificate, serverCertificate = certificatesForAuthorityAndServer()
     trustRoot = sslverify.OpenSSLCertificateAuthorities([caCertificate.original])
 
     sProto, cProto, sWrapped, cWrapped, pump = loopbackTLSConnectionInMemory(
@@ -2936,7 +2926,7 @@ class MultipleCertificateTrustRootTests(TestCase):
         L{optionsForClientTLS} to accept client connections to a server with
         certificate B where B is signed by A.
         """
-        caCert, serverCert = _certificatesForAuthorityAndServer()
+        caCert, serverCert = certificatesForAuthorityAndServer()
 
         trust = sslverify.trustRootFromCertificates([caCert])
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -14,6 +14,7 @@ import itertools
 import textwrap
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from functools import cache
 from typing import Any
 from weakref import ref
 
@@ -275,6 +276,16 @@ def certificatesForAuthorityAndServer(
         authority.authorityCertificate(),
         authority.serverCertificate("Testing Example Server", [serviceIdentity]),
     )
+
+
+@cache
+def _certificatesForAuthorityAndServer(
+    serviceIdentity: str = "example.com",
+) -> tuple[sslverify.Certificate, sslverify.PrivateCertificate]:
+    """
+    Generate and cache certificates shared by TLS connection tests.
+    """
+    return certificatesForAuthorityAndServer(serviceIdentity)
 
 
 class GreetingServer(protocol.Protocol):
@@ -2059,7 +2070,7 @@ class TrustRootTests(TestCase):
         completely invalid / unknown root CA certificates.  This is simply a
         smoke test to make sure that verification is happening at all.
         """
-        caSelfCert, serverCert = certificatesForAuthorityAndServer()
+        caSelfCert, serverCert = _certificatesForAuthorityAndServer()
         chainedCert = pathContainingDumpOf(self, serverCert, caSelfCert)
         privateKey = pathContainingDumpOf(self, serverCert.privateKey)
 
@@ -2083,7 +2094,7 @@ class TrustRootTests(TestCase):
         Specifying a L{Certificate} object for L{trustRoot} will result in that
         certificate being the only trust root for a client.
         """
-        caCert, serverCert = certificatesForAuthorityAndServer()
+        caCert, serverCert = _certificatesForAuthorityAndServer()
         sProto, cProto, sWrapped, cWrapped, pump = loopbackTLSConnection(
             trustRoot=caCert,
             privateKeyFile=pathContainingDumpOf(self, serverCert.privateKey),
@@ -2584,7 +2595,7 @@ def negotiateProtocol(
     @return: A L{tuple} of the negotiated protocol and the reason the
         connection was lost.
     """
-    caCertificate, serverCertificate = certificatesForAuthorityAndServer()
+    caCertificate, serverCertificate = _certificatesForAuthorityAndServer()
     trustRoot = sslverify.OpenSSLCertificateAuthorities([caCertificate.original])
 
     sProto, cProto, sWrapped, cWrapped, pump = loopbackTLSConnectionInMemory(
@@ -2846,7 +2857,7 @@ class MultipleCertificateTrustRootTests(TestCase):
         L{optionsForClientTLS} to accept client connections to a server with
         certificate B where B is signed by A.
         """
-        caCert, serverCert = certificatesForAuthorityAndServer()
+        caCert, serverCert = _certificatesForAuthorityAndServer()
 
         trust = sslverify.trustRootFromCertificates([caCert])
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3453,11 +3453,13 @@ class KeyPairTests(TestCase):
     if skipSSL:
         skip = skipSSL
 
-    def setUp(self):
-        """
-        Create test certificate.
-        """
-        self.sKey = makeCertificate(O=b"Server Test Certificate", CN=b"server")[0]
+    def __getattr__(self, name):
+        if name == "sKey":
+            self.sKey = PKey()
+            self.sKey.generate_key(TYPE_RSA, 2048)
+        else:
+            raise AttributeError(name)
+        return getattr(self, name)
 
     def test_getstateDeprecation(self):
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -142,6 +142,20 @@ def _keyPair(role: bytes) -> sslverify.KeyPair:
     """
     return sslverify.KeyPair.generate(kind=TYPE_RSA, size=2048)
 
+
+@cache
+def _authorityKey(role: str) -> RSAPrivateKey:
+    """
+    Generate one RSA-4096 private key for an authority, client or server.
+    The role parameter used to provide a unique identifier for the cache.
+    """
+    return generate_private_key(
+        public_exponent=65537,
+        key_size=4096,
+        backend=default_backend(),
+    )
+
+
 def makeCertificate(**kw):
     distinguishedName = sslverify.DistinguishedName(**kw)
     keyPair = _keyPair(distinguishedName.commonName)
@@ -168,14 +182,14 @@ class TestingAuthority:
 
     @classmethod
     def create(
-        cls, aroundTimestamp: datetime.datetime = datetime.datetime.today()
+        cls,
+        aroundTimestamp: datetime.datetime = datetime.datetime.today(),
+        role: str = "authority",
     ) -> TestingAuthority:
         commonNameForCA = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
         )
-        privateKeyForCA = generate_private_key(
-            public_exponent=65537, key_size=4096, backend=default_backend()
-        )
+        privateKeyForCA = _authorityKey(role)
         publicKeyForCA = privateKeyForCA.public_key()
         caCertificate = (
             x509.CertificateBuilder()
@@ -201,9 +215,7 @@ class TestingAuthority:
     def serverCertificate(
         self, commonName: str, subjects: list[str]
     ) -> sslverify.PrivateCertificate:
-        privateKeyForServer = generate_private_key(
-            public_exponent=65537, key_size=4096, backend=default_backend()
-        )
+        privateKeyForServer = _authorityKey(commonName)
         publicKeyForServer = privateKeyForServer.public_key()
         commonNameForServer = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, commonName)]
@@ -2259,12 +2271,12 @@ class ServiceIdentityTests(SynchronousTestCase):
             called, will move data between the created client and server
             protocol instances
         """
-        serverAuthority = TestingAuthority.create()
+        serverAuthority = TestingAuthority.create(role="server")
         serverCA = serverAuthority.authorityCertificate()
         other: dict[str, Any] = {}
         passClientCert = None
         if serverVerifies or (clientPresentsCertificate and validClientCertificate):
-            clientAuthority = TestingAuthority.create()
+            clientAuthority = TestingAuthority.create(role="client")
 
         if serverVerifies:
             clientCA = clientAuthority.authorityCertificate()
@@ -2276,7 +2288,7 @@ class ServiceIdentityTests(SynchronousTestCase):
             if not validCertificate and useDefaultTrust and not fakePlatformTrust:
                 untrustedAuthority = serverAuthority
             else:
-                untrustedAuthority = TestingAuthority.create()
+                untrustedAuthority = TestingAuthority.create(role="untrusted")
 
         if clientPresentsCertificate:
             if validClientCertificate:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3518,13 +3518,11 @@ class KeyPairTests(TestCase):
     if skipSSL:
         skip = skipSSL
 
-    def __getattr__(self, name):
-        if name == "sKey":
-            self.sKey = PKey()
-            self.sKey.generate_key(TYPE_RSA, 2048)
-        else:
-            raise AttributeError(name)
-        return getattr(self, name)
+    def setUp(self):
+        """
+        Create test certificate.
+        """
+        self.sKey = makeCertificate(O=b"Server Test Certificate", CN=b"server")[0]
 
     def test_getstateDeprecation(self):
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2213,7 +2213,10 @@ class ServiceIdentityTests(SynchronousTestCase):
         if not validCertificate or (
             clientPresentsCertificate and not validClientCertificate
         ):
-            untrustedAuthority = TestingAuthority.create()
+            if not validCertificate and useDefaultTrust and not fakePlatformTrust:
+                untrustedAuthority = serverAuthority
+            else:
+                untrustedAuthority = TestingAuthority.create()
 
         if clientPresentsCertificate:
             if validClientCertificate:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2184,27 +2184,37 @@ class ServiceIdentityTests(SynchronousTestCase):
             called, will move data between the created client and server
             protocol instances
         """
-        clientAuthority = TestingAuthority.create()
         serverAuthority = TestingAuthority.create()
-        untrustedAuthority = TestingAuthority.create()
         serverCA = serverAuthority.authorityCertificate()
-        serverCert = serverAuthority.serverCertificate("Valid Cert", [serverHostname])
         other: dict[str, Any] = {}
         passClientCert = None
-        clientCA = clientAuthority.authorityCertificate()
-        clientCert = clientAuthority.serverCertificate("Client Cert", ["client"])
-        if serverVerifies:
-            other.update(trustRoot=clientCA)
+        if serverVerifies or (clientPresentsCertificate and validClientCertificate):
+            clientAuthority = TestingAuthority.create()
+
+            if serverVerifies:
+                clientCA = clientAuthority.authorityCertificate()
+                other.update(trustRoot=clientCA)
+
+        if not validCertificate or (
+            clientPresentsCertificate and not validClientCertificate
+        ):
+            untrustedAuthority = TestingAuthority.create()
 
         if clientPresentsCertificate:
             if validClientCertificate:
-                passClientCert = clientCert
+                passClientCert = clientAuthority.serverCertificate(
+                    "Client Cert", ["client"]
+                )
             else:
                 passClientCert = untrustedAuthority.serverCertificate(
                     "Client Cert", ["client"]
                 )
 
-        if not validCertificate:
+        if validCertificate:
+            serverCert = serverAuthority.serverCertificate(
+                "Valid Cert", [serverHostname]
+            )
+        else:
             serverCert = untrustedAuthority.serverCertificate(
                 "Invalid Cert", [serverHostname]
             )

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -143,17 +143,30 @@ def _keyPair(role: bytes) -> sslverify.KeyPair:
     return sslverify.KeyPair.generate(kind=TYPE_RSA, size=2048)
 
 
-@cache
-def _authorityKey(role: str) -> RSAPrivateKey:
-    """
-    Generate one RSA-4096 private key for an authority, client or server.
-    The role parameter used to provide a unique identifier for the cache.
-    """
+def _generatePrivateKey() -> RSAPrivateKey:
     return generate_private_key(
         public_exponent=65537,
         key_size=4096,
         backend=default_backend(),
     )
+
+
+@cache
+def _certificateAuthorityPrivateKey(uniqueName: str) -> RSAPrivateKey:
+    """
+    Return a cached private key for the certificate authority identified by
+    C{uniqueName}.
+    """
+    return _generatePrivateKey()
+
+
+@cache
+def _leafPrivateKey(uniqueName: str) -> RSAPrivateKey:
+    """
+    Return a cached private key for the leaf certificate identified by
+    C{uniqueName}.
+    """
+    return _generatePrivateKey()
 
 
 @cache
@@ -193,13 +206,13 @@ class TestingAuthority:
     @classmethod
     def create(
         cls,
+        uniqueName: str,
         aroundTimestamp: datetime.datetime = datetime.datetime.today(),
-        role: str = "authority",
     ) -> TestingAuthority:
         commonNameForCA = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
         )
-        privateKeyForCA = _authorityKey(role)
+        privateKeyForCA = _certificateAuthorityPrivateKey(uniqueName)
         publicKeyForCA = privateKeyForCA.public_key()
         caCertificate = (
             x509.CertificateBuilder()
@@ -225,7 +238,7 @@ class TestingAuthority:
     def serverCertificate(
         self, commonName: str, subjects: list[str]
     ) -> sslverify.PrivateCertificate:
-        privateKeyForServer = _authorityKey(commonName)
+        privateKeyForServer = _leafPrivateKey(commonName)
         publicKeyForServer = privateKeyForServer.public_key()
         commonNameForServer = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, commonName)]
@@ -297,10 +310,10 @@ def certificatesForAuthorityAndServer(
     @return: a 2-tuple of C{(certificate_authority_certificate,
         server_certificate)}
     """
-    authority = TestingAuthority.create()
+    serverAuthority = TestingAuthority.create("server")
     return (
-        authority.authorityCertificate(),
-        authority.serverCertificate("Testing Example Server", [serviceIdentity]),
+        serverAuthority.authorityCertificate(),
+        serverAuthority.serverCertificate("Testing Example Server", [serviceIdentity]),
     )
 
 
@@ -2209,12 +2222,12 @@ class ServiceIdentityTests(SynchronousTestCase):
             called, will move data between the created client and server
             protocol instances
         """
-        serverAuthority = TestingAuthority.create(role="server")
+        serverAuthority = TestingAuthority.create("server")
         serverCA = serverAuthority.authorityCertificate()
         other: dict[str, Any] = {}
         passClientCert = None
         if serverVerifies or (clientPresentsCertificate and validClientCertificate):
-            clientAuthority = TestingAuthority.create(role="client")
+            clientAuthority = TestingAuthority.create("client")
 
         if serverVerifies:
             clientCA = clientAuthority.authorityCertificate()
@@ -2226,7 +2239,7 @@ class ServiceIdentityTests(SynchronousTestCase):
             if not validCertificate and useDefaultTrust and not fakePlatformTrust:
                 untrustedAuthority = serverAuthority
             else:
-                untrustedAuthority = TestingAuthority.create(role="untrusted")
+                untrustedAuthority = TestingAuthority.create("untrusted")
 
         if clientPresentsCertificate:
             if validClientCertificate:

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -33,7 +33,6 @@ from twisted.internet.interfaces import (
     IProtocolNegotiationFactory,
 )
 from twisted.internet.task import Clock
-from twisted.python.compat import nativeString
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.python.modules import getModule
@@ -135,22 +134,27 @@ def counter(counter=itertools.count()):
     return next(counter)
 
 
+@cache
+def _keyPair(role: bytes) -> sslverify.KeyPair:
+    """
+    Generate one RSA-2048 key pair for a certificate common name.
+    The role parameter used to provide a unique identifier for the cache.
+    """
+    return sslverify.KeyPair.generate(kind=TYPE_RSA, size=2048)
+
 def makeCertificate(**kw):
-    keypair = PKey()
-    keypair.generate_key(TYPE_RSA, 2048)
+    distinguishedName = sslverify.DistinguishedName(**kw)
+    keyPair = _keyPair(distinguishedName.commonName)
+    certificateRequest = keyPair.certificateRequest(distinguishedName)
+    certificateData = keyPair.signCertificateRequest(
+        distinguishedName,
+        certificateRequest,
+        lambda dn: True,
+        counter(),
+    )
+    certificate = keyPair.newCertificate(certificateData)
 
-    certificate = X509()
-    certificate.gmtime_adj_notBefore(0)
-    certificate.gmtime_adj_notAfter(60 * 60 * 24 * 365)  # One year
-    for xname in certificate.get_issuer(), certificate.get_subject():
-        for k, v in kw.items():
-            setattr(xname, k, nativeString(v))
-
-    certificate.set_serial_number(counter())
-    certificate.set_pubkey(keypair)
-    certificate.sign(keypair, "md5")
-
-    return keypair, certificate
+    return keyPair.original, certificate.original
 
 
 oneDay = datetime.timedelta(1, 0, 0)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -774,22 +774,17 @@ class OpenSSLOptionsTestsMixin:
     def _setUpCertificates(
         self,
         *,
-        serverCertificate: bool = True,
         client: bool = False,
         authorities: bool = False,
     ) -> None:
         """
         Only create certificates and keys required by a test.
 
-        A server key is always created. The server certificate, client certificate,
-        and authority certificates are optional.
+        A server certificate is always created. Client certificate and authority certificates are optional.
         """
-        if serverCertificate:
-            self.sKey, self.sCert = makeCertificate(
-                O=b"Server Test Certificate", CN=b"server"
-            )
-        else:
-            self.sKey = _keyPair(b"server").original
+        self.sKey, self.sCert = makeCertificate(
+            O=b"Server Test Certificate", CN=b"server"
+        )
 
         if client:
             self.cKey, self.cCert = makeCertificate(
@@ -866,7 +861,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         """
         C{privateKey} and C{certificate} make only sense if both are set.
         """
-        self._setUpCertificates(serverCertificate=False)
+        self._setUpCertificates()
         self.assertRaises(
             ValueError, sslverify.OpenSSLCertificateOptions, privateKey=self.sKey
         )
@@ -986,7 +981,7 @@ class OpenSSLOptionsTests(OpenSSLOptionsTestsMixin, TestCase):
         A C{extraCertChain} without C{certificate} doesn't make sense and is
         thus rejected.
         """
-        self._setUpCertificates(serverCertificate=False, authorities=True)
+        self._setUpCertificates(authorities=True)
         self.assertRaises(
             ValueError,
             sslverify.OpenSSLCertificateOptions,


### PR DESCRIPTION
## Scope and purpose

Fixes #12752

**Note:** All the speed up results (seconds) in the commit messages are based on results on the Windows 11 machine.

Results on Ubuntu 26.04 and Windows 11 when I execute all `test_sslverify` tests using 

`trial --reporter=timing src/twisted/test/test_sslverify.py > after.txt`


Ubuntu 26.04:
* Before 50.657s
* After: 20.564s
* Note: This is a laptop so is expected to run a bit slower than my Windows 11 results.
* Hardware info:
    * Lenovo ThinkPad T14 Gen 1
    * AMD Ryzen™ 7 PRO 4750U with Radeon™ Graphics × 16
    * 16.0 GiB memory

Windows 11 (25H2 26200.8875):
* Before: 40.079s
* After: 17.046s
* Hardware info:
    * AMD Ryzen 7 5800X3D 8-Core Processor (3.40 GHz) 
    * 32.0 GB memory
* Note: I notice there is a lot of variance on Windows in my results. But always there is a huge improvement between `trunk `and this branch so there is definitely more good than harm in my changes I think. I did not take any significant measures to try and reduce system noise... so my numbers likely have some significant error bars :)

There is also minor improvements for the `test_endpoints` tests, its around 2 seconds faster.

All the code is mine. No LLM involved.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
