### PR TITLE
#12765 Optimize `twisted.test.test_sslverify.serviceIdentitySetup`

### DIFF
--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2205,17 +2205,17 @@ class ServiceIdentityTests(SynchronousTestCase):
             **serverOptionsKwargs,
         )
 
-        signature: dict[str, Any] = {"hostname": clientHostname}
+        clientOptionsKwargs: dict[str, Any] = {"hostname": clientHostname}
         if passClientCert:
-            signature.update(clientCertificate=passClientCert)
+            clientOptionsKwargs.update(clientCertificate=passClientCert)
         if not useDefaultTrust:
-            signature.update(trustRoot=serverCA)
+            clientOptionsKwargs.update(trustRoot=serverCA)
         if fakePlatformTrust:
             self.patch(sslverify, "platformTrust", lambda: serverCA)
         if clientSkipSNI:
-            signature.update(sendServerName=False)
+            clientOptionsKwargs.update(sendServerName=False)
 
-        clientOpts = sslverify.optionsForClientTLS(**signature)
+        clientOpts = sslverify.optionsForClientTLS(**clientOptionsKwargs)
 
         class GreetingServer(protocol.Protocol):
             greeting = b"greetings!"

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2178,12 +2178,12 @@ class ServiceIdentityTests(SynchronousTestCase):
         untrustedAuthority = TestingAuthority.create()
         serverCA = serverAuthority.authorityCertificate()
         serverCert = serverAuthority.serverCertificate("Valid Cert", [serverHostname])
-        other: dict[str, Any] = {}
+        serverOptionsKwargs: dict[str, Any] = {}
         passClientCert = None
         clientCA = clientAuthority.authorityCertificate()
         clientCert = clientAuthority.serverCertificate("Client Cert", ["client"])
         if serverVerifies:
-            other.update(trustRoot=clientCA)
+            serverOptionsKwargs.update(trustRoot=clientCA)
 
         if clientPresentsCertificate:
             if validClientCertificate:
@@ -2202,7 +2202,7 @@ class ServiceIdentityTests(SynchronousTestCase):
             privateKey=serverCert.privateKey.original,
             certificate=serverCert.original,
             contextForServerName=serverNameCallback,
-            **other,
+            **serverOptionsKwargs,
         )
 
         signature: dict[str, Any] = {"hostname": clientHostname}

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -2173,27 +2173,36 @@ class ServiceIdentityTests(SynchronousTestCase):
             called, will move data between the created client and server
             protocol instances
         """
-        clientAuthority = TestingAuthority.create()
         serverAuthority = TestingAuthority.create()
-        untrustedAuthority = TestingAuthority.create()
         serverCA = serverAuthority.authorityCertificate()
-        serverCert = serverAuthority.serverCertificate("Valid Cert", [serverHostname])
         serverOptionsKwargs: dict[str, Any] = {}
         passClientCert = None
-        clientCA = clientAuthority.authorityCertificate()
-        clientCert = clientAuthority.serverCertificate("Client Cert", ["client"])
+
+        clientAuthority = serverAuthority
+        untrustedAuthority = serverAuthority
+
         if serverVerifies:
-            serverOptionsKwargs.update(trustRoot=clientCA)
+            clientAuthority = TestingAuthority.create()
+            serverOptionsKwargs.update(trustRoot=clientAuthority.authorityCertificate())
+
+        if not validCertificate and (not useDefaultTrust or fakePlatformTrust):
+            untrustedAuthority = TestingAuthority.create()
 
         if clientPresentsCertificate:
             if validClientCertificate:
-                passClientCert = clientCert
+                passClientCert = clientAuthority.serverCertificate(
+                    "Client Cert", ["client"]
+                )
             else:
                 passClientCert = untrustedAuthority.serverCertificate(
                     "Client Cert", ["client"]
                 )
 
-        if not validCertificate:
+        if validCertificate:
+            serverCert = serverAuthority.serverCertificate(
+                "Valid Cert", [serverHostname]
+            )
+        else:
             serverCert = untrustedAuthority.serverCertificate(
                 "Invalid Cert", [serverHostname]
             )
@@ -2208,10 +2217,13 @@ class ServiceIdentityTests(SynchronousTestCase):
         clientOptionsKwargs: dict[str, Any] = {"hostname": clientHostname}
         if passClientCert:
             clientOptionsKwargs.update(clientCertificate=passClientCert)
+
         if not useDefaultTrust:
             clientOptionsKwargs.update(trustRoot=serverCA)
+
         if fakePlatformTrust:
             self.patch(sslverify, "platformTrust", lambda: serverCA)
+
         if clientSkipSNI:
             clientOptionsKwargs.update(sendServerName=False)
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12765 

* Refactor `serviceIdentitySetup` such that it doesn't create `TestingAuthority` instances unless its really needed. The most expensive operation here is the generation of 4096-bit RSA keys.
* Renamed two variables so they are a bit more descriptive


Tested the timings using: `hyperfine --warmup 1 --runs 5 'trial src/twisted/test/test_sslverify.py'` on Ubuntu 26.04

Before:
```
Benchmark 1: trial src/twisted/test/test_sslverify.py
  Time (mean ± σ):     46.547 s ±  1.332 s    [User: 46.455 s, System: 0.081 s]
  Range (min … max):   45.403 s … 48.297 s    5 runs
```

After:
```
Benchmark 1: trial src/twisted/test/test_sslverify.py
  Time (mean ± σ):     33.516 s ±  2.574 s    [User: 33.423 s, System: 0.084 s]
  Range (min … max):   30.897 s … 37.059 s    5 runs
```

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
