### PR TITLE
#12777 Complete type annotating `twisted.internet.abstract`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -463,7 +463,6 @@ module = [
     'twisted.internet._sslverify',
     'twisted.internet._win32serialport',
     'twisted.internet._win32stdio',
-    'twisted.internet.abstract',
     'twisted.internet.asyncioreactor',
     'twisted.internet.cfreactor',
     'twisted.internet.endpoints',

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -369,11 +369,17 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.connectionLost(reason)
 
     def getHost(self) -> interfaces.IAddress:
-        # ITransport.getHost
+        """
+        This is not a complete implementation of L{ITransport.getHost}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
     def getPeer(self) -> interfaces.IAddress:
-        # ITransport.getPeer
+        """
+        This is not a complete implementation of L{ITransport.getPeer}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
     def _isSendBufferFull(self) -> bool:

--- a/src/twisted/internet/abstract.py
+++ b/src/twisted/internet/abstract.py
@@ -8,28 +8,29 @@ Support for generic select()able objects.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from socket import AF_INET, AF_INET6, inet_pton
 from typing import Protocol, cast
 
 from zope.interface import implementer
 
 from twisted.internet import interfaces, main
+from twisted.internet.error import ConnectionDone
 from twisted.python import failure, reflect
 
 # Twisted Imports
 from twisted.python.compat import lazyByteSlice
 
 
-def _dataMustBeBytes(obj):
+def _dataMustBeBytes(obj: object) -> None:
     if not isinstance(obj, bytes):  # no, really, I mean it
         raise TypeError("Data must be bytes")
 
 
 # Python 3.4+ can join bytes and memoryviews; using a
 # memoryview prevents the slice from copying
-def _concatenate(bObj, offset, bArray):
-    return b"".join([memoryview(bObj)[offset:]] + bArray)
+def _concatenate(bObj: bytes, offset: int, bArray: Sequence[bytes]) -> bytes:
+    return b"".join((memoryview(bObj)[offset:], *bArray))
 
 
 class _ConsumerMixinType(Protocol):
@@ -169,7 +170,7 @@ class _LogOwner:
             return applicationObject.logPrefix()
         return applicationObject.__class__.__name__
 
-    def logPrefix(self):
+    def logPrefix(self) -> str:
         """
         Override this method to insert custom logging behavior.  Its
         return value will be inserted in front of every line.  It may
@@ -210,7 +211,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
 
     SEND_LIMIT = 128 * 1024
 
-    def __init__(self, reactor: interfaces.IReactorFDSet | None = None):
+    def __init__(self, reactor: interfaces.IReactorFDSet | None = None) -> None:
         """
         @param reactor: An L{IReactorFDSet} provider which this descriptor will
             use to get readable and writeable event notifications.  If no value
@@ -225,7 +226,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self._tempDataBuffer: list[bytes] = []
         self._tempDataLen = 0
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason: failure.Failure) -> None:
         """The connection was lost.
 
         This is called when the connection on a selectable object has been
@@ -243,7 +244,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self.stopReading()
         self.stopWriting()
 
-    def writeSomeData(self, data: bytes) -> int | BaseException:
+    def writeSomeData(self, data: bytes) -> int | Exception:
         """
         Write as much as possible of the given data, immediately.
 
@@ -257,7 +258,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             "%s does not implement writeSomeData" % reflect.qual(self.__class__)
         )
 
-    def doRead(self):
+    def doRead(self) -> failure.Failure | None:
         """
         Called when data is available for reading.
 
@@ -268,7 +269,11 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             "%s does not implement doRead" % reflect.qual(self.__class__)
         )
 
-    def doWrite(self):
+    # IWriteDescriptor only declares Failure | None, but this implementation
+    # historically returns exception instances and negative integers.
+    def doWrite(  # type: ignore[override]
+        self,
+    ) -> failure.Failure | Exception | int | None:
         """
         Called when data can be written.
 
@@ -323,7 +328,12 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             ):
                 # tell them to supply some more.
                 self.producerPaused = False
-                self.producer.resumeProducing()
+                if self.streamingProducer:
+                    pushProducer = cast(interfaces.IPushProducer, self.producer)
+                    pushProducer.resumeProducing()
+                else:
+                    pullProducer = cast(interfaces.IPullProducer, self.producer)
+                    pullProducer.resumeProducing()
             elif self.disconnecting:
                 # But if I was previously asked to let the connection die, do
                 # so.
@@ -338,7 +348,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
                 return result
         return None
 
-    def _postLoseConnection(self):
+    def _postLoseConnection(self) -> ConnectionDone:
         """Called after a loseConnection(), when all data has been written.
 
         Whatever this returns is then returned by doWrite.
@@ -346,11 +356,11 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         # default implementation, telling reactor we're finished
         return main.CONNECTION_DONE
 
-    def _closeWriteConnection(self):
+    def _closeWriteConnection(self) -> failure.Failure | Exception | int | None:
         # override in subclasses
         pass
 
-    def writeConnectionLost(self, reason):
+    def writeConnectionLost(self, reason: failure.Failure) -> None:
         # in current code should never be called
         self.connectionLost(reason)
 
@@ -358,15 +368,15 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         # override in subclasses
         self.connectionLost(reason)
 
-    def getHost(self):
+    def getHost(self) -> interfaces.IAddress:
         # ITransport.getHost
         raise NotImplementedError()
 
-    def getPeer(self):
+    def getPeer(self) -> interfaces.IAddress:
         # ITransport.getPeer
         raise NotImplementedError()
 
-    def _isSendBufferFull(self):
+    def _isSendBufferFull(self) -> bool:
         """
         Determine whether the user-space send buffer for this transport is full
         or not.
@@ -379,7 +389,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         """
         return len(self.dataBuffer) + self._tempDataLen > self.bufferSize
 
-    def _maybePauseProducer(self):
+    def _maybePauseProducer(self) -> None:
         """
         Possibly pause a producer, if there is one and the send buffer is full.
         """
@@ -389,7 +399,8 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
             if self._isSendBufferFull():
                 # pause it.
                 self.producerPaused = True
-                self.producer.pauseProducing()
+                pushProducer = cast(interfaces.IPushProducer, self.producer)
+                pushProducer.pauseProducing()
 
     def write(self, data: bytes) -> None:
         """Reliably write some data.
@@ -434,7 +445,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         self._maybePauseProducer()
         self.startWriting()
 
-    def loseConnection(self):
+    def loseConnection(self) -> None:
         """Close the connection at the next available opportunity.
 
         Call this to cause this FileDescriptor to lose its connection.  It will
@@ -459,11 +470,11 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
                 self.startWriting()
                 self.disconnecting = 1
 
-    def loseWriteConnection(self):
+    def loseWriteConnection(self) -> None:
         self._writeDisconnecting = True
         self.startWriting()
 
-    def stopReading(self):
+    def stopReading(self) -> None:
         """Stop waiting for read availability.
 
         Call this to remove this selectable from being notified when it is
@@ -471,7 +482,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         """
         self.reactor.removeReader(self)
 
-    def stopWriting(self):
+    def stopWriting(self) -> None:
         """Stop waiting for write availability.
 
         Call this to remove this selectable from being notified when it is ready
@@ -479,11 +490,11 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
         """
         self.reactor.removeWriter(self)
 
-    def startReading(self):
+    def startReading(self) -> None:
         """Start waiting for read availability."""
         self.reactor.addReader(self)
 
-    def startWriting(self):
+    def startWriting(self) -> None:
         """Start waiting for write availability.
 
         Call this to have this FileDescriptor be notified whenever it is ready for
@@ -499,7 +510,7 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
     producer: interfaces.IProducer | None = None
     bufferSize = 2**2**2**2
 
-    def stopConsuming(self):
+    def stopConsuming(self) -> None:
         """Stop consuming data.
 
         This is called when a producer has lost its connection, to tell the
@@ -511,17 +522,17 @@ class FileDescriptor(_ConsumerMixin, _LogOwner):
 
     # producer interface implementation
 
-    def resumeProducing(self):
+    def resumeProducing(self) -> None:
         if self.connected and not self.disconnecting:
             self.startReading()
 
-    def pauseProducing(self):
+    def pauseProducing(self) -> None:
         self.stopReading()
 
-    def stopProducing(self):
+    def stopProducing(self) -> None:
         self.loseConnection()
 
-    def fileno(self):
+    def fileno(self) -> int:
         """File Descriptor number for select().
 
         This method must be overridden or assigned in subclasses to
@@ -576,11 +587,9 @@ def isIPv6Address(addr: str) -> bool:
 
     @param addr: A string which may or may not be the hex
         representation of an IPv6 address.
-    @type addr: C{str}
 
     @return: C{True} if C{addr} represents an IPv6 address, C{False}
         otherwise.
-    @rtype: C{bool}
     """
     return isIPAddress(addr, AF_INET6)
 

--- a/src/twisted/internet/iocpreactor/abstract.py
+++ b/src/twisted/internet/iocpreactor/abstract.py
@@ -375,12 +375,18 @@ class FileHandle(_ConsumerMixin, _LogOwner):
     def stopProducing(self):
         self.loseConnection()
 
-    def getHost(self):
-        # ITransport.getHost
+    def getHost(self) -> interfaces.IAddress:
+        """
+        This is not a complete implementation of L{ITransport.getHost}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
-    def getPeer(self):
-        # ITransport.getPeer
+    def getPeer(self) -> interfaces.IAddress:
+        """
+        This is not a complete implementation of L{ITransport.getPeer}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
 

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -241,7 +241,11 @@ class Connection(
         """Return the socket for this connection."""
         return self.socket
 
-    def doRead(self) -> ConnectionLost | ConnectionDone | None:
+    # IReadDescriptor requires Failure | None, but this implementation
+    # historically returns exception instances for the reactor to interpret.
+    def doRead(  # type: ignore[override]
+        self,
+    ) -> ConnectionLost | ConnectionDone | None:
         """Calls self.protocol.dataReceived with all available data.
 
         This reads up to self.bufferSize bytes of data from its socket, then
@@ -353,6 +357,14 @@ class Connection(
 
     def setTcpKeepAlive(self, enabled: bool) -> None:
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, enabled)
+
+    def getHost(self) -> address.IPv4Address | address.IPv6Address:
+        # ITCPTransport.getHost
+        raise NotImplementedError()
+
+    def getPeer(self) -> address.IPv4Address | address.IPv6Address:
+        # ITCPTransport.getPeer
+        raise NotImplementedError()
 
 
 class _BaseBaseClient:

--- a/src/twisted/internet/tcp.py
+++ b/src/twisted/internet/tcp.py
@@ -359,11 +359,17 @@ class Connection(
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, enabled)
 
     def getHost(self) -> address.IPv4Address | address.IPv6Address:
-        # ITCPTransport.getHost
+        """
+        This is not a complete implementation of L{ITCPTransport.getHost}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
     def getPeer(self) -> address.IPv4Address | address.IPv6Address:
-        # ITCPTransport.getPeer
+        """
+        This is not a complete implementation of L{ITCPTransport.getPeer}.
+        Subclasses must override this method.
+        """
         raise NotImplementedError()
 
 

--- a/src/twisted/internet/unix.py
+++ b/src/twisted/internet/unix.py
@@ -17,7 +17,7 @@ import socket
 import stat
 import struct
 from errno import EAGAIN, ECONNREFUSED, EINTR, EMSGSIZE, ENOBUFS, EWOULDBLOCK
-from typing import Any
+from typing import Any, cast
 
 from zope.interface import implementedBy, implementer, implementer_only
 
@@ -290,11 +290,14 @@ class Server(_SendmsgMixin, tcp.Server):
         proto.makeConnection(self)
         return self
 
-    def getHost(self):
+    # UNIX transports inherit ITCPTransport for its socket-option methods, but
+    # their endpoints are UNIXAddress instances rather than IP addresses.
+    def getHost(self) -> address.UNIXAddress:  # type: ignore[override]
         return address.UNIXAddress(self.socket.getsockname())
 
-    def getPeer(self):
-        return address.UNIXAddress(self.hostname or None)
+    def getPeer(self) -> address.UNIXAddress:  # type: ignore[override]
+        name = cast(bytes | str | None, self.hostname or None)
+        return address.UNIXAddress(name)
 
     def getTcpNoDelay(self):
         """
@@ -488,10 +491,12 @@ class Client(_SendmsgMixin, tcp.BaseClient):
             self._finishInit(None, None, error.BadFileError(filename), reactor)
         self._finishInit(self.doConnect, self.createInternetSocket(), None, reactor)
 
-    def getPeer(self):
+    # UNIX transports inherit ITCPTransport for its socket-option methods, but
+    # their endpoints are UNIXAddress instances rather than IP addresses.
+    def getPeer(self) -> address.UNIXAddress:  # type: ignore[override]
         return address.UNIXAddress(self.addr)
 
-    def getHost(self):
+    def getHost(self) -> address.UNIXAddress:  # type: ignore[override]
         return address.UNIXAddress(None)
 
     def getTcpNoDelay(self):


### PR DESCRIPTION

## Scope and purpose

Fixes #12777

I was initially only going to type annotate `twisted.internet.abstract.FileDescriptor` class but I ended up going for the entire file while at it.

This isn't perfect but hopefully better than before. There are some inconsistencies in the typing which made this a bit challenging. Such as `FileDescriptor.doWrite()`

----

There is one change to typing compared to `trunk`:

Change return type of `FileDescriptor.writeSomeData()` from `BaseException` to `Exception` to match the existing `isinstance()` check in `doWrite()`. 
This isn't perfect and ideally this behavior of returning an exception should be deprecated to respect IWriteDescriptor's interface definition. But that's out of scope in this commit.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
