### PR TITLE
#12783 Fix CertificateRequest.getSubject()

### DIFF
--- a/src/twisted/internet/_sslverify.py
+++ b/src/twisted/internet/_sslverify.py
@@ -540,7 +540,7 @@ class CertificateRequest(CertBase):
             )
         return cls(req)
 
-    def _subjectToDistinguishedName(self) -> DistinguishedName:
+    def getSubject(self) -> DistinguishedName:
         """
         Retrieve the subject of this certificate request.
 
@@ -821,7 +821,7 @@ class KeyPair(PublicKey):
         """
         hlreq = CertificateRequest.load(requestData, requestFormat)
 
-        dn = hlreq._subjectToDistinguishedName()
+        dn = hlreq.getSubject()
         vval = verifyDNCallback(dn)
 
         def verified(value):
@@ -858,7 +858,7 @@ class KeyPair(PublicKey):
         req = requestObject.original
         cert = crypto.X509()
         issuerDistinguishedName._copyInto(cert.get_issuer())
-        requestObject._subjectToDistinguishedName()._copyInto(cert.get_subject())
+        requestObject.getSubject()._copyInto(cert.get_subject())
         cert.set_pubkey(crypto.PKey.from_cryptography_key(req.public_key()))
         cert.gmtime_adj_notBefore(0)
         cert.gmtime_adj_notAfter(secondsToExpiry)

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3471,7 +3471,7 @@ class CertificateRequestTests(SynchronousTestCase):
         dn = sslverify.DistinguishedName(commonName="example.twistedmatrix.com")
         return sslverify.KeyPair.generate().requestObject(dn)
 
-    def test_getSubject(self):
+    def test_getSubject(self) -> None:
         """
         L{sslverify.CertificateRequest.getSubject} returns the request subject.
         """

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3471,6 +3471,16 @@ class CertificateRequestTests(SynchronousTestCase):
         dn = sslverify.DistinguishedName(commonName="example.twistedmatrix.com")
         return sslverify.KeyPair.generate().requestObject(dn)
 
+    def test_getSubject(self):
+        """
+        L{sslverify.CertificateRequest.getSubject} returns the request subject.
+        """
+        request = self._makeRequest()
+        self.assertEqual(
+            request.getSubject(),
+            sslverify.DistinguishedName(commonName="example.twistedmatrix.com")
+        )
+
     def test_pemRoundTrip(self):
         """
         A L{sslverify.CertificateRequest} dumped to PEM format and loaded back

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3491,8 +3491,8 @@ class CertificateRequestTests(SynchronousTestCase):
         self.assertIn(b"BEGIN CERTIFICATE REQUEST", pem)
         loaded = sslverify.CertificateRequest.load(pem, FILETYPE_PEM)
         self.assertEqual(
-            loaded._subjectToDistinguishedName(),
-            request._subjectToDistinguishedName(),
+            loaded.getSubject(),
+            request.getSubject(),
         )
 
     def test_loadUnsupportedFormat(self):
@@ -3526,9 +3526,9 @@ class CertificateRequestTests(SynchronousTestCase):
 
     def test_subjectUnknownAttribute(self):
         """
-        L{sslverify.CertificateRequest._subjectToDistinguishedName} raises
-        L{ValueError} when the subject contains a name attribute that does not
-        correspond to a known L{sslverify.DistinguishedName} field.
+        L{sslverify.CertificateRequest.getSubject} raises L{ValueError} when
+        the subject contains a name attribute that does not correspond to a
+        known L{sslverify.DistinguishedName} field.
         """
         key = ec.generate_private_key(ec.SECP256R1())
         csr = (
@@ -3538,4 +3538,4 @@ class CertificateRequestTests(SynchronousTestCase):
         )
         request = sslverify.CertificateRequest(csr)
         with self.assertRaises(ValueError):
-            request._subjectToDistinguishedName()
+            request.getSubject()

--- a/src/twisted/test/test_sslverify.py
+++ b/src/twisted/test/test_sslverify.py
@@ -3478,7 +3478,7 @@ class CertificateRequestTests(SynchronousTestCase):
         request = self._makeRequest()
         self.assertEqual(
             request.getSubject(),
-            sslverify.DistinguishedName(commonName="example.twistedmatrix.com")
+            sslverify.DistinguishedName(commonName="example.twistedmatrix.com"),
         )
 
     def test_pemRoundTrip(self):


### PR DESCRIPTION
## Scope and purpose

Fixes #12783

Overload the `getSubject` method from `CertBase` with now renamed `_subjectToDistinguishedName`.

This passed the test suite, but please keep in mind that I am not very familiar with this code and there might have been a good reason why `_subjectToDistinguishedName` was introduced in the first place.

## Contributor Checklist:

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
