### PR TITLE
Reject a bare CR or LF in an HTTP header value (#12754)

### DIFF
--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2499,7 +2499,9 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
             return False
 
         data = data.strip(b" \t")
-        if b"\x00" in data:
+        # Reject NUL, CR, and LF in a header value (RFC 9110 section 5.5); a
+        # bare CR or LF would let a lenient proxy smuggle a following header.
+        if b"\x00" in data or b"\r" in data or b"\n" in data:
             self._respondToBadRequestAndDisconnect()
             return False
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2499,9 +2499,9 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
             return False
 
         data = data.strip(b" \t")
-        # Reject NUL, CR, and LF in a header value (RFC 9110 section 5.5); a
-        # bare CR or LF would let a lenient proxy smuggle a following header.
-        if b"\x00" in data or b"\r" in data or b"\n" in data:
+        # A header value must not contain NUL, CR, or LF (RFC 9110 section 5.5).
+        # A bare CR or LF here would let a lenient proxy smuggle a header.
+        if len(data.translate(None, b"\x00\r\n")) != len(data):
             self._respondToBadRequestAndDisconnect()
             return False
 

--- a/src/twisted/web/http.py
+++ b/src/twisted/web/http.py
@@ -2500,7 +2500,6 @@ class HTTPChannel(basic.LineReceiver, policies.TimeoutMixin):
 
         data = data.strip(b" \t")
         # A header value must not contain NUL, CR, or LF (RFC 9110 section 5.5).
-        # A bare CR or LF here would let a lenient proxy smuggle a header.
         if len(data.translate(None, b"\x00\r\n")) != len(data):
             self._respondToBadRequestAndDisconnect()
             return False

--- a/src/twisted/web/newsfragments/12754.bugfix
+++ b/src/twisted/web/newsfragments/12754.bugfix
@@ -1,0 +1,1 @@
+twisted.web.http.HTTPChannel.headerReceived now rejects a header value that contains a bare carriage return or line feed, closing a request-smuggling gap where such a value could hide a following header from the parser (RFC 9110 section 5.5).

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2196,34 +2196,24 @@ class ParsingTests(unittest.TestCase):
                 [b"GET / HTTP/1.1", b"Host: foo.example", header, b"", b""]
             )
 
-    def test_invalidHeaderValueNUL(self):
+    def test_invalidHeaderValueControlChars(self) -> None:
         """
-        A request with a header value that contains a NUL byte
-        is rejected with a 400 status code.
-        """
-        for header in [
-            b"x-foo: \x00",  # NUL byte
-            b"x-foo: a\x00",  # trailing NUL
-            b"x-foo: \x00baz",  # leading NUL
-            b"x-foo:  \x00\x00\x00x0\0 ",  # lots of NULs
-        ]:
-            self.assertRequestRejected(
-                [b"GET / HTTP/1.1", b"Host: foo.example", header, b"", b""]
-            )
-
-    def test_invalidHeaderValueCRLF(self):
-        """
-        A header value containing a bare CR or LF is rejected with a 400, as
-        required by RFC 9110 section 5.5; accepting it would let a following
-        header be hidden from the parser and enable request smuggling. The bytes
-        are fed directly because L{runRequest} normalises a bare LF to CRLF.
+        A header value containing NUL, CR, or LF is rejected with a 400 (RFC
+        9110 section 5.5). A bare CR or LF would additionally let a following
+        header be hidden from the parser, enabling request smuggling.
         """
         for value in [
-            b"a\nContent-Length: 5",  # bare LF hiding a header
-            b"a\rContent-Length: 5",  # bare CR hiding a header
-            b"a\nb",  # bare LF
+            b"\x00",  # NUL
+            b"a\x00",  # trailing NUL
+            b"\x00baz",  # leading NUL
             b"a\rb",  # bare CR
+            b"a\rContent-Length: 5",  # bare CR hiding a header
         ]:
+            self.assertRequestRejected(
+                [b"GET / HTTP/1.1", b"Host: foo.example", b"x-foo: " + value, b"", b""]
+            )
+        # runRequest normalises a bare LF to CRLF, so feed those bytes directly.
+        for value in [b"a\nb", b"a\nContent-Length: 5"]:
             channel = http.HTTPChannel()
             transport = StringTransport()
             channel.makeConnection(transport)

--- a/src/twisted/web/test/test_http.py
+++ b/src/twisted/web/test/test_http.py
@@ -2211,6 +2211,28 @@ class ParsingTests(unittest.TestCase):
                 [b"GET / HTTP/1.1", b"Host: foo.example", header, b"", b""]
             )
 
+    def test_invalidHeaderValueCRLF(self):
+        """
+        A header value containing a bare CR or LF is rejected with a 400, as
+        required by RFC 9110 section 5.5; accepting it would let a following
+        header be hidden from the parser and enable request smuggling. The bytes
+        are fed directly because L{runRequest} normalises a bare LF to CRLF.
+        """
+        for value in [
+            b"a\nContent-Length: 5",  # bare LF hiding a header
+            b"a\rContent-Length: 5",  # bare CR hiding a header
+            b"a\nb",  # bare LF
+            b"a\rb",  # bare CR
+        ]:
+            channel = http.HTTPChannel()
+            transport = StringTransport()
+            channel.makeConnection(transport)
+            channel.dataReceived(
+                b"GET / HTTP/1.1\r\nHost: foo.example\r\nx-foo: " + value + b"\r\n\r\n"
+            )
+            self.assertTrue(transport.disconnecting)
+            self.assertEqual(transport.value(), b"HTTP/1.1 400 Bad Request\r\n\r\n")
+
     def test_headerLimitPerRequest(self):
         """
         C{HTTPChannel} enforces the limit of C{HTTPChannel.maxHeaders} per


### PR DESCRIPTION
Fixes #12754

This rejects a bare CR or LF in an HTTP header value. `twisted.web.http.HTTPChannel.headerReceived` rejects a NUL byte in a value but not a bare carriage return or line feed. Because the channel splits on CRLF, a header like `Foo: x` followed by a bare LF and `Content-Length: 39` arrives as one line, so the `Content-Length` is folded into the `Foo` value and the request is framed with no body. A front-end that treats the bare LF as a line break reads it as a real header, so the two disagree on where the request ends and a request is smuggled past it.

The fix adds CR and LF to the existing NUL check, so a value with any of the three is rejected with a 400, as RFC 9110 section 5.5 requires. This closes the incomplete fix left by the earlier smuggling advisories. The header name and request line already reject these characters.

New test covers a bare CR and a bare LF in a header value being rejected. The full `twisted.web.test.test_http` passes.
