### PR TITLE
#12800 Reject duplicate subsystem channel requests per RFC 4254

### DIFF
--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -78,6 +78,9 @@ class SSHSession(channel.SSHChannel):
             return 0
 
     def request_shell(self, data):
+        if self.client is not None:
+            log.error("Rejecting shell request on session with active program")
+            return 0
         log.info("Getting shell")
         if not self.session:
             self.session = ISession(self.avatar)
@@ -92,6 +95,9 @@ class SSHSession(channel.SSHChannel):
             return 1
 
     def request_exec(self, data):
+        if self.client is not None:
+            log.error("Rejecting exec request on session with active program")
+            return 0
         if not self.session:
             self.session = ISession(self.avatar)
         f, data = common.getNS(data)

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -59,9 +59,14 @@ class SSHSession(channel.SSHChannel):
         self.client = None
         self.session = None
 
-    def request_subsystem(self, data):
+    def request_subsystem(self, data: bytes) -> int:
         if self.client is not None:
-            log.error("Rejecting duplicate subsystem request on existing session")
+            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            log.warn(
+                "Rejecting concurrent subsystem request on channel {channelId} from {peer}: a program is already active",
+                channelId=getattr(self, "id", None),
+                peer=peer,
+            )
             return 0
         subsystem, ignored = common.getNS(data)
         log.info('Asking for subsystem "{subsystem}"', subsystem=subsystem)
@@ -77,9 +82,14 @@ class SSHSession(channel.SSHChannel):
             log.error("Failed to get subsystem")
             return 0
 
-    def request_shell(self, data):
+    def request_shell(self, data: bytes) -> int:
         if self.client is not None:
-            log.error("Rejecting shell request on session with active program")
+            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            log.warn(
+                "Rejecting concurrent shell request on channel {channelId} from {peer}: a program is already active",
+                channelId=getattr(self, "id", None),
+                peer=peer,
+            )
             return 0
         log.info("Getting shell")
         if not self.session:
@@ -94,9 +104,14 @@ class SSHSession(channel.SSHChannel):
             self.client = pp
             return 1
 
-    def request_exec(self, data):
+    def request_exec(self, data: bytes) -> int:
         if self.client is not None:
-            log.error("Rejecting exec request on session with active program")
+            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            log.warn(
+                "Rejecting concurrent exec request on channel {channelId} from {peer}: a program is already active",
+                channelId=getattr(self, "id", None),
+                peer=peer,
+            )
             return 0
         if not self.session:
             self.session = ISession(self.avatar)

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -61,7 +61,9 @@ class SSHSession(channel.SSHChannel):
 
     def request_subsystem(self, data: bytes) -> int:
         if self.client is not None:
-            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            peer = getattr(
+                getattr(self.conn, "transport", None), "getPeer", lambda: None
+            )()
             log.warn(
                 "Rejecting concurrent subsystem request on channel {channelId} from {peer}: a program is already active",
                 channelId=getattr(self, "id", None),
@@ -84,7 +86,9 @@ class SSHSession(channel.SSHChannel):
 
     def request_shell(self, data: bytes) -> int:
         if self.client is not None:
-            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            peer = getattr(
+                getattr(self.conn, "transport", None), "getPeer", lambda: None
+            )()
             log.warn(
                 "Rejecting concurrent shell request on channel {channelId} from {peer}: a program is already active",
                 channelId=getattr(self, "id", None),
@@ -106,7 +110,9 @@ class SSHSession(channel.SSHChannel):
 
     def request_exec(self, data: bytes) -> int:
         if self.client is not None:
-            peer = getattr(getattr(self.conn, "transport", None), "getPeer", lambda: None)()
+            peer = getattr(
+                getattr(self.conn, "transport", None), "getPeer", lambda: None
+            )()
             log.warn(
                 "Rejecting concurrent exec request on channel {channelId} from {peer}: a program is already active",
                 channelId=getattr(self, "id", None),

--- a/src/twisted/conch/ssh/session.py
+++ b/src/twisted/conch/ssh/session.py
@@ -60,6 +60,9 @@ class SSHSession(channel.SSHChannel):
         self.session = None
 
     def request_subsystem(self, data):
+        if self.client is not None:
+            log.error("Rejecting duplicate subsystem request on existing session")
+            return 0
         subsystem, ignored = common.getNS(data)
         log.info('Asking for subsystem "{subsystem}"', subsystem=subsystem)
         client = self.avatar.lookupSubsystem(subsystem, data)

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -610,6 +610,46 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         self.assertFalse(ret2)
         self.assertIs(self.session.client, originalClient)
 
+    def test_multipleProgramExecutionRequestsRejected(self):
+        """
+        Per RFC 4254 Section 6.5, only one of "shell", "exec", or "subsystem"
+        requests can succeed per channel. Once any program has started, subsequent
+        requests for shell, exec, or subsystem are rejected.
+        """
+        # 1. Start with shell, reject shell, exec, and subsystem
+        s1 = self.getSSHSession()
+        self.assertTrue(s1.requestReceived(b"shell", b""))
+        client1 = s1.client
+        self.assertIsNotNone(client1)
+        self.assertFalse(s1.requestReceived(b"shell", b""))
+        self.assertFalse(s1.requestReceived(b"exec", common.NS(b"success")))
+        self.assertFalse(s1.requestReceived(b"subsystem", common.NS(b"TestSubsystem")))
+        self.assertIs(s1.client, client1)
+
+        # 2. Start with exec, reject exec, shell, and subsystem
+        s2 = self.getSSHSession()
+        self.assertTrue(s2.requestReceived(b"exec", common.NS(b"success")))
+        client2 = s2.client
+        self.assertIsNotNone(client2)
+        self.assertFalse(s2.requestReceived(b"exec", common.NS(b"success")))
+        self.assertFalse(s2.requestReceived(b"shell", b""))
+        self.assertFalse(s2.requestReceived(b"subsystem", common.NS(b"TestSubsystem")))
+        self.assertIs(s2.client, client2)
+
+        # 3. Start with subsystem, reject subsystem, shell, and exec
+        s3 = self.getSSHSession()
+        self.assertTrue(
+            s3.requestReceived(b"subsystem", common.NS(b"TestSubsystem") + b"data")
+        )
+        client3 = s3.client
+        self.assertIsNotNone(client3)
+        self.assertFalse(
+            s3.requestReceived(b"subsystem", common.NS(b"TestSubsystem") + b"data")
+        )
+        self.assertFalse(s3.requestReceived(b"shell", b""))
+        self.assertFalse(s3.requestReceived(b"exec", common.NS(b"success")))
+        self.assertIs(s3.client, client3)
+
     def test_lookupSubsystemDoesNotNeedISession(self):
         """
         Previously, if one only wanted to implement a subsystem, an ISession
@@ -689,9 +729,22 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         self.assertSessionIsStubSession()
         self.assertIsInstance(self.session.client, session.SSHSessionProcessProtocol)
         self.assertIs(self.session.session.shellProtocol, self.session.client)
-        # doesn't get a shell the second time
+        # doesn't get a shell the second time per RFC 4254 Section 6.5
+        self.assertFalse(self.session.requestReceived(b"shell", b""))
+
+    def test_requestShellError(self):
+        """
+        When openShell raises an exception on the initial request, the error
+        is logged and requestReceived returns False.
+        """
+        def failingOpenShell(pp):
+            raise RuntimeError("failed to open shell")
+
+        self.session.session = StubSessionForStubAvatar(self.session.avatar)
+        self.session.session.openShell = failingOpenShell
         self.assertFalse(self.session.requestReceived(b"shell", b""))
         self.assertRequestRaisedRuntimeError()
+        self.assertIsNone(self.session.client)
 
     def test_requestShellWithData(self):
         """

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -592,7 +592,7 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
             self.session.client.transport.proto, self.session.avatar.subsystem
         )
 
-    def test_duplicateSubsystemRequestRejected(self):
+    def test_duplicateSubsystemRequestRejected(self) -> None:
         """
         Subsequent subsystem requests on an active session channel are rejected
         with 0 per RFC 4254 Section 6.5.
@@ -610,7 +610,7 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         self.assertFalse(ret2)
         self.assertIs(self.session.client, originalClient)
 
-    def test_multipleProgramExecutionRequestsRejected(self):
+    def test_multipleProgramExecutionRequestsRejected(self) -> None:
         """
         Per RFC 4254 Section 6.5, only one of "shell", "exec", or "subsystem"
         requests can succeed per channel. Once any program has started, subsequent
@@ -732,7 +732,7 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         # doesn't get a shell the second time per RFC 4254 Section 6.5
         self.assertFalse(self.session.requestReceived(b"shell", b""))
 
-    def test_requestShellError(self):
+    def test_requestShellError(self) -> None:
         """
         When openShell raises an exception on the initial request, the error
         is logged and requestReceived returns False.

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -737,6 +737,7 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
         When openShell raises an exception on the initial request, the error
         is logged and requestReceived returns False.
         """
+
         def failingOpenShell(pp):
             raise RuntimeError("failed to open shell")
 

--- a/src/twisted/conch/test/test_session.py
+++ b/src/twisted/conch/test/test_session.py
@@ -592,6 +592,24 @@ class SessionInterfaceTests(RegistryUsingMixin, TestCase):
             self.session.client.transport.proto, self.session.avatar.subsystem
         )
 
+    def test_duplicateSubsystemRequestRejected(self):
+        """
+        Subsequent subsystem requests on an active session channel are rejected
+        with 0 per RFC 4254 Section 6.5.
+        """
+        ret1 = self.session.requestReceived(
+            b"subsystem", common.NS(b"TestSubsystem") + b"data"
+        )
+        self.assertTrue(ret1)
+        originalClient = self.session.client
+        self.assertIsNotNone(originalClient)
+
+        ret2 = self.session.requestReceived(
+            b"subsystem", common.NS(b"TestSubsystem") + b"data2"
+        )
+        self.assertFalse(ret2)
+        self.assertIs(self.session.client, originalClient)
+
     def test_lookupSubsystemDoesNotNeedISession(self):
         """
         Previously, if one only wanted to implement a subsystem, an ISession

--- a/src/twisted/newsfragments/12800.bugfix
+++ b/src/twisted/newsfragments/12800.bugfix
@@ -1,1 +1,1 @@
-twisted.conch.ssh.session.SSHSession now rejects duplicate subsystem channel requests per RFC 4254 Section 6.5, preventing multiple competing protocol handlers and server resource exhaustion.
+twisted.conch.ssh.session.SSHSession now rejects requests to start a shell, execute a command, or run a subsystem if a program has already been started on the session channel, strictly adhering to RFC 4254 Section 6.5.

--- a/src/twisted/newsfragments/12800.bugfix
+++ b/src/twisted/newsfragments/12800.bugfix
@@ -1,1 +1,2 @@
-twisted.conch.ssh.session.SSHSession now rejects requests to start a shell, execute a command, or run a subsystem if a program has already been started on the session channel, strictly adhering to RFC 4254 Section 6.5.
+twisted.conch.ssh.session.SSHSession now rejects `shell`, `exec`, and `subsystem` channel requests once one of them have been successful.  Per RFC 4254 Section 6.5, "Only one of these requests can succeed per channel." This prevents multiple protocol handlers from competing with each other and corrupting the channel's state.
+

--- a/src/twisted/newsfragments/12800.bugfix
+++ b/src/twisted/newsfragments/12800.bugfix
@@ -1,0 +1,1 @@
+twisted.conch.ssh.session.SSHSession now rejects duplicate subsystem channel requests per RFC 4254 Section 6.5, preventing multiple competing protocol handlers and server resource exhaustion.


### PR DESCRIPTION
## Scope and purpose

Fixes #12800

Per [RFC 4254 Section 6.5](https://www.rfc-editor.org/info/rfc4254/#section-6.5):
> Once the session has been set up, a program is started at the remote end. The program can be a shell, an application program, or a subsystem with a host-independent name. Only one of these requests can succeed per channel.

Previously, `request_subsystem` in `twisted.conch.ssh.session.SSHSession` did not check if an active client process handler was already associated with `self.client`. As a result, duplicate subsystem requests on an active session channel would instantiate additional `SSHSessionProcessProtocol` handlers and overwrite `self.client`, leading to competing background handlers and server resource consumption (CWE-400).

This change adds a one-shot guard in `SSHSession.request_subsystem`: if `self.client is not None`, an error is logged and `0` is returned, strictly enforcing the RFC 4254 single-program requirement per session channel.

## Contributor Checklist:

* [x] A GitHub Issue associated with the changes from this PR already exists.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [ ] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
* [x] I have not directly included the output of any generative AI system in this pull request, as per our [policy on generative AI](https://docs.twisted.org/en/latest/development/ai-policy.html).
