### PR TITLE
#12843 Remove `twisted.names.client.ThreadedResolver`

### DIFF
--- a/src/twisted/names/client.py
+++ b/src/twisted/names/client.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 import errno
 import os
-import warnings
 
 from zope.interface import moduleProvides
 
 from twisted.internet import defer, error, interfaces, protocol
 from twisted.internet.abstract import isIPv6Address
+from twisted.internet.base import ThreadedResolver
 from twisted.internet.interfaces import IDelayedCall
 from twisted.names import cache, common, dns, hosts as hostsModule, resolve, root
 from twisted.python import failure, log
@@ -514,23 +514,6 @@ class AXFRController:
                 self.deferred = None
 
 
-from twisted.internet.base import ThreadedResolver as _ThreadedResolverImpl
-
-
-class ThreadedResolver(_ThreadedResolverImpl):
-    def __init__(self, reactor=None):
-        if reactor is None:
-            from twisted.internet import reactor
-        _ThreadedResolverImpl.__init__(self, reactor)
-        warnings.warn(
-            "twisted.names.client.ThreadedResolver is deprecated since "
-            "Twisted 9.0, use twisted.internet.base.ThreadedResolver "
-            "instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-
 class DNSClientFactory(protocol.ClientFactory):
     def __init__(self, controller, timeout=10):
         self.controller = controller
@@ -605,7 +588,7 @@ def createResolver(servers=None, resolvconf=None, hosts=None):
             hosts = r"c:\windows\hosts"
         from twisted.internet import reactor
 
-        bootstrap = _ThreadedResolverImpl(reactor)
+        bootstrap = ThreadedResolver(reactor)
         hostResolver = hostsModule.Resolver(hosts)
         theResolver = root.bootstrap(bootstrap, resolverFactory=Resolver)
 

--- a/src/twisted/names/newsfragments/12843.removal
+++ b/src/twisted/names/newsfragments/12843.removal
@@ -1,0 +1,1 @@
+`twisted.names.client.ThreadedResolver`, deprecated since Twisted 9.0, has been removed.

--- a/src/twisted/names/test/test_client.py
+++ b/src/twisted/names/test/test_client.py
@@ -1190,25 +1190,3 @@ class RetryLogicTests(unittest.TestCase):
                 self.assertEqual(timeout, t)
 
         self.assertFalse(fakeProto.queries)
-
-
-class ThreadedResolverTests(unittest.TestCase):
-    """
-    Tests for L{client.ThreadedResolver}.
-    """
-
-    def test_deprecated(self):
-        """
-        L{client.ThreadedResolver} is deprecated.  Instantiating it emits a
-        deprecation warning pointing at the code that does the instantiation.
-        """
-        client.ThreadedResolver()
-        warnings = self.flushWarnings(offendingFunctions=[self.test_deprecated])
-        self.assertEqual(
-            warnings[0]["message"],
-            "twisted.names.client.ThreadedResolver is deprecated since "
-            "Twisted 9.0, use twisted.internet.base.ThreadedResolver "
-            "instead.",
-        )
-        self.assertEqual(warnings[0]["category"], DeprecationWarning)
-        self.assertEqual(len(warnings), 1)


### PR DESCRIPTION
## Scope and purpose

Fixes #12843

`twisted.names.client.ThreadedResolver` was deprecated in Twisted 9.0

`twisted.internet.base.ThreadedResolver` is a direct replacement.


## Contributor Checklist:

This process applies to *all* pull requests - no matter how small.
Have a look at [our developer documentation](https://docs.twisted.org/en/latest/development/dev-process.html) before submitting your Pull Request.

Below is a non-exhaustive list (as a reminder):

* [x] A GitHub Issue associated with the changes from this PR already exists.
  Please create one if missing.
  Someone from the core team will probably do this for you, but your review might go a bit faster if you do it yourself.
* [x] The title of the PR should describe the changes and starts with the associated issue number, like `#1234 Brief description`.
* [x] A release notes news fragment file was create in src/twisted/newsfragments/ (see: [Release notes fragments docs.](https://docs.twisted.org/en/latest/core/development/dev-process.html#release-notes-management))
* [x] The automated tests were updated.
* [x] Once all checks are green, request a review by leaving a comment that contains exactly the string `please review`.
* [x] I have not directly included the output of any generative AI system in this pull request, as per our [policy on generative AI](https://docs.twisted.org/en/latest/development/ai-policy.html).
  Our bot will trigger the review process, by applying the pending review label
  and requesting a review from the Twisted dev team.
