### PR TITLE
#12800 Reject repeated subsystem requests

### DIFF
--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -60,6 +60,9 @@ class SSHSession(channel.SSHChannel):
         self.session = None
 
     def request_subsystem(self, data):
+        if self.client is not None:
+            log.error("Cannot start subsystem: a program is already running")
+            return 0
         subsystem, ignored = common.getNS(data)
         log.info('Asking for subsystem "{subsystem}"', subsystem=subsystem)
         client = self.avatar.lookupSubsystem(subsystem, data)

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -61,7 +61,11 @@ class SSHSession(channel.SSHChannel):
 
     def request_subsystem(self, data):
         if self.client is not None:
-            log.error("Cannot start subsystem: a program is already running")
+            log.error(
+                "Cannot start subsystem on channel {channelID}: "
+                "a program is already running",
+                channelID=self.id,
+            )
             return 0
         subsystem, ignored = common.getNS(data)
         log.info('Asking for subsystem "{subsystem}"', subsystem=subsystem)

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -61,12 +61,16 @@ class StubAvatar:
     It implements the I{ISession} interface.
     """
 
+    def __init__(self) -> None:
+        self.subsystemRequests: list[tuple[bytes, bytes]] = []
+
     def lookupSubsystem(self, name, data):
         """
         If the user requests the TestSubsystem subsystem, connect them to a
         MockProtocol.  If they request neither, then None is returned which is
         interpreted by SSHSession as a failure.
         """
+        self.subsystemRequests.append((name, data))
         if name == b"TestSubsystem":
             self.subsystem = MockProtocol()
             self.subsystem.packetData = data
@@ -613,13 +617,21 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
             )
 
         self.assertFalse(result)
+        self.assertEqual(
+            self.session.avatar.subsystemRequests,
+            [(b"TestSubsystem", common.NS(b"TestSubsystem") + b"first")],
+        )
         self.assertIs(self.session.client, firstClient)
         self.assertIs(self.session.avatar.subsystem, firstSubsystem)
         rejections = [
             event
             for event in events
             if event.get("log_level") is LogLevel.error
-            and event.get("log_format", "").startswith("Cannot start subsystem")
+            and event.get("log_format")
+            == (
+                "Cannot start subsystem on channel {channelID}: "
+                "a program is already running"
+            )
         ]
         self.assertEqual(len(rejections), 1)
         self.assertEqual(rejections[0]["channelID"], 123)

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -19,6 +19,7 @@ from zope.interface import implementer
 from twisted.internet import defer, error, protocol
 from twisted.internet.address import IPv4Address
 from twisted.internet.error import ProcessDone, ProcessTerminated
+from twisted.logger import LogLevel, capturedLogs
 from twisted.python import components, failure
 from twisted.python.failure import Failure
 from twisted.python.reflect import requireModule
@@ -592,7 +593,7 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
             self.session.client.transport.proto, self.session.avatar.subsystem
         )
 
-    def test_repeatedSubsystemRequest(self):
+    def test_repeatedSubsystemRequest(self) -> None:
         """
         Once a subsystem has started, another subsystem request is rejected
         without looking up a new subsystem or replacing the existing client.
@@ -604,14 +605,24 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         )
         firstClient = self.session.client
         firstSubsystem = self.session.avatar.subsystem
+        self.session.id = 123
 
-        result = self.session.requestReceived(
-            b"subsystem", common.NS(b"TestSubsystem") + b"second"
-        )
+        with capturedLogs() as events:
+            result = self.session.requestReceived(
+                b"subsystem", common.NS(b"TestSubsystem") + b"second"
+            )
 
         self.assertFalse(result)
         self.assertIs(self.session.client, firstClient)
         self.assertIs(self.session.avatar.subsystem, firstSubsystem)
+        rejections = [
+            event
+            for event in events
+            if event.get("log_level") is LogLevel.error
+            and event.get("log_format", "").startswith("Cannot start subsystem")
+        ]
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0]["channelID"], 123)
 
     def test_lookupSubsystemDoesNotNeedISession(self):
         """

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -592,6 +592,27 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
             self.session.client.transport.proto, self.session.avatar.subsystem
         )
 
+    def test_repeatedSubsystemRequest(self):
+        """
+        Once a subsystem has started, another subsystem request is rejected
+        without looking up a new subsystem or replacing the existing client.
+        """
+        self.assertTrue(
+            self.session.requestReceived(
+                b"subsystem", common.NS(b"TestSubsystem") + b"first"
+            )
+        )
+        firstClient = self.session.client
+        firstSubsystem = self.session.avatar.subsystem
+
+        result = self.session.requestReceived(
+            b"subsystem", common.NS(b"TestSubsystem") + b"second"
+        )
+
+        self.assertFalse(result)
+        self.assertIs(self.session.client, firstClient)
+        self.assertIs(self.session.avatar.subsystem, firstSubsystem)
+
     def test_lookupSubsystemDoesNotNeedISession(self):
         """
         Previously, if one only wanted to implement a subsystem, an ISession

--- a/src/twisted/newsfragments/12800.bugfix
+++ b/src/twisted/newsfragments/12800.bugfix
@@ -1,0 +1,1 @@
+Conch SSH servers now reject additional subsystem requests after a program has already started on the channel.


### PR DESCRIPTION
## Scope and purpose

Fixes #12800.

RFC 4254 section 6.5 allows only one shell, command, or subsystem to succeed per session channel. `SSHSession.request_subsystem()` currently performs a fresh subsystem lookup for every request and replaces `self.client`, so repeated requests can instantiate multiple competing handlers.

This change rejects a subsystem request before lookup when a program is already running. It also logs the rejected request and leaves the existing client untouched.

The regression test verifies that:

* the first subsystem request succeeds;
* a second request fails;
* no second subsystem is looked up;
* the existing client is not replaced.

## Validation

* `python -m twisted.trial twisted.conch.test.test_session` — 54 passed
* `pre-commit run --files src/twisted/conch/ssh/session.py src/twisted/conch/test/test_session.py src/twisted/newsfragments/12800.bugfix` — passed
* `python -m towncrier check --compare-with=origin/trunk` — passed

## Contributor Checklist:

* [x] A GitHub issue associated with the changes from this PR already exists.
* [x] The title of the PR describes the changes and starts with the associated issue number.
* [x] A release notes news fragment was added in `src/twisted/newsfragments/`.
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
