### PR TITLE
#12832 Use gethostname for IRC server default hostname

### DIFF
--- a/src/twisted/words/newsfragments/12832.bugfix
+++ b/src/twisted/words/newsfragments/12832.bugfix
@@ -1,0 +1,1 @@
+twisted.words.protocols.irc.IRC now uses socket.gethostname() instead of socket.getfqdn() for its default hostname, avoiding multi-second stalls on platforms where reverse DNS is slow (such as macOS CI runners).

--- a/src/twisted/words/newsfragments/12832.bugfix
+++ b/src/twisted/words/newsfragments/12832.bugfix
@@ -1,1 +1,0 @@
-twisted.words.protocols.irc.IRC now uses socket.gethostname() instead of socket.getfqdn() for its default hostname, avoiding multi-second stalls on platforms where reverse DNS is slow (such as macOS CI runners).

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -268,7 +268,10 @@ class IRC(protocol.Protocol):
     def connectionMade(self):
         self.channels = []
         if self.hostname is None:
-            self.hostname = socket.getfqdn()
+            # Prefer gethostname() over getfqdn(). Reverse DNS for a
+            # fallback server name is slow on some platforms (notably
+            # macOS CI runners) and is not needed here.
+            self.hostname = socket.gethostname()
 
     def sendLine(self, line):
         line = line + CR + LF

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -268,9 +268,6 @@ class IRC(protocol.Protocol):
     def connectionMade(self):
         self.channels = []
         if self.hostname is None:
-            # Prefer gethostname() over getfqdn(). Reverse DNS for a
-            # fallback server name is slow on some platforms (notably
-            # macOS CI runners) and is not needed here.
             self.hostname = socket.gethostname()
 
     def sendLine(self, line):

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -261,7 +261,7 @@ class IRC(protocol.Protocol):
 
     buffer = ""
     MAX_LENGTH = 16384
-    hostname: Optional[str] = None
+    hostname: str | None = None
 
     encoding: Optional[str] = None
 

--- a/src/twisted/words/protocols/irc.py
+++ b/src/twisted/words/protocols/irc.py
@@ -261,7 +261,7 @@ class IRC(protocol.Protocol):
 
     buffer = ""
     MAX_LENGTH = 16384
-    hostname = None
+    hostname: Optional[str] = None
 
     encoding: Optional[str] = None
 

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1522,7 +1522,7 @@ class BasicServerFunctionalityTests(IRCTestCase):
             bufferValue = bufferValue.decode("utf-8")
         self.assertEqual(bufferValue, s)
 
-    def test_connectionMadeUsesLocalHostname(self):
+    def test_connectionMadeUsesLocalHostname(self) -> None:
         """
         When no hostname is configured, L{IRC.connectionMade} uses
         L{socket.gethostname} as the default hostname.
@@ -1533,12 +1533,14 @@ class BasicServerFunctionalityTests(IRCTestCase):
         protocolInstance.makeConnection(transport)
         self.assertEqual(protocolInstance.hostname, "test-local-host")
 
-    def test_connectionMadePreservesConfiguredHostname(self):
+    def test_connectionMadePreservesConfiguredHostname(self) -> None:
         """
         An explicitly configured hostname is not replaced on connection.
         """
-        protocolInstance = irc.IRC()
-        protocolInstance.hostname = "configured.example"
+        class ConfiguredIRC(irc.IRC):
+            hostname = "configured.example"
+
+        protocolInstance = ConfiguredIRC()
         transport = protocol.FileWrapper(StringIOWithoutClosing())
         protocolInstance.makeConnection(transport)
         self.assertEqual(protocolInstance.hostname, "configured.example")

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1522,6 +1522,27 @@ class BasicServerFunctionalityTests(IRCTestCase):
             bufferValue = bufferValue.decode("utf-8")
         self.assertEqual(bufferValue, s)
 
+    def test_connectionMadeUsesLocalHostname(self):
+        """
+        When no hostname is configured, L{IRC.connectionMade} uses
+        L{socket.gethostname} as the default hostname.
+        """
+        self.patch(irc.socket, "gethostname", lambda: "test-local-host")
+        protocolInstance = irc.IRC()
+        transport = protocol.FileWrapper(StringIOWithoutClosing())
+        protocolInstance.makeConnection(transport)
+        self.assertEqual(protocolInstance.hostname, "test-local-host")
+
+    def test_connectionMadePreservesConfiguredHostname(self):
+        """
+        An explicitly configured hostname is not replaced on connection.
+        """
+        protocolInstance = irc.IRC()
+        protocolInstance.hostname = "configured.example"
+        transport = protocol.FileWrapper(StringIOWithoutClosing())
+        protocolInstance.makeConnection(transport)
+        self.assertEqual(protocolInstance.hostname, "configured.example")
+
     def test_dataReceivedBoundsUnterminatedLine(self) -> None:
         """
         A line longer than L{irc.IRC.MAX_LENGTH} that arrives without a

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1537,6 +1537,7 @@ class BasicServerFunctionalityTests(IRCTestCase):
         """
         An explicitly configured hostname is not replaced on connection.
         """
+
         class ConfiguredIRC(irc.IRC):
             hostname = "configured.example"
 

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1537,11 +1537,8 @@ class BasicServerFunctionalityTests(IRCTestCase):
         """
         An explicitly configured hostname is not replaced on connection.
         """
-
-        class ConfiguredIRC(irc.IRC):
-            hostname = "configured.example"
-
-        protocolInstance = ConfiguredIRC()
+        protocolInstance = irc.IRC()
+        protocolInstance.hostname = "configured.example"
         transport = protocol.FileWrapper(StringIOWithoutClosing())
         protocolInstance.makeConnection(transport)
         self.assertEqual(protocolInstance.hostname, "configured.example")

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1533,16 +1533,6 @@ class BasicServerFunctionalityTests(IRCTestCase):
         protocolInstance.makeConnection(transport)
         self.assertEqual(protocolInstance.hostname, "test-local-host")
 
-    def test_connectionMadePreservesConfiguredHostname(self) -> None:
-        """
-        An explicitly configured hostname is not replaced on connection.
-        """
-        protocolInstance = irc.IRC()
-        protocolInstance.hostname = "configured.example"
-        transport = protocol.FileWrapper(StringIOWithoutClosing())
-        protocolInstance.makeConnection(transport)
-        self.assertEqual(protocolInstance.hostname, "configured.example")
-
     def test_dataReceivedBoundsUnterminatedLine(self) -> None:
         """
         A line longer than L{irc.IRC.MAX_LENGTH} that arrives without a

--- a/src/twisted/words/test/test_irc.py
+++ b/src/twisted/words/test/test_irc.py
@@ -1533,6 +1533,16 @@ class BasicServerFunctionalityTests(IRCTestCase):
         protocolInstance.makeConnection(transport)
         self.assertEqual(protocolInstance.hostname, "test-local-host")
 
+    def test_connectionMadePreservesConfiguredHostname(self) -> None:
+        """
+        An explicitly configured hostname is not replaced on connection.
+        """
+        protocolInstance = irc.IRC()
+        protocolInstance.hostname = "configured.example"
+        transport = protocol.FileWrapper(StringIOWithoutClosing())
+        protocolInstance.makeConnection(transport)
+        self.assertEqual(protocolInstance.hostname, "configured.example")
+
     def test_dataReceivedBoundsUnterminatedLine(self) -> None:
         """
         A line longer than L{irc.IRC.MAX_LENGTH} that arrives without a


### PR DESCRIPTION
## Scope and purpose

Fixes #12832

`IRC.connectionMade` used `socket.getfqdn()` as the default server hostname when none was configured. On some platforms (notably macOS 15+ GitHub Actions runners) that call performs reverse DNS and can stall for tens of seconds, which dominated Twisted's macOS CI runtime.

Per maintainer discussion on the issue, this fallback is not a load-bearing compatibility surface. This PR switches the default to `socket.gethostname()`, matching the practical intent (a local identifier) without the DNS lookup cost. Explicitly configured `hostname` values are unchanged.

This does not change client IRC protocol behavior, message parsing, or any other IRC APIs.

## Contributor Checklist:

* [x] A GitHub Issue associated with the changes from this PR already exists.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [ ] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
* [x] I have not directly included the output of any generative AI system in this pull request, as per our [policy on generative AI](https://docs.twisted.org/en/latest/development/ai-policy.html).