### PR TITLE
#12758 Drop unused usages of backend parameter when using cryptography

### DIFF
--- a/src/twisted/conch/scripts/ckeygen.py
+++ b/src/twisted/conch/scripts/ckeygen.py
@@ -134,15 +134,12 @@ def handleError():
 
 @_keyGenerator("rsa")
 def generateRSAkey(options):
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric import rsa
 
     if not options["bits"]:
         options["bits"] = 2048
     keyPrimitive = rsa.generate_private_key(
-        key_size=int(options["bits"]),
-        public_exponent=65537,
-        backend=default_backend(),
+        key_size=int(options["bits"]), public_exponent=65537
     )
     key = keys.Key(keyPrimitive)
     _saveKey(key, options)
@@ -150,22 +147,17 @@ def generateRSAkey(options):
 
 @_keyGenerator("dsa")
 def generateDSAkey(options):
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric import dsa
 
     if not options["bits"]:
         options["bits"] = 1024
-    keyPrimitive = dsa.generate_private_key(
-        key_size=int(options["bits"]),
-        backend=default_backend(),
-    )
+    keyPrimitive = dsa.generate_private_key(key_size=int(options["bits"]))
     key = keys.Key(keyPrimitive)
     _saveKey(key, options)
 
 
 @_keyGenerator("ecdsa")
 def generateECDSAkey(options):
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric import ec
 
     if not options["bits"]:
@@ -173,9 +165,7 @@ def generateECDSAkey(options):
     # OpenSSH supports only mandatory sections of RFC5656.
     # See https://www.openssh.com/txt/release-5.7
     curve = b"ecdsa-sha2-nistp" + str(options["bits"]).encode("ascii")
-    keyPrimitive = ec.generate_private_key(
-        curve=keys._curveTable[curve], backend=default_backend()
-    )
+    keyPrimitive = ec.generate_private_key(curve=keys._curveTable[curve])
     key = keys.Key(keyPrimitive)
     _saveKey(key, options)
 

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -19,7 +19,6 @@ import bcrypt
 from constantly import NamedConstant, Names
 from cryptography import utils
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -270,14 +269,14 @@ class Key:
         keyType, rest = common.getNS(blob)
         if keyType == b"ssh-rsa":
             e, n, rest = common.getMP(rest, 2)
-            return cls(rsa.RSAPublicNumbers(e, n).public_key(default_backend()))
+            return cls(rsa.RSAPublicNumbers(e, n).public_key())
 
         if keyType == b"ssh-dss":
             p, q, g, y, rest = common.getMP(rest, 4)
             return cls(
                 dsa.DSAPublicNumbers(
                     y=y, parameter_numbers=dsa.DSAParameterNumbers(p=p, q=q, g=g)
-                ).public_key(default_backend())
+                ).public_key()
             )
 
         if keyType in _curveTable:
@@ -405,7 +404,7 @@ class Key:
         # ECDSA keys don't need base64 decoding which is required
         # for RSA or DSA key.
         if data.startswith(b"ecdsa-sha2"):
-            return cls(load_ssh_public_key(data, default_backend()))
+            return cls(load_ssh_public_key(data))
         blob = decodebytes(data.split()[1])
         return cls._fromString_BLOB(blob)
 
@@ -483,7 +482,6 @@ class Key:
             decryptor = Cipher(
                 algorithmClass(decKey[:keySize]),
                 modes.CTR(decKey[keySize : keySize + ivSize]),
-                backend=default_backend(),
             ).decryptor()
             privKeyList = decryptor.update(encPrivKeyList) + decryptor.finalize()
         else:
@@ -544,7 +542,7 @@ class Key:
             passphrase = None
         if kind in (b"EC", b"RSA", b"DSA"):
             try:
-                key = load_pem_private_key(data, passphrase, default_backend())
+                key = load_pem_private_key(data, passphrase)
             except TypeError:
                 raise EncryptedKeyError(
                     "Passphrase must be provided for an encrypted key"
@@ -786,7 +784,7 @@ class Key:
         publicNumbers = rsa.RSAPublicNumbers(e=e, n=n)
         if d is None:
             # We have public components.
-            keyObject = publicNumbers.public_key(default_backend())
+            keyObject = publicNumbers.public_key()
         else:
             privateNumbers = rsa.RSAPrivateNumbers(
                 p=p,
@@ -797,7 +795,7 @@ class Key:
                 iqmp=rsa.rsa_crt_iqmp(p, q),
                 public_numbers=publicNumbers,
             )
-            keyObject = privateNumbers.private_key(default_backend())
+            keyObject = privateNumbers.private_key()
 
         return cls(keyObject)
 
@@ -829,10 +827,10 @@ class Key:
         )
         if x is None:
             # We have public components.
-            keyObject = publicNumbers.public_key(default_backend())
+            keyObject = publicNumbers.public_key()
         else:
             privateNumbers = dsa.DSAPrivateNumbers(x=x, public_numbers=publicNumbers)
-            keyObject = privateNumbers.private_key(default_backend())
+            keyObject = privateNumbers.private_key()
 
         return cls(keyObject)
 
@@ -859,12 +857,12 @@ class Key:
         )
         if privateValue is None:
             # We have public components.
-            keyObject = publicNumbers.public_key(default_backend())
+            keyObject = publicNumbers.public_key()
         else:
             privateNumbers = ec.EllipticCurvePrivateNumbers(
                 private_value=privateValue, public_numbers=publicNumbers
             )
-            keyObject = privateNumbers.private_key(default_backend())
+            keyObject = privateNumbers.private_key()
 
         return cls(keyObject)
 
@@ -890,9 +888,7 @@ class Key:
                 _curveTable[curve], encodedPoint
             )
         else:
-            keyObject = ec.derive_private_key(
-                privateValue, _curveTable[curve], default_backend()
-            )
+            keyObject = ec.derive_private_key(privateValue, _curveTable[curve])
 
         return cls(keyObject)
 
@@ -1550,9 +1546,7 @@ class Key:
         if passphrase:
             encKey = bcrypt.kdf(passphrase, salt, keySize + ivSize, 100)
             encryptor = Cipher(
-                cipher(encKey[:keySize]),
-                modes.CTR(encKey[keySize : keySize + ivSize]),
-                backend=default_backend(),
+                cipher(encKey[:keySize]), modes.CTR(encKey[keySize : keySize + ivSize])
             ).encryptor()
             encPrivKeyList = encryptor.update(privKeyList) + encryptor.finalize()
         else:
@@ -1915,9 +1909,7 @@ def _getPersistentRSAKey(location, keySize=4096):
 
     # If it doesn't exist, we want to generate a new key and save it
     if not location.exists():
-        privateKey = rsa.generate_private_key(
-            public_exponent=65537, key_size=keySize, backend=default_backend()
-        )
+        privateKey = rsa.generate_private_key(public_exponent=65537, key_size=keySize)
 
         pem = privateKey.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -1932,7 +1924,5 @@ def _getPersistentRSAKey(location, keySize=4096):
     # (Future archaeological readers: I chose not to short circuit above,
     # because then there's two exit paths to this code!)
     with location.open("rb") as keyFile:
-        privateKey = serialization.load_pem_private_key(
-            keyFile.read(), password=None, backend=default_backend()
-        )
+        privateKey = serialization.load_pem_private_key(keyFile.read(), password=None)
         return Key(privateKey)

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -21,6 +21,10 @@ from cryptography import utils
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, padding, rsa
+from cryptography.hazmat.primitives.asymmetric.utils import (
+    decode_dss_signature,
+    encode_dss_signature,
+)
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
@@ -32,18 +36,6 @@ from twisted.conch.ssh.common import int_to_bytes
 from twisted.python import randbytes
 from twisted.python.compat import iterbytes, nativeString
 from twisted.python.deprecate import _mutuallyExclusiveArguments
-
-try:
-    from cryptography.hazmat.primitives.asymmetric.utils import (
-        decode_dss_signature,
-        encode_dss_signature,
-    )
-except ImportError:
-    from cryptography.hazmat.primitives.asymmetric.utils import (  # type: ignore[no-redef,attr-defined]
-        decode_rfc6979_signature as decode_dss_signature,
-        encode_rfc6979_signature as encode_dss_signature,
-    )
-
 
 # Curve lookup table
 _curveTable = {

--- a/src/twisted/conch/ssh/keys.py
+++ b/src/twisted/conch/ssh/keys.py
@@ -30,6 +30,7 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
     load_ssh_public_key,
 )
+from typing_extensions import Self
 
 from twisted.conch.ssh import common, sexpy
 from twisted.conch.ssh.common import int_to_bytes
@@ -827,34 +828,26 @@ class Key:
         return cls(keyObject)
 
     @classmethod
-    def _fromECComponents(cls, x, y, curve, privateValue=None):
+    def _fromECComponents(cls, x: int, y: int, curve: bytes, privateValue: int) -> Self:
         """
         Build a key from EC components.
 
         @param x: The affine x component of the public point used for verifying.
-        @type x: L{int}
 
         @param y: The affine y component of the public point used for verifying.
-        @type y: L{int}
 
         @param curve: NIST name of elliptic curve.
-        @type curve: L{bytes}
 
         @param privateValue: The private value.
-        @type privateValue: L{int}
         """
 
         publicNumbers = ec.EllipticCurvePublicNumbers(
             x=x, y=y, curve=_curveTable[curve]
         )
-        if privateValue is None:
-            # We have public components.
-            keyObject = publicNumbers.public_key()
-        else:
-            privateNumbers = ec.EllipticCurvePrivateNumbers(
-                private_value=privateValue, public_numbers=publicNumbers
-            )
-            keyObject = privateNumbers.private_key()
+        privateNumbers = ec.EllipticCurvePrivateNumbers(
+            private_value=privateValue, public_numbers=publicNumbers
+        )
+        keyObject = privateNumbers.private_key()
 
         return cls(keyObject)
 

--- a/src/twisted/conch/ssh/transport.py
+++ b/src/twisted/conch/ssh/transport.py
@@ -181,7 +181,6 @@ class SSHCiphers:
         return Cipher(
             algorithmClass(key[:keySize]),
             modeClass(iv[: algorithmClass.block_size // 8]),
-            backend=default_backend(),
         )
 
     def _getMAC(
@@ -310,7 +309,6 @@ def _getSupportedCiphers():
             Cipher(
                 algorithmClass(b" " * keySize),
                 modeClass(b" " * (algorithmClass.block_size // 8)),
-                backend=default_backend(),
             ).encryptor()
         except UnsupportedAlgorithm:
             pass
@@ -1149,7 +1147,7 @@ class SSHTransportBase(protocol.Protocol):
         """
 
         numbers = dh.DHParameterNumbers(self.p, self.g)
-        parameters = numbers.parameters(default_backend())
+        parameters = numbers.parameters()
         self.dhSecretKey = parameters.generate_private_key()
         y = self.dhSecretKey.public_key().public_numbers().y
         self.dhSecretKeyPublicMP = MP(y)
@@ -1167,7 +1165,7 @@ class SSHTransportBase(protocol.Protocol):
 
         remoteKey = dh.DHPublicNumbers(
             remoteDHpublicKey, dh.DHParameterNumbers(self.p, self.g)
-        ).public_key(default_backend())
+        ).public_key()
         secret = self.dhSecretKey.exchange(remoteKey)
         del self.dhSecretKey
 
@@ -1354,7 +1352,7 @@ class SSHTransportBase(protocol.Protocol):
             except KeyError:
                 raise UnsupportedAlgorithm("unused-key")
 
-            return ec.generate_private_key(curve, default_backend())
+            return ec.generate_private_key(curve)
         elif self.kexAlg in (b"curve25519-sha256", b"curve25519-sha256@libssh.org"):
             return x25519.X25519PrivateKey.generate()
         else:

--- a/src/twisted/conch/test/test_keys.py
+++ b/src/twisted/conch/test/test_keys.py
@@ -1050,7 +1050,7 @@ xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
             common.NS(keydata.ECDatanistp256["curve"])
             + common.NS(keydata.ECDatanistp256["curve"][-8:])
             + common.NS(
-                publicNumbers.public_key(default_backend()).public_bytes(
+                publicNumbers.public_key().public_bytes(
                     serialization.Encoding.X962,
                     serialization.PublicFormat.UncompressedPoint,
                 )

--- a/src/twisted/conch/test/test_transport.py
+++ b/src/twisted/conch/test/test_transport.py
@@ -350,7 +350,7 @@ def generatePredictableKey(transport):
     try:
         transport.dhSecretKey = dh.DHPrivateNumbers(
             x, dh.DHPublicNumbers(y, dh.DHParameterNumbers(p, g))
-        ).private_key(default_backend())
+        ).private_key()
     except ValueError:
         print(f"\np={p}\ng={g}\nx={x}\n")
         raise
@@ -2462,11 +2462,11 @@ class ClientSSHTransportTests(ClientSSHTransportBaseCase, TransportTestCase):
 
         self.proto.dataReceived(b"SSH-2.0-OpenSSH\r\n")
 
-        self.proto.ecPriv = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        self.proto.ecPriv = ec.generate_private_key(ec.SECP256R1())
         self.proto.ecPub = self.proto.ecPriv.public_key()
 
         # Generate the private key
-        thisPriv = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        thisPriv = ec.generate_private_key(ec.SECP256R1())
         # Get the public key
         thisPub = thisPriv.public_key()
         encPub = thisPub.public_bytes(
@@ -2651,11 +2651,11 @@ class ClientSSHTransportDHGroupExchangeBaseCase(ClientSSHTransportBaseCase):
 
         self.proto.dataReceived(b"SSH-2.0-OpenSSH\r\n")
 
-        self.proto.ecPriv = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        self.proto.ecPriv = ec.generate_private_key(ec.SECP256R1())
         self.proto.ecPub = self.proto.ecPriv.public_key()
 
         # Generate the private key
-        thisPriv = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        thisPriv = ec.generate_private_key(ec.SECP256R1())
         # Get the public key
         thisPub = thisPriv.public_key()
         encPub = thisPub.public_bytes(

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -50,7 +50,6 @@ if requireModule("OpenSSL"):
     from OpenSSL.crypto import FILETYPE_PEM, TYPE_RSA, X509, PKey, get_elliptic_curves
 
     from cryptography import x509
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import ec
     from cryptography.hazmat.primitives.asymmetric.rsa import (
@@ -168,9 +167,7 @@ class TestingAuthority:
         commonNameForCA = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
         )
-        privateKeyForCA = generate_private_key(
-            public_exponent=65537, key_size=4096, backend=default_backend()
-        )
+        privateKeyForCA = generate_private_key(public_exponent=65537, key_size=4096)
         publicKeyForCA = privateKeyForCA.public_key()
         caCertificate = (
             x509.CertificateBuilder()
@@ -184,11 +181,7 @@ class TestingAuthority:
                 x509.BasicConstraints(ca=True, path_length=9),
                 critical=True,
             )
-            .sign(
-                private_key=privateKeyForCA,
-                algorithm=hashes.SHA256(),
-                backend=default_backend(),
-            )
+            .sign(private_key=privateKeyForCA, algorithm=hashes.SHA256())
         )
 
         return TestingAuthority(commonNameForCA, caCertificate, privateKeyForCA)
@@ -196,9 +189,7 @@ class TestingAuthority:
     def serverCertificate(
         self, commonName: str, subjects: list[str]
     ) -> sslverify.PrivateCertificate:
-        privateKeyForServer = generate_private_key(
-            public_exponent=65537, key_size=4096, backend=default_backend()
-        )
+        privateKeyForServer = generate_private_key(public_exponent=65537, key_size=4096)
         publicKeyForServer = privateKeyForServer.public_key()
         commonNameForServer = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, commonName)]
@@ -252,9 +243,7 @@ class TestingAuthority:
 
     def authoritize(self, builder: x509.CertificateBuilder) -> x509.Certificate:
         return builder.issuer_name(self.name).sign(
-            private_key=self.key,
-            algorithm=hashes.SHA256(),
-            backend=default_backend(),
+            private_key=self.key, algorithm=hashes.SHA256()
         )
 
 
@@ -3530,7 +3519,7 @@ class CertificateRequestTests(SynchronousTestCase):
         L{ValueError} when the subject contains a name attribute that does not
         correspond to a known L{sslverify.DistinguishedName} field.
         """
-        key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
+        key = ec.generate_private_key(ec.SECP256R1())
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(x509.Name([x509.NameAttribute(NameOID.GIVEN_NAME, "Alice")]))


### PR DESCRIPTION
## Scope and purpose

Fixes #12758 

Since Cryptography 36, the backend argument is no longer used or even documented.

It is deprecated but silently accepted.

Remove redundant uses in Twisted to simplify the code


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
