### PR TITLE
#12768 Speed up rebuild.py when using PyPy by calling `gc.get_referrers` only once 

### DIFF
--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -193,6 +193,7 @@ def rebuild(module, doLog=1):
             clazz.__module__ = module.__name__
     if newclasses:
         import gc
+        classReferrers = gc.get_referrers(*newclasses)
     for nclass in newclasses:
         ga = getattr(module, nclass.__name__)
         if ga is nclass:
@@ -202,7 +203,7 @@ def rebuild(module, doLog=1):
                 )
             )
         else:
-            for r in gc.get_referrers(nclass):
+            for r in classReferrers:
                 if getattr(r, "__class__", None) is nclass:
                     r.__class__ = ga
     if doLog:

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -140,7 +140,6 @@ def rebuild(module, doLog=1):
     _modDictIDMap[id(d)] = module
     newclasses = {}
     functions = {}
-    values = {}
     if doLog:
         log.msg(f"  (scanning {str(module.__name__)}): ")
     for k, v in d.items():
@@ -157,10 +156,8 @@ def rebuild(module, doLog=1):
                     log.logfile.write("o")
                     log.logfile.flush()
 
-    values.update(functions)
-    fromOldModule = values.__contains__
+    fromOldModule = functions.__contains__
     newclasses = newclasses.keys()
-    functions = functions.keys()
 
     if doLog:
         log.msg("")

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -50,10 +50,7 @@ class Sensitive:
         if t == types.FunctionType:
             return latestFunction(anObject)
         elif t == types.MethodType:
-            if anObject.__self__ is None:
-                return getattr(anObject.im_class, anObject.__name__)
-            else:
-                return getattr(anObject.__self__, anObject.__name__)
+            return getattr(anObject.__self__, anObject.__name__)
         else:
             log.msg("warning returning anObject!")
             return anObject

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -8,15 +8,12 @@
 """
 
 import linecache
-
-# System Imports
 import sys
 import time
 import types
 from importlib import reload
 from types import ModuleType
 
-# Sibling Imports
 from twisted.python import log, reflect
 
 lastRebuild = time.time()

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -168,6 +168,7 @@ def rebuild(module, doLog=1):
     if doLog:
         log.msg(f"  (cleaning {str(module.__name__)}): ")
 
+    classReferrers = []
     if newclasses:
         import gc
 

--- a/src/twisted/python/rebuild.py
+++ b/src/twisted/python/rebuild.py
@@ -142,7 +142,6 @@ def rebuild(module, doLog=1):
     d = module.__dict__
     _modDictIDMap[id(d)] = module
     newclasses = {}
-    classes = {}
     functions = {}
     values = {}
     if doLog:
@@ -161,11 +160,9 @@ def rebuild(module, doLog=1):
                     log.logfile.write("o")
                     log.logfile.flush()
 
-    values.update(classes)
     values.update(functions)
     fromOldModule = values.__contains__
     newclasses = newclasses.keys()
-    classes = classes.keys()
     functions = functions.keys()
 
     if doLog:
@@ -180,19 +177,9 @@ def rebuild(module, doLog=1):
     if doLog:
         log.msg(f"  (cleaning {str(module.__name__)}): ")
 
-    for clazz in classes:
-        if getattr(module, clazz.__name__) is clazz:
-            log.msg(f"WARNING: class {reflect.qual(clazz)} not replaced by reload!")
-        else:
-            if doLog:
-                log.logfile.write("x")
-                log.logfile.flush()
-            clazz.__bases__ = ()
-            clazz.__dict__.clear()
-            clazz.__getattr__ = __injectedgetattr__
-            clazz.__module__ = module.__name__
     if newclasses:
         import gc
+
         classReferrers = gc.get_referrers(*newclasses)
     for nclass in newclasses:
         ga = getattr(module, nclass.__name__)


### PR DESCRIPTION
## Scope and purpose

Fixes #12768 
Fixes #5255

Speed up `rebuild.py` when using PyPy by calling `gc.get_referrers` only once. The testsuite for PyPy runs around 20 seconds faster. The optimization is in commit 089d81845531f0ff8fa712b22a6b5d321849cea2, the rest of the commits are just minor cleanups.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/core/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* The title of the PR should describe the changes and starts with the associated issue number, like “#1234 Brief description”.
* A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* The automated tests were updated.
* Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
