### PR TITLE
#9519 Enable distrial for Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ on:
     tags:
       - twisted-*
   pull_request:
-    branches: [ trunk ]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -169,7 +169,8 @@ jobs:
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'
-            trial-args: '--reactor=iocp -j 4'
+            # Distributed trial is not yet suported on Windows with iocp.
+            trial-args: '--reactor=iocp'
 
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -169,8 +169,7 @@ jobs:
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'
-            # Distributed trial is not yet suported on Windows with iocp.
-            trial-args: '--reactor=iocp'
+            trial-args: '--reactor=iocp -j 4'
 
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,28 +158,19 @@ jobs:
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-select'
-            # Distributed trial is not yet suported on Windows so we overwrite
-            # the default trial-args to remove concurrent runs and to
-            # select a reactor.
-            trial-args: '--reactor=select'
 
           # Windows, newest Python supported version with select reactor.
           - python-version: '3.14'
             tox-env: 'nodeps-withcov-windows'
             job-name: 'nodeps-windows-select'
             runs-on: 'windows-2022'
-            # Should be removed once we can run distributed tests on Windows
-            # https://github.com/twisted/twisted/issues/12521
-            trial-args: '--reactor=select'
 
           # Windows, newest Python supported version with iocp reactor.
           - python-version: '3.14'
             runs-on: 'windows-2022'
             tox-env: 'alldeps-withcov-windows'
             job-name: 'win-default-tests-iocp'
-            # Distributed trial is not yet suported on Windows.
-            # https://github.com/twisted/twisted/issues/12521
-            trial-args: '--reactor=iocp'
+            trial-args: '--reactor=iocp -j 4'
 
           # On PYPY coverage is very slow (5min vs 30min) as there is no C
           # extension.

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -22,6 +22,7 @@ from attrs import define, field, frozen
 from attrs.converters import default_if_none
 
 from twisted.internet.defer import Deferred, DeferredList, gatherResults
+from twisted.internet.error import ReactorNotRunning
 from twisted.internet.interfaces import IReactorCore, IReactorProcess
 from twisted.logger import Logger
 from twisted.python.failure import Failure
@@ -461,7 +462,12 @@ class DistTrialRunner:
 
         def maybeStopReactor(result: object) -> object:
             if not reactorStopping:
-                self._reactor.stop()
+                try:
+                    self._reactor.stop()
+                except ReactorNotRunning:
+                    # The reactor has already stopped, so we don't need to do
+                    # anything.
+                    pass
             return result
 
         self._reactor.addSystemEventTrigger("before", "shutdown", maybeStopTests)

--- a/src/twisted/trial/_dist/disttrial.py
+++ b/src/twisted/trial/_dist/disttrial.py
@@ -22,7 +22,6 @@ from attrs import define, field, frozen
 from attrs.converters import default_if_none
 
 from twisted.internet.defer import Deferred, DeferredList, gatherResults
-from twisted.internet.error import ReactorNotRunning
 from twisted.internet.interfaces import IReactorCore, IReactorProcess
 from twisted.logger import Logger
 from twisted.python.failure import Failure
@@ -462,12 +461,7 @@ class DistTrialRunner:
 
         def maybeStopReactor(result: object) -> object:
             if not reactorStopping:
-                try:
-                    self._reactor.stop()
-                except ReactorNotRunning:
-                    # The reactor has already stopped, so we don't need to do
-                    # anything.
-                    pass
+                self._reactor.stop()
             return result
 
         self._reactor.addSystemEventTrigger("before", "shutdown", maybeStopTests)

--- a/src/twisted/trial/_dist/worker.py
+++ b/src/twisted/trial/_dist/worker.py
@@ -429,8 +429,16 @@ class LocalWorker(ProcessProtocol):
         On connection lost, close the log files that we're managing for stdin
         and stdout.
         """
-        self._outLog.close()
-        self._errLog.close()
+        try:
+            self._outLog.close()
+        except Exception:
+            # On Windows, sometimes this is somehow already closed.
+            pass
+        try:
+            self._errLog.close()
+        except Exception:
+            # On Windows, sometimes this is somehow already closed.
+            pass
         self.transport = None
 
     def processEnded(self, reason: Failure) -> None:

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -60,7 +60,9 @@ def main(_fdopen=os.fdopen):
 
     workerProtocol = WorkerProtocol(config["force-gc"])
 
-    if platform.isWindows():
+    # We check for non-default _fdopen callback to detect when we are
+    # inside the test.
+    if platform.isWindows() and _fdopen == os.fdopen:
         protocolIn = reactor.getWindowsInheritedHandle(
             _WORKER_AMP_STDIN, _fdopen=_fdopen
         )

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -14,7 +14,10 @@ import errno
 import os
 import sys
 
-from twisted.internet import reactor
+# !!!WARNING!!
+# Make sure the default reactor is not imported or installed at the top level
+# The main() function will install the reactor based on the
+# command line arguments.
 from twisted.internet.protocol import FileWrapper
 from twisted.python.log import startLoggingWithObserver, textFromEventDict
 from twisted.python.runtime import platform
@@ -50,6 +53,9 @@ def main(_fdopen=os.fdopen):
     """
     Main function to be run if __name__ == "__main__".
 
+    This will parse the command line arguments, and install the required
+    reactor.
+
     @param _fdopen: If specified, the function to use in place of C{os.fdopen}.
     @type _fdopen: C{callable}
     """
@@ -63,12 +69,10 @@ def main(_fdopen=os.fdopen):
     # We check for non-default _fdopen callback to detect when we are
     # inside the test.
     if platform.isWindows() and _fdopen == os.fdopen:
-        protocolIn = reactor.getWindowsInheritedHandle(
-            _WORKER_AMP_STDIN, _fdopen=_fdopen
-        )
-        protocolOut = reactor.getWindowsInheritedHandle(
-            _WORKER_AMP_STDOUT, _fdopen=_fdopen
-        )
+        from twisted.internet._dumbwin32proc import _getWindowsInheritedHandle
+
+        protocolIn = _getWindowsInheritedHandle(_WORKER_AMP_STDIN, _fdopen=_fdopen)
+        protocolOut = _getWindowsInheritedHandle(_WORKER_AMP_STDOUT, _fdopen=_fdopen)
 
     else:
         protocolIn = _fdopen(_WORKER_AMP_STDIN, "rb")

--- a/src/twisted/trial/_dist/workertrial.py
+++ b/src/twisted/trial/_dist/workertrial.py
@@ -14,8 +14,10 @@ import errno
 import os
 import sys
 
+from twisted.internet import reactor
 from twisted.internet.protocol import FileWrapper
 from twisted.python.log import startLoggingWithObserver, textFromEventDict
+from twisted.python.runtime import platform
 from twisted.trial._dist import _WORKER_AMP_STDIN, _WORKER_AMP_STDOUT
 from twisted.trial._dist.options import WorkerOptions
 
@@ -58,8 +60,18 @@ def main(_fdopen=os.fdopen):
 
     workerProtocol = WorkerProtocol(config["force-gc"])
 
-    protocolIn = _fdopen(_WORKER_AMP_STDIN, "rb")
-    protocolOut = _fdopen(_WORKER_AMP_STDOUT, "wb")
+    if platform.isWindows():
+        protocolIn = reactor.getWindowsInheritedHandle(
+            _WORKER_AMP_STDIN, _fdopen=_fdopen
+        )
+        protocolOut = reactor.getWindowsInheritedHandle(
+            _WORKER_AMP_STDOUT, _fdopen=_fdopen
+        )
+
+    else:
+        protocolIn = _fdopen(_WORKER_AMP_STDIN, "rb")
+        protocolOut = _fdopen(_WORKER_AMP_STDOUT, "wb")
+
     workerProtocol.makeConnection(FileWrapper(protocolOut))
 
     observer = WorkerLogObserver(workerProtocol)

--- a/src/twisted/trial/newsfragments/9519.feature
+++ b/src/twisted/trial/newsfragments/9519.feature
@@ -1,0 +1,1 @@
+trial with distributed jobs ``trial -j`` is now supported on Windows.


### PR DESCRIPTION
## Scope and purpose

Fixes #9519

For not this is just testing.

With distrial on Windows, we get Windows tests with select reactor in [3:30](https://github.com/twisted/twisted/actions/runs/32053941470/job/95459657024?pr=12794)
 vs [5:30](https://github.com/twisted/twisted/actions/runs/31963239315/job/95204314887) on trunk


With spawnProcess supporting childFDs, it's not that hard to get distrial working on Windows.

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [ ] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
