### PR TITLE
Fix docstring param names that do not match the signatures

### DIFF
--- a/src/twisted/conch/test/test_userauth.py
+++ b/src/twisted/conch/test/test_userauth.py
@@ -119,7 +119,7 @@ class FakeTransport(transport.SSHTransportBase):
     @ivar packets: a list of 2-tuples: (messageType, data).  Each 2-tuple is
         a sent packet.
     @type packets: C{list}
-    @param lostConnecion: True if loseConnection has been called on us.
+    @ivar lostConnection: True if loseConnection has been called on us.
     @type lostConnection: L{bool}
     """
 

--- a/src/twisted/newsfragments/12775.misc
+++ b/src/twisted/newsfragments/12775.misc
@@ -1,0 +1,1 @@
+Fix docstring param names that do not match the signatures.

--- a/src/twisted/protocols/test/test_tls.py
+++ b/src/twisted/protocols/test/test_tls.py
@@ -245,7 +245,7 @@ def handshakingClientAndServer(
     Construct a client and server L{TLSMemoryBIOProtocol} connected by an IO
     pump.
 
-    @param greetingData: The data which should be written in L{connectionMade}.
+    @param clientGreetingData: The data which should be written in L{connectionMade}.
 
     @return: 3-tuple of client protocol, server protocol, and a L{pump
         <twisted.test.iosim.IOPump>} that can move the data between the two

--- a/src/twisted/python/test/pullpipe.py
+++ b/src/twisted/python/test/pullpipe.py
@@ -18,10 +18,7 @@ def recvfd(socketfd: int) -> tuple[int, bytes]:
     @param socketfd: An C{AF_UNIX} socket, attached to another process waiting
         to send sockets via the ancillary data mechanism in L{send1msg}.
 
-    @type socketfd: C{int}
-
     @return: a 2-tuple of (new file descriptor, description).
-    @rtype: 2-tuple of (C{int}, C{bytes})
     """
     ourSocket = socket.fromfd(socketfd, socket.AF_UNIX, socket.SOCK_STREAM)
     data, ancillary, flags = recvmsg(ourSocket)

--- a/src/twisted/python/test/pullpipe.py
+++ b/src/twisted/python/test/pullpipe.py
@@ -18,7 +18,7 @@ def recvfd(socketfd: int) -> tuple[int, bytes]:
     @param socketfd: An C{AF_UNIX} socket, attached to another process waiting
         to send sockets via the ancillary data mechanism in L{send1msg}.
 
-    @param fd: C{int}
+    @type socketfd: C{int}
 
     @return: a 2-tuple of (new file descriptor, description).
     @rtype: 2-tuple of (C{int}, C{bytes})

--- a/src/twisted/test/test_internet.py
+++ b/src/twisted/test/test_internet.py
@@ -1271,7 +1271,7 @@ class ProducerTests(TestCase):
         Pull consumers don't get their C{pauseProducing} method called if the
         descriptor buffer fills up.
 
-        @param _methodName: Either 'write', or 'writeSequence', indicating
+        @param methodName: Either 'write', or 'writeSequence', indicating
             which transport method to write data to.
         """
         descriptor = SillyDescriptor()

--- a/src/twisted/trial/_dist/test/test_disttrial.py
+++ b/src/twisted/trial/_dist/test/test_disttrial.py
@@ -114,7 +114,6 @@ class CountingReactor(MemoryReactorClock):
 
         @param workerProto: See L{IReactorProcess.spawnProcess}.
         @param args: See L{IReactorProcess.spawnProcess}.
-        @param kwargs: See L{IReactorProcess.spawnProcess}.
         """
         self._workers.append(workerProto)
         workerProto.makeConnection(FakeTransport())

--- a/src/twisted/web/test/injectionhelpers.py
+++ b/src/twisted/web/test/injectionhelpers.py
@@ -31,8 +31,6 @@ class MethodInjectionTestsMixin:
 
         @param method: the method (e.g. C{GET\x00})
 
-        @param uri: the URI
-
         @type method:
         """
         raise NotImplementedError()

--- a/src/twisted/web/test/test_agent.py
+++ b/src/twisted/web/test/test_agent.py
@@ -3455,7 +3455,7 @@ class RequestURIInjectionTests(
         """
         Attempt a request with the provided URI.
 
-        @param method: see L{URIInjectionTestsMixin}
+        @param uri: see L{URIInjectionTestsMixin}
         """
         client.Request(
             method=b"GET",
@@ -3475,9 +3475,9 @@ class RequestWriteToURIInjectionTests(
 
     def attemptRequestWithMaliciousURI(self, uri):
         """
-        Attempt a request with the provided method.
+        Attempt a request with the provided URI.
 
-        @param method: see L{URIInjectionTestsMixin}
+        @param uri: see L{URIInjectionTestsMixin}
         """
         headers = http_headers.Headers({b"Host": [b"twisted.invalid"]})
         req = client.Request(


### PR DESCRIPTION
Eight `@param` fields name something the callable does not take. Docstrings only.

- `FakeTransport` in `test_userauth.py` documents `@param lostConnecion` — the next line already says `@type lostConnection`, correctly spelled. It is an attribute, not an argument, so it became `@ivar lostConnection`.
- `handshakingClientAndServer` documents `greetingData`; the argument is `clientGreetingData`.
- `recvfd` has `@param fd: C{int}` sitting under the real `@param socketfd`. That is a type line that lost its tag — changed to `@type socketfd: C{int}`.
- `_dontPausePullConsumerTest` documents `_methodName`; the argument is `methodName`.
- `FakeReactor.spawnProcess` documents `kwargs`, and there is no `**kwargs` in its signature.
- `attemptRequestWithMaliciousMethod` documents both `method` and `uri`; it takes only `method`.
- Both `attemptRequestWithMaliciousURI` overrides in `test_agent.py` document `method` while taking `uri`. The second one also had "Attempt a request with the provided method." as its summary, copied from the method helper above it.

One I left alone, because the fix is not a docstring fix: `URIInjectionTestsMixin.attemptRequestWithMaliciousURI` in `injectionhelpers.py` is declared as `(self, method)` but documents — and is implemented against — a URI. The two subclasses in `test_agent.py` both name the argument `uri`. It looks like the abstract signature has the wrong parameter name rather than the wrong docstring, so that is your call.

Every entry was opened and read against its signature.
