### PR TITLE
#12770 Bound the twisted.words IRC server line buffer.

### DIFF
--- a/src/twisted/words/newsfragments/12770.bugfix
+++ b/src/twisted/words/newsfragments/12770.bugfix
@@ -1,1 +1,1 @@
-twisted.words.protocols.irc.IRC now limits the length of a single line, so a peer can no longer exhaust server memory by sending data without a line delimiter.
+twisted.words.protocols.irc.IRC.dataReceived now limits the length of a single line, so a peer can no longer exhaust server memory by sending data without a line delimiter.

--- a/src/twisted/words/newsfragments/12770.bugfix
+++ b/src/twisted/words/newsfragments/12770.bugfix
@@ -1,0 +1,1 @@
+twisted.words.protocols.irc.IRC now limits the length of a single line, so a peer can no longer exhaust server memory by sending data without a line delimiter.

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -252,11 +252,14 @@ def parseModes(modes, params, paramModes=("", "")):
 class IRC(protocol.Protocol):
     """
     Internet Relay Chat server protocol.
+
+    @cvar MAX_LENGTH: The maximum length of a line to allow. A received line
+        longer than this drops the connection, matching
+        L{twisted.protocols.basic.LineReceiver}, so an unterminated line cannot
+        grow the buffer without bound. Default is 16384.
     """
 
     buffer = ""
-    # Longest line accepted, matching twisted.protocols.basic.LineReceiver.
-    # An unterminated line would otherwise grow self.buffer without bound.
     MAX_LENGTH = 16384
     hostname = None
 
@@ -421,12 +424,14 @@ class IRC(protocol.Protocol):
         if len(self.buffer) > self.MAX_LENGTH:
             # An unterminated line too long to be a valid message.
             line, self.buffer = self.buffer, ""
-            return self.lineLengthExceeded(line)
+            self.lineLengthExceeded(line)
+            return
 
         for line in lines:
             if len(line) > self.MAX_LENGTH:
                 self.buffer = ""
-                return self.lineLengthExceeded(line)
+                self.lineLengthExceeded(line)
+                return
             if len(line) <= 2:
                 # This is a blank line, at best.
                 continue
@@ -439,16 +444,16 @@ class IRC(protocol.Protocol):
 
             self.handleCommand(command, prefix, params)
 
-    def lineLengthExceeded(self, line):
+    def lineLengthExceeded(self, line: str) -> None:
         """
         Called when a line longer than C{MAX_LENGTH} is received. The default
         behaviour, matching L{twisted.protocols.basic.LineReceiver}, drops the
         connection.
 
         @param line: The line which exceeded the length limit.
-        @type line: L{str}
         """
-        return self.transport.loseConnection()
+        assert self.transport is not None
+        self.transport.loseConnection()
 
     def handleCommand(self, command, prefix, params):
         """

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -255,6 +255,9 @@ class IRC(protocol.Protocol):
     """
 
     buffer = ""
+    # Longest line accepted, matching twisted.protocols.basic.LineReceiver.
+    # An unterminated line would otherwise grow self.buffer without bound.
+    MAX_LENGTH = 16384
     hostname = None
 
     encoding: Optional[str] = None
@@ -415,8 +418,15 @@ class IRC(protocol.Protocol):
         # Put the (possibly empty) element after the last LF back in the
         # buffer
         self.buffer = lines.pop()
+        if len(self.buffer) > self.MAX_LENGTH:
+            # An unterminated line too long to be a valid message.
+            line, self.buffer = self.buffer, ""
+            return self.lineLengthExceeded(line)
 
         for line in lines:
+            if len(line) > self.MAX_LENGTH:
+                self.buffer = ""
+                return self.lineLengthExceeded(line)
             if len(line) <= 2:
                 # This is a blank line, at best.
                 continue
@@ -428,6 +438,17 @@ class IRC(protocol.Protocol):
             # DEBUG: log.msg( "%s %s %s" % (prefix, command, params))
 
             self.handleCommand(command, prefix, params)
+
+    def lineLengthExceeded(self, line):
+        """
+        Called when a line longer than C{MAX_LENGTH} is received. The default
+        behaviour, matching L{twisted.protocols.basic.LineReceiver}, drops the
+        connection.
+
+        @param line: The line which exceeded the length limit.
+        @type line: L{str}
+        """
+        return self.transport.loseConnection()
 
     def handleCommand(self, command, prefix, params):
         """

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1522,6 +1522,35 @@ class BasicServerFunctionalityTests(IRCTestCase):
             bufferValue = bufferValue.decode("utf-8")
         self.assertEqual(bufferValue, s)
 
+    def test_dataReceivedBoundsUnterminatedLine(self) -> None:
+        """
+        A line longer than L{irc.IRC.MAX_LENGTH} that arrives without a
+        delimiter is not buffered without bound. The buffer is cleared and the
+        connection is dropped, matching L{twisted.protocols.basic.LineReceiver}.
+        """
+        self.p.dataReceived(b"A" * (self.p.MAX_LENGTH + 1))
+        self.assertEqual(self.p.buffer, "")
+        self.assertTrue(self.t.closed)
+
+    def test_dataReceivedDropsOverlongTerminatedLine(self) -> None:
+        """
+        A delimited line longer than L{irc.IRC.MAX_LENGTH} is dropped rather
+        than dispatched.
+        """
+        self.p.dataReceived(b"A" * (self.p.MAX_LENGTH + 1) + b"\n")
+        self.assertEqual(self.p.buffer, "")
+        self.assertTrue(self.t.closed)
+
+    def test_dataReceivedAcceptsBoundedInput(self) -> None:
+        """
+        Input under the length limit is buffered normally and the connection is
+        left open.
+        """
+        self.p.dataReceived(b"\r\n")
+        self.p.dataReceived(b"AB")
+        self.assertEqual(self.p.buffer, "AB")
+        self.assertFalse(self.t.closed)
+
     def test_sendMessage(self):
         """
         Passing a command and parameters to L{IRC.sendMessage} results in a


### PR DESCRIPTION
Fixes #12770

This bounds the line buffer in the `twisted.words.protocols.irc.IRC` server. Right now `dataReceived` appends everything up to the next line feed to `self.buffer` with no limit, and `IRC` is not a `LineReceiver`, so an unauthenticated peer that sends data with no line feed grows the buffer until the server runs out of memory. The `twistd words` IRC server inherits this through `IRCUser`.

The fix mirrors `twisted.protocols.basic.LineReceiver`: a `MAX_LENGTH` of 16384 and a `lineLengthExceeded` that drops the connection, enforced on the unterminated buffer and on each parsed line. Normal IRC traffic is well under the limit, and the bound also removes the quadratic buffer copy.

New tests cover an unterminated over-length line and a delimited over-length line both being dropped, and bounded input being served normally.