### PR TITLE
#12773 Use equivalent public API in SSL tests

### DIFF
--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -21,10 +21,6 @@ from twisted.trial.unittest import TestCase
 try:
     from OpenSSL import SSL, crypto
 
-    from cryptography import x509
-    from cryptography.hazmat.primitives import hashes, serialization
-    from cryptography.x509.oid import NameOID
-
     from twisted.internet import ssl
     from twisted.test.ssl_helpers import ClientTLSContext, certPath
 except ImportError:
@@ -166,34 +162,13 @@ def generateCertificateObjects(organization, organizationalUnit):
 
     @return: a tuple of (key, request, certificate) objects.
     """
-    pkey = crypto.PKey()
-    pkey.generate_key(crypto.TYPE_RSA, 2048)
-    req = (
-        x509.CertificateSigningRequestBuilder()
-        .subject_name(
-            x509.Name(
-                [
-                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization),
-                    x509.NameAttribute(
-                        NameOID.ORGANIZATIONAL_UNIT_NAME, organizationalUnit
-                    ),
-                ]
-            )
-        )
-        .sign(pkey.to_cryptography_key(), hashes.SHA256())
+    pkey = ssl.KeyPair.generate()
+    distinguishedName = ssl.DistinguishedName(
+        organizationName=organization,
+        organizationalUnitName=organizationalUnit,
     )
-
-    # Here comes the actual certificate
-    cert = crypto.X509()
-    cert.set_serial_number(1)
-    cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(60)  # Testing certificates need not be long lived
-    subject = cert.get_subject()
-    subject.O = organization
-    subject.OU = organizationalUnit
-    cert.set_issuer(cert.get_subject())
-    cert.set_pubkey(pkey)
-    cert.sign(pkey, "md5")
+    req = pkey.requestObject(distinguishedName)
+    cert = pkey.signRequestObject(distinguishedName, req, 1, secondsToExpiry=60)
 
     return pkey, req, cert
 
@@ -206,9 +181,9 @@ def generateCertificateFiles(basename, organization, organizationalUnit):
     pkey, req, cert = generateCertificateObjects(organization, organizationalUnit)
 
     for ext, data in [
-        ("key", crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey)),
-        ("req", req.public_bytes(serialization.Encoding.PEM)),
-        ("cert", crypto.dump_certificate(crypto.FILETYPE_PEM, cert)),
+        ("key", pkey.dump(crypto.FILETYPE_PEM)),
+        ("req", req.dump(crypto.FILETYPE_PEM)),
+        ("cert", cert.dump(crypto.FILETYPE_PEM)),
     ]:
         fName = os.extsep.join((basename, ext)).encode("utf-8")
         FilePath(fName).setContent(data)

--- a/src/twisted/test/test_ssl.py
+++ b/src/twisted/test/test_ssl.py
@@ -5,6 +5,8 @@
 Tests for twisted SSL support.
 """
 
+from __future__ import annotations
+
 import os
 
 import hamcrest
@@ -156,7 +158,9 @@ class ImmediatelyDisconnectingProtocol(protocol.Protocol):
         self.factory.connectionDisconnected.callback(None)
 
 
-def generateCertificateObjects(organization, organizationalUnit):
+def generateCertificateObjects(
+    organization: str, organizationalUnit: str
+) -> tuple[ssl.KeyPair, ssl.CertificateRequest, ssl.Certificate]:
     """
     Create a certificate for given C{organization} and C{organizationalUnit}.
 

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -132,7 +132,7 @@ def counter(counter=itertools.count()):
     return next(counter)
 
 
-def makeCertificate(**kw):
+def makeCertificate(**kw: str | bytes) -> tuple[PKey, X509]:
     keypair = sslverify.KeyPair.generate()
     distinguishedName = sslverify.DistinguishedName(**kw)
     request = keypair.requestObject(distinguishedName)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -32,7 +32,6 @@ from twisted.internet.interfaces import (
     IProtocolNegotiationFactory,
 )
 from twisted.internet.task import Clock
-from twisted.python.compat import nativeString
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.python.modules import getModule
@@ -47,7 +46,7 @@ if requireModule("OpenSSL"):
     import ipaddress
 
     from OpenSSL import SSL
-    from OpenSSL.crypto import FILETYPE_PEM, TYPE_RSA, X509, PKey, get_elliptic_curves
+    from OpenSSL.crypto import FILETYPE_PEM, X509, PKey, get_elliptic_curves
 
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes
@@ -134,21 +133,11 @@ def counter(counter=itertools.count()):
 
 
 def makeCertificate(**kw):
-    keypair = PKey()
-    keypair.generate_key(TYPE_RSA, 2048)
-
-    certificate = X509()
-    certificate.gmtime_adj_notBefore(0)
-    certificate.gmtime_adj_notAfter(60 * 60 * 24 * 365)  # One year
-    for xname in certificate.get_issuer(), certificate.get_subject():
-        for k, v in kw.items():
-            setattr(xname, k, nativeString(v))
-
-    certificate.set_serial_number(counter())
-    certificate.set_pubkey(keypair)
-    certificate.sign(keypair, "md5")
-
-    return keypair, certificate
+    keypair = sslverify.KeyPair.generate()
+    distinguishedName = sslverify.DistinguishedName(**kw)
+    request = keypair.requestObject(distinguishedName)
+    certificate = keypair.signRequestObject(distinguishedName, request, counter())
+    return keypair.original, certificate.original
 
 
 oneDay = datetime.timedelta(1, 0, 0)


### PR DESCRIPTION
## Scope and purpose

Fixes #12773

This removes a few explicit calls to deprecated API.

When the public API is updated later, then this test code will create more coverage for those changes.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
