### PR TITLE
#12778 Clean up some ResourceWarnings in test suite

### DIFF
--- a/src/twisted/internet/test/connectionmixins.py
+++ b/src/twisted/internet/test/connectionmixins.py
@@ -462,6 +462,7 @@ class StreamClientTestsMixin:
         """
         reactor = self.buildReactor()
         connector = self.connect(reactor, ClientFactory())
+        self.addCleanup(connector.disconnect)
         self.assertTrue(verifyObject(IConnector, connector))
 
     def test_clientConnectionFailedStopsReactor(self):

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -266,7 +266,7 @@ class ProcessTestsBuilderBase(ReactorBuilder):
         # here, but that's okay because the signal handler was installed above,
         # before we could have gotten it).
         signaled.wait(120)
-        if not signaled.isSet():
+        if not signaled.is_set():
             self.fail("Timed out waiting for child process to exit.")
 
         # Capture the processEnded callback.

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -379,16 +379,15 @@ class ProcessTestsBuilderBase(ReactorBuilder):
             try:
                 exe = pyExe.decode(sys.getfilesystemencoding())
 
-                subprocess.Popen([exe, "-c", "import time; time.sleep(0.1)"])
-                f2 = subprocess.Popen(
-                    [exe, "-c", ("import time; time.sleep(0.5);" "print('Foo')")],
-                    stdout=subprocess.PIPE,
-                )
-                # The read call below will blow up with an EINTR from the
-                # SIGCHLD from the first process exiting if we install a
-                # SIGCHLD handler without SA_RESTART.  (which we used to do)
-                with f2.stdout:
-                    result.append(f2.stdout.read())
+                with subprocess.Popen([exe, "-c", "import time; time.sleep(0.1)"]):
+                    with subprocess.Popen(
+                        [exe, "-c", ("import time; time.sleep(0.5);" "print('Foo')")],
+                        stdout=subprocess.PIPE,
+                    ) as process:
+                        # The read call below will blow up with an EINTR from the
+                        # SIGCHLD from the first process exiting if we install a
+                        # SIGCHLD handler without SA_RESTART.  (which we used to do)
+                        result.append(process.stdout.read())
             finally:
                 reactor.stop()
 

--- a/src/twisted/internet/test/test_process.py
+++ b/src/twisted/internet/test/test_process.py
@@ -266,7 +266,8 @@ class ProcessTestsBuilderBase(ReactorBuilder):
         # here, but that's okay because the signal handler was installed above,
         # before we could have gotten it).
         signaled.wait(120)
-        if not signaled.is_set():
+        if not signaled.is_set():  # pragma: no cover
+            # This is not expected in normal test runs.
             self.fail("Timed out waiting for child process to exit.")
 
         # Capture the processEnded callback.

--- a/src/twisted/internet/test/test_stdio.py
+++ b/src/twisted/internet/test/test_stdio.py
@@ -122,18 +122,19 @@ class StdioFilesTests(ReactorBuilder):
         """
         reactor = self.buildReactor()
 
-        # Cleanup might fail if file is GCed too soon:
-        self.f = f = open(self.mktemp(), "wb")
-
-        # Have the reader added:
-        protocol = Protocol()
-        stdio = StandardIO(
-            protocol, stdout=f.fileno(), stdin=self.extraFile.fileno(), reactor=reactor
-        )
-        protocol.transport.write(b"hello")
-        self.assertIn(stdio._writer, reactor.getWriters())
-        stdio._writer.stopWriting()
-        self.assertNotIn(stdio._writer, reactor.getWriters())
+        with open(self.mktemp(), "wb") as f:
+            # Have the reader added:
+            protocol = Protocol()
+            stdio = StandardIO(
+                protocol,
+                stdout=f.fileno(),
+                stdin=self.extraFile.fileno(),
+                reactor=reactor,
+            )
+            protocol.transport.write(b"hello")
+            self.assertIn(stdio._writer, reactor.getWriters())
+            stdio._writer.stopWriting()
+            self.assertNotIn(stdio._writer, reactor.getWriters())
 
     def test_removeAll(self):
         """
@@ -145,20 +146,18 @@ class StdioFilesTests(ReactorBuilder):
         path = self.mktemp()
         open(path, "wb").close()
 
-        # Cleanup might fail if file is GCed too soon:
-        self.f = f = open(path, "rb")
-
-        # Have the reader added:
-        stdio = StandardIO(
-            Protocol(),
-            stdin=f.fileno(),
-            stdout=self.extraFile.fileno(),
-            reactor=reactor,
-        )
-        # And then removed:
-        removed = reactor.removeAll()
-        self.assertIn(stdio._reader, removed)
-        self.assertNotIn(stdio._reader, reactor.getReaders())
+        with open(path, "rb") as f:
+            # Have the reader added:
+            stdio = StandardIO(
+                Protocol(),
+                stdin=f.fileno(),
+                stdout=self.extraFile.fileno(),
+                reactor=reactor,
+            )
+            # And then removed:
+            removed = reactor.removeAll()
+            self.assertIn(stdio._reader, removed)
+            self.assertNotIn(stdio._reader, reactor.getReaders())
 
     def test_getReaders(self):
         """
@@ -186,19 +185,18 @@ class StdioFilesTests(ReactorBuilder):
         """
         reactor = self.buildReactor()
 
-        # Cleanup might fail if file is GCed too soon:
-        self.f = f = open(self.mktemp(), "wb")
-
-        # Have the reader added:
-        stdio = StandardIO(
-            Protocol(),
-            stdout=f.fileno(),
-            stdin=self.extraFile.fileno(),
-            reactor=reactor,
-        )
-        self.assertNotIn(stdio._writer, reactor.getWriters())
-        stdio._writer.startWriting()
-        self.assertIn(stdio._writer, reactor.getWriters())
+        with open(self.mktemp(), "wb") as f:
+            # Have the reader added:
+            stdio = StandardIO(
+                Protocol(),
+                stdout=f.fileno(),
+                stdin=self.extraFile.fileno(),
+                reactor=reactor,
+            )
+            self.assertNotIn(stdio._writer, reactor.getWriters())
+            stdio._writer.startWriting()
+            self.assertIn(stdio._writer, reactor.getWriters())
+            stdio._writer.stopWriting()
 
     if platform.isWindows():
         skip = (

--- a/src/twisted/internet/test/test_stdio.py
+++ b/src/twisted/internet/test/test_stdio.py
@@ -6,12 +6,26 @@ Tests for L{twisted.internet.stdio}.
 """
 
 
-from twisted.internet.protocol import Protocol
+from twisted.internet.interfaces import IReactorCore
+from twisted.internet.protocol import Protocol, connectionDone
 from twisted.internet.test.reactormixins import ReactorBuilder
+from twisted.python.failure import Failure
 from twisted.python.runtime import platform
 
 if not platform.isWindows():
     from twisted.internet.stdio import StandardIO
+
+
+class DisconnectProtocol(Protocol):
+    """
+    Stop a reactor when the protocol is disconnected.
+    """
+
+    def __init__(self, reactor: IReactorCore) -> None:
+        self._reactor = reactor
+
+    def connectionLost(self, reason: Failure = connectionDone) -> None:
+        self._reactor.stop()
 
 
 class StdioFilesTests(ReactorBuilder):
@@ -68,16 +82,12 @@ class StdioFilesTests(ReactorBuilder):
         """
         reactor = self.buildReactor()
 
-        class DisconnectProtocol(Protocol):
-            def connectionLost(self, reason):
-                reactor.stop()
-
         path = self.mktemp()
 
         with open(path, "wb") as f:
             # Write bytes to a transport, hopefully have them written to a
             # file:
-            protocol = DisconnectProtocol()
+            protocol = DisconnectProtocol(reactor)
             StandardIO(
                 protocol,
                 stdout=f.fileno(),
@@ -124,7 +134,7 @@ class StdioFilesTests(ReactorBuilder):
 
         with open(self.mktemp(), "wb") as f:
             # Have the reader added:
-            protocol = Protocol()
+            protocol = DisconnectProtocol(reactor)
             stdio = StandardIO(
                 protocol,
                 stdout=f.fileno(),
@@ -135,6 +145,9 @@ class StdioFilesTests(ReactorBuilder):
             self.assertIn(stdio._writer, reactor.getWriters())
             stdio._writer.stopWriting()
             self.assertNotIn(stdio._writer, reactor.getWriters())
+
+            stdio.loseConnection()
+            self.runReactor(reactor)
 
     def test_removeAll(self):
         """
@@ -168,16 +181,18 @@ class StdioFilesTests(ReactorBuilder):
         path = self.mktemp()
         open(path, "wb").close()
 
-        # Cleanup might fail if file is GCed too soon:
         with open(path, "rb") as f:
             # Have the reader added:
             stdio = StandardIO(
-                Protocol(),
+                DisconnectProtocol(reactor),
                 stdin=f.fileno(),
                 stdout=self.extraFile.fileno(),
                 reactor=reactor,
             )
             self.assertIn(stdio._reader, reactor.getReaders())
+
+            stdio.loseConnection()
+            self.runReactor(reactor)
 
     def test_getWriters(self):
         """
@@ -188,7 +203,7 @@ class StdioFilesTests(ReactorBuilder):
         with open(self.mktemp(), "wb") as f:
             # Have the reader added:
             stdio = StandardIO(
-                Protocol(),
+                DisconnectProtocol(reactor),
                 stdout=f.fileno(),
                 stdin=self.extraFile.fileno(),
                 reactor=reactor,
@@ -196,7 +211,9 @@ class StdioFilesTests(ReactorBuilder):
             self.assertNotIn(stdio._writer, reactor.getWriters())
             stdio._writer.startWriting()
             self.assertIn(stdio._writer, reactor.getWriters())
-            stdio._writer.stopWriting()
+
+            stdio.loseConnection()
+            self.runReactor(reactor)
 
     if platform.isWindows():
         skip = (

--- a/src/twisted/internet/test/test_tcp.py
+++ b/src/twisted/internet/test/test_tcp.py
@@ -2518,6 +2518,7 @@ class AdoptStreamConnectionTestsBuilder(
         client.protocolConnectionLost = Deferred()
 
         port = reactor.listenTCP(0, firstServer, interface=interface)
+        self.addCleanup(port.stopListening)
 
         def firtServerConnected(proto):
             reactor.removeReader(proto.transport)
@@ -2525,6 +2526,7 @@ class AdoptStreamConnectionTestsBuilder(
             reactor.adoptStreamConnection(
                 proto.transport.fileno(), addressFamily, server
             )
+            proto.transport.socket.close()
 
         firstServer.protocolConnectionMade.addCallback(firtServerConnected)
 

--- a/src/twisted/internet/test/test_unix.py
+++ b/src/twisted/internet/test/test_unix.py
@@ -936,6 +936,7 @@ class UNIXAdoptStreamConnectionTestsBuilder(WriteSequenceTestsMixin, ReactorBuil
             reactor.removeReader(proto.transport)
             reactor.removeWriter(proto.transport)
             reactor.adoptStreamConnection(proto.transport.fileno(), AF_UNIX, server)
+            proto.transport.socket.close()
 
         firstServer.protocolConnectionMade.addCallback(firstServerConnected)
 

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -555,7 +555,8 @@ class RaceConditionTests(unittest.SynchronousTestCase):
             self.threadpool.callInThread(self.event.wait)
         self.threadpool.callInThread(self.event.set)
         self.event.wait(timeout)
-        if not self.event.is_set():
+        if not self.event.is_set():  # pragma: no cover
+            # This is not expected in normal test runs.
             self.event.set()
             self.fail("'set' did not run in thread; timed out waiting on 'wait'.")
 

--- a/src/twisted/test/test_threadpool.py
+++ b/src/twisted/test/test_threadpool.py
@@ -555,7 +555,7 @@ class RaceConditionTests(unittest.SynchronousTestCase):
             self.threadpool.callInThread(self.event.wait)
         self.threadpool.callInThread(self.event.set)
         self.event.wait(timeout)
-        if not self.event.isSet():
+        if not self.event.is_set():
             self.event.set()
             self.fail("'set' did not run in thread; timed out waiting on 'wait'.")
 

--- a/src/twisted/test/test_threads.py
+++ b/src/twisted/test/test_threads.py
@@ -64,7 +64,7 @@ class ReactorThreadsTests(TestCase):
 
             reactor.callInThread(threadedFunc)
             waiter.wait(120)
-            if not waiter.isSet():
+            if not waiter.is_set():
                 self.fail("Timed out waiting for event.")
             else:
                 self.assertEqual(result, [False])
@@ -115,7 +115,7 @@ class ReactorThreadsTests(TestCase):
 
             reactor.callInThread(threadedFunction)
             waiter.wait(120)
-            if not waiter.isSet():
+            if not waiter.is_set():
                 self.fail("Timed out waiting for event")
             if self.failure is not None:
                 return defer.fail(self.failure)
@@ -144,7 +144,7 @@ class ReactorThreadsTests(TestCase):
             return threads.deferToThread(waiter.wait, self.getTimeout())
 
         def cb2(ign):
-            if not waiter.isSet():
+            if not waiter.is_set():
                 self.fail("Timed out waiting for event")
             return results, errors
 

--- a/src/twisted/test/test_threads.py
+++ b/src/twisted/test/test_threads.py
@@ -64,7 +64,8 @@ class ReactorThreadsTests(TestCase):
 
             reactor.callInThread(threadedFunc)
             waiter.wait(120)
-            if not waiter.is_set():
+            if not waiter.is_set():  # pragma: no cover
+                # This is not expected in normal test runs.
                 self.fail("Timed out waiting for event.")
             else:
                 self.assertEqual(result, [False])
@@ -115,7 +116,8 @@ class ReactorThreadsTests(TestCase):
 
             reactor.callInThread(threadedFunction)
             waiter.wait(120)
-            if not waiter.is_set():
+            if not waiter.is_set():  # pragma: no cover
+                # This is not expected in normal test runs.
                 self.fail("Timed out waiting for event")
             if self.failure is not None:
                 return defer.fail(self.failure)
@@ -144,7 +146,8 @@ class ReactorThreadsTests(TestCase):
             return threads.deferToThread(waiter.wait, self.getTimeout())
 
         def cb2(ign):
-            if not waiter.is_set():
+            if not waiter.is_set():  # pragma: no cover
+                # This is not expected in normal test runs.
                 self.fail("Timed out waiting for event")
             return results, errors
 


### PR DESCRIPTION
## Scope and purpose

Fixes #12778 

Tested the changes using `PYTHONWARNINGS=always trial src/twisted > resource-warnings6.txt 2>&1` on Ubuntu 26.04

On my end this reduces the number of `ResourceWarning`'s from 317 to 212.

Also fixed one `DeprecationWarning` which was introduced in Python 3.10. `isSet()` is an alias for `is_set()` so seems like a very low risk change.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
