### PR TITLE
#12767 Fix interface implementation for asyncio reactor

### DIFF
--- a/src/twisted/internet/asyncioreactor.py
+++ b/src/twisted/internet/asyncioreactor.py
@@ -286,15 +286,15 @@ class AsyncioSelectorReactor(PosixReactorBase):
         PosixReactorBase._moveCallLaterSooner(self, tple)
         self._reschedule()
 
-    def callLater(self, seconds, f, *args, **kwargs):
-        dc = PosixReactorBase.callLater(self, seconds, f, *args, **kwargs)
+    def callLater(self, delay, callable, *args, **kwargs):
+        dc = PosixReactorBase.callLater(self, delay, callable, *args, **kwargs)
         abs_time = self._asyncioEventloop.time() + self.timeout()
         if self._scheduledAt is None or abs_time < self._scheduledAt:
             self._reschedule()
         return dc
 
-    def callFromThread(self, f, *args, **kwargs):
-        g = lambda: self.callLater(0, f, *args, **kwargs)
+    def callFromThread(self, callable, *args, **kwargs):
+        g = lambda: self.callLater(0, callable, *args, **kwargs)
         self._asyncioEventloop.call_soon_threadsafe(g)
 
 

--- a/src/twisted/newsfragments/12767.bugfix
+++ b/src/twisted/newsfragments/12767.bugfix
@@ -1,0 +1,4 @@
+twisted.internet.asyncioreactor.AsyncioSelectorReactor.callLater now has the
+same signature as twisted.internet.interfaces.IReactorTime.callLater.
+twisted.internet.asyncioreactor.AsyncioSelectorReactor.callFromThread now has the
+same signature as twisted.internet.interfaces.IReactorFromThreads.callFromThread.


### PR DESCRIPTION
## Scope and purpose

Fixes #12767

Update the implementation to comply with the interface.


--------

I also found this issue in [DNSMixin](https://docs.twisted.org/en/stable/api/twisted.names.dns.DNSMixin.html#callLater) and [TImeoutMixin](https://docs.twisted.org/en/stable/api/twisted.protocols.policies.TimeoutMixin.html#callLater)  and [ThrottlingFactory](https://docs.twisted.org/en/stable/api/twisted.protocols.policies.ThrottlingFactory.html#callLater) where `period` and `func` are used.

There were not changes since in theory they are not implemeting an interface.

But maybe we should also update them in the same PR.


For now, I have not touched that code, trying not to break backward compatiblity 

## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
