### PR TITLE
#12694 Fix a race condition in `test_threadCreationArgumentsCallInThreadWithCallback`

### DIFF
--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -185,6 +185,7 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
             refdict["workerRef"] = workerRef()
             refdict["uniqueRef"] = uniqueRef()
             resultRef.append(weakref.ref(result))
+            onResultDone.set()
 
         # Here's our function
         def worker(arg, test):
@@ -203,9 +204,6 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
 
         # Put some work in
         tp.callInThreadWithCallback(onResult, worker, unique, test=unique)
-
-        # Set event on callback's completion
-        tp.callInThread(onResultDone.set)
 
         del worker
         del unique

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -176,13 +176,14 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
 
         # result callback
         def onResult(success, result):
+            # Wait for main thread to delete worker and unique
+            onResultWait.wait(self.getTimeout())
+
             # Spin the GC, which should now delete worker and unique if it's
             # not held on to by callInThreadWithCallback after it is complete
             gc.collect()
-            onResultWait.wait(self.getTimeout())
             refdict["workerRef"] = workerRef()
             refdict["uniqueRef"] = uniqueRef()
-            onResultDone.set()
             resultRef.append(weakref.ref(result))
 
         # Here's our function
@@ -203,6 +204,9 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         # Put some work in
         tp.callInThreadWithCallback(onResult, worker, unique, test=unique)
 
+        # Set event on callback's completion
+        tp.callInThread(onResultDone.set)
+
         del worker
         del unique
 
@@ -210,14 +214,9 @@ class ThreadPoolTests(unittest.SynchronousTestCase):
         onResultWait.set()
         # wait for onResult
         onResultDone.wait(self.getTimeout())
-        gc.collect()
 
         self.assertIsNone(uniqueRef())
         self.assertIsNone(workerRef())
-
-        # XXX There's a race right here - has onResult in the worker thread
-        # returned and the locals in _worker holding it and the result been
-        # deleted yet?
 
         del onResult
         gc.collect()


### PR DESCRIPTION
## Scope and purpose

Fixes #12694 

See https://github.com/twisted/twisted/issues/12694#issuecomment-5169492727 example of how I could easily reproduce it.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
