### PR TITLE
#11625 Prevent stale epoll state after file descriptor reuse

### DIFF
--- a/newsfragments/11625.bugfix
+++ b/newsfragments/11625.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.epollreactor now recognizes when an operating-system file descriptor number has been reused for a different selectable, preventing stale reactor bookkeeping from causing epoll registration failures.

--- a/newsfragments/11625.bugfix
+++ b/newsfragments/11625.bugfix
@@ -1,1 +1,0 @@
-twisted.internet.epollreactor now recognizes when an operating-system file descriptor number has been reused for a different selectable, preventing stale reactor bookkeeping from causing epoll registration failures.

--- a/src/twisted/internet/epollreactor.py
+++ b/src/twisted/internet/epollreactor.py
@@ -91,6 +91,16 @@ class EPollReactor(posixbase.PosixReactorBase, posixbase._PollLikeMixin):
         for another state (read -> read/write for example).
         """
         fd = xer.fileno()
+
+        # File descriptor numbers can be reused after the old descriptor is
+        # closed.  If this number is still tracked for a different selectable,
+        # its old epoll registration is already gone and this must be a fresh
+        # registration.
+        if (fd in primary or fd in other) and selectables.get(fd) is not xer:
+            primary.discard(fd)
+            other.discard(fd)
+            selectables.pop(fd, None)
+
         if fd not in primary:
             flags = event
             # epoll_ctl can raise all kinds of IOErrors, and every one

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -73,6 +73,15 @@ class EPollReactorTests(TestCase):
         reactor._selectables = {}
         return reactor
 
+    def test_fakeEPollModifyMissingDescriptorRaises(self):
+        """
+        Modifying a descriptor that is not registered reproduces epoll's
+        ENOENT failure mode.
+        """
+        poller = FakeEPoll()
+        error = self.assertRaises(FileNotFoundError, poller.modify, 1, 0)
+        self.assertEqual(error.errno, errno.ENOENT)
+
     def test_reusedDescriptorInOtherSetIsRegistered(self):
         """
         A reused descriptor number tracked for a different writer is treated

--- a/src/twisted/internet/test/test_epollreactor.py
+++ b/src/twisted/internet/test/test_epollreactor.py
@@ -5,6 +5,7 @@
 Tests for L{twisted.internet.epollreactor}.
 """
 
+import errno
 from unittest import skipIf
 
 from twisted.internet.error import ConnectionDone
@@ -38,6 +39,96 @@ class Descriptor:
     def connectionLost(self, reason):
         reason.trap(ConnectionDone)
         self.events.append("lost")
+
+
+class FakeEPoll:
+    """
+    Minimal epoll implementation that models registration lifetime.
+    """
+
+    def __init__(self):
+        self.registrations = {}
+
+    def register(self, fd, flags):
+        self.registrations[fd] = flags
+
+    def modify(self, fd, flags):
+        if fd not in self.registrations:
+            raise FileNotFoundError(errno.ENOENT, "No such file or directory")
+        self.registrations[fd] = flags
+
+
+@skipIf(not epollreactor, "epoll not supported in this environment.")
+class EPollReactorTests(TestCase):
+    """
+    L{epollreactor.EPollReactor} keeps its descriptor tracking synchronized
+    with epoll.
+    """
+
+    def _reactor(self):
+        reactor = object.__new__(epollreactor.EPollReactor)
+        reactor._poller = FakeEPoll()
+        reactor._reads = set()
+        reactor._writes = set()
+        reactor._selectables = {}
+        return reactor
+
+    def test_reusedDescriptorInOtherSetIsRegistered(self):
+        """
+        A reused descriptor number tracked for a different writer is treated
+        as a fresh reader registration rather than an epoll modification.
+        """
+        reactor = self._reactor()
+        old = Descriptor()
+        new = Descriptor()
+        reactor._writes.add(1)
+        reactor._selectables[1] = old
+
+        reactor.addReader(new)
+
+        self.assertEqual(reactor._poller.registrations, {1: epollreactor.EPOLLIN})
+        self.assertEqual(reactor._reads, {1})
+        self.assertEqual(reactor._writes, set())
+        self.assertIs(reactor._selectables[1], new)
+
+    def test_reusedDescriptorInPrimarySetIsRegistered(self):
+        """
+        A reused descriptor number tracked for a different reader does not
+        cause registration of the new reader to be silently skipped.
+        """
+        reactor = self._reactor()
+        old = Descriptor()
+        new = Descriptor()
+        reactor._reads.add(1)
+        reactor._selectables[1] = old
+
+        reactor.addReader(new)
+
+        self.assertEqual(reactor._poller.registrations, {1: epollreactor.EPOLLIN})
+        self.assertEqual(reactor._reads, {1})
+        self.assertEqual(reactor._writes, set())
+        self.assertIs(reactor._selectables[1], new)
+
+    def test_sameDescriptorAddsSecondEventByModify(self):
+        """
+        A descriptor already registered as a writer is modified when the same
+        selectable is also registered as a reader.
+        """
+        reactor = self._reactor()
+        descriptor = Descriptor()
+        reactor._poller.register(1, epollreactor.EPOLLOUT)
+        reactor._writes.add(1)
+        reactor._selectables[1] = descriptor
+
+        reactor.addReader(descriptor)
+
+        self.assertEqual(
+            reactor._poller.registrations,
+            {1: epollreactor.EPOLLIN | epollreactor.EPOLLOUT},
+        )
+        self.assertEqual(reactor._reads, {1})
+        self.assertEqual(reactor._writes, {1})
+        self.assertIs(reactor._selectables[1], descriptor)
 
 
 @skipIf(not epollreactor, "epoll not supported in this environment.")

--- a/src/twisted/newsfragments/11625.bugfix
+++ b/src/twisted/newsfragments/11625.bugfix
@@ -1,0 +1,1 @@
+twisted.internet.epollreactor now recognizes when an operating-system file descriptor number has been reused for a different selectable, preventing stale reactor bookkeeping from causing epoll registration failures.


### PR DESCRIPTION
## Scope and purpose

Fixes #11625.

`EPollReactor._add()` currently assumes that when an integer file descriptor is present in its read/write bookkeeping, it still belongs to the same selectable object.

On Linux, a closed file descriptor can be removed from epoll and then its integer value can be reused by a new connection while stale reactor bookkeeping still references the old selectable. In that state, Twisted can call `epoll.modify()` for the new connection and receive `ENOENT`, or can silently skip registering the new selectable.

This change detects when a tracked file descriptor number now belongs to a different selectable, clears the stale read/write bookkeeping for that descriptor, and registers the new selectable as fresh.

Regression tests cover:
- the `epoll.modify()` ENOENT failure path;
- the silent skipped-registration path;
- the normal read/write transition as a control.

The change is limited to stale file-descriptor reuse handling in the epoll reactor.

## Contributor Checklist:

* [x] A GitHub Issue associated with the changes from this PR already exists.
* [x] The title of the PR describes the changes and starts with the associated issue number.
* [x] A release notes news fragment was added in `src/twisted/newsfragments/`.
* [x] The automated tests were updated.
* [ ] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.