### PR TITLE
Reject a negative IMAP literal size

### DIFF
--- a/src/twisted/mail/imap4.py
+++ b/src/twisted/mail/imap4.py
@@ -4757,6 +4757,8 @@ def parseNestedParens(s, handleLiteral=1):
                     if end == -1:
                         raise ValueError("Malformed literal")
                     literalSize = int(s[i + 1 : end])
+                    if literalSize < 0:
+                        raise ValueError("Illegal literal size")
                     contentStack[-1].append((s[end + 3 : end + 3 + literalSize],))
                     i = end + 3 + literalSize
                 elif c == b"(" or c == b"[":

--- a/src/twisted/mail/newsfragments/12763.bugfix
+++ b/src/twisted/mail/newsfragments/12763.bugfix
@@ -1,0 +1,1 @@
+twisted.mail.imap4.IMAP4Server now rejects a SEARCH command containing a literal with a negative octet count, so an authenticated client can no longer freeze the server with a crafted command.

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1323,6 +1323,14 @@ class IMAP4HelperTests(TestCase):
         for case, expected in cases:
             self.assertEqual(imap4.parseNestedParens(case), expected)
 
+    def test_literalNegativeSize(self):
+        """
+        A literal with a negative octet count is rejected with L{ValueError}
+        instead of driving the parser into a non-terminating loop.
+        """
+        self.assertRaises(ValueError, imap4.parseNestedParens, b"{-1}", 1)
+        self.assertRaises(ValueError, imap4.parseNestedParens, b"foo {-100}bar", 1)
+
     def test_queryBuilder(self):
         inputs = [
             imap4.Query(flagged=1),

--- a/src/twisted/mail/test/test_imap.py
+++ b/src/twisted/mail/test/test_imap.py
@@ -1323,7 +1323,7 @@ class IMAP4HelperTests(TestCase):
         for case, expected in cases:
             self.assertEqual(imap4.parseNestedParens(case), expected)
 
-    def test_literalNegativeSize(self):
+    def test_literalNegativeSize(self) -> None:
         """
         A literal with a negative octet count is rejected with L{ValueError}
         instead of driving the parser into a non-terminating loop.


### PR DESCRIPTION
Fixes #12763

This rejects negative values from literal IMAP sizes.

~~This bounds the line buffer in the `twisted.words.protocols.irc.IRC` server. Right now `dataReceived` appends everything up to the next line feed to `self.buffer` with no limit, and `IRC` is not a `LineReceiver`, so an unauthenticated peer that sends data with no line feed grows the buffer until the server runs out of memory. The `twistd words` IRC server inherits this through `IRCUser`.~~

~~The fix mirrors `twisted.protocols.basic.LineReceiver`: a `MAX_LENGTH` of 16384 and a `lineLengthExceeded` that drops the connection, enforced on the unterminated buffer and on each parsed line. Normal IRC traffic is well under the limit, and the bound also removes the quadratic buffer copy.~~

~~New tests cover an unterminated over-length line and a delimited over-length line both being dropped, and bounded input being served normally. The full `twisted.words.test.test_irc` passes and I added a newsfragment.~~
