### PR TITLE
#12780 Optimize `test_sslverify` by preferring 2048-bit keys over 4096-bit

### DIFF
--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -156,7 +156,7 @@ class TestingAuthority:
         commonNameForCA = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, "Testing Example CA")]
         )
-        privateKeyForCA = generate_private_key(public_exponent=65537, key_size=4096)
+        privateKeyForCA = generate_private_key(public_exponent=65537, key_size=2048)
         publicKeyForCA = privateKeyForCA.public_key()
         caCertificate = (
             x509.CertificateBuilder()
@@ -178,7 +178,7 @@ class TestingAuthority:
     def serverCertificate(
         self, commonName: str, subjects: list[str]
     ) -> sslverify.PrivateCertificate:
-        privateKeyForServer = generate_private_key(public_exponent=65537, key_size=4096)
+        privateKeyForServer = generate_private_key(public_exponent=65537, key_size=2048)
         publicKeyForServer = privateKeyForServer.public_key()
         commonNameForServer = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, commonName)]


### PR DESCRIPTION
## Scope and purpose

Fixes #12780 

On my end this reduces to the test time by roughly 50%. From what I can find online for SSL/TLS, 2048-bit keys are the minimum allowed. I don't see any reason why 4096-bit keys would be needed in these tests as we are not testing their security strength.

Test command:
`hyperfine --warmup 1 --runs 5 'trial src/twisted/test/test_sslverify.py'`

Before:
```
Benchmark 1: trial src/twisted/test/test_sslverify.py
  Time (mean ± σ):     43.062 s ±  2.909 s    [User: 42.956 s, System: 0.094 s]
  Range (min … max):   38.859 s … 46.789 s    5 runs
```

After:
```
Benchmark 1: trial src/twisted/test/test_sslverify.py
  Time (mean ± σ):     21.150 s ±  0.804 s    [User: 21.067 s, System: 0.080 s]
  Range (min … max):   20.455 s … 22.280 s    5 runs
```

I still believe some sort of caching would benefit these tests to bring the test time even lower. But if we can half the testing time now, that would really save some time when debugging/testing further optimisations.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
