### PR TITLE
[web] Document static.File.createSimilarFile (fixes #3762)

### DIFF
--- a/src/twisted/newsfragments/3762.doc
+++ b/src/twisted/newsfragments/3762.doc
@@ -1,0 +1,1 @@
+Document L{twisted.web.static.File.createSimilarFile}.

--- a/src/twisted/web/static.py
+++ b/src/twisted/web/static.py
@@ -690,6 +690,20 @@ class File(resource.Resource, filepath.FilePath[str]):
         )
 
     def createSimilarFile(self, path):
+        """
+        Create a new L{File} (or subclass) instance for the given path,
+        inheriting configuration parameters from this instance.
+
+        This method copies properties such as C{defaultType}, C{ignoredExts},
+        C{registry}, C{processors}, C{indexNames}, and C{childNotFound} to
+        the newly created instance.
+
+        @param path: The path for the new L{File} resource.
+        @type path: L{bytes} or L{str}
+
+        @return: A new L{File} (or subclass) instance.
+        @rtype: L{File}
+        """
         f = self.__class__(path, self.defaultType, self.ignoredExts, self.registry)
         # refactoring by steps, here - constructor should almost certainly take these
         f.processors = self.processors


### PR DESCRIPTION
## Description
This PR addresses issue #3762 by adding a detailed docstring to .

 creates a new  (or subclass) instance for a target path while copying configuration parameters (, , , , , and ).

## Newsfragment
Added .

Fixes #3762
