### PR TITLE
[web] Update Tag.__call__ docstring regarding flatteners (fixes #4982)

### DIFF
--- a/src/twisted/newsfragments/4982.doc
+++ b/src/twisted/newsfragments/4982.doc
@@ -1,0 +1,1 @@
+Update Tag.__call__ docstring to accurately describe flattenable objects and attributes.

--- a/src/twisted/web/_stan.py
+++ b/src/twisted/web/_stan.py
@@ -172,13 +172,12 @@ class Tag:
 
           table(tr1, tr2, width="100%", height="50%", border="1")
 
-        Children may be other tag instances, strings, functions, or any other
-        object which has a registered flatten.
+        Children may be other L{Tag} instances, strings, bytes, or any other
+        object which is flattenable (i.e. for which a flattener function has
+        been registered via L{twisted.web.template.registerFlattener}).
 
-        Attributes may be 'transparent' tag instances (so that
-        C{a(href=transparent(data="foo", render=myhrefrenderer))} works),
-        strings, functions, or any other object which has a registered
-        flattener.
+        Attributes may be strings, bytes, or any other object for which a
+        flattener function has been registered.
 
         If the attribute is a python keyword, such as 'class', you can add an
         underscore to the name, like 'class_'.


### PR DESCRIPTION
Fixes #4982

## Description
This PR updates the docstring of  in :
- Clarifies that child elements and attribute values can be strings, bytes,  instances, or any object for which a flattener function has been registered (via ).
- Removes outdated references to 'registered flatten' and 'transparent' tag instances.
- Adds newsfragment .
